### PR TITLE
Add support for NodeSelector in TargetGroupBindings

### DIFF
--- a/apis/elbv2/v1beta1/targetgroupbinding_types.go
+++ b/apis/elbv2/v1beta1/targetgroupbinding_types.go
@@ -127,6 +127,10 @@ type TargetGroupBindingSpec struct {
 	// networking defines the networking rules to allow ELBV2 LoadBalancer to access targets in TargetGroup.
 	// +optional
 	Networking *TargetGroupBindingNetworking `json:"networking,omitempty"`
+
+	// node selector for instance type target groups to only register certain nodes
+	// +optional
+	NodeSelector *metav1.LabelSelector `json:"nodeSelector,omitempty"`
 }
 
 // TargetGroupBindingStatus defines the observed state of TargetGroupBinding

--- a/apis/elbv2/v1beta1/zz_generated.deepcopy.go
+++ b/apis/elbv2/v1beta1/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -243,6 +244,11 @@ func (in *TargetGroupBindingSpec) DeepCopyInto(out *TargetGroupBindingSpec) {
 	if in.Networking != nil {
 		in, out := &in.Networking, &out.Networking
 		*out = new(TargetGroupBindingNetworking)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.NodeSelector != nil {
+		in, out := &in.NodeSelector, &out.NodeSelector
+		*out = new(v1.LabelSelector)
 		(*in).DeepCopyInto(*out)
 	}
 }

--- a/config/crd/bases/elbv2.k8s.aws_targetgroupbindings.yaml
+++ b/config/crd/bases/elbv2.k8s.aws_targetgroupbindings.yaml
@@ -40,143 +40,262 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
-  validation:
-    openAPIV3Schema:
-      description: TargetGroupBinding is the Schema for the TargetGroupBinding API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: TargetGroupBindingSpec defines the desired state of TargetGroupBinding
-          properties:
-            networking:
-              description: networking provides the networking setup for ELBV2 LoadBalancer
-                to access targets in TargetGroup.
-              properties:
-                ingress:
-                  description: List of ingress rules to allow ELBV2 LoadBalancer to
-                    access targets in TargetGroup.
-                  items:
-                    properties:
-                      from:
-                        description: List of peers which should be able to access
-                          the targets in TargetGroup. At least one NetworkingPeer
-                          should be specified.
-                        items:
-                          description: NetworkingPeer defines the source/destination
-                            peer for networking rules.
-                          properties:
-                            ipBlock:
-                              description: IPBlock defines an IPBlock peer. If specified,
-                                none of the other fields can be set.
-                              properties:
-                                cidr:
-                                  description: CIDR is the network CIDR. Both IPV4
-                                    or IPV6 CIDR are accepted.
-                                  type: string
-                              required:
-                              - cidr
-                              type: object
-                            securityGroup:
-                              description: SecurityGroup defines a SecurityGroup peer.
-                                If specified, none of the other fields can be set.
-                              properties:
-                                groupID:
-                                  description: GroupID is the EC2 SecurityGroupID.
-                                  type: string
-                              required:
-                              - groupID
-                              type: object
-                          type: object
-                        type: array
-                      ports:
-                        description: List of ports which should be made accessible
-                          on the targets in TargetGroup. If ports is empty or unspecified,
-                          it defaults to all ports with TCP.
-                        items:
-                          properties:
-                            port:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              description: The port which traffic must match. When
-                                NodePort endpoints(instance TargetType) is used, this
-                                must be a numerical port. When Port endpoints(ip TargetType)
-                                is used, this can be either numerical or named port
-                                on pods. if port is unspecified, it defaults to all
-                                ports.
-                              x-kubernetes-int-or-string: true
-                            protocol:
-                              description: The protocol which traffic must match.
-                                If protocol is unspecified, it defaults to TCP.
-                              enum:
-                              - TCP
-                              - UDP
-                              type: string
-                          type: object
-                        type: array
-                    required:
-                    - from
-                    - ports
-                    type: object
-                  type: array
-              type: object
-            serviceRef:
-              description: serviceRef is a reference to a Kubernetes Service and ServicePort.
-              properties:
-                name:
-                  description: Name is the name of the Service.
-                  type: string
-                port:
-                  anyOf:
-                  - type: integer
-                  - type: string
-                  description: Port is the port of the ServicePort.
-                  x-kubernetes-int-or-string: true
-              required:
-              - name
-              - port
-              type: object
-            targetGroupARN:
-              description: targetGroupARN is the Amazon Resource Name (ARN) for the
-                TargetGroup.
-              type: string
-            targetType:
-              description: targetType is the TargetType of TargetGroup. If unspecified,
-                it will be automatically inferred.
-              enum:
-              - instance
-              - ip
-              type: string
-          required:
-          - serviceRef
-          - targetGroupARN
-          type: object
-        status:
-          description: TargetGroupBindingStatus defines the observed state of TargetGroupBinding
-          properties:
-            observedGeneration:
-              description: The generation observed by the TargetGroupBinding controller.
-              format: int64
-              type: integer
-          type: object
-      type: object
   version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TargetGroupBinding is the Schema for the TargetGroupBinding API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TargetGroupBindingSpec defines the desired state of TargetGroupBinding
+            properties:
+              networking:
+                description: networking provides the networking setup for ELBV2 LoadBalancer to access targets in TargetGroup.
+                properties:
+                  ingress:
+                    description: List of ingress rules to allow ELBV2 LoadBalancer to access targets in TargetGroup.
+                    items:
+                      properties:
+                        from:
+                          description: List of peers which should be able to access the targets in TargetGroup. At least one NetworkingPeer should be specified.
+                          items:
+                            description: NetworkingPeer defines the source/destination peer for networking rules.
+                            properties:
+                              ipBlock:
+                                description: IPBlock defines an IPBlock peer. If specified, none of the other fields can be set.
+                                properties:
+                                  cidr:
+                                    description: CIDR is the network CIDR. Both IPV4 or IPV6 CIDR are accepted.
+                                    type: string
+                                required:
+                                - cidr
+                                type: object
+                              securityGroup:
+                                description: SecurityGroup defines a SecurityGroup peer. If specified, none of the other fields can be set.
+                                properties:
+                                  groupID:
+                                    description: GroupID is the EC2 SecurityGroupID.
+                                    type: string
+                                required:
+                                - groupID
+                                type: object
+                            type: object
+                          type: array
+                        ports:
+                          description: List of ports which should be made accessible on the targets in TargetGroup. If ports is empty or unspecified, it defaults to all ports with TCP.
+                          items:
+                            properties:
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: The port which traffic must match. When NodePort endpoints(instance TargetType) is used, this must be a numerical port. When Port endpoints(ip TargetType) is used, this can be either numerical or named port on pods. if port is unspecified, it defaults to all ports.
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                description: The protocol which traffic must match. If protocol is unspecified, it defaults to TCP.
+                                enum:
+                                - TCP
+                                - UDP
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - from
+                      - ports
+                      type: object
+                    type: array
+                type: object
+              serviceRef:
+                description: serviceRef is a reference to a Kubernetes Service and ServicePort.
+                properties:
+                  name:
+                    description: Name is the name of the Service.
+                    type: string
+                  port:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: Port is the port of the ServicePort.
+                    x-kubernetes-int-or-string: true
+                required:
+                - name
+                - port
+                type: object
+              targetGroupARN:
+                description: targetGroupARN is the Amazon Resource Name (ARN) for the TargetGroup.
+                type: string
+              targetType:
+                description: targetType is the TargetType of TargetGroup. If unspecified, it will be automatically inferred.
+                enum:
+                - instance
+                - ip
+                type: string
+            required:
+            - serviceRef
+            - targetGroupARN
+            type: object
+          status:
+            description: TargetGroupBindingStatus defines the observed state of TargetGroupBinding
+            properties:
+              observedGeneration:
+                description: The generation observed by the TargetGroupBinding controller.
+                format: int64
+                type: integer
+            type: object
+        type: object
     served: true
     storage: false
   - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: TargetGroupBinding is the Schema for the TargetGroupBinding API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TargetGroupBindingSpec defines the desired state of TargetGroupBinding
+            properties:
+              networking:
+                description: networking defines the networking rules to allow ELBV2 LoadBalancer to access targets in TargetGroup.
+                properties:
+                  ingress:
+                    description: List of ingress rules to allow ELBV2 LoadBalancer to access targets in TargetGroup.
+                    items:
+                      description: NetworkingIngressRule defines a particular set of traffic that is allowed to access TargetGroup's targets.
+                      properties:
+                        from:
+                          description: List of peers which should be able to access the targets in TargetGroup. At least one NetworkingPeer should be specified.
+                          items:
+                            description: NetworkingPeer defines the source/destination peer for networking rules.
+                            properties:
+                              ipBlock:
+                                description: IPBlock defines an IPBlock peer. If specified, none of the other fields can be set.
+                                properties:
+                                  cidr:
+                                    description: CIDR is the network CIDR. Both IPV4 or IPV6 CIDR are accepted.
+                                    type: string
+                                required:
+                                - cidr
+                                type: object
+                              securityGroup:
+                                description: SecurityGroup defines a SecurityGroup peer. If specified, none of the other fields can be set.
+                                properties:
+                                  groupID:
+                                    description: GroupID is the EC2 SecurityGroupID.
+                                    type: string
+                                required:
+                                - groupID
+                                type: object
+                            type: object
+                          type: array
+                        ports:
+                          description: List of ports which should be made accessible on the targets in TargetGroup. If ports is empty or unspecified, it defaults to all ports with TCP.
+                          items:
+                            description: NetworkingPort defines the port and protocol for networking rules.
+                            properties:
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: The port which traffic must match. When NodePort endpoints(instance TargetType) is used, this must be a numerical port. When Port endpoints(ip TargetType) is used, this can be either numerical or named port on pods. if port is unspecified, it defaults to all ports.
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                description: The protocol which traffic must match. If protocol is unspecified, it defaults to TCP.
+                                enum:
+                                - TCP
+                                - UDP
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - from
+                      - ports
+                      type: object
+                    type: array
+                type: object
+              nodeSelector:
+                description: node selector for instance type target groups to only register certain nodes
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              serviceRef:
+                description: serviceRef is a reference to a Kubernetes Service and ServicePort.
+                properties:
+                  name:
+                    description: Name is the name of the Service.
+                    type: string
+                  port:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: Port is the port of the ServicePort.
+                    x-kubernetes-int-or-string: true
+                required:
+                - name
+                - port
+                type: object
+              targetGroupARN:
+                description: targetGroupARN is the Amazon Resource Name (ARN) for the TargetGroup.
+                type: string
+              targetType:
+                description: targetType is the TargetType of TargetGroup. If unspecified, it will be automatically inferred.
+                enum:
+                - instance
+                - ip
+                type: string
+            required:
+            - serviceRef
+            - targetGroupARN
+            type: object
+          status:
+            description: TargetGroupBindingStatus defines the observed state of TargetGroupBinding
+            properties:
+              observedGeneration:
+                description: The generation observed by the TargetGroupBinding controller.
+                format: int64
+                type: integer
+            type: object
+        type: object
     served: true
     storage: true
 status:

--- a/controllers/elbv2/eventhandlers/node.go
+++ b/controllers/elbv2/eventhandlers/node.go
@@ -2,6 +2,7 @@ package eventhandlers
 
 import (
 	"context"
+
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -79,7 +80,11 @@ func (h *enqueueRequestsForNodeEvent) enqueueImpactedTargetGroupBindings(queue w
 			continue
 		}
 
-		nodeSelector := backend.GetTrafficProxyNodeSelector(&tgb)
+		nodeSelector, err := backend.GetTrafficProxyNodeSelector(&tgb)
+		if err != nil {
+			h.logger.Error(err, "failed to get nodeSelector", "TargetGroupBinding", tgb)
+			return
+		}
 
 		nodeOldIsTrafficProxy := false
 		nodeNewIsTrafficProxy := false

--- a/docs/guide/targetgroupbinding/targetgroupbinding.md
+++ b/docs/guide/targetgroupbinding/targetgroupbinding.md
@@ -18,7 +18,7 @@ TargetGroupBinding CR supports TargetGroups of either `instance` or `ip` TargetT
 
 
 ## Sample YAML
-```
+```yaml
 apiVersion: elbv2.k8s.aws/v1beta1
 kind: TargetGroupBinding
 metadata:
@@ -30,5 +30,47 @@ spec:
   targetGroupARN: <arn-to-targetGroup>
 ```
 
+
+## NodeSelector
+
+### Default Node Selector
+
+For `TargetType: instance`, all nodes of a cluster that match the following
+selector are added to the target group by default:
+
+```yaml
+matchExpressions:
+  - key: node-role.kubernetes.io/master
+    operator: DoesNotExist
+  - key: node.kubernetes.io/exclude-from-external-load-balancers
+    operator: DoesNotExist
+  - key: alpha.service-controller.kubernetes.io/exclude-balancer
+    operator: DoesNotExist
+  - key: eks.amazonaws.com/compute-type
+    operator: NotIn
+    values: ["fargate"]
+```
+
+### Custom Node Selector
+
+TargetGroupBinding CR supports `NodeSelector` which is a
+[LabelSelector][LabelSelector]. This will select nodes to attach to the
+`instance` TargetType target group and **override the default**.
+
+```yaml
+apiVersion: elbv2.k8s.aws/v1beta1
+kind: TargetGroupBinding
+metadata:
+  name: my-tgb
+spec:
+  nodeSelector:
+    matchLabels:
+      foo: bar
+  ...
+```
+
+
 ## Reference
 See the [reference](./spec.md) for TargetGroupBinding CR
+
+[LabelSelector]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#labelselector-v1-meta

--- a/docs/guide/targetgroupbinding/targetgroupbinding.md
+++ b/docs/guide/targetgroupbinding/targetgroupbinding.md
@@ -55,7 +55,8 @@ matchExpressions:
 
 TargetGroupBinding CR supports `NodeSelector` which is a
 [LabelSelector][LabelSelector]. This will select nodes to attach to the
-`instance` TargetType target group and **override the default**.
+`instance` TargetType target group and **is merged with the default node
+selector above**.
 
 ```yaml
 apiVersion: elbv2.k8s.aws/v1beta1

--- a/pkg/backend/endpoint_utils.go
+++ b/pkg/backend/endpoint_utils.go
@@ -40,8 +40,17 @@ var (
 
 // GetTrafficProxyNodeSelector returns the trafficProxy node label selector for specific targetGroupBinding.
 func GetTrafficProxyNodeSelector(tgb *elbv2api.TargetGroupBinding) (labels.Selector, error) {
-	if tgb.Spec.NodeSelector != nil {
-		return metav1.LabelSelectorAsSelector(tgb.Spec.NodeSelector)
+	selector, err := metav1.LabelSelectorAsSelector(&defaultTrafficProxyNodeLabelSelector)
+	if err != nil {
+		return nil, err
 	}
-	return metav1.LabelSelectorAsSelector(&defaultTrafficProxyNodeLabelSelector)
+	if tgb.Spec.NodeSelector != nil {
+		customSelector, err := metav1.LabelSelectorAsSelector(tgb.Spec.NodeSelector)
+		if err != nil {
+			return nil, err
+		}
+		req, _ := customSelector.Requirements()
+		selector = selector.Add(req...)
+	}
+	return selector, nil
 }

--- a/pkg/backend/endpoint_utils.go
+++ b/pkg/backend/endpoint_utils.go
@@ -14,6 +14,7 @@ const (
 )
 
 var (
+	// Remember to update docs/guide/targetgroupbinding/targetgroupbinding.md if changing
 	defaultTrafficProxyNodeLabelSelector = metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{
 			{
@@ -38,8 +39,9 @@ var (
 )
 
 // GetTrafficProxyNodeSelector returns the trafficProxy node label selector for specific targetGroupBinding.
-func GetTrafficProxyNodeSelector(_ *elbv2api.TargetGroupBinding) labels.Selector {
-	// TODO: consider expose nodeSelector on targetGroupBindings, so users can optionally specify different nodes for different tgbs.
-	selector, _ := metav1.LabelSelectorAsSelector(&defaultTrafficProxyNodeLabelSelector)
-	return selector
+func GetTrafficProxyNodeSelector(tgb *elbv2api.TargetGroupBinding) (labels.Selector, error) {
+	if tgb.Spec.NodeSelector != nil {
+		return metav1.LabelSelectorAsSelector(tgb.Spec.NodeSelector)
+	}
+	return metav1.LabelSelectorAsSelector(&defaultTrafficProxyNodeLabelSelector)
 }

--- a/pkg/backend/endpoint_utils_test.go
+++ b/pkg/backend/endpoint_utils_test.go
@@ -11,12 +11,21 @@ import (
 	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
 )
 
+func TestDefaultTrafficProxyNodeLabelSelector(t *testing.T) {
+	// Test that the default is able to be converted into a label selector
+	_, err := metav1.LabelSelectorAsSelector(&defaultTrafficProxyNodeLabelSelector)
+	assert.NoError(t, err)
+}
+
 func TestGetTrafficProxyNodeSelector(t *testing.T) {
 	// Set up the labels.Selector expected objects
 	defaultSelector, _ := metav1.LabelSelectorAsSelector(&defaultTrafficProxyNodeLabelSelector)
+	reqs, _ := defaultSelector.Requirements()
+
 	customSelector := labels.NewSelector()
 	req, _ := labels.NewRequirement("key", selection.Equals, []string{"value"})
 	customSelector = customSelector.Add(*req)
+	customSelector = customSelector.Add(reqs...) // add default selector rules as well
 
 	tests := []struct {
 		name               string

--- a/webhooks/elbv2/targetgroupbinding_validator_test.go
+++ b/webhooks/elbv2/targetgroupbinding_validator_test.go
@@ -2,11 +2,13 @@ package elbv2
 
 import (
 	"context"
+	"testing"
+
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"testing"
 )
 
 func Test_targetGroupBindingValidator_ValidateCreate(t *testing.T) {
@@ -14,6 +16,7 @@ func Test_targetGroupBindingValidator_ValidateCreate(t *testing.T) {
 		obj *elbv2api.TargetGroupBinding
 	}
 	instanceTargetType := elbv2api.TargetTypeInstance
+	ipTargetType := elbv2api.TargetTypeIP
 	tests := []struct {
 		name    string
 		args    args
@@ -43,6 +46,18 @@ func Test_targetGroupBindingValidator_ValidateCreate(t *testing.T) {
 			},
 			wantErr: nil,
 		},
+		{
+			name: "[err] targetType is ip, nodeSelector is set",
+			args: args{
+				obj: &elbv2api.TargetGroupBinding{
+					Spec: elbv2api.TargetGroupBindingSpec{
+						TargetType:   &ipTargetType,
+						NodeSelector: &v1.LabelSelector{},
+					},
+				},
+			},
+			wantErr: errors.New("TargetGroupBinding cannot set NodeSelector when TargetType is ip"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -61,6 +76,7 @@ func Test_targetGroupBindingValidator_ValidateCreate(t *testing.T) {
 
 func Test_targetGroupBindingValidator_ValidateUpdate(t *testing.T) {
 	instanceTargetType := elbv2api.TargetTypeInstance
+	ipTargetType := elbv2api.TargetTypeIP
 	type args struct {
 		obj    *elbv2api.TargetGroupBinding
 		oldObj *elbv2api.TargetGroupBinding
@@ -105,6 +121,40 @@ func Test_targetGroupBindingValidator_ValidateUpdate(t *testing.T) {
 				},
 			},
 			wantErr: errors.New("TargetGroupBinding update may not change these fields: spec.targetGroupARN"),
+		},
+		{
+			name: "[err] targetType is ip, nodeSelector is set",
+			args: args{
+				obj: &elbv2api.TargetGroupBinding{
+					Spec: elbv2api.TargetGroupBindingSpec{
+						TargetType:   &ipTargetType,
+						NodeSelector: &v1.LabelSelector{},
+					},
+				},
+				oldObj: &elbv2api.TargetGroupBinding{
+					Spec: elbv2api.TargetGroupBindingSpec{
+						TargetType:   &ipTargetType,
+						NodeSelector: &v1.LabelSelector{},
+					},
+				},
+			},
+			wantErr: errors.New("TargetGroupBinding cannot set NodeSelector when TargetType is ip"),
+		},
+		{
+			name: "[ok] no update to spec",
+			args: args{
+				obj: &elbv2api.TargetGroupBinding{
+					Spec: elbv2api.TargetGroupBindingSpec{
+						TargetType: &ipTargetType,
+					},
+				},
+				oldObj: &elbv2api.TargetGroupBinding{
+					Spec: elbv2api.TargetGroupBindingSpec{
+						TargetType: &ipTargetType,
+					},
+				},
+			},
+			wantErr: nil,
 		},
 	}
 	for _, tt := range tests {
@@ -299,6 +349,80 @@ func Test_targetGroupBindingValidator_checkImmutableFields(t *testing.T) {
 				logger: &log.NullLogger{},
 			}
 			err := v.checkImmutableFields(tt.args.tgb, tt.args.oldTGB)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_targetGroupBindingValidator_checkNodeSelector(t *testing.T) {
+	type args struct {
+		tgb *elbv2api.TargetGroupBinding
+	}
+	instanceTargetType := elbv2api.TargetTypeInstance
+	ipTargetType := elbv2api.TargetTypeIP
+	nodeSelector := v1.LabelSelector{}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr error
+	}{
+		{
+			name: "[ok] targetType is ip, nodeSelector is nil",
+			args: args{
+				tgb: &elbv2api.TargetGroupBinding{
+					Spec: elbv2api.TargetGroupBindingSpec{
+						TargetType: &ipTargetType,
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "[ok] targetType is instance, nodeSelector is nil",
+			args: args{
+				tgb: &elbv2api.TargetGroupBinding{
+					Spec: elbv2api.TargetGroupBindingSpec{
+						TargetType: &instanceTargetType,
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "[ok] targetType is instance, nodeSelector is set",
+			args: args{
+				tgb: &elbv2api.TargetGroupBinding{
+					Spec: elbv2api.TargetGroupBindingSpec{
+						TargetType:   &instanceTargetType,
+						NodeSelector: &nodeSelector,
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "[err] targetType is ip, nodeSelector is set",
+			args: args{
+				tgb: &elbv2api.TargetGroupBinding{
+					Spec: elbv2api.TargetGroupBindingSpec{
+						TargetType:   &ipTargetType,
+						NodeSelector: &nodeSelector,
+					},
+				},
+			},
+			wantErr: errors.New("TargetGroupBinding cannot set NodeSelector when TargetType is ip"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &targetGroupBindingValidator{
+				logger: &log.NullLogger{},
+			}
+			err := v.checkNodeSelector(tt.args.tgb)
 			if tt.wantErr != nil {
 				assert.EqualError(t, err, tt.wantErr.Error())
 			} else {


### PR DESCRIPTION
# Summary

- fixes https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/1575
- add optional`NodeSelector` to `TargetGroupBindingSpec `
- does not add support for ingress or service annotation at this time, can be added later.
- Update validating webhook to ensure that `NodeSelector` is only set when `TargetType: instance`
- Update tests for validating webhook
  - update tests for ValidateCreate
  - update tests for ValidateUpdate
  - add tests for checkNodeSelector
- Update `GetTrafficProxyNodeSelector`
  -  to use `NodeSelector` is set, fallback to default
  - return an error
  - update all usages of this function to check for error
- Add tests for `GetTrafficProxyNodeSelector` 
- Update docs in `docs/guide/targetgroupbinding/targetgroupbinding.md`