### PR TITLE
add service event handler for targetGroupBinding

### DIFF
--- a/controllers/elbv2/eventhandlers/endpoints_test.go
+++ b/controllers/elbv2/eventhandlers/endpoints_test.go
@@ -1,0 +1,180 @@
+package eventhandlers
+
+import (
+	"context"
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
+	mock_client "sigs.k8s.io/aws-load-balancer-controller/mocks/controller-runtime/client"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/testutils"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllertest"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"testing"
+)
+
+func Test_enqueueRequestsForEndpointsEvent_enqueueImpactedTargetGroupBindings(t *testing.T) {
+	instanceTargetType := elbv2api.TargetTypeInstance
+	ipTargetType := elbv2api.TargetTypeIP
+
+	type tgbListCall struct {
+		opts []client.ListOption
+		tgbs []*elbv2api.TargetGroupBinding
+		err  error
+	}
+	type fields struct {
+		tgbListCalls []tgbListCall
+	}
+	type args struct {
+		eps *corev1.Endpoints
+	}
+	tests := []struct {
+		name         string
+		fields       fields
+		args         args
+		wantRequests []ctrl.Request
+	}{
+		{
+			name: "service event should enqueue impacted ip TargetType TGBs",
+			fields: fields{
+				tgbListCalls: []tgbListCall{
+					{
+						opts: []client.ListOption{
+							client.InNamespace("awesome-ns"),
+							client.MatchingFields{"spec.serviceRef.name": "awesome-svc"},
+						},
+						tgbs: []*elbv2api.TargetGroupBinding{
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "awesome-ns",
+									Name:      "tgb-1",
+								},
+								Spec: elbv2api.TargetGroupBindingSpec{
+									TargetType: &ipTargetType,
+								},
+							},
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "awesome-ns",
+									Name:      "tgb-2",
+								},
+								Spec: elbv2api.TargetGroupBindingSpec{
+									TargetType: &instanceTargetType,
+								},
+							},
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "awesome-ns",
+									Name:      "tgb-3",
+								},
+								Spec: elbv2api.TargetGroupBindingSpec{
+									TargetType: &ipTargetType,
+								},
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				eps: &corev1.Endpoints{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Name:      "awesome-svc",
+					},
+				},
+			},
+			wantRequests: []ctrl.Request{
+				{
+					NamespacedName: types.NamespacedName{Namespace: "awesome-ns", Name: "tgb-1"},
+				},
+				{
+					NamespacedName: types.NamespacedName{Namespace: "awesome-ns", Name: "tgb-3"},
+				},
+			},
+		},
+		{
+			name: "service event should enqueue impacted ip TargetType TGBs - ignore nil TargetType",
+			fields: fields{
+				tgbListCalls: []tgbListCall{
+					{
+						opts: []client.ListOption{
+							client.InNamespace("awesome-ns"),
+							client.MatchingFields{"spec.serviceRef.name": "awesome-svc"},
+						},
+						tgbs: []*elbv2api.TargetGroupBinding{
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "awesome-ns",
+									Name:      "tgb-1",
+								},
+								Spec: elbv2api.TargetGroupBindingSpec{
+									TargetType: &ipTargetType,
+								},
+							},
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "awesome-ns",
+									Name:      "tgb-2",
+								},
+								Spec: elbv2api.TargetGroupBindingSpec{
+									TargetType: nil,
+								},
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				eps: &corev1.Endpoints{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Name:      "awesome-svc",
+					},
+				},
+			},
+			wantRequests: []ctrl.Request{
+				{
+					NamespacedName: types.NamespacedName{Namespace: "awesome-ns", Name: "tgb-1"},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			k8sClient := mock_client.NewMockClient(ctrl)
+			for _, call := range tt.fields.tgbListCalls {
+				var extraMatchers []interface{}
+				for _, opt := range call.opts {
+					extraMatchers = append(extraMatchers, testutils.NewListOptionEquals(opt))
+				}
+				k8sClient.EXPECT().List(gomock.Any(), gomock.Any(), extraMatchers...).DoAndReturn(
+					func(ctx context.Context, tgbList *elbv2api.TargetGroupBindingList, opts ...client.ListOption) error {
+						for _, tgb := range call.tgbs {
+							tgbList.Items = append(tgbList.Items, *(tgb.DeepCopy()))
+						}
+						return call.err
+					},
+				)
+			}
+
+			h := &enqueueRequestsForEndpointsEvent{
+				k8sClient: k8sClient,
+				logger:    &log.NullLogger{},
+			}
+			queue := controllertest.Queue{Interface: workqueue.New()}
+			h.enqueueImpactedTargetGroupBindings(queue, tt.args.eps)
+			gotRequests := testutils.ExtractCTRLRequestsFromQueue(queue)
+			assert.True(t, cmp.Equal(tt.wantRequests, gotRequests),
+				"diff", cmp.Diff(tt.wantRequests, gotRequests))
+		})
+	}
+}

--- a/controllers/elbv2/eventhandlers/service.go
+++ b/controllers/elbv2/eventhandlers/service.go
@@ -1,0 +1,86 @@
+package eventhandlers
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/targetgroupbinding"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// NewEnqueueRequestsForServiceEvent constructs new enqueueRequestsForServiceEvent.
+func NewEnqueueRequestsForServiceEvent(k8sClient client.Client, logger logr.Logger) handler.EventHandler {
+	return &enqueueRequestsForServiceEvent{
+		k8sClient: k8sClient,
+		logger:    logger,
+	}
+}
+
+type enqueueRequestsForServiceEvent struct {
+	k8sClient client.Client
+	logger    logr.Logger
+}
+
+// Create is called in response to an create event - e.g. Pod Creation.
+func (h *enqueueRequestsForServiceEvent) Create(e event.CreateEvent, queue workqueue.RateLimitingInterface) {
+	svcNew := e.Object.(*corev1.Service)
+	h.enqueueImpactedTargetGroupBindings(queue, svcNew)
+}
+
+// Update is called in response to an update event -  e.g. Pod Updated.
+func (h *enqueueRequestsForServiceEvent) Update(e event.UpdateEvent, queue workqueue.RateLimitingInterface) {
+	svcOld := e.ObjectOld.(*corev1.Service)
+	svcNew := e.ObjectNew.(*corev1.Service)
+	if !equality.Semantic.DeepEqual(svcOld.Spec.Ports, svcNew.Spec.Ports) {
+		h.enqueueImpactedTargetGroupBindings(queue, svcNew)
+	}
+}
+
+// Delete is called in response to a delete event - e.g. Pod Deleted.
+func (h *enqueueRequestsForServiceEvent) Delete(e event.DeleteEvent, queue workqueue.RateLimitingInterface) {
+	svcOld := e.Object.(*corev1.Service)
+	h.enqueueImpactedTargetGroupBindings(queue, svcOld)
+}
+
+// Generic is called in response to an event of an unknown type or a synthetic event triggered as a cron or
+// external trigger request - e.g. reconcile AutoScaling, or a WebHook.
+func (h *enqueueRequestsForServiceEvent) Generic(e event.GenericEvent, queue workqueue.RateLimitingInterface) {
+	// nothing to do here
+}
+
+// enqueueImpactedEndpointBindings will enqueue all impacted TargetGroupBindings for service events.
+func (h *enqueueRequestsForServiceEvent) enqueueImpactedTargetGroupBindings(queue workqueue.RateLimitingInterface, svc *corev1.Service) {
+	tgbList := &elbv2api.TargetGroupBindingList{}
+	if err := h.k8sClient.List(context.Background(), tgbList,
+		client.InNamespace(svc.Namespace),
+		client.MatchingFields{targetgroupbinding.IndexKeyServiceRefName: svc.Name}); err != nil {
+		h.logger.Error(err, "failed to fetch targetGroupBindings")
+		return
+	}
+
+	svcKey := k8s.NamespacedName(svc)
+	for _, tgb := range tgbList.Items {
+		if tgb.Spec.TargetType == nil || (*tgb.Spec.TargetType) != elbv2api.TargetTypeInstance {
+			continue
+		}
+
+		h.logger.V(1).Info("enqueue targetGroupBinding for service event",
+			"service", svcKey,
+			"targetGroupBinding", k8s.NamespacedName(&tgb),
+		)
+		queue.Add(reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: tgb.Namespace,
+				Name:      tgb.Name,
+			},
+		})
+	}
+}

--- a/controllers/elbv2/eventhandlers/service_test.go
+++ b/controllers/elbv2/eventhandlers/service_test.go
@@ -1,0 +1,201 @@
+package eventhandlers
+
+import (
+	"context"
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/util/workqueue"
+	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
+	mock_client "sigs.k8s.io/aws-load-balancer-controller/mocks/controller-runtime/client"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/testutils"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllertest"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"testing"
+)
+
+func Test_enqueueRequestsForServiceEvent_enqueueImpactedTargetGroupBindings(t *testing.T) {
+	instanceTargetType := elbv2api.TargetTypeInstance
+	ipTargetType := elbv2api.TargetTypeIP
+
+	type tgbListCall struct {
+		opts []client.ListOption
+		tgbs []*elbv2api.TargetGroupBinding
+		err  error
+	}
+	type fields struct {
+		tgbListCalls []tgbListCall
+	}
+	type args struct {
+		svc *corev1.Service
+	}
+	tests := []struct {
+		name         string
+		fields       fields
+		args         args
+		wantRequests []ctrl.Request
+	}{
+		{
+			name: "service event should enqueue impacted instance TargetType TGBs",
+			fields: fields{
+				tgbListCalls: []tgbListCall{
+					{
+						opts: []client.ListOption{
+							client.InNamespace("awesome-ns"),
+							client.MatchingFields{"spec.serviceRef.name": "awesome-svc"},
+						},
+						tgbs: []*elbv2api.TargetGroupBinding{
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "awesome-ns",
+									Name:      "tgb-1",
+								},
+								Spec: elbv2api.TargetGroupBindingSpec{
+									TargetType: &instanceTargetType,
+								},
+							},
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "awesome-ns",
+									Name:      "tgb-2",
+								},
+								Spec: elbv2api.TargetGroupBindingSpec{
+									TargetType: &ipTargetType,
+								},
+							},
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "awesome-ns",
+									Name:      "tgb-3",
+								},
+								Spec: elbv2api.TargetGroupBindingSpec{
+									TargetType: &instanceTargetType,
+								},
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				svc: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Name:      "awesome-svc",
+					},
+					Spec: corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{
+							{
+								Name:       "http",
+								Port:       80,
+								TargetPort: intstr.FromInt(8080),
+								NodePort:   38888,
+							},
+						},
+					},
+				},
+			},
+			wantRequests: []ctrl.Request{
+				{
+					NamespacedName: types.NamespacedName{Namespace: "awesome-ns", Name: "tgb-1"},
+				},
+				{
+					NamespacedName: types.NamespacedName{Namespace: "awesome-ns", Name: "tgb-3"},
+				},
+			},
+		},
+		{
+			name: "service event should enqueue impacted instance TargetType TGBs - ignore nil TargetType",
+			fields: fields{
+				tgbListCalls: []tgbListCall{
+					{
+						opts: []client.ListOption{
+							client.InNamespace("awesome-ns"),
+							client.MatchingFields{"spec.serviceRef.name": "awesome-svc"},
+						},
+						tgbs: []*elbv2api.TargetGroupBinding{
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "awesome-ns",
+									Name:      "tgb-1",
+								},
+								Spec: elbv2api.TargetGroupBindingSpec{
+									TargetType: &instanceTargetType,
+								},
+							},
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "awesome-ns",
+									Name:      "tgb-2",
+								},
+								Spec: elbv2api.TargetGroupBindingSpec{
+									TargetType: nil,
+								},
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				svc: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Name:      "awesome-svc",
+					},
+					Spec: corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{
+							{
+								Name:       "http",
+								Port:       80,
+								TargetPort: intstr.FromInt(8080),
+								NodePort:   38888,
+							},
+						},
+					},
+				},
+			},
+			wantRequests: []ctrl.Request{
+				{
+					NamespacedName: types.NamespacedName{Namespace: "awesome-ns", Name: "tgb-1"},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			k8sClient := mock_client.NewMockClient(ctrl)
+			for _, call := range tt.fields.tgbListCalls {
+				var extraMatchers []interface{}
+				for _, opt := range call.opts {
+					extraMatchers = append(extraMatchers, testutils.NewListOptionEquals(opt))
+				}
+				k8sClient.EXPECT().List(gomock.Any(), gomock.Any(), extraMatchers...).DoAndReturn(
+					func(ctx context.Context, tgbList *elbv2api.TargetGroupBindingList, opts ...client.ListOption) error {
+						for _, tgb := range call.tgbs {
+							tgbList.Items = append(tgbList.Items, *(tgb.DeepCopy()))
+						}
+						return call.err
+					},
+				)
+			}
+
+			h := &enqueueRequestsForServiceEvent{
+				k8sClient: k8sClient,
+				logger:    &log.NullLogger{},
+			}
+			queue := controllertest.Queue{Interface: workqueue.New()}
+			h.enqueueImpactedTargetGroupBindings(queue, tt.args.svc)
+			gotRequests := testutils.ExtractCTRLRequestsFromQueue(queue)
+			assert.True(t, cmp.Equal(tt.wantRequests, gotRequests),
+				"diff", cmp.Diff(tt.wantRequests, gotRequests))
+		})
+	}
+}

--- a/controllers/elbv2/targetgroupbinding_controller.go
+++ b/controllers/elbv2/targetgroupbinding_controller.go
@@ -145,14 +145,17 @@ func (r *targetGroupBindingReconciler) SetupWithManager(ctx context.Context, mgr
 		return err
 	}
 
-	epEventsHandler := eventhandlers.NewEnqueueRequestsForEndpointsEvent(r.k8sClient,
+	svcEventHandler := eventhandlers.NewEnqueueRequestsForServiceEvent(r.k8sClient,
+		r.logger.WithName("eventHandlers").WithName("service"))
+	epsEventsHandler := eventhandlers.NewEnqueueRequestsForEndpointsEvent(r.k8sClient,
 		r.logger.WithName("eventHandlers").WithName("endpoints"))
 	nodeEventsHandler := eventhandlers.NewEnqueueRequestsForNodeEvent(r.k8sClient,
 		r.logger.WithName("eventHandlers").WithName("node"))
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&elbv2api.TargetGroupBinding{}).
 		Named(controllerName).
-		Watches(&source.Kind{Type: &corev1.Endpoints{}}, epEventsHandler).
+		Watches(&source.Kind{Type: &corev1.Service{}}, svcEventHandler).
+		Watches(&source.Kind{Type: &corev1.Endpoints{}}, epsEventsHandler).
 		Watches(&source.Kind{Type: &corev1.Node{}}, nodeEventsHandler).
 		WithOptions(controller.Options{MaxConcurrentReconciles: r.maxConcurrentReconciles}).
 		Complete(r)

--- a/pkg/testutils/client_test_utils.go
+++ b/pkg/testutils/client_test_utils.go
@@ -1,0 +1,36 @@
+package testutils
+
+import (
+	"github.com/golang/mock/gomock"
+	"reflect"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// NewListOptionEquals constructs new goMock matcher for client's ListOption
+func NewListOptionEquals(expectedListOption client.ListOption) *listOptionEquals {
+	return &listOptionEquals{
+		expectedListOption: expectedListOption,
+	}
+}
+
+type listOptionEquals struct {
+	expectedListOption client.ListOption
+}
+
+var _ gomock.Matcher = &listOptionEquals{}
+
+func (m *listOptionEquals) Matches(x interface{}) bool {
+	actualListOpt, ok := x.(client.ListOption)
+	if !ok {
+		return false
+	}
+	optA := client.ListOptions{}
+	optB := client.ListOptions{}
+	actualListOpt.ApplyToList(&optA)
+	m.expectedListOption.ApplyToList(&optB)
+	return reflect.DeepEqual(optA, optB)
+}
+
+func (m *listOptionEquals) String() string {
+	return "list option equals"
+}

--- a/pkg/testutils/event_handler_test_utils.go
+++ b/pkg/testutils/event_handler_test_utils.go
@@ -1,0 +1,16 @@
+package testutils
+
+import (
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func ExtractCTRLRequestsFromQueue(queue workqueue.RateLimitingInterface) []ctrl.Request {
+	var requests []ctrl.Request
+	for queue.Len() > 0 {
+		item, _ := queue.Get()
+		queue.Done(item)
+		requests = append(requests, item.(ctrl.Request))
+	}
+	return requests
+}


### PR DESCRIPTION
## add service event handler for targetGroupBinding.
1. Service changes should trigger enqueue for TGB of instance targetType since nodePort might changed.
2. we only enqueue TGB of instance targetType for service creation and deletion since IP targetType is driving by the endpoints object. (service creation and deletion will results in endpoints creation and deletion)
Fix #1651 

