### PR TITLE
Undo resourceName restriction on leader election role

### DIFF
--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -8,8 +8,6 @@ rules:
       - ""
     resources:
       - configmaps
-    resourceNames:
-      - aws-load-balancer-controller-leader
     verbs:
       - create
       - get

--- a/docs/install/v2_0_0_full.yaml
+++ b/docs/install/v2_0_0_full.yaml
@@ -259,8 +259,6 @@ metadata:
 rules:
   - apiGroups:
       - ""
-    resourceNames:
-      - aws-load-balancer-controller-leader
     resources:
       - configmaps
     verbs:


### PR DESCRIPTION
The prior `resourceName` constraint on the leader election role doesn't work as intended since we cannot restrict create request by `resourceName`. For create, this limitation is because the object name is not known at authorization time.

For further reference https://kubernetes.io/docs/reference/access-authn-authz/rbac/