### PR TITLE
Add health check SG rule from VPC if preserve client IP is configured

### DIFF
--- a/pkg/service/model_build_target_group.go
+++ b/pkg/service/model_build_target_group.go
@@ -370,7 +370,7 @@ func (t *defaultModelBuildTask) buildTargetGroupBindingNetworking(ctx context.Co
 			},
 		},
 	}
-	if tgProtocol == corev1.ProtocolUDP || (hcPort.String() != healthCheckPortTrafficPort && hcPort.IntValue() != tgPort.IntValue()) {
+	if preserveClientIP || tgProtocol == corev1.ProtocolUDP || (hcPort.String() != healthCheckPortTrafficPort && hcPort.IntValue() != tgPort.IntValue()) {
 		var healthCheckPorts []elbv2api.NetworkingPort
 		networkingProtocolTCP := elbv2api.NetworkingProtocolTCP
 		networkingHealthCheckPort := hcPort

--- a/pkg/service/model_build_target_group_test.go
+++ b/pkg/service/model_build_target_group_test.go
@@ -519,6 +519,26 @@ func Test_defaultModelBuilderTask_buildTargetGroupBindingNetworking(t *testing.T
 							},
 						},
 					},
+					{
+						From: []elbv2.NetworkingPeer{
+							{
+								IPBlock: &elbv2api.IPBlock{
+									CIDR: "172.16.0.0/19",
+								},
+							},
+							{
+								IPBlock: &elbv2api.IPBlock{
+									CIDR: "1.2.3.4/19",
+								},
+							},
+						},
+						Ports: []elbv2api.NetworkingPort{
+							{
+								Protocol: &networkingProtocolTCP,
+								Port:     &port80,
+							},
+						},
+					},
 				},
 			},
 		},
@@ -639,6 +659,72 @@ func Test_defaultModelBuilderTask_buildTargetGroupBindingNetworking(t *testing.T
 							{
 								Protocol: &networkingProtocolTCP,
 								Port:     &port808,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "tcp-service with preserve Client IP, hc is traffic port, source range specified ",
+			svc: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					LoadBalancerSourceRanges: []string{"10.0.0.0/16", "1.2.3.4/24"},
+				},
+			},
+			tgPort: port80,
+			hcPort: port80,
+			subnets: []*ec2.Subnet{
+				{
+					CidrBlock: aws.String("172.16.0.0/19"),
+					SubnetId:  aws.String("sn-1"),
+				},
+				{
+					CidrBlock: aws.String("1.2.3.4/19"),
+					SubnetId:  aws.String("sn-2"),
+				},
+			},
+			tgProtocol:       corev1.ProtocolTCP,
+			preserveClientIP: true,
+			want: &elbv2.TargetGroupBindingNetworking{
+				Ingress: []elbv2.NetworkingIngressRule{
+					{
+						From: []elbv2.NetworkingPeer{
+							{
+								IPBlock: &elbv2api.IPBlock{
+									CIDR: "10.0.0.0/16",
+								},
+							},
+							{
+								IPBlock: &elbv2api.IPBlock{
+									CIDR: "1.2.3.4/24",
+								},
+							},
+						},
+						Ports: []elbv2api.NetworkingPort{
+							{
+								Protocol: &networkingProtocolTCP,
+								Port:     &port80,
+							},
+						},
+					},
+					{
+						From: []elbv2.NetworkingPeer{
+							{
+								IPBlock: &elbv2api.IPBlock{
+									CIDR: "172.16.0.0/19",
+								},
+							},
+							{
+								IPBlock: &elbv2api.IPBlock{
+									CIDR: "1.2.3.4/19",
+								},
+							},
+						},
+						Ports: []elbv2api.NetworkingPort{
+							{
+								Protocol: &networkingProtocolTCP,
+								Port:     &port80,
 							},
 						},
 					},

--- a/test/framework/utils/poll.go
+++ b/test/framework/utils/poll.go
@@ -8,5 +8,5 @@ const (
 	PollIntervalLong   = 30 * time.Second
 	PollTimeoutShort   = 1 * time.Minute
 	PollTimeoutMedium  = 5 * time.Minute
-	PollTimeoutLong    = 10 * time.Minute
+	PollTimeoutLong    = 15 * time.Minute
 )


### PR DESCRIPTION
Fixes #1830 

When preserve client IP is configured for NLB, add SG rules to permit traffic from the load balancer subnet CIDRs for the health check traffic.

Testing done
Verified that when preserve client IP is set, SG rules get created for both the source ranges specified in the service spec/annotation and the load balancer subnet CIDRs
