### PR TITLE
doc: fix wrong itemization format

### DIFF
--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -33,6 +33,7 @@ Along with the above, the controller also...
 
 ### Ingress Traffic
 AWS Load Balancer controller supports two traffic modes:
+
 * Instance mode
 * IP mode
 


### PR DESCRIPTION
Itemization are broken at https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/how-it-works/ because of wrong itemization format. So I fix it.

![image](https://user-images.githubusercontent.com/1219666/101135168-c8d9d480-364e-11eb-8cc4-16542dbe852f.png)
