### PR TITLE
Allow stringMap annotation values containing equal sign

### DIFF
--- a/pkg/annotations/parser.go
+++ b/pkg/annotations/parser.go
@@ -136,7 +136,7 @@ func (p *suffixAnnotationParser) ParseStringMapAnnotation(annotation string, val
 	rawKVPairs := splitCommaSeparatedString(raw)
 	keyValues := make(map[string]string)
 	for _, kvPair := range rawKVPairs {
-		parts := strings.Split(kvPair, "=")
+		parts := strings.SplitN(kvPair, "=", 2)
 		if len(parts) != 2 {
 			return false, errors.Errorf("failed to parse stringMap annotation, %v: %v", matchedKey, raw)
 		}

--- a/pkg/annotations/parser_test.go
+++ b/pkg/annotations/parser_test.go
@@ -279,6 +279,21 @@ func Test_serviceAnnotationParser_ParseStringMapAnnotation(t *testing.T) {
 			},
 		},
 		{
+			name:   "values containing equals sign",
+			prefix: "prefix",
+			suffix: "tags",
+			annotations: map[string]string{
+				"first-value": "1",
+				"prefix/tags": "key1=Mjk5NzkyNDU4Cg==, foo=ZGF=0=ZQo=, res=value_:/=+-@",
+			},
+			wantExist: true,
+			wantValue: map[string]string{
+				"key1": "Mjk5NzkyNDU4Cg==",
+				"foo":  "ZGF=0=ZQo=",
+				"res":  "value_:/=+-@",
+			},
+		},
+		{
 			name:   "invalid key-value pair - no '=' between k/v",
 			prefix: "p.co",
 			suffix: "sfx",


### PR DESCRIPTION
Fixes #1673
Fix stringMap annotation type to accept values with the equal sign. For example, the following annotation will now be accepted - 
```
alb.ingress.kubernetes.io/tags: foo=ZXF1YWxzCg==, another=tag"
```
and would be parsed to 
```
map[string]string{
	"foo":     "ZXF1YWxzCg==,",
	"another": "tag",
}
```
