### PR TITLE
enable e2e tests for service

### DIFF
--- a/scripts/ci_e2e_test.sh
+++ b/scripts/ci_e2e_test.sh
@@ -214,12 +214,22 @@ test_controller_image() {
     return 1
   fi
 
-  ginkgo -v -r test/e2e/ingress/ -- \
+  AWS_ACCOUNT_ID=$(aws sts get-caller-identity --region ${AWS_REGION} --query Account --output text)
+  S3_BUCKET=${S3_BUCKET:-"lb-controller-e2e-${AWS_ACCOUNT_ID}"}
+  CERTIFICATE_ARN_PREFIX=arn:aws:acm:${AWS_REGION}:${AWS_ACCOUNT_ID}:certificate
+  CERT_ID1="7caec311-1e1f-4b04-a061-bfa688fe813f"
+  CERT_ID2="724963dd-f571-4f2c-b549-5c7d0e35e4b8"
+  CERT_ID3="1001570b-1779-40c3-9b49-9a9a41e30058"
+  CERTIFICATE_ARNS=${CERTIFICATE_ARNS:-"${CERTIFICATE_ARN_PREFIX}/${CERT_ID1},${CERTIFICATE_ARN_PREFIX}/${CERT_ID2},${CERTIFICATE_ARN_PREFIX}/${CERT_ID3}"}
+
+  ginkgo -v -r test/e2e -- \
     --kubeconfig=${CLUSTER_KUBECONFIG} \
     --cluster-name=${CLUSTER_NAME} \
     --aws-region=${AWS_REGION} \
     --aws-vpc-id=${cluster_vpc_id} \
-    --controller-image=${CONTROLLER_IMAGE_NAME}
+    --controller-image=${CONTROLLER_IMAGE_NAME} \
+    --s3-bucket-name=${S3_BUCKET} \
+    --certificate-arns=${CERTIFICATE_ARNS}
 }
 
 #######################################

--- a/test/framework/options.go
+++ b/test/framework/options.go
@@ -20,6 +20,10 @@ type Options struct {
 
 	// AWS Load Balancer Controller image. leave empty to use default one from helm chart.
 	ControllerImage string
+
+	// Additional parameters for e2e tests
+	S3BucketName    string
+	CertificateARNs string
 }
 
 func (options *Options) BindFlags() {
@@ -28,6 +32,9 @@ func (options *Options) BindFlags() {
 	flag.StringVar(&options.AWSVPCID, "aws-vpc-id", "", `AWS VPC ID for the kubernetes cluster`)
 
 	flag.StringVar(&options.ControllerImage, "controller-image", "", `AWS Load Balancer Controller image`)
+
+	flag.StringVar(&options.S3BucketName, "s3-bucket-name", "", `S3 bucket to use for testing load balancer access logging feature`)
+	flag.StringVar(&options.CertificateARNs, "certificate-arns", "", `Certificate ARNs to use for TLS listeners`)
 }
 
 func (options *Options) Validate() error {


### PR DESCRIPTION
# Description
Enable Prow e2e tests for service

# Changes
The service e2e tests take additional arguments `--s3-bucket-name` and `--certificate-arns`. The S3 bucket is used for access logging feature, and the certificates are used for creating TLS listeners. If the arguments are not specified, those tests get skipped.

# Tests
- verified the e2e script works locally with/without the arguments
- access logging and TLS listener tests get skipped when the options are not specified
- make e2e-tests locally