### PR TITLE
Issue #1609 - Handling Cluster AutoScaler Taint to determine the healthiness of node

### DIFF
--- a/controllers/elbv2/eventhandlers/node.go
+++ b/controllers/elbv2/eventhandlers/node.go
@@ -61,11 +61,11 @@ func (h *enqueueRequestsForNodeEvent) enqueueImpactedTargetGroupBindings(queue w
 	nodeNewIsReady := false
 	if nodeOld != nil {
 		nodeKey = k8s.NamespacedName(nodeOld)
-		nodeOldIsReady = k8s.IsNodeSuitableForTraffic(nodeOld)
+		nodeOldIsReady = k8s.IsNodeSuitableAsTrafficProxy(nodeOld)
 	}
 	if nodeNew != nil {
 		nodeKey = k8s.NamespacedName(nodeNew)
-		nodeNewIsReady = k8s.IsNodeSuitableForTraffic(nodeNew)
+		nodeNewIsReady = k8s.IsNodeSuitableAsTrafficProxy(nodeNew)
 	}
 
 	tgbList := &elbv2api.TargetGroupBindingList{}

--- a/controllers/elbv2/eventhandlers/node.go
+++ b/controllers/elbv2/eventhandlers/node.go
@@ -61,11 +61,11 @@ func (h *enqueueRequestsForNodeEvent) enqueueImpactedTargetGroupBindings(queue w
 	nodeNewIsReady := false
 	if nodeOld != nil {
 		nodeKey = k8s.NamespacedName(nodeOld)
-		nodeOldIsReady = k8s.IsNodeReady(nodeOld)
+		nodeOldIsReady = k8s.IsNodeSuitableForTraffic(nodeOld)
 	}
 	if nodeNew != nil {
 		nodeKey = k8s.NamespacedName(nodeNew)
-		nodeNewIsReady = k8s.IsNodeReady(nodeNew)
+		nodeNewIsReady = k8s.IsNodeSuitableForTraffic(nodeNew)
 	}
 
 	tgbList := &elbv2api.TargetGroupBindingList{}

--- a/pkg/backend/endpoint_resolver.go
+++ b/pkg/backend/endpoint_resolver.go
@@ -133,7 +133,7 @@ func (r *defaultEndpointResolver) ResolveNodePortEndpoints(ctx context.Context, 
 	var endpoints []NodePortEndpoint
 	for i := range nodeList.Items {
 		node := &nodeList.Items[i]
-		if !k8s.IsNodeReady(node) {
+		if !k8s.IsNodeSuitableForTraffic(node) {
 			continue
 		}
 		instanceID, err := k8s.ExtractNodeInstanceID(node)

--- a/pkg/backend/endpoint_resolver.go
+++ b/pkg/backend/endpoint_resolver.go
@@ -133,7 +133,7 @@ func (r *defaultEndpointResolver) ResolveNodePortEndpoints(ctx context.Context, 
 	var endpoints []NodePortEndpoint
 	for i := range nodeList.Items {
 		node := &nodeList.Items[i]
-		if !k8s.IsNodeSuitableForTraffic(node) {
+		if !k8s.IsNodeSuitableAsTrafficProxy(node) {
 			continue
 		}
 		instanceID, err := k8s.ExtractNodeInstanceID(node)

--- a/pkg/k8s/node_utils.go
+++ b/pkg/k8s/node_utils.go
@@ -6,10 +6,32 @@ import (
 	"strings"
 )
 
+const (
+	toBeDeletedTaint = "ToBeDeletedByClusterAutoscaler"
+)
+
 // IsNodeReady returns whether node is ready.
 func IsNodeReady(node *corev1.Node) bool {
 	nodeReadyCond := GetNodeCondition(node, corev1.NodeReady)
 	return nodeReadyCond != nil && nodeReadyCond.Status == corev1.ConditionTrue
+}
+
+// IsNodeSuitableAsTrafficProxy check whether node is suitable as a traffic proxy.
+// mimic the logic of serviceController: https://github.com/kubernetes/kubernetes/blob/b6b494b4484b51df8dc6b692fab234573da30ab4/pkg/controller/service/controller.go#L605
+func IsNodeSuitableForTraffic(node *corev1.Node) bool {
+	if node.Spec.Unschedulable {
+		return false
+	}
+
+	// ToBeDeletedByClusterAutoscaler taint is added by cluster autoscaler before removing node from cluster
+	// Marking the node as unsuitable for traffic once the taint is observed on the node
+	for _, taint := range node.Spec.Taints {
+		if taint.Key == toBeDeletedTaint {
+			return false
+		}
+	}
+
+	return IsNodeReady(node)
 }
 
 // GetNodeCondition will get pointer to Node's existing condition.

--- a/pkg/k8s/node_utils.go
+++ b/pkg/k8s/node_utils.go
@@ -19,10 +19,6 @@ func IsNodeReady(node *corev1.Node) bool {
 // IsNodeSuitableAsTrafficProxy check whether node is suitable as a traffic proxy.
 // mimic the logic of serviceController: https://github.com/kubernetes/kubernetes/blob/b6b494b4484b51df8dc6b692fab234573da30ab4/pkg/controller/service/controller.go#L605
 func IsNodeSuitableAsTrafficProxy(node *corev1.Node) bool {
-	if node.Spec.Unschedulable {
-		return false
-	}
-
 	// ToBeDeletedByClusterAutoscaler taint is added by cluster autoscaler before removing node from cluster
 	// Marking the node as unsuitable for traffic once the taint is observed on the node
 	for _, taint := range node.Spec.Taints {

--- a/pkg/k8s/node_utils.go
+++ b/pkg/k8s/node_utils.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	toBeDeletedTaint = "ToBeDeletedByClusterAutoscaler"
+	toBeDeletedByCATaint = "ToBeDeletedByClusterAutoscaler"
 )
 
 // IsNodeReady returns whether node is ready.
@@ -18,7 +18,7 @@ func IsNodeReady(node *corev1.Node) bool {
 
 // IsNodeSuitableAsTrafficProxy check whether node is suitable as a traffic proxy.
 // mimic the logic of serviceController: https://github.com/kubernetes/kubernetes/blob/b6b494b4484b51df8dc6b692fab234573da30ab4/pkg/controller/service/controller.go#L605
-func IsNodeSuitableForTraffic(node *corev1.Node) bool {
+func IsNodeSuitableAsTrafficProxy(node *corev1.Node) bool {
 	if node.Spec.Unschedulable {
 		return false
 	}
@@ -26,7 +26,7 @@ func IsNodeSuitableForTraffic(node *corev1.Node) bool {
 	// ToBeDeletedByClusterAutoscaler taint is added by cluster autoscaler before removing node from cluster
 	// Marking the node as unsuitable for traffic once the taint is observed on the node
 	for _, taint := range node.Spec.Taints {
-		if taint.Key == toBeDeletedTaint {
+		if taint.Key == toBeDeletedByCATaint {
 			return false
 		}
 	}

--- a/pkg/k8s/node_utils_test.go
+++ b/pkg/k8s/node_utils_test.go
@@ -132,7 +132,7 @@ func TestIsNodeSuitableForTraffic(t *testing.T) {
 						Unschedulable: false,
 						Taints: []corev1.Taint{
 							{
-								Key:   toBeDeletedTaint,
+								Key:   toBeDeletedByCATaint,
 								Value: "True",
 							},
 						},
@@ -144,7 +144,7 @@ func TestIsNodeSuitableForTraffic(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := IsNodeSuitableForTraffic(tt.args.node)
+			got := IsNodeSuitableAsTrafficProxy(tt.args.node)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/k8s/node_utils_test.go
+++ b/pkg/k8s/node_utils_test.go
@@ -98,26 +98,7 @@ func TestIsNodeSuitableForTraffic(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "node is ready but node is Unschedulable",
-			args: args{
-				node: &corev1.Node{
-					Status: corev1.NodeStatus{
-						Conditions: []corev1.NodeCondition{
-							{
-								Type:   corev1.NodeReady,
-								Status: corev1.ConditionTrue,
-							},
-						},
-					},
-					Spec: corev1.NodeSpec{
-						Unschedulable: true,
-					},
-				},
-			},
-			want: false,
-		},
-		{
-			name: "node is ready and schedulable but tained with ToBeDeletedByClusterAutoscaler",
+			name: "node is ready but tainted with ToBeDeletedByClusterAutoscaler",
 			args: args{
 				node: &corev1.Node{
 					Status: corev1.NodeStatus{


### PR DESCRIPTION
Issue #1609 - Checking if the current node is tainted with ClusterAutoScaler and avoid marking that node as healthy so that it could be removed from load balancer target groups. This PR also adds node.Spec.UnSchedulable check as present in master branch too.