### PR TITLE
abstract retry_utils and add retry for listener certificate attachment

### DIFF
--- a/pkg/deploy/ec2/security_group_manager_test.go
+++ b/pkg/deploy/ec2/security_group_manager_test.go
@@ -1,0 +1,47 @@
+package ec2
+
+import (
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_isSecurityGroupDependencyViolationError(t *testing.T) {
+	type args struct {
+		err error
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "is DependencyViolation error",
+			args: args{
+				err: awserr.New("DependencyViolation", "some message", nil),
+			},
+			want: true,
+		},
+		{
+			name: "wraps DependencyViolation error",
+			args: args{
+				err: errors.Wrap(awserr.New("DependencyViolation", "some message", nil), "wrapped message"),
+			},
+			want: true,
+		},
+		{
+			name: "isn't DependencyViolation error",
+			args: args{
+				err: errors.New("some other error"),
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isSecurityGroupDependencyViolationError(tt.args.err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/deploy/elbv2/listener_utils_test.go
+++ b/pkg/deploy/elbv2/listener_utils_test.go
@@ -1,0 +1,47 @@
+package elbv2
+
+import (
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_isListenerNotFoundError(t *testing.T) {
+	type args struct {
+		err error
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "is ListenerNotFound error",
+			args: args{
+				err: awserr.New("ListenerNotFound", "some message", nil),
+			},
+			want: true,
+		},
+		{
+			name: "wraps ListenerNotFound error",
+			args: args{
+				err: errors.Wrap(awserr.New("ListenerNotFound", "some message", nil), "wrapped message"),
+			},
+			want: true,
+		},
+		{
+			name: "isn't ListenerNotFound error",
+			args: args{
+				err: errors.New("some other error"),
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isListenerNotFoundError(tt.args.err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/deploy/elbv2/target_group_manager.go
+++ b/pkg/deploy/elbv2/target_group_manager.go
@@ -7,10 +7,10 @@ import (
 	elbv2sdk "github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/services"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/tracking"
 	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/runtime"
 	"time"
 )
 
@@ -107,19 +107,12 @@ func (m *defaultTargetGroupManager) Delete(ctx context.Context, sdkTG TargetGrou
 		TargetGroupArn: sdkTG.TargetGroup.TargetGroupArn,
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, m.waitTGDeletionTimeout)
-	defer cancel()
 	m.logger.Info("deleting targetGroup",
 		"arn", awssdk.StringValue(req.TargetGroupArn))
-	if err := wait.PollImmediateUntil(m.waitTGDeletionPollInterval, func() (done bool, err error) {
-		if _, err := m.elbv2Client.DeleteTargetGroupWithContext(ctx, req); err != nil {
-			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "ResourceInUse" {
-				return false, nil
-			}
-			return false, err
-		}
-		return true, nil
-	}, ctx.Done()); err != nil {
+	if err := runtime.RetryImmediateOnError(m.waitTGDeletionPollInterval, m.waitTGDeletionTimeout, isTargetGroupResourceInUseError, func() error {
+		_, err := m.elbv2Client.DeleteTargetGroupWithContext(ctx, req)
+		return err
+	}); err != nil {
 		return errors.Wrap(err, "failed to delete targetGroup")
 	}
 	m.logger.Info("deleted targetGroup",
@@ -247,4 +240,12 @@ func buildResTargetGroupStatus(sdkTG TargetGroupWithTags) elbv2model.TargetGroup
 	return elbv2model.TargetGroupStatus{
 		TargetGroupARN: awssdk.StringValue(sdkTG.TargetGroup.TargetGroupArn),
 	}
+}
+
+func isTargetGroupResourceInUseError(err error) bool {
+	var awsErr awserr.Error
+	if errors.As(err, &awsErr) {
+		return awsErr.Code() == "ResourceInUse"
+	}
+	return false
 }

--- a/pkg/runtime/retry_utils.go
+++ b/pkg/runtime/retry_utils.go
@@ -1,0 +1,20 @@
+package runtime
+
+import (
+	"k8s.io/apimachinery/pkg/util/wait"
+	"time"
+)
+
+// RetryImmediateOnError tries to run fn every interval until it succeeds, a non-retryable error occurs or the timeout is reached.
+func RetryImmediateOnError(interval time.Duration, timeout time.Duration, retryable func(error) bool, fn func() error) error {
+	return wait.PollImmediate(interval, timeout, func() (bool, error) {
+		err := fn()
+		if err != nil {
+			if retryable(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	})
+}

--- a/pkg/runtime/retry_utils_test.go
+++ b/pkg/runtime/retry_utils_test.go
@@ -1,0 +1,106 @@
+package runtime
+
+import (
+	"errors"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func Test_RetryImmediateOnError(t *testing.T) {
+	retryable := func(err error) bool {
+		return err.Error() == "retryable"
+	}
+
+	failureAfterRetryCountFnGen := func(x int) func() error {
+		return func() error {
+			x = x - 1
+			if x < 0 {
+				return errors.New("failure")
+			}
+			return errors.New("retryable")
+		}
+	}
+	successAfterRetryCountFnGen := func(x int) func() error {
+		return func() error {
+			x = x - 1
+			if x < 0 {
+				return nil
+			}
+			return errors.New("retryable")
+		}
+	}
+
+	type args struct {
+		interval  time.Duration
+		timeout   time.Duration
+		retryable func(error) bool
+		fn        func() error
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantCount int
+		wantErr   error
+	}{
+		{
+			name: "retry 4 times before failure",
+			args: args{
+				interval:  10 * time.Millisecond,
+				timeout:   100 * time.Millisecond,
+				retryable: retryable,
+				fn:        failureAfterRetryCountFnGen(4),
+			},
+			wantCount: 5,
+			wantErr:   errors.New("failure"),
+		},
+		{
+			name: "retry 4 times before failure - but timeout after 2nd retry",
+			args: args{
+				interval:  10 * time.Millisecond,
+				timeout:   19 * time.Millisecond,
+				retryable: retryable,
+				fn:        failureAfterRetryCountFnGen(4),
+			},
+			wantCount: 3,
+			wantErr:   errors.New("timed out waiting for the condition"),
+		},
+		{
+			name: "retry 4 times before success",
+			args: args{
+				interval:  10 * time.Millisecond,
+				timeout:   100 * time.Millisecond,
+				retryable: retryable,
+				fn:        successAfterRetryCountFnGen(4),
+			},
+			wantCount: 5,
+			wantErr:   nil,
+		},
+		{
+			name: "retry 4 times before success - but timeout after 2nd retry",
+			args: args{
+				interval:  10 * time.Millisecond,
+				timeout:   19 * time.Millisecond,
+				retryable: retryable,
+				fn:        successAfterRetryCountFnGen(4),
+			},
+			wantCount: 3,
+			wantErr:   errors.New("timed out waiting for the condition"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			count := 0
+			err := RetryImmediateOnError(tt.args.interval, tt.args.timeout, tt.args.retryable, func() error {
+				count += 1
+				return tt.args.fn()
+			})
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantCount, count)
+		})
+	}
+}


### PR DESCRIPTION
## description
1. abstract retry_urils.RetryImmediateOnError functionality. It should be preferred over `wait.PollImmediate` when the intention is to retry an action. (otherwise, `wait.PollImmediate` should be preferred when wait for a condition)
2. add retry for ListenerNotFound error when attach certificate to newly created listener.

## test done
1. unit test
2. e2e test
3. tested with HTTPS listeners with multiple certificates.