### PR TITLE
Doc update for NLB-IP prereq

### DIFF
--- a/docs/guide/service/nlb_ip_mode.md
+++ b/docs/guide/service/nlb_ip_mode.md
@@ -4,7 +4,7 @@ AWS Load Balancer Controller supports Network Load Balancer (NLB) with IP target
 ## Prerequisites
 * AWS LoadBalancer Controller >= v2.0.0
 * Kubernetes >= v1.15 for Service type NodePort.
-* Kubernetes >= v1.20 or EKS >= 1.18 for Service type LoadBalancer.
+* Kubernetes >= v1.20 or EKS >= 1.16 for Service type LoadBalancer.
 * Pods have native AWS VPC networking configured, see [Amazon VPC CNI plugin](https://github.com/aws/amazon-vpc-cni-k8s)
 
 ## Configuration


### PR DESCRIPTION
Recent platform releases of EKS 1.16 and later supports Service of type LoadBalancer for NLB-IP. Update NLB-IP prereq in the doc to reflect this.