### PR TITLE
move README.md to top-level and adjust links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
-    <img src="assets/images/kubernetes_icon.svg" alt="Kubernetes logo" width="200" />
-    <img src="assets/images/aws_load_balancer_icon.svg" alt="AWS Load Balancer logo" width="200" />
+    <img src="docs/assets/images/kubernetes_icon.svg" alt="Kubernetes logo" width="200" />
+    <img src="docs/assets/images/aws_load_balancer_icon.svg" alt="AWS Load Balancer logo" width="200" />
 </p>
 <p align="center">
     <strong>


### PR DESCRIPTION
move README.md to top-level and adjust links as mkdocs requires only either index.md nor README.md under strict mode.

ref: https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/1619