### PR TITLE
Support for IPv6 and NLB  

### DIFF
--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -14,7 +14,6 @@
 | service.beta.kubernetes.io/aws-load-balancer-type                              | string     |                           |                        |
 | service.beta.kubernetes.io/aws-load-balancer-internal                          | boolean    | false                     |                        |
 | [service.beta.kubernetes.io/aws-load-balancer-proxy-protocol](#proxy-protocol-v2)                 | string     |        | Set to `"*"` to enable |
-| service.beta.kubernetes.io/aws-load-balancer-type                              | string     |                           |                        |
 | service.beta.kubernetes.io/aws-load-balancer-ip-address-type                   | string     | ipv4                      | ipv4 \| dualstack      |
 | service.beta.kubernetes.io/aws-load-balancer-access-log-enabled                | boolean    | false                     |                        |
 | service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-name         | string     |                           |                        |

--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -16,7 +16,7 @@
 | [service.beta.kubernetes.io/aws-load-balancer-proxy-protocol](#proxy-protocol-v2)                 | string     |        | Set to `"*"` to enable |
 | service.beta.kubernetes.io/aws-load-balancer-type                              | string     |                           |                        |
 | service.beta.kubernetes.io/aws-load-balancer-ip-address-type                   | string     | ipv4                      | ipv4 \| dualstack      |
-| service.beta.kubernetes.io/aws-load-balancer-access-log-enabled                | boolean    |                           |                        |
+| service.beta.kubernetes.io/aws-load-balancer-access-log-enabled                | boolean    | false                     |                        |
 | service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-name         | string     |                           |                        |
 | service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix       | string     |                           |                        |
 | service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled | boolean    | false                     |                        |

--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -14,7 +14,8 @@
 | service.beta.kubernetes.io/aws-load-balancer-type                              | string     |                           |                        |
 | service.beta.kubernetes.io/aws-load-balancer-internal                          | boolean    | false                     |                        |
 | [service.beta.kubernetes.io/aws-load-balancer-proxy-protocol](#proxy-protocol-v2)                 | string     |        | Set to `"*"` to enable |
-| service.beta.kubernetes.io/aws-load-balancer-access-log-enabled                | boolean    | false                     |                        |
+| service.beta.kubernetes.io/aws-load-balancer-type                              | string     |                           |                        |
+| service.beta.kubernetes.io/aws-load-balancer-access-log-enabled                | boolean    | ipv4                      | ipv4 \| dualstack      |
 | service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-name         | string     |                           |                        |
 | service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix       | string     |                           |                        |
 | service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled | boolean    | false                     |                        |

--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -15,7 +15,8 @@
 | service.beta.kubernetes.io/aws-load-balancer-internal                          | boolean    | false                     |                        |
 | [service.beta.kubernetes.io/aws-load-balancer-proxy-protocol](#proxy-protocol-v2)                 | string     |        | Set to `"*"` to enable |
 | service.beta.kubernetes.io/aws-load-balancer-type                              | string     |                           |                        |
-| service.beta.kubernetes.io/aws-load-balancer-access-log-enabled                | boolean    | ipv4                      | ipv4 \| dualstack      |
+| service.beta.kubernetes.io/aws-load-balancer-ip-address-type                   | string     | ipv4                      | ipv4 \| dualstack      |
+| service.beta.kubernetes.io/aws-load-balancer-access-log-enabled                | boolean    |                           |                        |
 | service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-name         | string     |                           |                        |
 | service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix       | string     |                           |                        |
 | service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled | boolean    | false                     |                        |

--- a/pkg/annotations/constants.go
+++ b/pkg/annotations/constants.go
@@ -46,6 +46,7 @@ const (
 	SvcLBSuffixSourceRanges                  = "load-balancer-source-ranges"
 	SvcLBSuffixLoadBalancerType              = "aws-load-balancer-type"
 	SvcLBSuffixInternal                      = "aws-load-balancer-internal"
+	SvcLBSuffixIPAddressType                 = "aws-load-balancer-ip-address-type"
 	SvcLBSuffixProxyProtocol                 = "aws-load-balancer-proxy-protocol"
 	SvcLBSuffixAccessLogEnabled              = "aws-load-balancer-access-log-enabled"
 	SvcLBSuffixAccessLogS3BucketName         = "aws-load-balancer-access-log-s3-bucket-name"

--- a/pkg/service/model_builder.go
+++ b/pkg/service/model_builder.go
@@ -2,11 +2,13 @@ package service
 
 import (
 	"context"
+
 	"github.com/aws/aws-sdk-go/service/ec2"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/core"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
 	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/networking"
 )
@@ -48,6 +50,7 @@ func (b *defaultModelBuilder) Build(ctx context.Context, service *corev1.Service
 		defaultAccessLogS3Enabled:            false,
 		defaultAccessLogsS3Bucket:            "",
 		defaultAccessLogsS3Prefix:            "",
+		defaultIPAddressType:                 elbv2model.IPAddressTypeIPV4,
 		defaultLoadBalancingCrossZoneEnabled: false,
 		defaultProxyProtocolV2Enabled:        false,
 		defaultHealthCheckProtocol:           elbv2model.ProtocolTCP,
@@ -79,7 +82,8 @@ type defaultModelBuildTask struct {
 	defaultAccessLogS3Enabled            bool
 	defaultAccessLogsS3Bucket            string
 	defaultAccessLogsS3Prefix            string
-	defaultLoadBalancingCrossZoneEnabled bool
+	defaultIPAddressType                 elbv2.IPAddressType
+	defaultLoadBalancingCrossZoneEnabled bool	
 	defaultProxyProtocolV2Enabled        bool
 	defaultHealthCheckProtocol           elbv2model.Protocol
 	defaultHealthCheckPort               string

--- a/pkg/service/model_builder.go
+++ b/pkg/service/model_builder.go
@@ -8,7 +8,6 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/core"
-	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
 	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/networking"
 )
@@ -82,7 +81,7 @@ type defaultModelBuildTask struct {
 	defaultAccessLogS3Enabled            bool
 	defaultAccessLogsS3Bucket            string
 	defaultAccessLogsS3Prefix            string
-	defaultIPAddressType                 elbv2.IPAddressType
+	defaultIPAddressType                 elbv2model.IPAddressType
 	defaultLoadBalancingCrossZoneEnabled bool	
 	defaultProxyProtocolV2Enabled        bool
 	defaultHealthCheckProtocol           elbv2model.Protocol

--- a/pkg/service/model_builder_test.go
+++ b/pkg/service/model_builder_test.go
@@ -75,7 +75,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 					Namespace: "default",
 					UID:       "bdca2bd0-bfc6-449a-88a3-03451f05f18c",
 					Annotations: map[string]string{
-						"service.beta.kubernetes.io/aws-load-balancer-type":            "nlb-ip",
+						"service.beta.kubernetes.io/aws-load-balancer-type": "nlb-ip",
 					},
 				},
 				Spec: corev1.ServiceSpec{


### PR DESCRIPTION
- Added optional `service.beta.kubernetes.io/aws-load-balancer-ip-address-type: (ipv4|dualstack)` annotation for NLB

Implements #1655 