### PR TITLE
fix test script by reorder go get command

### DIFF
--- a/scripts/ci_e2e_test.sh
+++ b/scripts/ci_e2e_test.sh
@@ -255,11 +255,10 @@ cleanup() {
 #
 #######################################
 main() {
-  go get github.com/mikefarah/yq/v4
-  go get github.com/onsi/ginkgo/ginkgo
-
   build_push_controller_image
 
+  go get github.com/mikefarah/yq/v4
+  go get github.com/onsi/ginkgo/ginkgo
   trap "cleanup" EXIT
   setup_cluster
   setup_controller_iam_sa


### PR DESCRIPTION
reorder the go get commands(used to install tools) to after docker image build. (the docker image build cannot upgrade go.mod and go.sum).

after go1.16 is released, we can use go install to install tools without touch go.mod.