### PR TITLE
add ingress class support

### DIFF
--- a/controllers/ingress/group_controller.go
+++ b/controllers/ingress/group_controller.go
@@ -52,7 +52,7 @@ func NewGroupReconciler(cloud aws.Cloud, k8sClient client.Client, eventRecorder 
 	stackDeployer := deploy.NewDefaultStackDeployer(cloud, k8sClient, networkingSGManager, networkingSGReconciler,
 		config, ingressTagPrefix, logger)
 	ingressConfig := config.IngressConfig
-	groupLoader := ingress.NewDefaultGroupLoader(k8sClient, annotationParser, ingressConfig.IngressClass)
+	groupLoader := ingress.NewDefaultGroupLoader(k8sClient, eventRecorder, annotationParser, ingressConfig.IngressClass)
 	groupFinalizerManager := ingress.NewDefaultFinalizerManager(finalizerManager)
 
 	return &groupReconciler{

--- a/pkg/config/ingress_config.go
+++ b/pkg/config/ingress_config.go
@@ -14,6 +14,7 @@ type IngressConfig struct {
 	// Name of the Ingress class this controller satisfies
 	// If empty, all Ingresses without ingress.class annotation, or ingress.class==alb get considered
 	IngressClass string
+
 	// Max concurrent reconcile loops for Ingress objects
 	MaxConcurrentReconciles int
 }

--- a/pkg/ingress/group_loader.go
+++ b/pkg/ingress/group_loader.go
@@ -133,7 +133,7 @@ func (m *defaultGroupLoader) matchesIngressClass(ctx context.Context, ing *netwo
 
 	if len(matchesIngressClassResults) == 2 {
 		if matchesIngressClassResults[0] != matchesIngressClassResults[1] {
-			m.eventRecorder.Event(ing, corev1.EventTypeWarning, k8s.IngressEventReasonConflictIngressClass, "conflict IngressClass by `spec.IngressClass` and `kubernetes.io/ingress.class` annotation")
+			m.eventRecorder.Event(ing, corev1.EventTypeWarning, k8s.IngressEventReasonConflictingIngressClass, "conflicting values for IngressClass by `spec.IngressClass` and `kubernetes.io/ingress.class` annotation")
 		}
 		return matchesIngressClassResults[0], nil
 	}

--- a/pkg/k8s/events.go
+++ b/pkg/k8s/events.go
@@ -2,6 +2,7 @@ package k8s
 
 const (
 	// Ingress events
+	IngressEventReasonConflictIngressClass   = "ConflictIngressClass"
 	IngressEventReasonFailedLoadGroupID      = "FailedLoadGroupID"
 	IngressEventReasonFailedAddFinalizer     = "FailedAddFinalizer"
 	IngressEventReasonFailedRemoveFinalizer  = "FailedRemoveFinalizer"

--- a/pkg/k8s/events.go
+++ b/pkg/k8s/events.go
@@ -2,14 +2,14 @@ package k8s
 
 const (
 	// Ingress events
-	IngressEventReasonConflictIngressClass   = "ConflictIngressClass"
-	IngressEventReasonFailedLoadGroupID      = "FailedLoadGroupID"
-	IngressEventReasonFailedAddFinalizer     = "FailedAddFinalizer"
-	IngressEventReasonFailedRemoveFinalizer  = "FailedRemoveFinalizer"
-	IngressEventReasonFailedUpdateStatus     = "FailedUpdateStatus"
-	IngressEventReasonFailedBuildModel       = "FailedBuildModel"
-	IngressEventReasonFailedDeployModel      = "FailedDeployModel"
-	IngressEventReasonSuccessfullyReconciled = "SuccessfullyReconciled"
+	IngressEventReasonConflictingIngressClass = "ConflictingIngressClass"
+	IngressEventReasonFailedLoadGroupID       = "FailedLoadGroupID"
+	IngressEventReasonFailedAddFinalizer      = "FailedAddFinalizer"
+	IngressEventReasonFailedRemoveFinalizer   = "FailedRemoveFinalizer"
+	IngressEventReasonFailedUpdateStatus      = "FailedUpdateStatus"
+	IngressEventReasonFailedBuildModel        = "FailedBuildModel"
+	IngressEventReasonFailedDeployModel       = "FailedDeployModel"
+	IngressEventReasonSuccessfullyReconciled  = "SuccessfullyReconciled"
 
 	// Service events
 	ServiceEventReasonFailedAddFinalizer     = "FailedAddFinalizer"


### PR DESCRIPTION
## Add ingress class support
This change will add Ingress class support, the only supported field in IngressClass is the `controller` field. In the future, we'll leverage the `parameters` field for more customizations.

## Behavior
* If only `kubernete.io/ingress.class` annotations presents, we consider IngressClass matches this controller if 
   * when `--ingress-class` is specified with non-empty value, and it matches annotation value (when install via YAML/Helm, by default it's specified as `alb`):
   * when `--ingress-class` is specified with empty value, and annotation value is empty or `alb`.

* If only `spec.ingressClassName` non-nil, we consider IngressClass matches this controller if
   * the corresponding IngressClass exists and the `spec.controller` of IngressClass have value `ingress.k8s.aws/alb`

* If both `kubernete.io/ingress.class` annotation presents and `spec.ingressClassName` non-nil, we will favor `kubernete.io/ingress.class` and issue a warning event to Ingress if match result conflicts. 
    we do this to align with IngressSpec's recommendation:`For backwards compatibility, when that annotation is set, it must be given precedence over this field. The controller may emit a warning if the field and annotation have different values.`

* If neither `kubernete.io/ingress.class` annotation presents and `spec.ingressClassName` non-nil, we consider IngressClass matches this controller if `--ingress-class` is specified with empty value

## Future plans
1. we'll offer an option to disable `kubernete.io/ingress.class` annotation support in future versions with default value `false` in future versions. (this will help us enforce permission control via IngressClass)
2. we'll change the option above to have default value `true` post X versions.
3. we'll remove the code that support `kubernete.io/ingress.class` post Y versions.
4. IngressClass's parameters will only be respected if IngressClass is decided from `spec.ingressClassName`. (i.e. `kubernete.io/ingress.class` annotation absents)

## Note to reviewer:
1. I'll have follow up PR to add RBAC permissions
2. I'll have follow up PR to adjust the behavior of decide whether Ingress should be groupMember if there are errors like ingressClassName not found.