### PR TITLE
add event recording and ingress info in error messages

### DIFF
--- a/controllers/ingress/eventhandlers/ingress_events.go
+++ b/controllers/ingress/eventhandlers/ingress_events.go
@@ -2,6 +2,7 @@ package eventhandlers
 
 import (
 	"context"
+	"fmt"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1beta1"
@@ -70,7 +71,7 @@ func (h *enqueueRequestsForIngressEvent) enqueueIfBelongsToGroup(queue workqueue
 	for _, ing := range ingList {
 		groupID, err := h.groupLoader.FindGroupID(context.Background(), ing)
 		if err != nil {
-			h.eventRecorder.Eventf(ing, corev1.EventTypeWarning, k8s.IngressEventReasonFailedToLoadGroupID, "failed to load groupID for Ingress due to %w", err)
+			h.eventRecorder.Event(ing, corev1.EventTypeWarning, k8s.IngressEventReasonFailedLoadGroupID, fmt.Sprintf("failed load groupID due to %v", err))
 			continue
 		}
 

--- a/main.go
+++ b/main.go
@@ -111,7 +111,8 @@ func main() {
 	svcReconciler := service.NewServiceReconciler(cloud, mgr.GetClient(), mgr.GetEventRecorderFor("service"),
 		finalizerManager, sgManager, sgReconciler, subnetResolver,
 		controllerCFG, ctrl.Log.WithName("controllers").WithName("service"))
-	tgbReconciler := elbv2controller.NewTargetGroupBindingReconciler(mgr.GetClient(), finalizerManager, tgbResManager,
+	tgbReconciler := elbv2controller.NewTargetGroupBindingReconciler(mgr.GetClient(), mgr.GetEventRecorderFor("targetGroupBinding"),
+		finalizerManager, tgbResManager,
 		controllerCFG, ctrl.Log.WithName("controllers").WithName("targetGroupBinding"))
 	ctx := context.Background()
 	if err = ingGroupReconciler.SetupWithManager(ctx, mgr); err != nil {

--- a/pkg/ingress/model_build_listener_rules.go
+++ b/pkg/ingress/model_build_listener_rules.go
@@ -2,9 +2,10 @@ package ingress
 
 import (
 	"context"
-	"errors"
+	"github.com/pkg/errors"
 	"fmt"
 	networking "k8s.io/api/networking/v1beta1"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/core"
 	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
 )
@@ -19,15 +20,15 @@ func (t *defaultModelBuildTask) buildListenerRules(ctx context.Context, lsARN co
 			for _, path := range rule.HTTP.Paths {
 				enhancedBackend, err := t.enhancedBackendBuilder.Build(ctx, ing, path.Backend)
 				if err != nil {
-					return err
+					return errors.Wrapf(err, "ingress: %v", k8s.NamespacedName(ing))
 				}
 				conditions, err := t.buildRuleConditions(ctx, rule, path, enhancedBackend)
 				if err != nil {
-					return err
+					return errors.Wrapf(err, "ingress: %v", k8s.NamespacedName(ing))
 				}
 				actions, err := t.buildActions(ctx, protocol, ing, enhancedBackend)
 				if err != nil {
-					return err
+					return errors.Wrapf(err, "ingress: %v", k8s.NamespacedName(ing))
 				}
 				rules = append(rules, Rule{
 					Conditions: conditions,

--- a/pkg/ingress/model_builder.go
+++ b/pkg/ingress/model_builder.go
@@ -160,7 +160,7 @@ func (t *defaultModelBuildTask) run(ctx context.Context) error {
 	for _, ing := range t.ingGroup.Members {
 		listenPortConfigByPortForIngress, err := t.computeIngressListenPortConfigByPort(ctx, ing)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "ingress: %v", k8s.NamespacedName(ing))
 		}
 		ingKey := k8s.NamespacedName(ing)
 		for port, cfg := range listenPortConfigByPortForIngress {

--- a/pkg/k8s/events.go
+++ b/pkg/k8s/events.go
@@ -1,5 +1,27 @@
 package k8s
 
 const (
-	IngressEventReasonFailedToLoadGroupID = "FailedToLoadGroupID"
+	// Ingress events
+	IngressEventReasonFailedLoadGroupID      = "FailedLoadGroupID"
+	IngressEventReasonFailedAddFinalizer     = "FailedAddFinalizer"
+	IngressEventReasonFailedRemoveFinalizer  = "FailedRemoveFinalizer"
+	IngressEventReasonFailedUpdateStatus     = "FailedUpdateStatus"
+	IngressEventReasonFailedBuildModel       = "FailedBuildModel"
+	IngressEventReasonFailedDeployModel      = "FailedDeployModel"
+	IngressEventReasonSuccessfullyReconciled = "SuccessfullyReconciled"
+
+	// Service events
+	ServiceEventReasonFailedAddFinalizer     = "FailedAddFinalizer"
+	ServiceEventReasonFailedRemoveFinalizer  = "FailedRemoveFinalizer"
+	ServiceEventReasonFailedUpdateStatus     = "FailedUpdateStatus"
+	ServiceEventReasonFailedBuildModel       = "FailedBuildModel"
+	ServiceEventReasonFailedDeployModel      = "FailedDeployModel"
+	ServiceEventReasonSuccessfullyReconciled = "SuccessfullyReconciled"
+
+	// TargetGroupBinding events
+	TargetGroupBindingEventReasonFailedAddFinalizer     = "FailedAddFinalizer"
+	TargetGroupBindingEventReasonFailedRemoveFinalizer  = "FailedRemoveFinalizer"
+	TargetGroupBindingEventReasonFailedUpdateStatus     = "FailedUpdateStatus"
+	TargetGroupBindingEventReasonFailedCleanup          = "FailedCleanup"
+	TargetGroupBindingEventReasonSuccessfullyReconciled = "SuccessfullyReconciled"
 )


### PR DESCRIPTION
1. add event recording for errors and success messages to each resource.
2. add ingress namespace/names for errors when handling individual ingress within IngressGroup.
Fix https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/1565

Test done:
```
Events:
  Type     Reason                  Age                From     Message
  ----     ------                  ----               ----     -------
  Warning  FailedBuildModel        9s (x14 over 52s)  ingress  Failed build model due to ingress: bugbash/echo: Service "echo-sew" not found
  Normal   SuccessfullyReconciled  2s                 ingress  Successfully reconciled
```