### PR TITLE
add support for default-tags

### DIFF
--- a/controllers/ingress/group_controller.go
+++ b/controllers/ingress/group_controller.go
@@ -47,7 +47,7 @@ func NewGroupReconciler(cloud aws.Cloud, k8sClient client.Client, eventRecorder 
 		cloud.EC2(), cloud.ACM(),
 		annotationParser, subnetsResolver,
 		authConfigBuilder, enhancedBackendBuilder,
-		cloud.VpcID(), config.ClusterName, logger)
+		cloud.VpcID(), config.ClusterName, config.DefaultTags, logger)
 	stackMarshaller := deploy.NewDefaultStackMarshaller()
 	stackDeployer := deploy.NewDefaultStackDeployer(cloud, k8sClient, networkingSGManager, networkingSGReconciler,
 		config, ingressTagPrefix, logger)

--- a/controllers/service/service_controller.go
+++ b/controllers/service/service_controller.go
@@ -37,7 +37,7 @@ func NewServiceReconciler(cloud aws.Cloud, k8sClient client.Client, eventRecorde
 	config config.ControllerConfig, logger logr.Logger) *serviceReconciler {
 
 	annotationParser := annotations.NewSuffixAnnotationParser(serviceAnnotationPrefix)
-	modelBuilder := service.NewDefaultModelBuilder(annotationParser, subnetsResolver, config.ClusterName)
+	modelBuilder := service.NewDefaultModelBuilder(annotationParser, subnetsResolver, config.ClusterName, config.DefaultTags)
 	stackMarshaller := deploy.NewDefaultStackMarshaller()
 	stackDeployer := deploy.NewDefaultStackDeployer(cloud, k8sClient, networkingSGManager, networkingSGReconciler, config, serviceTagPrefix, logger)
 	return &serviceReconciler{

--- a/pkg/config/controller_config.go
+++ b/pkg/config/controller_config.go
@@ -10,6 +10,7 @@ import (
 const (
 	flagLogLevel                                  = "log-level"
 	flagK8sClusterName                            = "cluster-name"
+	flagDefaultTags                               = "default-tags"
 	flagServiceMaxConcurrentReconciles            = "service-max-concurrent-reconciles"
 	flagTargetGroupBindingMaxConcurrentReconciles = "targetgroupbinding-max-concurrent-reconciles"
 	defaultLogLevel                               = "info"
@@ -33,6 +34,9 @@ type ControllerConfig struct {
 	// Configurations for Addons feature
 	AddonsConfig AddonsConfig
 
+	// Default AWS Tags that will be applied to all AWS resources managed by this controller.
+	DefaultTags map[string]string
+
 	// Max concurrent reconcile loops for Service objects
 	ServiceMaxConcurrentReconciles int
 	// Max concurrent reconcile loops for TargetGroupBinding objects
@@ -44,6 +48,8 @@ func (cfg *ControllerConfig) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&cfg.LogLevel, flagLogLevel, defaultLogLevel,
 		"Set the controller log level - info(default), debug")
 	fs.StringVar(&cfg.ClusterName, flagK8sClusterName, "", "Kubernetes cluster name")
+	fs.StringToStringVar(&cfg.DefaultTags, flagDefaultTags, nil,
+		"Default AWS Tags that will be applied to all AWS resources managed by this controller")
 	fs.IntVar(&cfg.ServiceMaxConcurrentReconciles, flagServiceMaxConcurrentReconciles, defaultMaxConcurrentReconciles,
 		"Maximum number of concurrently running reconcile loops for service")
 	fs.IntVar(&cfg.TargetGroupBindingMaxConcurrentReconciles, flagTargetGroupBindingMaxConcurrentReconciles, defaultMaxConcurrentReconciles,

--- a/pkg/ingress/model_build_load_balancer_test.go
+++ b/pkg/ingress/model_build_load_balancer_test.go
@@ -200,3 +200,167 @@ func Test_defaultModelBuildTask_buildLoadBalancerCOIPv4Pool(t *testing.T) {
 		})
 	}
 }
+
+func Test_defaultModelBuildTask_buildLoadBalancerTags(t *testing.T) {
+	type fields struct {
+		ingGroup    Group
+		defaultTags map[string]string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    map[string]string
+		wantErr error
+	}{
+		{
+			name: "empty default tags, no tags annotation",
+			fields: fields{
+				ingGroup: Group{
+					Members: []*networking.Ingress{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{},
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{},
+							},
+						},
+					},
+				},
+				defaultTags: nil,
+			},
+			want: map[string]string{},
+		},
+		{
+			name: "empty default tags, non-empty tags annotation",
+			fields: fields{
+				ingGroup: Group{
+					Members: []*networking.Ingress{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/tags": "k1=v1",
+								},
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/tags": "k2=v2",
+								},
+							},
+						},
+					},
+				},
+				defaultTags: nil,
+			},
+			want: map[string]string{
+				"k1": "v1",
+				"k2": "v2",
+			},
+		},
+		{
+			name: "non-empty default tags, empty tags annotation",
+			fields: fields{
+				ingGroup: Group{
+					Members: []*networking.Ingress{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{},
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{},
+							},
+						},
+					},
+				},
+				defaultTags: map[string]string{
+					"k3": "v3",
+					"k4": "v4",
+				},
+			},
+			want: map[string]string{
+				"k3": "v3",
+				"k4": "v4",
+			},
+		},
+		{
+			name: "non-empty default tags, non-empty tags annotation",
+			fields: fields{
+				ingGroup: Group{
+					Members: []*networking.Ingress{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/tags": "k1=v1,k3=v3a",
+								},
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/tags": "k2=v2",
+								},
+							},
+						},
+					},
+				},
+				defaultTags: map[string]string{
+					"k3": "v3",
+					"k4": "v4",
+				},
+			},
+			want: map[string]string{
+				"k1": "v1",
+				"k2": "v2",
+				"k3": "v3a",
+				"k4": "v4",
+			},
+		},
+		{
+			name: "empty default tags, conflicting tags annotation",
+			fields: fields{
+				ingGroup: Group{
+					Members: []*networking.Ingress{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/tags": "k1=v1,k3=v3a",
+								},
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/tags": "k2=v2,k3=v3b",
+								},
+							},
+						},
+					},
+				},
+				defaultTags: nil,
+			},
+			wantErr: errors.New("conflicting tag k3: v3a | v3b"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := &defaultModelBuildTask{
+				ingGroup:         tt.fields.ingGroup,
+				defaultTags:      tt.fields.defaultTags,
+				annotationParser: annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io"),
+			}
+			got, err := task.buildLoadBalancerTags(context.Background())
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}

--- a/pkg/ingress/model_build_managed_sg.go
+++ b/pkg/ingress/model_build_managed_sg.go
@@ -62,18 +62,25 @@ func (t *defaultModelBuildTask) buildManagedSecurityGroupName(_ context.Context)
 }
 
 func (t *defaultModelBuildTask) buildManagedSecurityGroupTags(_ context.Context) (map[string]string, error) {
-	mergedTags := make(map[string]string)
+	annotationTags := make(map[string]string)
 	for _, ing := range t.ingGroup.Members {
 		var rawTags map[string]string
 		if _, err := t.annotationParser.ParseStringMapAnnotation(annotations.IngressSuffixTags, &rawTags, ing.Annotations); err != nil {
 			return nil, err
 		}
 		for tagKey, tagValue := range rawTags {
-			if existingTagValue, exists := mergedTags[tagKey]; exists && existingTagValue != tagValue {
+			if existingTagValue, exists := annotationTags[tagKey]; exists && existingTagValue != tagValue {
 				return nil, errors.Errorf("conflicting tag %v: %v | %v", tagKey, existingTagValue, tagValue)
 			}
-			mergedTags[tagKey] = tagValue
+			annotationTags[tagKey] = tagValue
 		}
+	}
+	mergedTags := make(map[string]string)
+	for k, v := range t.defaultTags {
+		mergedTags[k] = v
+	}
+	for k, v := range annotationTags {
+		mergedTags[k] = v
 	}
 	return mergedTags, nil
 }

--- a/pkg/ingress/model_build_managed_sg_test.go
+++ b/pkg/ingress/model_build_managed_sg_test.go
@@ -1,0 +1,175 @@
+package ingress
+
+import (
+	"context"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	networking "k8s.io/api/networking/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
+	"testing"
+)
+
+func Test_defaultModelBuildTask_buildManagedSecurityGroupTags(t *testing.T) {
+	type fields struct {
+		ingGroup    Group
+		defaultTags map[string]string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    map[string]string
+		wantErr error
+	}{
+		{
+			name: "empty default tags, no tags annotation",
+			fields: fields{
+				ingGroup: Group{
+					Members: []*networking.Ingress{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{},
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{},
+							},
+						},
+					},
+				},
+				defaultTags: nil,
+			},
+			want: map[string]string{},
+		},
+		{
+			name: "empty default tags, non-empty tags annotation",
+			fields: fields{
+				ingGroup: Group{
+					Members: []*networking.Ingress{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/tags": "k1=v1",
+								},
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/tags": "k2=v2",
+								},
+							},
+						},
+					},
+				},
+				defaultTags: nil,
+			},
+			want: map[string]string{
+				"k1": "v1",
+				"k2": "v2",
+			},
+		},
+		{
+			name: "non-empty default tags, empty tags annotation",
+			fields: fields{
+				ingGroup: Group{
+					Members: []*networking.Ingress{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{},
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{},
+							},
+						},
+					},
+				},
+				defaultTags: map[string]string{
+					"k3": "v3",
+					"k4": "v4",
+				},
+			},
+			want: map[string]string{
+				"k3": "v3",
+				"k4": "v4",
+			},
+		},
+		{
+			name: "non-empty default tags, non-empty tags annotation",
+			fields: fields{
+				ingGroup: Group{
+					Members: []*networking.Ingress{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/tags": "k1=v1,k3=v3a",
+								},
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/tags": "k2=v2",
+								},
+							},
+						},
+					},
+				},
+				defaultTags: map[string]string{
+					"k3": "v3",
+					"k4": "v4",
+				},
+			},
+			want: map[string]string{
+				"k1": "v1",
+				"k2": "v2",
+				"k3": "v3a",
+				"k4": "v4",
+			},
+		},
+		{
+			name: "empty default tags, conflicting tags annotation",
+			fields: fields{
+				ingGroup: Group{
+					Members: []*networking.Ingress{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/tags": "k1=v1,k3=v3a",
+								},
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/tags": "k2=v2,k3=v3b",
+								},
+							},
+						},
+					},
+				},
+				defaultTags: nil,
+			},
+			wantErr: errors.New("conflicting tag k3: v3a | v3b"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := &defaultModelBuildTask{
+				ingGroup:         tt.fields.ingGroup,
+				defaultTags:      tt.fields.defaultTags,
+				annotationParser: annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io"),
+			}
+			got, err := task.buildManagedSecurityGroupTags(context.Background())
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}

--- a/pkg/ingress/model_build_target_group.go
+++ b/pkg/ingress/model_build_target_group.go
@@ -370,11 +370,18 @@ func (t *defaultModelBuildTask) buildTargetGroupAttributes(_ context.Context, sv
 }
 
 func (t *defaultModelBuildTask) buildTargetGroupTags(_ context.Context, svcAndIngAnnotations map[string]string) (map[string]string, error) {
-	var rawTags map[string]string
-	if _, err := t.annotationParser.ParseStringMapAnnotation(annotations.IngressSuffixTags, &rawTags, svcAndIngAnnotations); err != nil {
+	var annotationTags map[string]string
+	if _, err := t.annotationParser.ParseStringMapAnnotation(annotations.IngressSuffixTags, &annotationTags, svcAndIngAnnotations); err != nil {
 		return nil, err
 	}
-	return rawTags, nil
+	mergedTags := make(map[string]string)
+	for k, v := range t.defaultTags {
+		mergedTags[k] = v
+	}
+	for k, v := range annotationTags {
+		mergedTags[k] = v
+	}
+	return mergedTags, nil
 }
 
 func (t *defaultModelBuildTask) buildTargetGroupResourceID(ingKey types.NamespacedName, svcKey types.NamespacedName, port intstr.IntOrString) string {

--- a/pkg/ingress/model_builder.go
+++ b/pkg/ingress/model_builder.go
@@ -34,7 +34,7 @@ func NewDefaultModelBuilder(k8sClient client.Client, eventRecorder record.EventR
 	ec2Client services.EC2, acmClient services.ACM,
 	annotationParser annotations.Parser, subnetsResolver networkingpkg.SubnetsResolver,
 	authConfigBuilder AuthConfigBuilder, enhancedBackendBuilder EnhancedBackendBuilder,
-	vpcID string, clusterName string, logger logr.Logger) *defaultModelBuilder {
+	vpcID string, clusterName string, defaultTags map[string]string, logger logr.Logger) *defaultModelBuilder {
 	certDiscovery := NewACMCertDiscovery(acmClient, logger)
 	ruleOptimizer := NewDefaultRuleOptimizer(logger)
 	return &defaultModelBuilder{
@@ -49,6 +49,7 @@ func NewDefaultModelBuilder(k8sClient client.Client, eventRecorder record.EventR
 		authConfigBuilder:      authConfigBuilder,
 		enhancedBackendBuilder: enhancedBackendBuilder,
 		ruleOptimizer:          ruleOptimizer,
+		defaultTags:            defaultTags,
 		logger:                 logger,
 	}
 }
@@ -70,6 +71,7 @@ type defaultModelBuilder struct {
 	authConfigBuilder      AuthConfigBuilder
 	enhancedBackendBuilder EnhancedBackendBuilder
 	ruleOptimizer          RuleOptimizer
+	defaultTags            map[string]string
 
 	logger logr.Logger
 }
@@ -94,6 +96,7 @@ func (b *defaultModelBuilder) Build(ctx context.Context, ingGroup Group) (core.S
 		ingGroup: ingGroup,
 		stack:    stack,
 
+		defaultTags:                               b.defaultTags,
 		defaultIPAddressType:                      elbv2model.IPAddressTypeIPV4,
 		defaultScheme:                             elbv2model.LoadBalancerSchemeInternal,
 		defaultSSLPolicy:                          "ELBSecurityPolicy-2016-08",
@@ -134,6 +137,7 @@ type defaultModelBuildTask struct {
 	ingGroup Group
 	stack    core.Stack
 
+	defaultTags                               map[string]string
 	defaultIPAddressType                      elbv2model.IPAddressType
 	defaultScheme                             elbv2model.LoadBalancerScheme
 	defaultSSLPolicy                          string

--- a/pkg/service/model_build_load_balancer.go
+++ b/pkg/service/model_build_load_balancer.go
@@ -65,7 +65,7 @@ func (t *defaultModelBuildTask) buildLoadBalancerSpec(ctx context.Context, schem
 
 func (t *defaultModelBuildTask) buildLoadBalancerIPAddressType(_ context.Context) (elbv2model.IPAddressType, error) {
 	rawIPAddressType := ""
-	if exists := t.annotationParser.ParseStringAnnotation(annotations.SvcLBSuffixIPAddressType, &rawIPAddressType, t.service.Annotations); !exists{
+	if exists := t.annotationParser.ParseStringAnnotation(annotations.SvcLBSuffixIPAddressType, &rawIPAddressType, t.service.Annotations); !exists {
 		return t.defaultIPAddressType, nil
 	}
 
@@ -79,7 +79,6 @@ func (t *defaultModelBuildTask) buildLoadBalancerIPAddressType(_ context.Context
 	}
 }
 
-
 func (t *defaultModelBuildTask) buildLoadBalancerScheme(_ context.Context) (elbv2model.LoadBalancerScheme, error) {
 	internal := false
 	if _, err := t.annotationParser.ParseBoolAnnotation(annotations.SvcLBSuffixInternal, &internal, t.service.Annotations); err != nil {
@@ -92,12 +91,18 @@ func (t *defaultModelBuildTask) buildLoadBalancerScheme(_ context.Context) (elbv
 }
 
 func (t *defaultModelBuildTask) buildAdditionalResourceTags(_ context.Context) (map[string]string, error) {
-	tags := make(map[string]string)
-	_, err := t.annotationParser.ParseStringMapAnnotation(annotations.SvcLBSuffixAdditionalTags, &tags, t.service.Annotations)
-	if err != nil {
+	var annotationTags map[string]string
+	if _, err := t.annotationParser.ParseStringMapAnnotation(annotations.SvcLBSuffixAdditionalTags, &annotationTags, t.service.Annotations); err != nil {
 		return nil, err
 	}
-	return tags, nil
+	mergedTags := make(map[string]string)
+	for k, v := range t.defaultTags {
+		mergedTags[k] = v
+	}
+	for k, v := range annotationTags {
+		mergedTags[k] = v
+	}
+	return mergedTags, nil
 }
 
 func (t *defaultModelBuildTask) buildLoadBalancerTags(ctx context.Context) (map[string]string, error) {

--- a/pkg/service/model_builder.go
+++ b/pkg/service/model_builder.go
@@ -19,11 +19,12 @@ type ModelBuilder interface {
 }
 
 // NewDefaultModelBuilder construct a new defaultModelBuilder
-func NewDefaultModelBuilder(annotationParser annotations.Parser, subnetsResolver networking.SubnetsResolver, clusterName string) *defaultModelBuilder {
+func NewDefaultModelBuilder(annotationParser annotations.Parser, subnetsResolver networking.SubnetsResolver, clusterName string, defaultTags map[string]string) *defaultModelBuilder {
 	return &defaultModelBuilder{
 		annotationParser: annotationParser,
 		subnetsResolver:  subnetsResolver,
 		clusterName:      clusterName,
+		defaultTags:      defaultTags,
 	}
 }
 
@@ -33,6 +34,7 @@ type defaultModelBuilder struct {
 	annotationParser annotations.Parser
 	subnetsResolver  networking.SubnetsResolver
 	clusterName      string
+	defaultTags      map[string]string
 }
 
 func (b *defaultModelBuilder) Build(ctx context.Context, service *corev1.Service) (core.Stack, *elbv2model.LoadBalancer, error) {
@@ -46,6 +48,7 @@ func (b *defaultModelBuilder) Build(ctx context.Context, service *corev1.Service
 		stack:     stack,
 		tgByResID: make(map[string]*elbv2model.TargetGroup),
 
+		defaultTags:                          b.defaultTags,
 		defaultAccessLogS3Enabled:            false,
 		defaultAccessLogsS3Bucket:            "",
 		defaultAccessLogsS3Prefix:            "",
@@ -78,11 +81,12 @@ type defaultModelBuildTask struct {
 	tgByResID    map[string]*elbv2model.TargetGroup
 	ec2Subnets   []*ec2.Subnet
 
+	defaultTags                          map[string]string
 	defaultAccessLogS3Enabled            bool
 	defaultAccessLogsS3Bucket            string
 	defaultAccessLogsS3Prefix            string
 	defaultIPAddressType                 elbv2model.IPAddressType
-	defaultLoadBalancingCrossZoneEnabled bool	
+	defaultLoadBalancingCrossZoneEnabled bool
 	defaultProxyProtocolV2Enabled        bool
 	defaultHealthCheckProtocol           elbv2model.Protocol
 	defaultHealthCheckPort               string

--- a/pkg/service/model_builder_test.go
+++ b/pkg/service/model_builder_test.go
@@ -224,7 +224,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 }
 `,
 			wantNumResources: 4,
-      },
+		},
 		{
 			testName: "Dualstack service",
 			svc: &corev1.Service{
@@ -383,7 +383,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 }
 `,
 			wantNumResources: 4,
-		},      
+		},
 		{
 			testName: "Multiple listeners, multiple target groups",
 			svc: &corev1.Service{
@@ -1051,7 +1051,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 			}
 
 			annotationParser := annotations.NewSuffixAnnotationParser("service.beta.kubernetes.io")
-			builder := NewDefaultModelBuilder(annotationParser, subnetsResolver, "my-cluster")
+			builder := NewDefaultModelBuilder(annotationParser, subnetsResolver, "my-cluster", nil)
 			ctx := context.Background()
 			stack, _, err := builder.Build(ctx, tt.svc)
 			if tt.wantError {


### PR DESCRIPTION
## Add support for `default-tags` annotation.
1. DefaultTags will be applied to all AWS resources managed by this controller.
2. DefaultTags have lower priority than tags annotation

Fix #1683 

### Test done
1. unit test
2. same test as unit test with controller built with this change.