### PR TITLE
sort subnets by id

### DIFF
--- a/pkg/networking/subnet_resolver.go
+++ b/pkg/networking/subnet_resolver.go
@@ -156,6 +156,7 @@ func (r *defaultSubnetsResolver) ResolveViaDiscovery(ctx context.Context, opts .
 	if err := r.validateSubnetsMinimalCount(chosenSubnets, subnetLocale, resolveOpts); err != nil {
 		return nil, err
 	}
+	sortSubnetsByID(chosenSubnets)
 	return chosenSubnets, nil
 }
 
@@ -219,7 +220,7 @@ func (r *defaultSubnetsResolver) ResolveViaNameOrIDSlice(ctx context.Context, su
 	if err := r.validateSubnetsMinimalCount(resolvedSubnets, subnetLocale, resolveOpts); err != nil {
 		return nil, err
 	}
-
+	sortSubnetsByID(resolvedSubnets)
 	return resolvedSubnets, nil
 }
 
@@ -289,4 +290,11 @@ func buildSDKSubnetLocaleType(subnet *ec2sdk.Subnet) subnetLocaleType {
 	}
 	// TODO: add localZone as well once we have fixed logic to compute whether it's localZone.
 	return subnetLocaleTypeAvailabilityZone
+}
+
+// sortSubnetsByID sorts given subnets slice by subnetID.
+func sortSubnetsByID(subnets []*ec2sdk.Subnet) {
+	sort.Slice(subnets, func(i, j int) bool {
+		return awssdk.StringValue(subnets[i].SubnetId) < awssdk.StringValue(subnets[j].SubnetId)
+	})
 }

--- a/pkg/networking/subnet_resolver_test.go
+++ b/pkg/networking/subnet_resolver_test.go
@@ -944,3 +944,74 @@ func Test_buildSDKSubnetLocaleType(t *testing.T) {
 		})
 	}
 }
+
+func Test_sortSubnetsByID(t *testing.T) {
+	type args struct {
+		subnets []*ec2sdk.Subnet
+	}
+	tests := []struct {
+		name        string
+		args        args
+		wantSubnets []*ec2sdk.Subnet
+	}{
+		{
+			name: "subnets already sorted",
+			args: args{
+				subnets: []*ec2sdk.Subnet{
+					{
+						SubnetId: awssdk.String("subnet-a"),
+					},
+					{
+						SubnetId: awssdk.String("subnet-b"),
+					}, {
+						SubnetId: awssdk.String("subnet-c"),
+					},
+				},
+			},
+			wantSubnets: []*ec2sdk.Subnet{
+				{
+					SubnetId: awssdk.String("subnet-a"),
+				},
+				{
+					SubnetId: awssdk.String("subnet-b"),
+				}, {
+					SubnetId: awssdk.String("subnet-c"),
+				},
+			},
+		},
+		{
+			name: "subnets not sorted",
+			args: args{
+				subnets: []*ec2sdk.Subnet{
+					{
+						SubnetId: awssdk.String("subnet-c"),
+					},
+					{
+						SubnetId: awssdk.String("subnet-b"),
+					},
+					{
+						SubnetId: awssdk.String("subnet-a"),
+					},
+				},
+			},
+			wantSubnets: []*ec2sdk.Subnet{
+				{
+					SubnetId: awssdk.String("subnet-a"),
+				},
+				{
+					SubnetId: awssdk.String("subnet-b"),
+				},
+				{
+					SubnetId: awssdk.String("subnet-c"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			subnetsClone := append(tt.args.subnets[:0:0], tt.args.subnets...)
+			sortSubnetsByID(subnetsClone)
+			assert.Equal(t, tt.wantSubnets, subnetsClone)
+		})
+	}
+}


### PR DESCRIPTION
sort subnets by id in subnetDiscovery, so that the subnets are returned in a determined order.