### PR TITLE
add IAM permission that needed by when using with outpost+coIP pool

### DIFF
--- a/docs/install/iam_policy.json
+++ b/docs/install/iam_policy.json
@@ -14,6 +14,8 @@
                 "ec2:DescribeInstances",
                 "ec2:DescribeNetworkInterfaces",
                 "ec2:DescribeTags",
+                "ec2:GetCoipPoolUsage",
+                "ec2:DescribeCoipPools",
                 "elasticloadbalancing:DescribeLoadBalancers",
                 "elasticloadbalancing:DescribeLoadBalancerAttributes",
                 "elasticloadbalancing:DescribeListeners",

--- a/docs/install/iam_policy_cn.json
+++ b/docs/install/iam_policy_cn.json
@@ -14,6 +14,8 @@
                 "ec2:DescribeInstances",
                 "ec2:DescribeNetworkInterfaces",
                 "ec2:DescribeTags",
+                "ec2:GetCoipPoolUsage",
+                "ec2:DescribeCoipPools",
                 "elasticloadbalancing:DescribeLoadBalancers",
                 "elasticloadbalancing:DescribeLoadBalancerAttributes",
                 "elasticloadbalancing:DescribeListeners",


### PR DESCRIPTION
When creating ALB on outpost with COIP pool, two additional iam permission is needed:
* `ec2:GetCoipPoolUsage`
* `ec2:DescribeCoipPools`
Fix https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/1761