### PR TITLE
Add support for NLB ALPN policy

### DIFF
--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -33,6 +33,7 @@
 | service.beta.kubernetes.io/aws-load-balancer-eip-allocations                   | stringList |                           |                        |
 | [service.beta.kubernetes.io/aws-load-balancer-target-group-attributes](#target-group-attributes)  | stringMap  |        |                        |
 | [service.beta.kubernetes.io/aws-load-balancer-subnets](#subnets)              | stringList  |                           |                        |
+| [service.beta.kubernetes.io/aws-load-balancer-alpn-policy](#alpn-policy)      | stringList  |                           |                        |
 
 
 ## Traffic Routing
@@ -54,6 +55,23 @@ the NLB will route traffic to. See [Network Load Balancers](https://docs.aws.ama
     !!!example
         ```
         service.beta.kubernetes.io/aws-load-balancer-subnets: subnet-xxxx, mySubnet
+        ```
+- <a name="alpn-policy">`service.beta.kubernetes.io/aws-load-balancer-alpn-policy`</a> allows you to configure the [ALPN policies](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/create-tls-listener.html#alpn-policies)
+on the load balancer.
+
+    !!!note "requirements"
+        TLS listener forwarding to a TLS target group
+
+    !!!tip "supported policies"
+        - `HTTP1Only` Negotiate only HTTP/1.*. The ALPN preference list is http/1.1, http/1.0.
+        - `HTTP2Only` Negotiate only HTTP/2. The ALPN preference list is h2.
+        - `HTTP2Optional` Prefer HTTP/1.* over HTTP/2 (which can be useful for HTTP/2 testing). The ALPN preference list is http/1.1, http/1.0, h2.
+        - `HTTP2Preferred` Prefer HTTP/2 over HTTP/1.*. The ALPN preference list is h2, http/1.1, http/1.0.
+        - `None` Do not negotiate ALPN. This is the default.
+
+    !!!example
+        ```
+        service.beta.kubernetes.io/aws-load-balancer-alpn-policy: HTTP2Preferred
         ```
 
 ## Resource attributes

--- a/pkg/annotations/constants.go
+++ b/pkg/annotations/constants.go
@@ -66,4 +66,5 @@ const (
 	SvcLBSuffixEIPAllocations                = "aws-load-balancer-eip-allocations"
 	SvcLBSuffixTargetGroupAttributes         = "aws-load-balancer-target-group-attributes"
 	SvcLBSuffixSubnets                       = "aws-load-balancer-subnets"
+	SvcLBSuffixALPNPolicy                    = "aws-load-balancer-alpn-policy"
 )

--- a/pkg/deploy/elbv2/listener_manager.go
+++ b/pkg/deploy/elbv2/listener_manager.go
@@ -224,7 +224,7 @@ func isSDKListenerSettingsDrifted(lsSpec elbv2model.ListenerSpec, sdkLS *elbv2sd
 	if lsSpec.SSLPolicy != nil && awssdk.StringValue(lsSpec.SSLPolicy) != awssdk.StringValue(sdkLS.SslPolicy) {
 		return true
 	}
-	if !cmp.Equal(lsSpec.ALPNPolicy, awssdk.StringValueSlice(sdkLS.AlpnPolicy), cmpopts.EquateEmpty()) {
+	if len(lsSpec.ALPNPolicy) != 0 && !cmp.Equal(lsSpec.ALPNPolicy, awssdk.StringValueSlice(sdkLS.AlpnPolicy), cmpopts.EquateEmpty()) {
 		return true
 	}
 

--- a/pkg/deploy/elbv2/listener_manager_test.go
+++ b/pkg/deploy/elbv2/listener_manager_test.go
@@ -65,6 +65,58 @@ func Test_isSDKListenerSettingsDrifted(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Ignore ALPN configuration if not specified in model",
+			args: args{
+				lsSpec: elbv2model.ListenerSpec{
+					Port:      80,
+					Protocol:  elbv2model.ProtocolHTTPS,
+					SSLPolicy: awssdk.String("ELBSecurityPolicy-FS-1-2-Res-2019-08"),
+				},
+				sdkLS: &elbv2sdk.Listener{
+					Port:     awssdk.Int64(80),
+					Protocol: awssdk.String("HTTPS"),
+					Certificates: []*elbv2sdk.Certificate{
+						{
+							CertificateArn: awssdk.String("cert-arn1"),
+							IsDefault:      awssdk.Bool(true),
+						},
+					},
+					DefaultActions: []*elbv2sdk.Action{
+						{
+							Type: awssdk.String("forward-config"),
+							ForwardConfig: &elbv2sdk.ForwardActionConfig{
+								TargetGroups: []*elbv2sdk.TargetGroupTuple{
+									{
+										TargetGroupArn: awssdk.String("target-group"),
+									},
+								},
+							},
+						},
+					},
+					SslPolicy:  awssdk.String("ELBSecurityPolicy-FS-1-2-Res-2019-08"),
+					AlpnPolicy: awssdk.StringSlice([]string{"HTTP2Preferred"}),
+				},
+				desiredDefaultCerts: []*elbv2sdk.Certificate{
+					{
+						CertificateArn: awssdk.String("cert-arn1"),
+						IsDefault:      awssdk.Bool(true),
+					},
+				},
+				desiredDefaultActions: []*elbv2sdk.Action{
+					{
+						Type: awssdk.String("forward-config"),
+						ForwardConfig: &elbv2sdk.ForwardActionConfig{
+							TargetGroups: []*elbv2sdk.TargetGroupTuple{
+								{
+									TargetGroupArn: awssdk.String("target-group"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/model/elbv2/listener.go
+++ b/pkg/model/elbv2/listener.go
@@ -292,6 +292,18 @@ type Certificate struct {
 	CertificateARN *string `json:"certificateARN,omitempty"`
 }
 
+// ALPNPolicy ALPN policy configuration for TLS listeners forwarding to TLS target groups
+type ALPNPolicy string
+
+// Supported ALPN policies
+const (
+	ALPNPolicyNone           ALPNPolicy = "None"
+	ALPNPolicyHTTP1Only      ALPNPolicy = "HTTP1Only"
+	ALPNPolicyHTTP2Only      ALPNPolicy = "HTTP2Only"
+	ALPNPolicyHTTP2Optional  ALPNPolicy = "HTTP2Optional"
+	ALPNPolicyHTTP2Preferred ALPNPolicy = "HTTP2Preferred"
+)
+
 // ListenerSpec defines the desired state of Listener
 type ListenerSpec struct {
 	// The Amazon Resource Name (ARN) of the load balancer.

--- a/pkg/service/model_build_listener_test.go
+++ b/pkg/service/model_build_listener_test.go
@@ -1,0 +1,88 @@
+package service
+
+import (
+	"context"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
+	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
+	"testing"
+)
+
+func Test_defaultModelBuilderTask_buildListenerALPNPolicy(t *testing.T) {
+	tests := []struct {
+		name             string
+		svc              *corev1.Service
+		wantErr          error
+		want             []string
+		listenerProtocol elbv2model.Protocol
+		targetProtocol   elbv2model.Protocol
+	}{
+		{
+			name:             "Service without annotation",
+			svc:              &corev1.Service{},
+			listenerProtocol: elbv2model.ProtocolTLS,
+		},
+		{
+			name:             "Service without annotation TLS",
+			svc:              &corev1.Service{},
+			listenerProtocol: elbv2model.ProtocolTLS,
+			targetProtocol:   elbv2model.ProtocolTLS,
+		},
+		{
+			name: "Service with annotation, non-tls target",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/aws-load-balancer-alpn-policy": "HTTP2Only",
+					},
+				},
+			},
+			listenerProtocol: elbv2model.ProtocolTLS,
+		},
+		{
+			name: "Service with annotation, TLS targets",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/aws-load-balancer-alpn-policy": "HTTP1Only",
+					},
+				},
+			},
+			want:             []string{string(elbv2model.ALPNPolicyHTTP1Only)},
+			listenerProtocol: elbv2model.ProtocolTLS,
+			targetProtocol:   elbv2model.ProtocolTLS,
+		},
+		{
+			name: "Service with invalid annotation, TLS targets",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/aws-load-balancer-alpn-policy": "unknown",
+					},
+				},
+			},
+			wantErr:          errors.New("invalid ALPN policy unknown, policy must be one of [None, HTTP1Only, HTTP2Only, HTTP2Optional, HTTP2Preferred]"),
+			listenerProtocol: elbv2model.ProtocolTLS,
+			targetProtocol:   elbv2model.ProtocolTLS,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := annotations.NewSuffixAnnotationParser("service.beta.kubernetes.io")
+			builder := &defaultModelBuildTask{
+				annotationParser: parser,
+				service:          tt.svc,
+			}
+			got, err := builder.buildListenerALPNPolicy(context.Background(), tt.listenerProtocol, tt.targetProtocol)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #1546 Allow configuration of ALPN policies for NLB

Support additional annotation `service.beta.kubernetes.io/aws-load-balancer-alpn-policy` on the service object which allows users to configure ALPN policy on the NLB. ALPN can be configured only if both the listener and the target group protocol is TLS.

Tests run
Service requires at least the following annotations
```
    service.beta.kubernetes.io/aws-load-balancer-alpn-policy: <ALPN>
    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: ssl
    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: <certs>
    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: nlb-ip
```
- When the alpn policy annotation is not specified, the default gets used
- ALPN policy can be specified via the annotation.
- When previously specified alpn policy annotation gets deleted, the existing configuration remains in place
- Invalid ALPN policy configuration results in error