### PR TITLE
Update prerequisites for NLB-IP mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 *.dylib
 bin
 
+# mkdocs generated live docs
+site
+
 # Test binary, build with `go test -c`
 *.test
 

--- a/docs/guide/service/nlb_ip_mode.md
+++ b/docs/guide/service/nlb_ip_mode.md
@@ -3,8 +3,8 @@ AWS Load Balancer Controller supports Network Load Balancer (NLB) with IP target
 
 ## Prerequisites
 * AWS LoadBalancer Controller >= v2.0.0
-* Kubernetes >= v1.14 for Service type NodePort.
-* Kubernetes >= v1.20 for Service type LoadBalancer.
+* Kubernetes >= v1.15 for Service type NodePort.
+* Kubernetes >= v1.20 or EKS >= 1.18 for Service type LoadBalancer.
 * Pods have native AWS VPC networking configured, see [Amazon VPC CNI plugin](https://github.com/aws/amazon-vpc-cni-k8s)
 
 ## Configuration


### PR DESCRIPTION
Mention that NLB-IP mode is also supported in EKS version 1.18 or later.