### PR TITLE
fix two targetGroup related bug

### DIFF
--- a/pkg/deploy/elbv2/target_group_synthesizer.go
+++ b/pkg/deploy/elbv2/target_group_synthesizer.go
@@ -162,9 +162,6 @@ func isSDKTargetGroupRequiresReplacement(sdkTG TargetGroupWithTags, resTG *elbv2
 	if string(resTG.Spec.TargetType) != awssdk.StringValue(sdkTG.TargetGroup.TargetType) {
 		return true
 	}
-	if resTG.Spec.Port != awssdk.Int64Value(sdkTG.TargetGroup.Port) {
-		return true
-	}
 	if string(resTG.Spec.Protocol) != awssdk.StringValue(sdkTG.TargetGroup.Protocol) {
 		return true
 	}

--- a/pkg/deploy/elbv2/target_group_synthesizer_test.go
+++ b/pkg/deploy/elbv2/target_group_synthesizer_test.go
@@ -553,12 +553,12 @@ func Test_isSDKTargetGroupRequiresReplacement(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "targetType change need replacement",
+			name: "port-only change shouldn't need replacement",
 			args: args{
 				sdkTG: TargetGroupWithTags{
 					TargetGroup: &elbv2sdk.TargetGroup{
-						TargetType:      awssdk.String("instance"),
-						Port:            awssdk.Int64(8080),
+						TargetType:      awssdk.String("ip"),
+						Port:            awssdk.Int64(9090),
 						Protocol:        awssdk.String("HTTP"),
 						TargetGroupName: awssdk.String("my-tg"),
 					},
@@ -572,15 +572,15 @@ func Test_isSDKTargetGroupRequiresReplacement(t *testing.T) {
 					},
 				},
 			},
-			want: true,
+			want: false,
 		},
 		{
-			name: "port change need replacement",
+			name: "targetType change need replacement",
 			args: args{
 				sdkTG: TargetGroupWithTags{
 					TargetGroup: &elbv2sdk.TargetGroup{
-						TargetType:      awssdk.String("ip"),
-						Port:            awssdk.Int64(9090),
+						TargetType:      awssdk.String("instance"),
+						Port:            awssdk.Int64(8080),
 						Protocol:        awssdk.String("HTTP"),
 						TargetGroupName: awssdk.String("my-tg"),
 					},

--- a/pkg/ingress/model_build_target_group.go
+++ b/pkg/ingress/model_build_target_group.go
@@ -138,7 +138,7 @@ func (t *defaultModelBuildTask) buildTargetGroupSpec(ctx context.Context,
 
 var invalidTargetGroupNamePattern = regexp.MustCompile("[[:^alnum:]]")
 
-// buildTargetGroupName will calculate the targetGroup's
+// buildTargetGroupName will calculate the targetGroup's name.
 func (t *defaultModelBuildTask) buildTargetGroupName(_ context.Context,
 	ingKey types.NamespacedName, svc *corev1.Service, port intstr.IntOrString, tgPort int64,
 	targetType elbv2model.TargetType, tgProtocol elbv2model.Protocol) string {

--- a/pkg/ingress/model_build_target_group.go
+++ b/pkg/ingress/model_build_target_group.go
@@ -173,8 +173,8 @@ func (t *defaultModelBuildTask) buildTargetGroupTargetType(_ context.Context, sv
 }
 
 // buildTargetGroupPort constructs the TargetGroup's port.
-// Note: TargetGroup's port setting don't actually matter to this controller since we always register targets with port specified.
-// however, we'll do our best to use the most appropriate port as TargetGroup's port to avoid UX confusing.
+// Note: TargetGroup's port is not in the data path as we always register targets with port specified.
+// so this settings don't really matter to our controller, and we do our best to use the most appropriate port as targetGroup's port to avoid UX confusing.
 func (t *defaultModelBuildTask) buildTargetGroupPort(_ context.Context, targetType elbv2model.TargetType, svcPort corev1.ServicePort) int64 {
 	if targetType == elbv2model.TargetTypeInstance {
 		return int64(svcPort.NodePort)
@@ -183,7 +183,8 @@ func (t *defaultModelBuildTask) buildTargetGroupPort(_ context.Context, targetTy
 		return int64(svcPort.TargetPort.IntValue())
 	}
 
-	// when a literal targetPort is used, it can actually be different ports for different pods. so we use a fixed 1 here.
+	// when a literal targetPort is used, we just use a fixed 1 here as this setting is not in the data path.
+	// also, under extreme edge case, it can actually be different ports for different pods.
 	return 1
 }
 

--- a/pkg/ingress/model_build_target_group_test.go
+++ b/pkg/ingress/model_build_target_group_test.go
@@ -1,0 +1,185 @@
+package ingress
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
+	"testing"
+)
+
+func Test_defaultModelBuildTask_buildTargetGroupName(t *testing.T) {
+	type args struct {
+		ingKey     types.NamespacedName
+		svc        *corev1.Service
+		port       intstr.IntOrString
+		tgPort     int64
+		targetType elbv2model.TargetType
+		tgProtocol elbv2model.Protocol
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "standard case",
+			args: args{
+				ingKey: types.NamespacedName{Namespace: "ns-1", Name: "name-1"},
+				svc: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns-1",
+						Name:      "name-1",
+						UID:       "my-uuid",
+					},
+				},
+				port:       intstr.FromString("http"),
+				tgPort:     8080,
+				targetType: elbv2model.TargetTypeIP,
+				tgProtocol: elbv2model.ProtocolHTTP,
+			},
+			want: "k8s-ns1-name1-59797694c2",
+		},
+		{
+			name: "standard case - port differs",
+			args: args{
+				ingKey: types.NamespacedName{Namespace: "ns-1", Name: "name-1"},
+				svc: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns-1",
+						Name:      "name-1",
+						UID:       "my-uuid",
+					},
+				},
+				port:       intstr.FromInt(80),
+				tgPort:     8080,
+				targetType: elbv2model.TargetTypeIP,
+				tgProtocol: elbv2model.ProtocolHTTP,
+			},
+			want: "k8s-ns1-name1-70ebbeea02",
+		},
+		{
+			name: "standard case - tgPort differs",
+			args: args{
+				ingKey: types.NamespacedName{Namespace: "ns-1", Name: "name-1"},
+				svc: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns-1",
+						Name:      "name-1",
+						UID:       "my-uuid",
+					},
+				},
+				port:       intstr.FromString("http"),
+				tgPort:     9090,
+				targetType: elbv2model.TargetTypeIP,
+				tgProtocol: elbv2model.ProtocolHTTP,
+			},
+			want: "k8s-ns1-name1-cf545f64e8",
+		},
+		{
+			name: "standard case - targetType differs",
+			args: args{
+				ingKey: types.NamespacedName{Namespace: "ns-1", Name: "name-1"},
+				svc: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns-1",
+						Name:      "name-1",
+						UID:       "my-uuid",
+					},
+				},
+				port:       intstr.FromString("http"),
+				tgPort:     8080,
+				targetType: elbv2model.TargetTypeInstance,
+				tgProtocol: elbv2model.ProtocolHTTP,
+			},
+			want: "k8s-ns1-name1-e66dadb781",
+		},
+		{
+			name: "standard case - protocol differs",
+			args: args{
+				ingKey: types.NamespacedName{Namespace: "ns-1", Name: "name-1"},
+				svc: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns-1",
+						Name:      "name-1",
+						UID:       "my-uuid",
+					},
+				},
+				port:       intstr.FromString("http"),
+				tgPort:     8080,
+				targetType: elbv2model.TargetTypeIP,
+				tgProtocol: elbv2model.ProtocolHTTPS,
+			},
+			want: "k8s-ns1-name1-3e1463213f",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := &defaultModelBuildTask{}
+			got := task.buildTargetGroupName(context.Background(), tt.args.ingKey, tt.args.svc, tt.args.port, tt.args.tgPort, tt.args.targetType, tt.args.tgProtocol)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_defaultModelBuildTask_buildTargetGroupPort(t *testing.T) {
+	type args struct {
+		targetType elbv2model.TargetType
+		svcPort    corev1.ServicePort
+	}
+	tests := []struct {
+		name string
+		args args
+		want int64
+	}{
+		{
+			name: "instance targetGroup should use nodePort as port",
+			args: args{
+				targetType: elbv2model.TargetTypeInstance,
+				svcPort: corev1.ServicePort{
+					Name:       "http",
+					Port:       80,
+					TargetPort: intstr.FromInt(8080),
+					NodePort:   32768,
+				},
+			},
+			want: 32768,
+		},
+		{
+			name: "ip targetGroup with numeric targetPort should use targetPort as port",
+			args: args{
+				targetType: elbv2model.TargetTypeIP,
+				svcPort: corev1.ServicePort{
+					Name:       "http",
+					Port:       80,
+					TargetPort: intstr.FromInt(8080),
+					NodePort:   32768,
+				},
+			},
+			want: 8080,
+		},
+		{
+			name: "ip targetGroup with literal targetPort should use 1 as port",
+			args: args{
+				targetType: elbv2model.TargetTypeIP,
+				svcPort: corev1.ServicePort{
+					Name:       "http",
+					Port:       80,
+					TargetPort: intstr.FromString("http"),
+					NodePort:   32768,
+				},
+			},
+			want: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := &defaultModelBuildTask{}
+			got := task.buildTargetGroupPort(context.Background(), tt.args.targetType, tt.args.svcPort)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/ingress/model_builder_test.go
+++ b/pkg/ingress/model_builder_test.go
@@ -50,6 +50,7 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 					Name:       "http",
 					Port:       80,
 					TargetPort: intstr.FromInt(8080),
+					NodePort:   32768,
 				},
 			},
 		},
@@ -77,6 +78,7 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 					Name:       "http",
 					Port:       80,
 					TargetPort: intstr.FromInt(8080),
+					NodePort:   32768,
 				},
 			},
 		},
@@ -104,6 +106,7 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 					Name:       "https",
 					Port:       443,
 					TargetPort: intstr.FromInt(8443),
+					NodePort:   32768,
 				},
 			},
 		},
@@ -398,9 +401,9 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
         "AWS::ElasticLoadBalancingV2::TargetGroup":{
             "ns-1/ing-1-svc-1:http":{
                 "spec":{
-                    "name":"k8s-ns1-svc1-1939f42801",
+                    "name":"k8s-ns1-svc1-55af160316",
                     "targetType":"instance",
-                    "port":8080,
+                    "port":32768,
                     "protocol":"HTTP",
                     "healthCheckConfig":{
                         "port":"traffic-port",
@@ -418,9 +421,9 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
             },
             "ns-1/ing-1-svc-2:http":{
                 "spec":{
-                    "name":"k8s-ns1-svc2-1939f42801",
+                    "name":"k8s-ns1-svc2-55af160316",
                     "targetType":"instance",
-                    "port":8080,
+                    "port":32768,
                     "protocol":"HTTP",
                     "healthCheckConfig":{
                         "port":"traffic-port",
@@ -438,7 +441,7 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
             },
             "ns-1/ing-1-svc-3:https":{
                 "spec":{
-                    "name":"k8s-ns1-svc3-59d2f49fb4",
+                    "name":"k8s-ns1-svc3-88605f2ae1",
                     "targetType":"ip",
                     "port":8443,
                     "protocol":"HTTPS",
@@ -462,7 +465,7 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
                 "spec":{
                     "template":{
                         "metadata":{
-                            "name":"k8s-ns1-svc1-1939f42801",
+                            "name":"k8s-ns1-svc1-55af160316",
                             "namespace":"ns-1",
                             "creationTimestamp":null
                         },
@@ -503,7 +506,7 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
                 "spec":{
                     "template":{
                         "metadata":{
-                            "name":"k8s-ns1-svc2-1939f42801",
+                            "name":"k8s-ns1-svc2-55af160316",
                             "namespace":"ns-1",
                             "creationTimestamp":null
                         },
@@ -544,7 +547,7 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
                 "spec":{
                     "template":{
                         "metadata":{
-                            "name":"k8s-ns1-svc3-59d2f49fb4",
+                            "name":"k8s-ns1-svc3-88605f2ae1",
                             "namespace":"ns-1",
                             "creationTimestamp":null
                         },
@@ -844,9 +847,9 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
         "AWS::ElasticLoadBalancingV2::TargetGroup":{
             "ns-1/ing-1-svc-1:http":{
                 "spec":{
-                    "name":"k8s-ns1-svc1-1939f42801",
+                    "name":"k8s-ns1-svc1-55af160316",
                     "targetType":"instance",
-                    "port":8080,
+                    "port":32768,
                     "protocol":"HTTP",
                     "healthCheckConfig":{
                         "port":"traffic-port",
@@ -864,9 +867,9 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
             },
             "ns-1/ing-1-svc-2:http":{
                 "spec":{
-                    "name":"k8s-ns1-svc2-1939f42801",
+                    "name":"k8s-ns1-svc2-55af160316",
                     "targetType":"instance",
-                    "port":8080,
+                    "port":32768,
                     "protocol":"HTTP",
                     "healthCheckConfig":{
                         "port":"traffic-port",
@@ -884,7 +887,7 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
             },
             "ns-1/ing-1-svc-3:https":{
                 "spec":{
-                    "name":"k8s-ns1-svc3-59d2f49fb4",
+                    "name":"k8s-ns1-svc3-88605f2ae1",
                     "targetType":"ip",
                     "port":8443,
                     "protocol":"HTTPS",
@@ -908,7 +911,7 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
                 "spec":{
                     "template":{
                         "metadata":{
-                            "name":"k8s-ns1-svc1-1939f42801",
+                            "name":"k8s-ns1-svc1-55af160316",
                             "namespace":"ns-1",
                             "creationTimestamp":null
                         },
@@ -949,7 +952,7 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
                 "spec":{
                     "template":{
                         "metadata":{
-                            "name":"k8s-ns1-svc2-1939f42801",
+                            "name":"k8s-ns1-svc2-55af160316",
                             "namespace":"ns-1",
                             "creationTimestamp":null
                         },
@@ -990,7 +993,7 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
                 "spec":{
                     "template":{
                         "metadata":{
-                            "name":"k8s-ns1-svc3-59d2f49fb4",
+                            "name":"k8s-ns1-svc3-88605f2ae1",
                             "namespace":"ns-1",
                             "creationTimestamp":null
                         },
@@ -1002,6 +1005,332 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
                             "serviceRef":{
                                 "name":"svc-3",
                                 "port":"https"
+                            },
+                            "networking":{
+                                "ingress":[
+                                    {
+                                        "from":[
+                                            {
+                                                "securityGroup":{
+                                                    "groupID":{
+                                                        "$ref":"#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "ports":[
+                                            {
+                                                "protocol":"TCP"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}`,
+		},
+		{
+			name: "Ingress - referenced same service port with both name and port",
+			env: env{
+				svcs: []*corev1.Service{ns_1_svc_1, ns_1_svc_2, ns_1_svc_3},
+			},
+			fields: fields{
+				resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
+			},
+			args: args{
+				ingGroup: Group{
+					ID: GroupID{Namespace: "ns-1", Name: "ing-1"},
+					Members: []*networking.Ingress{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "ns-1",
+								Name:      "ing-1",
+							},
+							Spec: networking.IngressSpec{
+								Rules: []networking.IngressRule{
+									{
+										Host: "app-1.example.com",
+										IngressRuleValue: networking.IngressRuleValue{
+											HTTP: &networking.HTTPIngressRuleValue{
+												Paths: []networking.HTTPIngressPath{
+													{
+														Path: "/svc-1-name",
+														Backend: networking.IngressBackend{
+															ServiceName: ns_1_svc_1.Name,
+															ServicePort: intstr.FromString("http"),
+														},
+													},
+													{
+														Path: "/svc-1-port",
+														Backend: networking.IngressBackend{
+															ServiceName: ns_1_svc_1.Name,
+															ServicePort: intstr.FromInt(80),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantStackJSON: `
+{
+    "id":"ns-1/ing-1",
+    "resources":{
+        "AWS::EC2::SecurityGroup":{
+            "ManagedLBSecurityGroup":{
+                "spec":{
+                    "groupName":"k8s-ns1-ing1-bd83176788",
+                    "description":"[k8s] Managed SecurityGroup for LoadBalancer",
+                    "ingress":[
+                        {
+                            "ipProtocol":"tcp",
+                            "fromPort":80,
+                            "toPort":80,
+                            "ipRanges":[
+                                {
+                                    "cidrIP":"0.0.0.0/0"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
+        "AWS::ElasticLoadBalancingV2::Listener":{
+            "80":{
+                "spec":{
+                    "loadBalancerARN":{
+                        "$ref":"#/resources/AWS::ElasticLoadBalancingV2::LoadBalancer/LoadBalancer/status/loadBalancerARN"
+                    },
+                    "port":80,
+                    "protocol":"HTTP",
+                    "defaultActions":[
+                        {
+                            "type":"fixed-response",
+                            "fixedResponseConfig":{
+                                "contentType":"text/plain",
+                                "statusCode":"404"
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "AWS::ElasticLoadBalancingV2::ListenerRule":{
+            "80:1":{
+                "spec":{
+                    "listenerARN":{
+                        "$ref":"#/resources/AWS::ElasticLoadBalancingV2::Listener/80/status/listenerARN"
+                    },
+                    "priority":1,
+                    "actions":[
+                        {
+                            "type":"forward",
+                            "forwardConfig":{
+                                "targetGroups":[
+                                    {
+                                        "targetGroupARN":{
+                                            "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/ns-1/ing-1-svc-1:http/status/targetGroupARN"
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "conditions":[
+                        {
+                            "field":"host-header",
+                            "hostHeaderConfig":{
+                                "values":[
+                                    "app-1.example.com"
+                                ]
+                            }
+                        },
+                        {
+                            "field":"path-pattern",
+                            "pathPatternConfig":{
+                                "values":[
+                                    "/svc-1-name"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "80:2":{
+                "spec":{
+                    "listenerARN":{
+                        "$ref":"#/resources/AWS::ElasticLoadBalancingV2::Listener/80/status/listenerARN"
+                    },
+                    "priority":2,
+                    "actions":[
+                        {
+                            "type":"forward",
+                            "forwardConfig":{
+                                "targetGroups":[
+                                    {
+                                        "targetGroupARN":{
+                                            "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/ns-1/ing-1-svc-1:80/status/targetGroupARN"
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "conditions":[
+                        {
+                            "field":"host-header",
+                            "hostHeaderConfig":{
+                                "values":[
+                                    "app-1.example.com"
+                                ]
+                            }
+                        },
+                        {
+                            "field":"path-pattern",
+                            "pathPatternConfig":{
+                                "values":[
+                                    "/svc-1-port"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "AWS::ElasticLoadBalancingV2::LoadBalancer":{
+            "LoadBalancer":{
+                "spec":{
+                    "name":"k8s-ns1-ing1-b7e914000d",
+                    "type":"application",
+                    "scheme":"internal",
+                    "ipAddressType":"ipv4",
+                    "subnetMapping":[
+                        {
+                            "subnetID":"subnet-a"
+                        },
+                        {
+                            "subnetID":"subnet-b"
+                        }
+                    ],
+                    "securityGroups":[
+                        {
+                            "$ref":"#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+                        }
+                    ]
+                }
+            }
+        },
+        "AWS::ElasticLoadBalancingV2::TargetGroup":{
+            "ns-1/ing-1-svc-1:80":{
+                "spec":{
+                    "name":"k8s-ns1-svc1-cb6b6554c7",
+                    "targetType":"instance",
+                    "port":32768,
+                    "protocol":"HTTP",
+                    "healthCheckConfig":{
+                        "port":"traffic-port",
+                        "protocol":"HTTP",
+                        "path":"/",
+                        "matcher":{
+                            "httpCode":"200"
+                        },
+                        "intervalSeconds":15,
+                        "timeoutSeconds":5,
+                        "healthyThresholdCount":2,
+                        "unhealthyThresholdCount":2
+                    }
+                }
+            },
+            "ns-1/ing-1-svc-1:http":{
+                "spec":{
+                    "name":"k8s-ns1-svc1-55af160316",
+                    "targetType":"instance",
+                    "port":32768,
+                    "protocol":"HTTP",
+                    "healthCheckConfig":{
+                        "port":"traffic-port",
+                        "protocol":"HTTP",
+                        "path":"/",
+                        "matcher":{
+                            "httpCode":"200"
+                        },
+                        "intervalSeconds":15,
+                        "timeoutSeconds":5,
+                        "healthyThresholdCount":2,
+                        "unhealthyThresholdCount":2
+                    }
+                }
+            }
+        },
+        "K8S::ElasticLoadBalancingV2::TargetGroupBinding":{
+            "ns-1/ing-1-svc-1:80":{
+                "spec":{
+                    "template":{
+                        "metadata":{
+                            "name":"k8s-ns1-svc1-cb6b6554c7",
+                            "namespace":"ns-1",
+                            "creationTimestamp":null
+                        },
+                        "spec":{
+                            "targetGroupARN":{
+                                "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/ns-1/ing-1-svc-1:80/status/targetGroupARN"
+                            },
+                            "targetType":"instance",
+                            "serviceRef":{
+                                "name":"svc-1",
+                                "port":80
+                            },
+                            "networking":{
+                                "ingress":[
+                                    {
+                                        "from":[
+                                            {
+                                                "securityGroup":{
+                                                    "groupID":{
+                                                        "$ref":"#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "ports":[
+                                            {
+                                                "protocol":"TCP"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            },
+            "ns-1/ing-1-svc-1:http":{
+                "spec":{
+                    "template":{
+                        "metadata":{
+                            "name":"k8s-ns1-svc1-55af160316",
+                            "namespace":"ns-1",
+                            "creationTimestamp":null
+                        },
+                        "spec":{
+                            "targetGroupARN":{
+                                "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/ns-1/ing-1-svc-1:http/status/targetGroupARN"
+                            },
+                            "targetType":"instance",
+                            "serviceRef":{
+                                "name":"svc-1",
+                                "port":"http"
                             },
                             "networking":{
                                 "ingress":[


### PR DESCRIPTION
## Changes done
1. remove TargetGroup's port from TargetGroup replacement criteria. so that TargetGroups can be reused if only port differs.
    * this allow us to migrate from AWSALBIngressController/AWSLoadBalancerController(v2.0.0) with 0 downtime.
2. change the port for instance TargetGroup to be nodePort for better UX. (the port don't matter)
3. fix an edge that when same service referenced by both name and port, only a single TargetGroup are created. Now two different targetGroup will be created.
    Details:
        1. in both AWSALBIngressController and AWSLoadBalancerController(v2.0.0), we used the backendPort specified as resourceID(so it can be either port name or port number). Ideally different resourceID should result in different TargetGroup.
        2. in v2.0.0, even the model contains two targetGroup, only a single targetGroup will be created since the TG name is same, and due to ELBV2's API's idempotency. This works fine, however, it relies on ELBv2 API's implementation details and hacky.
        3. an alternative design is to always use the numeric port as resourceID. and to be backwards-compatible for backend port referenced by name, we can add a logic in targetGroup's cleanup logic to ignore TargetGroups's arn been used. we decided not to take this approach as it's hacky. (also, in the future, we might have extra logic to compress TargetGroup usage across Ingresses, so no need to compress for this edge case this time).

## Test done
### Pre steps:
1.  Install AWSALBIngressController with 0 replica
2. Install AWSLoadBalancerController with 1 replica
### compatibility test with AWSALBIngressController:
1. scale up AWSALBIngressController to 1 replica
2. launch Ingress with 4 path: `echo: http`, `echo: 80`, `echo-ip: http`, `echo-ip:80`. (`echo` is instance TargetType, `echo-ip` is ip TargetType, both `http` and `80` refers to same servicePort).
3. verify that traffic works, and 4 target group created.
4. scale down AWSALBIngressController to 0 replica
5. scale up AWSLoadBalancerController to 1 replica
6. verify the controller added `elbv2.k8s.aws/cluster":"m00nf1sh-dev` tags to resources, and kept old resources like LoadBalancer/TargetGroups.
### compatibility test with AWSLoadBalancerController:
1. change to AWSLoadBalancerController v2.0.0 and scale up AWSLoadBalancerController to 1 replica
2. launch Ingress with 4 path: `echo: http`, `echo: 80`, `echo-ip: http`, `echo-ip:80`. (`echo` is instance TargetType, `echo-ip` is ip TargetType, both `http` and `80` refers to same servicePort).
3. verify that traffic works, and only two target group created.
4. change to AWSLoadBalancerController to image built with this change and scale up AWSLoadBalancerController to 1 replica
5. verify that the controller added two new targetGroup and configure rules properly.

