### PR TITLE
update docs to point to 2.1.0 spec

### DIFF
--- a/docs/guide/controller/installation.md
+++ b/docs/guide/controller/installation.md
@@ -57,9 +57,9 @@
     - For Kubernetes <1.16: `kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.0.2/cert-manager-legacy.yaml`
     
     ### Download and apply the yaml spec
-    - https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/main/docs/install/v2_0_1_full.yaml
+    - https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/main/docs/install/v2_1_0_full.yaml
     - Edit the saved yaml file, go to the Deployment spec, and set the controller --cluster-name arg value to your EKS cluster name
-    - Apply the yaml file kubectl apply -f install_v2_0_1.yaml
+    - Apply the yaml file: `kubectl apply -f v2_1_0_full.yaml`
     
     !!!note ""
         If you use IAM roles for service accounts, we recommend that you delete the ServiceAccount from the yaml spec. Doing so will preserve the eksctl created iamserviceaccount if you delete the installation.


### PR DESCRIPTION
This should close #1704 by updating the 2.1.0 docs to use the updated YAML specs