### PR TITLE
fix egrep script in walkthrough doc to correctly filter aws-load-balancer-controller

### DIFF
--- a/docs/guide/walkthrough/echo_server.md
+++ b/docs/guide/walkthrough/echo_server.md
@@ -45,7 +45,7 @@ In this walkthrough, you'll
 1.  Verify the deployment was successful and the controller started.
 
     ```bash
-    kubectl logs -n kube-system $(kubectl get po -n kube-system | egrep -o aws-load-balancer-controller[a-zA-Z0-9-]+)
+    kubectl logs -n kube-system $(kubectl get po -n kube-system | egrep -o 'aws-load-balancer-controller[a-zA-Z0-9-]+')
     ```
 
     Should display output similar to the following.


### PR DESCRIPTION
### Description
Found the egrep script is missing apostrophe so it will fail to get the log of pod "aws-load-balancer-controller".
```
# original
kubectl logs -n kube-system $(kubectl get po -n kube-system | egrep -o aws-load-balancer-controller[a-zA-Z0-9-]+)

# fixed
kubectl logs -n kube-system $(kubectl get po -n kube-system | egrep -o 'aws-load-balancer-controller[a-zA-Z0-9-]+')
```
### Test
![image](https://user-images.githubusercontent.com/28039402/97992402-9a819300-1e1d-11eb-8292-91f27f74c0e6.png)
