### PR TITLE
fix RBAC permission

### DIFF
--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -10,6 +10,13 @@ rules:
       - configmaps
     verbs:
       - create
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - aws-load-balancer-controller-leader
+    verbs:
       - get
       - update
       - patch

--- a/docs/install/v2_0_0_full.yaml
+++ b/docs/install/v2_0_0_full.yaml
@@ -263,6 +263,13 @@ rules:
       - configmaps
     verbs:
       - create
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - aws-load-balancer-controller-leader
+    verbs:
       - get
       - update
       - patch


### PR DESCRIPTION
1. fix RBAC permission for leadership election in YAML install.

created a github issue to track this `https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/1556` before we merge and released new helm charts.
# test done:
1. delete old `aws-load-balancer-controller-leader`, install via yaml => works.

Follow up items:
1. update the helm chart to strict RBAC permission