### PR TITLE
doc: workaround fix for deploying external-dns

### DIFF
--- a/docs/examples/external-dns.yaml
+++ b/docs/examples/external-dns.yaml
@@ -50,6 +50,8 @@ spec:
         app: external-dns
     spec:
       serviceAccountName: external-dns
+      securityContext:
+        fsGroup: 65534
       containers:
       - name: external-dns
         image: bitnami/external-dns:0.7.1


### PR DESCRIPTION
make bitnami/external-dns working with IRSA

closes #1289