### PR TITLE
docs: update iam service account creation command

### DIFF
--- a/docs/deploy/installation.md
+++ b/docs/deploy/installation.md
@@ -41,6 +41,7 @@ The IAM permissions can either be setup via IAM roles for ServiceAccount or can 
     --namespace=kube-system \
     --name=aws-load-balancer-controller \
     --attach-policy-arn=arn:aws:iam::<AWS_ACCOUNT_ID>:policy/AWSLoadBalancerControllerIAMPolicy \
+    --override-existing-serviceaccounts \
     --approve
     ```
 Setup IAM manually


### PR DESCRIPTION
Keep the sig doc consistent with documentation from AWS public documentations
https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html
--override-existing-serviceaccounts flag is required if service account is already in the cluster