### PR TITLE
Adding `endpoints` resource permission

### DIFF
--- a/docs/examples/external-dns.yaml
+++ b/docs/examples/external-dns.yaml
@@ -20,6 +20,9 @@ rules:
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["list"]
+- apiGroups: [""]
+  resources: ["endpoints"]
+  verbs: ["get", "watch", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding


### PR DESCRIPTION
According to https://github.com/kubernetes-sigs/external-dns/issues/961#issuecomment-664849509, an `endpoints` resource permission is needed 
I'm using EKS 1.17