### PR TITLE
Add support for NLB instance mode

### DIFF
--- a/pkg/annotations/constants.go
+++ b/pkg/annotations/constants.go
@@ -71,4 +71,6 @@ const (
 	SvcLBSuffixTargetGroupAttributes         = "aws-load-balancer-target-group-attributes"
 	SvcLBSuffixSubnets                       = "aws-load-balancer-subnets"
 	SvcLBSuffixALPNPolicy                    = "aws-load-balancer-alpn-policy"
+	SvcLBSuffixTargetType                    = "aws-load-balancer-target-type"
+	SvcLBSuffixTargetNodeLabels              = "aws-load-balancer-target-node-labels"
 )

--- a/pkg/deploy/elbv2/target_group_binding_manager.go
+++ b/pkg/deploy/elbv2/target_group_binding_manager.go
@@ -185,6 +185,7 @@ func buildK8sTargetGroupBindingSpec(ctx context.Context, resTGB *elbv2model.Targ
 		}
 		k8sTGBSpec.Networking = &k8sTGBNetworking
 	}
+	k8sTGBSpec.NodeSelector = resTGB.Spec.Template.Spec.NodeSelector
 	return k8sTGBSpec, nil
 }
 

--- a/pkg/model/elbv2/target_group_binding.go
+++ b/pkg/model/elbv2/target_group_binding.go
@@ -97,7 +97,7 @@ type TargetGroupBindingSpec struct {
 	Networking *TargetGroupBindingNetworking `json:"networking,omitempty"`
 
 	// node selector for instance type target groups to only register certain nodes
-	//+optional
+	// +optional
 	NodeSelector *metav1.LabelSelector `json:"nodeSelector,omitempty"`
 }
 

--- a/pkg/model/elbv2/target_group_binding.go
+++ b/pkg/model/elbv2/target_group_binding.go
@@ -95,6 +95,10 @@ type TargetGroupBindingSpec struct {
 	// networking provides the networking setup for ELBV2 LoadBalancer to access targets in TargetGroup.
 	// +optional
 	Networking *TargetGroupBindingNetworking `json:"networking,omitempty"`
+
+	// node selector for instance type target groups to only register certain nodes
+	//+optional
+	NodeSelector *metav1.LabelSelector `json:"nodeSelector,omitempty"`
 }
 
 // Template for TargetGroupBinding Custom Resource.

--- a/pkg/service/model_build_target_group_test.go
+++ b/pkg/service/model_build_target_group_test.go
@@ -13,6 +13,7 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
 	"sort"
+	"strconv"
 	"testing"
 )
 
@@ -161,11 +162,13 @@ func Test_defaultModelBuilderTask_targetGroupAttrs(t *testing.T) {
 func Test_defaultModelBuilderTask_buildTargetHealthCheck(t *testing.T) {
 	trafficPort := intstr.FromString(healthCheckPortTrafficPort)
 	port8888 := intstr.FromInt(8888)
+	port31223 := intstr.FromInt(31223)
 	tests := []struct {
-		testName  string
-		svc       *corev1.Service
-		wantError bool
-		wantValue *elbv2.TargetGroupHealthCheckConfig
+		testName   string
+		svc        *corev1.Service
+		targetType elbv2.TargetType
+		wantError  bool
+		wantValue  *elbv2.TargetGroupHealthCheckConfig
 	}{
 		{
 			testName: "Default config",
@@ -182,6 +185,7 @@ func Test_defaultModelBuilderTask_buildTargetHealthCheck(t *testing.T) {
 				HealthyThresholdCount:   aws.Int64(3),
 				UnhealthyThresholdCount: aws.Int64(3),
 			},
+			targetType: elbv2.TargetTypeIP,
 		},
 		{
 			testName: "With annotations",
@@ -207,6 +211,7 @@ func Test_defaultModelBuilderTask_buildTargetHealthCheck(t *testing.T) {
 				HealthyThresholdCount:   aws.Int64(2),
 				UnhealthyThresholdCount: aws.Int64(2),
 			},
+			targetType: elbv2.TargetTypeInstance,
 		},
 		{
 			testName: "default path",
@@ -226,6 +231,7 @@ func Test_defaultModelBuilderTask_buildTargetHealthCheck(t *testing.T) {
 				HealthyThresholdCount:   aws.Int64(3),
 				UnhealthyThresholdCount: aws.Int64(3),
 			},
+			targetType: elbv2.TargetTypeIP,
 		},
 		{
 			testName: "invalid values",
@@ -241,7 +247,94 @@ func Test_defaultModelBuilderTask_buildTargetHealthCheck(t *testing.T) {
 					},
 				},
 			},
-			wantError: true,
+			targetType: elbv2.TargetTypeIP,
+			wantError:  true,
+		},
+		{
+			testName: "invalid values target type local, instance mode",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol":            "HTTP",
+						"service.beta.kubernetes.io/aws-load-balancer-healthcheck-port":                "invalid",
+						"service.beta.kubernetes.io/aws-load-balancer-healthcheck-interval":            "10",
+						"service.beta.kubernetes.io/aws-load-balancer-healthcheck-timeout":             "30",
+						"service.beta.kubernetes.io/aws-load-balancer-healthcheck-healthy-threshold":   "2",
+						"service.beta.kubernetes.io/aws-load-balancer-healthcheck-unhealthy-threshold": "2",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
+					HealthCheckNodePort:   31223,
+				},
+			},
+			targetType: elbv2.TargetTypeInstance,
+			wantError:  true,
+		},
+		{
+			testName: "traffic policy local, target type IP, default healthcheck",
+			svc: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
+				},
+			},
+			wantError: false,
+			wantValue: &elbv2.TargetGroupHealthCheckConfig{
+				Port:                    &trafficPort,
+				Protocol:                (*elbv2.Protocol)(aws.String(string(elbv2.ProtocolTCP))),
+				IntervalSeconds:         aws.Int64(10),
+				HealthyThresholdCount:   aws.Int64(3),
+				UnhealthyThresholdCount: aws.Int64(3),
+			},
+			targetType: elbv2.TargetTypeIP,
+		},
+		{
+			testName: "traffic policy local, target type Instance, default healthcheck",
+			svc: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
+					HealthCheckNodePort:   31223,
+				},
+			},
+			wantError: false,
+			wantValue: &elbv2.TargetGroupHealthCheckConfig{
+				Port:                    &port31223,
+				Protocol:                (*elbv2.Protocol)(aws.String(string(elbv2.ProtocolHTTP))),
+				Path:                    aws.String("/healthz"),
+				IntervalSeconds:         aws.Int64(10),
+				HealthyThresholdCount:   aws.Int64(2),
+				UnhealthyThresholdCount: aws.Int64(2),
+			},
+			targetType: elbv2.TargetTypeInstance,
+		},
+		{
+			testName: "traffic policy local, target type Instance, override default",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol":            "TCP",
+						"service.beta.kubernetes.io/aws-load-balancer-healthcheck-port":                "8888",
+						"service.beta.kubernetes.io/aws-load-balancer-healthcheck-path":                "/healthz",
+						"service.beta.kubernetes.io/aws-load-balancer-healthcheck-interval":            "10",
+						"service.beta.kubernetes.io/aws-load-balancer-healthcheck-timeout":             "30",
+						"service.beta.kubernetes.io/aws-load-balancer-healthcheck-healthy-threshold":   "5",
+						"service.beta.kubernetes.io/aws-load-balancer-healthcheck-unhealthy-threshold": "5",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
+					HealthCheckNodePort:   31223,
+				},
+			},
+			wantError: false,
+			wantValue: &elbv2.TargetGroupHealthCheckConfig{
+				Port:                    &port8888,
+				Protocol:                (*elbv2.Protocol)(aws.String(string(elbv2.ProtocolTCP))),
+				IntervalSeconds:         aws.Int64(10),
+				HealthyThresholdCount:   aws.Int64(5),
+				UnhealthyThresholdCount: aws.Int64(5),
+			},
+			targetType: elbv2.TargetTypeInstance,
 		},
 	}
 	for _, tt := range tests {
@@ -261,8 +354,16 @@ func Test_defaultModelBuilderTask_buildTargetHealthCheck(t *testing.T) {
 				defaultHealthCheckTimeout:            10,
 				defaultHealthCheckHealthyThreshold:   3,
 				defaultHealthCheckUnhealthyThreshold: 3,
+
+				defaultHealthCheckProtocolForInstanceModeLocal:           elbv2.ProtocolHTTP,
+				defaultHealthCheckPortForInstanceModeLocal:               strconv.FormatInt(int64(int(tt.svc.Spec.HealthCheckNodePort)), 10),
+				defaultHealthCheckPathForInstanceModeLocal:               "/healthz",
+				defaultHealthCheckIntervalForInstanceModeLocal:           10,
+				defaultHealthCheckTimeoutForInstanceModeLocal:            6,
+				defaultHealthCheckHealthyThresholdForInstanceModeLocal:   2,
+				defaultHealthCheckUnhealthyThresholdForInstanceModeLocal: 2,
 			}
-			hc, err := builder.buildTargetGroupHealthCheckConfig(context.Background())
+			hc, err := builder.buildTargetGroupHealthCheckConfig(context.Background(), tt.targetType)
 			if tt.wantError {
 				assert.Error(t, err)
 			} else {
@@ -847,7 +948,7 @@ func Test_defaultModelBuilder_buildTargetType(t *testing.T) {
 		{
 			testName: "empty annotation",
 			svc:      &corev1.Service{},
-			wantErr:  errors.New("unsupported target type"),
+			wantErr:  errors.New("unsupported target type \"\" for load balancer type \"\""),
 		},
 		{
 			testName: "lb type nlb-ip",
@@ -893,7 +994,7 @@ func Test_defaultModelBuilder_buildTargetType(t *testing.T) {
 					},
 				},
 			},
-			wantErr: errors.New("unsupported target type"),
+			wantErr: errors.New("unsupported target type \"\" for load balancer type \"external\""),
 		},
 		{
 			testName: "external, some other target type",
@@ -901,11 +1002,11 @@ func Test_defaultModelBuilder_buildTargetType(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"service.beta.kubernetes.io/aws-load-balancer-type":        "external",
-						"service.beta.kubernetes.io/aws-load-balancer-target-type": "unsupported",
+						"service.beta.kubernetes.io/aws-load-balancer-target-type": "unknown",
 					},
 				},
 			},
-			wantErr: errors.New("unsupported target type"),
+			wantErr: errors.New("unsupported target type \"unknown\" for load balancer type \"external\""),
 		},
 	}
 	for _, tt := range tests {
@@ -1060,7 +1161,7 @@ func Test_defaultModelBuilder_buildTargetGroupHealthCheckPort(t *testing.T) {
 				service:                tt.svc,
 				defaultHealthCheckPort: tt.defaultPort,
 			}
-			got, err := builder.buildTargetGroupHealthCheckPort(context.Background())
+			got, err := builder.buildTargetGroupHealthCheckPort(context.Background(), tt.defaultPort)
 			if tt.wantErr != nil {
 				assert.EqualError(t, err, tt.wantErr.Error())
 			} else {

--- a/pkg/service/model_builder.go
+++ b/pkg/service/model_builder.go
@@ -70,21 +70,16 @@ func (b *defaultModelBuilder) Build(ctx context.Context, service *corev1.Service
 		defaultHealthCheckTimeout:            10,
 		defaultHealthCheckHealthyThreshold:   3,
 		defaultHealthCheckUnhealthyThreshold: 3,
+
+		defaultHealthCheckPortForInstanceModeLocal:               strconv.Itoa(int(service.Spec.HealthCheckNodePort)),
+		defaultHealthCheckProtocolForInstanceModeLocal:           elbv2model.ProtocolHTTP,
+		defaultHealthCheckPathForInstanceModeLocal:               "/healthz",
+		defaultHealthCheckIntervalForInstanceModeLocal:           10,
+		defaultHealthCheckTimeoutForInstanceModeLocal:            6,
+		defaultHealthCheckHealthyThresholdForInstanceModeLocal:   2,
+		defaultHealthCheckUnhealthyThresholdForInstanceModeLocal: 2,
 	}
-	targetType, err := task.buildTargetType(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	if targetType == elbv2model.TargetTypeInstance &&
-		service.Spec.ExternalTrafficPolicy == corev1.ServiceExternalTrafficPolicyTypeLocal {
-		task.defaultHealthCheckPort = strconv.Itoa(int(service.Spec.HealthCheckNodePort))
-		task.defaultHealthCheckProtocol = elbv2model.ProtocolHTTP
-		task.defaultHealthCheckPath = "/healthz"
-		task.defaultHealthCheckInterval = 10
-		task.defaultHealthCheckTimeout = 6
-		task.defaultHealthCheckHealthyThreshold = 2
-		task.defaultHealthCheckUnhealthyThreshold = 2
-	}
+
 	if err := task.run(ctx); err != nil {
 		return nil, nil, err
 	}
@@ -117,6 +112,15 @@ type defaultModelBuildTask struct {
 	defaultHealthCheckTimeout            int64
 	defaultHealthCheckHealthyThreshold   int64
 	defaultHealthCheckUnhealthyThreshold int64
+
+	// Default health check settings for NLB instance mode with spec.ExternalTrafficPolicy set to Local
+	defaultHealthCheckProtocolForInstanceModeLocal           elbv2model.Protocol
+	defaultHealthCheckPortForInstanceModeLocal               string
+	defaultHealthCheckPathForInstanceModeLocal               string
+	defaultHealthCheckIntervalForInstanceModeLocal           int64
+	defaultHealthCheckTimeoutForInstanceModeLocal            int64
+	defaultHealthCheckHealthyThresholdForInstanceModeLocal   int64
+	defaultHealthCheckUnhealthyThresholdForInstanceModeLocal int64
 }
 
 func (t *defaultModelBuildTask) run(ctx context.Context) error {


### PR DESCRIPTION
Fixes: #1744 

## Overview
The support for NLB instance mode is available from the k8s service controller, and any changes or improvements are tied to the upstream release schedule. In addition, there are also limitations on using CRDs in the in-tree controller.

This PR is for adding support for NLB instance mode in the AWS Load balancer controller. The controller already supports instance mode for ALB, and we will build up on  the `TargetGroupBinding` feature for NLB instance mode as well. 

Moving forward, the k8s AWS service controller will have support for NLB instance mode and CLB with basic features only. For more NLB features like the TargetGroupBinding, proxy v2 support, improved health checks, IP target mode we recommend running the AWS load balancer controller. Each service of type LoadBalancer on AWS k8s is reconciled either by the in-tree controller or the external controller based on the annotations provided the version requirements are met.

## k8s version requirement
The instance mode support for service type LoadBalancer requires k8s 1.20 (non-EKS) or later where we've modified the in-tree controller to ignore service with aws-load-balancer-type annotation of `external` or `nlb-ip`. For EKS, we've backported the changes to EKS 1.16 and later releases.

## How to configure load balancer target type?
If the service annotation `service.beta.kubernetes.io/aws-load-balancer-type` is external, this controller will look for an additional annotation `service.beta.kubernetes.io/aws-load-balancer-target-type` to determine the target type. The current supported values for the target types annotation are `nlb-instance` and `nlb-ip`.

### Instance target
Example service spec for instance target
```
kind: Service
apiVersion: v1
metadata:
  name: nlb-svc
  annotations:
    service.beta.kubernetes.io/aws-load-balancer-type: "external"
    service.beta.kubernetes.io/aws-load-balancer-target-type: "nlb-instance"
spec:
  ports:
    - name: port
      port: 80
      targetPort: 80
      protocol: TCP
  type: LoadBalancer
  selector:
    app: instance-mode
```

### IP target
For consistency with instance target mode, IP mode will also be determined based on the following annotations - 
```
service.beta.kubernetes.io/aws-load-balancer-type: external
service.beta.kubernetes.io/aws-load-balancer-target-type: nlb-ip
```
For backwards compatibility, the `service.beta.kubernetes.io/aws-load-balancer-type` annotation value of `nlb-ip` will still be interpreted as IP mode NLB.

### Alternative considered
Modify the in-tree controller to support additional value for the `service.beta.kubernetes.io/aws-load-balancer-type` annotation, for example 
```
service.beta.kubernetes.io/aws-load-balancer-type: nlb-instance
```
Pros:
- Single annotation, and is similar to `nlb-ip`

Cons:
- We have to backport the change to all supported EKS versions, and will be dependent on the patch rollout. This results in different behavior across multiple platform versions and will be more confusing to the end users
- One more patch to the in-tree controller we need to maintain.

## Testing
- Create service of type Load Balancer with instance targets, External Traffic Policy set to Cluster
- Create service of type Load Balancer with instance targets, External Traffic Policy set to Local
- health check annotations get honored
- proxy protocol v2
- preserve client IP can be disabled for instance mode
- Security group rules get added as expected
- The labels specified in`service.beta.kubernetes.io/aws-load-balancer-target-node-labels` annotation works as expected
   - Without this annotation, the default filter gets applied
   - When service is created/edited with this annotaton, only matching nodes get registered
   - On edit, any nodes not matching the labels get de-registered from the target group
   - Node label edits are correctly reconciled