### PR TITLE
On node events, reduce reconciling ingresses requests.

### DIFF
--- a/internal/ingress/controller/controller.go
+++ b/internal/ingress/controller/controller.go
@@ -28,8 +28,12 @@ import (
 )
 
 func Initialize(config *config.Configuration, mgr manager.Manager, mc metric.Collector, cloud aws.CloudAPI) error {
+	store, err := store.New(mgr, config)
+	if err != nil {
+		return err
+	}
 	authModule := auth.NewModule(mgr.GetCache())
-	reconciler, err := newReconciler(config, mgr, mc, cloud, authModule)
+	reconciler, err := newReconciler(config, mgr, mc, store, cloud, authModule)
 	if err != nil {
 		return err
 	}
@@ -46,18 +50,14 @@ func Initialize(config *config.Configuration, mgr manager.Manager, mc metric.Col
 	if err := authModule.Init(c, ingressChan, serviceChan); err != nil {
 		return fmt.Errorf("failed to init auth module due to %v", err)
 	}
-	if err := watchClusterEvents(c, mgr.GetCache(), ingressChan, serviceChan, config.IngressClass); err != nil {
+	if err := watchClusterEvents(c, mgr.GetCache(), store, ingressChan, serviceChan, config.IngressClass); err != nil {
 		return fmt.Errorf("failed to watch cluster events due to %v", err)
 	}
 
 	return nil
 }
 
-func newReconciler(config *config.Configuration, mgr manager.Manager, mc metric.Collector, cloud aws.CloudAPI, authModule auth.Module) (reconcile.Reconciler, error) {
-	store, err := store.New(mgr, config)
-	if err != nil {
-		return nil, err
-	}
+func newReconciler(config *config.Configuration, mgr manager.Manager, mc metric.Collector, store store.Storer, cloud aws.CloudAPI, authModule auth.Module) (reconcile.Reconciler, error) {
 	client := mgr.GetClient()
 	nameTagGenerator := generator.NewNameTagGenerator(*config)
 	tagsController := tags.NewController(cloud)
@@ -78,7 +78,7 @@ func newReconciler(config *config.Configuration, mgr manager.Manager, mc metric.
 	}, nil
 }
 
-func watchClusterEvents(c controller.Controller, cache cache.Cache, ingressChan <-chan event.GenericEvent, serviceChan <-chan event.GenericEvent, ingressClass string) error {
+func watchClusterEvents(c controller.Controller, cache cache.Cache, store store.Storer, ingressChan <-chan event.GenericEvent, serviceChan <-chan event.GenericEvent, ingressClass string) error {
 	if err := c.Watch(&source.Kind{Type: &extensions.Ingress{}}, &handlers.EnqueueRequestsForIngressEvent{
 		IngressClass: ingressClass,
 	}); err != nil {
@@ -112,6 +112,7 @@ func watchClusterEvents(c controller.Controller, cache cache.Cache, ingressChan 
 	if err := c.Watch(&source.Kind{Type: &corev1.Node{}}, &handlers.EnqueueRequestsForNodeEvent{
 		IngressClass: ingressClass,
 		Cache:        cache,
+		Store:        store,
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
The pr is same as #1225.
We manage node on demand and we have some fargate instances. So that there are many node events in our system.
Ingress controller receives node change event and reconciles all ingresses. We have about 100 ingresses in our kubernetes cluster. It take about 2-3mins for AWS ingress controller to reconcile with k8s cluster. Once the pod was deleted, it may not deregister targets in time, this results some 5xx(502 and 504)