### PR TITLE
State supported target-type more clearly in pod readiness gate documentation

### DIFF
--- a/docs/deploy/pod_readiness_gate.md
+++ b/docs/deploy/pod_readiness_gate.md
@@ -2,7 +2,8 @@
 
 AWS Load Balancer controller supports [»Pod readiness gates«](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-readiness-gate) to indicate that pod is registered to the ALB/NLB and healthy to receive traffic.
 The controller automatically injects the necessary readiness gate configuration to the pod spec via mutating webhook during pod creation.
-For readiness gate configuration to be injected to the pod spec, you need to apply the label `elbv2.k8s.aws/pod-readiness-gate-inject: enabled` to the pod namespace.
+
+For readiness gate configuration to be injected to the pod spec, you need to apply the label `elbv2.k8s.aws/pod-readiness-gate-inject: enabled` to the pod namespace. However, note that this only works with `target-type: ip`, since when using `target-type: instance`, it's the node used as backend, the ALB itself is not aware of pod/podReadiness in such case.
 
 The pod readiness gate is needed under certain circumstances to achieve full zero downtime rolling deployments. Consider the following example:
 


### PR DESCRIPTION
Because I spent too much time trying to figure out why pod readiness gates weren't being injected when I had `target-type: instance` all along. 🤦🏽‍♂️ 😅 

Closes https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/1814.