### PR TITLE
docs: make external-dns example to 0.7.2+ working in AWS China

### DIFF
--- a/docs/examples/external-dns.yaml
+++ b/docs/examples/external-dns.yaml
@@ -20,6 +20,9 @@ rules:
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["list"]
+- apiGroups: [""]
+  resources: ["endpoints"]
+  verbs: ["get","watch","list"]  
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -52,7 +55,11 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: bitnami/external-dns:0.7.1
+        image: bitnami/external-dns:0.7.4
+        # must specify env AWS_REGION in AWS china regions
+        # env:
+        # - name: AWS_REGION
+        #   value: cn-north-1
         args:
         - --source=service
         - --source=ingress


### PR DESCRIPTION
external-dns supports AWS China since 0.7.2, it also requires additional **endpoints** permission