### PR TITLE
add COIP support for ALB on outpost

### DIFF
--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -132,7 +132,7 @@ Traffic Listening can be controlled with following annotations:
 
     !!!example
         ```
-        alb.ingress.kubernetes.io/customer-owned-ipv4-poole: ipv4pool-coip-xxxxxxxx
+        alb.ingress.kubernetes.io/customer-owned-ipv4-pool: ipv4pool-coip-xxxxxxxx
         ```
 
 ## Traffic Routing

--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -23,6 +23,7 @@ You can add annotations to kubernetes Ingress and Service objects to customize t
 |[alb.ingress.kubernetes.io/scheme](#scheme)|internal \| internet-facing|internal|Ingress|Exclusive|
 |[alb.ingress.kubernetes.io/subnets](#subnets)|stringList|N/A|Ingress|Exclusive|
 |[alb.ingress.kubernetes.io/security-groups](#security-groups)|stringList|N/A|Ingress|Exclusive|
+|[alb.ingress.kubernetes.io/customer-owned-ipv4-pool](#customer-owned-ipv4-pool)|string|N/A|Ingress|Exclusive|
 |[alb.ingress.kubernetes.io/load-balancer-attributes](#load-balancer-attributes)|stringMap|N/A|Ingress|Merge|
 |[alb.ingress.kubernetes.io/wafv2-acl-arn](#wafv2-acl-arn)|string|N/A|Ingress|Exclusive|
 |[alb.ingress.kubernetes.io/waf-acl-id](#waf-acl-id)|string|N/A|Ingress|Exclusive|
@@ -122,6 +123,16 @@ Traffic Listening can be controlled with following annotations:
     !!!example
         ```
         alb.ingress.kubernetes.io/ip-address-type: ipv4
+        ```
+
+- <a name="customer-owned-ipv4-pool">`alb.ingress.kubernetes.io/customer-owned-ipv4-pool`</a> specifies the customer-owned IPv4 address pool for ALB on Outpost.
+    
+    !!!warning ""
+        This annotation should be treated as immutable. To remove or change coIPv4Pool, you need to recreate Ingress.
+
+    !!!example
+        ```
+        alb.ingress.kubernetes.io/customer-owned-ipv4-poole: ipv4pool-coip-xxxxxxxx
         ```
 
 ## Traffic Routing

--- a/pkg/annotations/constants.go
+++ b/pkg/annotations/constants.go
@@ -11,6 +11,7 @@ const (
 	IngressSuffixIPAddressType                = "ip-address-type"
 	IngressSuffixScheme                       = "scheme"
 	IngressSuffixSubnets                      = "subnets"
+	IngressSuffixCustomerOwnedIPv4Pool        = "customer-owned-ipv4-pool"
 	IngressSuffixLoadBalancerAttributes       = "load-balancer-attributes"
 	IngressSuffixWAFv2ACLARN                  = "wafv2-acl-arn"
 	IngressSuffixWAFACLID                     = "waf-acl-id"

--- a/pkg/deploy/elbv2/load_balancer_manager.go
+++ b/pkg/deploy/elbv2/load_balancer_manager.go
@@ -236,6 +236,8 @@ func buildSDKCreateLoadBalancerInput(lbSpec elbv2model.LoadBalancerSpec) (*elbv2
 	} else {
 		sdkObj.SecurityGroups = sdkSecurityGroups
 	}
+
+	sdkObj.CustomerOwnedIpv4Pool = lbSpec.CustomerOwnedIPv4Pool
 	return sdkObj, nil
 }
 

--- a/pkg/deploy/elbv2/load_balancer_manager.go
+++ b/pkg/deploy/elbv2/load_balancer_manager.go
@@ -6,6 +6,7 @@ import (
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	elbv2sdk "github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/services"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/tracking"
@@ -90,6 +91,9 @@ func (m *defaultLoadBalancerManager) Update(ctx context.Context, resLB *elbv2mod
 		return elbv2model.LoadBalancerStatus{}, err
 	}
 	if err := m.attributesReconciler.Reconcile(ctx, resLB, sdkLB); err != nil {
+		return elbv2model.LoadBalancerStatus{}, err
+	}
+	if err := m.checkSDKLoadBalancerWithCOIPv4Pool(ctx, resLB, sdkLB); err != nil {
 		return elbv2model.LoadBalancerStatus{}, err
 	}
 	return buildResLoadBalancerStatus(sdkLB), nil
@@ -203,6 +207,13 @@ func (m *defaultLoadBalancerManager) updateSDKLoadBalancerWithSecurityGroups(ctx
 		"resourceID", resLB.ID(),
 		"arn", awssdk.StringValue(sdkLB.LoadBalancer.LoadBalancerArn))
 
+	return nil
+}
+
+func (m *defaultLoadBalancerManager) checkSDKLoadBalancerWithCOIPv4Pool(_ context.Context, resLB *elbv2model.LoadBalancer, sdkLB LoadBalancerWithTags) error {
+	if awssdk.StringValue(resLB.Spec.CustomerOwnedIPv4Pool) != awssdk.StringValue(sdkLB.LoadBalancer.CustomerOwnedIpv4Pool) {
+		return errors.New("loadBalancer has drifted CustomerOwnedIPv4Pool setting")
+	}
 	return nil
 }
 

--- a/pkg/deploy/elbv2/load_balancer_manager_test.go
+++ b/pkg/deploy/elbv2/load_balancer_manager_test.go
@@ -1,6 +1,8 @@
 package elbv2
 
 import (
+	"context"
+	"errors"
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	elbv2sdk "github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/stretchr/testify/assert"
@@ -301,6 +303,110 @@ func Test_buildResLoadBalancerStatus(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := buildResLoadBalancerStatus(tt.args.sdkLB)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_defaultLoadBalancerManager_checkSDKLoadBalancerWithCOIPv4Pool(t *testing.T) {
+	type args struct {
+		resLB *elbv2model.LoadBalancer
+		sdkLB LoadBalancerWithTags
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr error
+	}{
+		{
+			name: "both resLB and sdkLB don't have CustomerOwnedIPv4Pool setting",
+			args: args{
+				resLB: &elbv2model.LoadBalancer{
+					Spec: elbv2model.LoadBalancerSpec{
+						CustomerOwnedIPv4Pool: nil,
+					},
+				},
+				sdkLB: LoadBalancerWithTags{
+					LoadBalancer: &elbv2sdk.LoadBalancer{
+						CustomerOwnedIpv4Pool: nil,
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "both resLB and sdkLB have same CustomerOwnedIPv4Pool setting",
+			args: args{
+				resLB: &elbv2model.LoadBalancer{
+					Spec: elbv2model.LoadBalancerSpec{
+						CustomerOwnedIPv4Pool: awssdk.String("ipv4pool-coip-abc"),
+					},
+				},
+				sdkLB: LoadBalancerWithTags{
+					LoadBalancer: &elbv2sdk.LoadBalancer{
+						CustomerOwnedIpv4Pool: awssdk.String("ipv4pool-coip-abc"),
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "both resLB and sdkLB have different CustomerOwnedIPv4Pool setting",
+			args: args{
+				resLB: &elbv2model.LoadBalancer{
+					Spec: elbv2model.LoadBalancerSpec{
+						CustomerOwnedIPv4Pool: awssdk.String("ipv4pool-coip-abc"),
+					},
+				},
+				sdkLB: LoadBalancerWithTags{
+					LoadBalancer: &elbv2sdk.LoadBalancer{
+						CustomerOwnedIpv4Pool: awssdk.String("ipv4pool-coip-def"),
+					},
+				},
+			},
+			wantErr: errors.New("loadBalancer has drifted CustomerOwnedIPv4Pool setting"),
+		},
+		{
+			name: "only resLB have CustomerOwnedIPv4Pool setting",
+			args: args{
+				resLB: &elbv2model.LoadBalancer{
+					Spec: elbv2model.LoadBalancerSpec{
+						CustomerOwnedIPv4Pool: awssdk.String("ipv4pool-coip-abc"),
+					},
+				},
+				sdkLB: LoadBalancerWithTags{
+					LoadBalancer: &elbv2sdk.LoadBalancer{
+						CustomerOwnedIpv4Pool: nil,
+					},
+				},
+			},
+			wantErr: errors.New("loadBalancer has drifted CustomerOwnedIPv4Pool setting"),
+		},
+		{
+			name: "only sdkLB have CustomerOwnedIPv4Pool setting",
+			args: args{
+				resLB: &elbv2model.LoadBalancer{
+					Spec: elbv2model.LoadBalancerSpec{
+						CustomerOwnedIPv4Pool: nil,
+					},
+				},
+				sdkLB: LoadBalancerWithTags{
+					LoadBalancer: &elbv2sdk.LoadBalancer{
+						CustomerOwnedIpv4Pool: awssdk.String("ipv4pool-coip-abc"),
+					},
+				},
+			},
+			wantErr: errors.New("loadBalancer has drifted CustomerOwnedIPv4Pool setting"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &defaultLoadBalancerManager{}
+			err := m.checkSDKLoadBalancerWithCOIPv4Pool(context.Background(), tt.args.resLB, tt.args.sdkLB)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }

--- a/pkg/deploy/elbv2/load_balancer_manager_test.go
+++ b/pkg/deploy/elbv2/load_balancer_manager_test.go
@@ -92,6 +92,46 @@ func Test_buildSDKCreateLoadBalancerInput(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "application loadBalancer - with CoIP pool",
+			args: args{
+				lbSpec: elbv2model.LoadBalancerSpec{
+					Name:          "my-alb",
+					Type:          elbv2model.LoadBalancerTypeApplication,
+					Scheme:        &schemeInternetFacing,
+					IPAddressType: &addressTypeDualStack,
+					SubnetMappings: []elbv2model.SubnetMapping{
+						{
+							SubnetID: "subnet-A",
+						},
+						{
+							SubnetID: "subnet-B",
+						},
+					},
+					SecurityGroups: []coremodel.StringToken{
+						coremodel.LiteralStringToken("sg-A"),
+						coremodel.LiteralStringToken("sg-B"),
+					},
+					CustomerOwnedIPv4Pool: awssdk.String("coIP-pool-x"),
+				},
+			},
+			want: &elbv2sdk.CreateLoadBalancerInput{
+				Name:          awssdk.String("my-alb"),
+				Type:          awssdk.String("application"),
+				IpAddressType: awssdk.String("dualstack"),
+				Scheme:        awssdk.String("internet-facing"),
+				SubnetMappings: []*elbv2sdk.SubnetMapping{
+					{
+						SubnetId: awssdk.String("subnet-A"),
+					},
+					{
+						SubnetId: awssdk.String("subnet-B"),
+					},
+				},
+				SecurityGroups:        awssdk.StringSlice([]string{"sg-A", "sg-B"}),
+				CustomerOwnedIpv4Pool: awssdk.String("coIP-pool-x"),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/ingress/model_build_load_balancer_test.go
+++ b/pkg/ingress/model_build_load_balancer_test.go
@@ -1,0 +1,202 @@
+package ingress
+
+import (
+	"context"
+	"errors"
+	awssdk "github.com/aws/aws-sdk-go/aws"
+	"github.com/stretchr/testify/assert"
+	networking "k8s.io/api/networking/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
+	"testing"
+)
+
+func Test_defaultModelBuildTask_buildLoadBalancerCOIPv4Pool(t *testing.T) {
+	type fields struct {
+		ingGroup Group
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    *string
+		wantErr error
+	}{
+		{
+			name: "COIPv4 not configured on standalone Ingress",
+			fields: fields{
+				ingGroup: Group{
+					Members: []*networking.Ingress{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace:   "awesome-ns",
+								Name:        "ing-1",
+								Annotations: map[string]string{},
+							},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "COIPv4 configured on standalone Ingress",
+			fields: fields{
+				ingGroup: Group{
+					Members: []*networking.Ingress{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "awesome-ns",
+								Name:      "ing-1",
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/customer-owned-ipv4-pool": "my-ip-pool",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: awssdk.String("my-ip-pool"),
+		},
+		{
+			name: "specified empty COIPv4 on standalone Ingress",
+			fields: fields{
+				ingGroup: Group{
+					Members: []*networking.Ingress{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "awesome-ns",
+								Name:      "ing-1",
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/customer-owned-ipv4-pool": "",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: errors.New("cannot use empty value for customer-owned-ipv4-pool annotation, ingress: awesome-ns/ing-1"),
+		},
+		{
+			name: "COIPv4 not configured on all Ingresses among IngressGroup",
+			fields: fields{
+				ingGroup: Group{
+					Members: []*networking.Ingress{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace:   "awesome-ns",
+								Name:        "ing-1",
+								Annotations: map[string]string{},
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace:   "awesome-ns",
+								Name:        "ing-2",
+								Annotations: map[string]string{},
+							},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "COIPv4 configured on one Ingress among IngressGroup",
+			fields: fields{
+				ingGroup: Group{
+					Members: []*networking.Ingress{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "awesome-ns",
+								Name:      "ing-1",
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/customer-owned-ipv4-pool": "my-ip-pool",
+								},
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace:   "awesome-ns",
+								Name:        "ing-2",
+								Annotations: map[string]string{},
+							},
+						},
+					},
+				},
+			},
+			want: awssdk.String("my-ip-pool"),
+		},
+		{
+			name: "COIPv4 configured on multiple Ingresses among IngressGroup - with same value",
+			fields: fields{
+				ingGroup: Group{
+					Members: []*networking.Ingress{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "awesome-ns",
+								Name:      "ing-1",
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/customer-owned-ipv4-pool": "my-ip-pool",
+								},
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "awesome-ns",
+								Name:      "ing-2",
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/customer-owned-ipv4-pool": "my-ip-pool",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: awssdk.String("my-ip-pool"),
+		},
+		{
+			name: "COIPv4 configured on multiple Ingress among IngressGroup - with different value",
+			fields: fields{
+				ingGroup: Group{
+					Members: []*networking.Ingress{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "awesome-ns",
+								Name:      "ing-1",
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/customer-owned-ipv4-pool": "my-ip-pool",
+								},
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "awesome-ns",
+								Name:      "ing-2",
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/customer-owned-ipv4-pool": "my-another-pool",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: errors.New("conflicting CustomerOwnedIPv4Pool: [my-another-pool my-ip-pool]"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t1 *testing.T) {
+			annotationParser := annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io")
+			task := &defaultModelBuildTask{
+				annotationParser: annotationParser,
+				ingGroup:         tt.fields.ingGroup,
+			}
+			got, err := task.buildLoadBalancerCOIPv4Pool(context.Background())
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/model/elbv2/load_balancer.go
+++ b/pkg/model/elbv2/load_balancer.go
@@ -140,6 +140,10 @@ type LoadBalancerSpec struct {
 	// +optional
 	SecurityGroups []core.StringToken `json:"securityGroups,omitempty"`
 
+	// [Application Load Balancers on Outposts] The ID of the customer-owned address pool (CoIP pool).
+	// +optional
+	CustomerOwnedIPv4Pool *string `json:"customerOwnedIPv4Pool,omitempty"`
+
 	// The load balancer attributes.
 	// +optional
 	LoadBalancerAttributes []LoadBalancerAttribute `json:"loadBalancerAttributes,omitempty"`


### PR DESCRIPTION
## add COIP support for ALB on outpost

This PR supports to specify the ID of the customer-owned address pool via annotation `alb.ingress.kubernetes.io/customer-owned-ipv4-pool`. 

Note: coIPv4 pool for ALB should be immutable.
  1. currently we don't have webhooks to enforce the immutability).
  2. we didn't take the approach of recreate ALB if the coIPv4 pool changes, which is left as improvement for future versions. (depends on whether ALB exposes the API to modify coIP pool)

## Test done
1. normal ALB continue to work without been impacted.
2. with coIPPool on normal subnet, got error "You must use a customer owned IPv4 pool with an Application Load Balancer on an Outpost"
2. with coIPPool on outpost subnet:
```
LoadBalancers:
- AvailabilityZones:
  - LoadBalancerAddresses: []
    OutpostId: op-<redacted>
    SubnetId: subnet-<redacted>
    ZoneName: us-west-2a
  CanonicalHostedZoneId: <redacted>
  CreatedTime: '2020-11-24T22:48:08.690000+00:00'
  CustomerOwnedIpv4Pool: ipv4pool-coip-<redacted>
  DNSName: k8s-echoserv-echoserv-<redacted>.us-west-2.elb.amazonaws.com
  IpAddressType: ipv4
  LoadBalancerArn: <redacted>
  LoadBalancerName: k8s-echoserv-echoserv-<redacted>
  Scheme: internet-facing
  SecurityGroups:
  - sg-<redacted>
  State:
    Code: active
  Type: application
  VpcId: vpc-<redacted>
```