### PR TITLE
add support for ssl-redirect annotation

### DIFF
--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -29,6 +29,7 @@ You can add annotations to kubernetes Ingress and Service objects to customize t
 |[alb.ingress.kubernetes.io/waf-acl-id](#waf-acl-id)|string|N/A|Ingress|Exclusive|
 |[alb.ingress.kubernetes.io/shield-advanced-protection](#shield-advanced-protection)|boolean|N/A|Ingress|Exclusive|
 |[alb.ingress.kubernetes.io/listen-ports](#listen-ports)|json|'[{"HTTP": 80}]' \| '[{"HTTPS": 443}]'|Ingress|Merge|
+|[alb.ingress.kubernetes.io/ssl-redirect](#ssl-redirect)|integer|N/A|Ingress|Exclusive|
 |[alb.ingress.kubernetes.io/inbound-cidrs](#inbound-cidrs)|stringList|0.0.0.0/0, ::/0|Ingress|Exclusive|
 |[alb.ingress.kubernetes.io/certificate-arn](#certificate-arn)|stringList|N/A|Ingress|Merge|
 |[alb.ingress.kubernetes.io/ssl-policy](#ssl-policy)|string|ELBSecurityPolicy-2016-08|Ingress|Exclusive|
@@ -116,6 +117,22 @@ Traffic Listening can be controlled with following annotations:
     !!!example
         ```
         alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}, {"HTTP": 8080}, {"HTTPS": 8443}]'
+        ```
+  
+- <a name="ssl-redirect">`alb.ingress.kubernetes.io/ssl-redirect`</a> enables SSLRedirect and specifies the SSL port that redirects to.
+  
+    !!!note "Merge Behavior"
+        `ssl-redirect` is exclusive across all Ingresses in IngressGroup.
+
+        - Once defined on a single Ingress, it impacts every Ingress within IngressGroup.
+
+    !!!note ""
+        - Once enabled SSLRedirect, every HTTP listener will be configured with default action which redirects to HTTPS, other rules will be ignored.
+        - The SSL port that redirects to must exists on LoadBalancer. See [alb.ingress.kubernetes.io/listen-ports](#listen-ports) for the listen ports configuration.
+
+    !!!example
+        ```
+        alb.ingress.kubernetes.io/ssl-redirect: '443'
         ```
 
 - <a name="ip-address-type">`alb.ingress.kubernetes.io/ip-address-type`</a> specifies the [IP address type](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#ip-address-type) of ALB.

--- a/pkg/annotations/constants.go
+++ b/pkg/annotations/constants.go
@@ -19,6 +19,7 @@ const (
 	IngressSuffixShieldAdvancedProtection     = "shield-advanced-protection"
 	IngressSuffixSecurityGroups               = "security-groups"
 	IngressSuffixListenPorts                  = "listen-ports"
+	IngressSuffixSSLRedirect                  = "ssl-redirect"
 	IngressSuffixInboundCIDRs                 = "inbound-cidrs"
 	IngressSuffixCertificateARN               = "certificate-arn"
 	IngressSuffixSSLPolicy                    = "ssl-policy"

--- a/pkg/ingress/model_build_actions.go
+++ b/pkg/ingress/model_build_actions.go
@@ -2,6 +2,7 @@ package ingress
 
 import (
 	"context"
+	"fmt"
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -238,6 +239,17 @@ func (t *defaultModelBuildTask) build404Action(_ context.Context) elbv2model.Act
 		FixedResponseConfig: &elbv2model.FixedResponseActionConfig{
 			ContentType: awssdk.String("text/plain"),
 			StatusCode:  "404",
+		},
+	}
+}
+
+func (t *defaultModelBuildTask) buildSSLRedirectAction(_ context.Context, sslRedirectConfig SSLRedirectConfig) elbv2model.Action {
+	return elbv2model.Action{
+		Type: elbv2model.ActionTypeRedirect,
+		RedirectConfig: &elbv2model.RedirectActionConfig{
+			Port:       awssdk.String(fmt.Sprintf("%v", sslRedirectConfig.SSLPort)),
+			Protocol:   awssdk.String(string(elbv2model.ProtocolHTTPS)),
+			StatusCode: sslRedirectConfig.StatusCode,
 		},
 	}
 }

--- a/pkg/ingress/model_build_actions_test.go
+++ b/pkg/ingress/model_build_actions_test.go
@@ -248,3 +248,39 @@ func Test_defaultModelBuildTask_buildAuthenticateOIDCAction(t *testing.T) {
 		})
 	}
 }
+
+func Test_defaultModelBuildTask_buildSSLRedirectAction(t *testing.T) {
+	type args struct {
+		sslRedirectConfig SSLRedirectConfig
+	}
+	tests := []struct {
+		name string
+		args args
+		want elbv2model.Action
+	}{
+		{
+			name: "SSLRedirect to 443 with 301",
+			args: args{
+				sslRedirectConfig: SSLRedirectConfig{
+					SSLPort:    443,
+					StatusCode: "HTTP_301",
+				},
+			},
+			want: elbv2model.Action{
+				Type: elbv2model.ActionTypeRedirect,
+				RedirectConfig: &elbv2model.RedirectActionConfig{
+					Port:       awssdk.String("443"),
+					Protocol:   awssdk.String("HTTPS"),
+					StatusCode: "HTTP_301",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t1 *testing.T) {
+			task := &defaultModelBuildTask{}
+			got := task.buildSSLRedirectAction(context.Background(), tt.args.sslRedirectConfig)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/ingress/model_build_listener.go
+++ b/pkg/ingress/model_build_listener.go
@@ -49,6 +49,10 @@ func (t *defaultModelBuildTask) buildListenerSpec(ctx context.Context, lbARN cor
 }
 
 func (t *defaultModelBuildTask) buildListenerDefaultActions(ctx context.Context, protocol elbv2model.Protocol, ingList []*networking.Ingress) ([]elbv2model.Action, error) {
+	if t.sslRedirectConfig != nil && protocol == elbv2model.ProtocolHTTP {
+		return []elbv2model.Action{t.buildSSLRedirectAction(ctx, *t.sslRedirectConfig)}, nil
+	}
+
 	ingsWithDefaultBackend := make([]*networking.Ingress, 0, len(ingList))
 	for _, ing := range ingList {
 		if ing.Spec.Backend != nil {

--- a/pkg/ingress/model_build_listener_rules.go
+++ b/pkg/ingress/model_build_listener_rules.go
@@ -12,6 +12,10 @@ import (
 )
 
 func (t *defaultModelBuildTask) buildListenerRules(ctx context.Context, lsARN core.StringToken, port int64, protocol elbv2model.Protocol, ingList []*networking.Ingress) error {
+	if t.sslRedirectConfig != nil && protocol == elbv2model.ProtocolHTTP {
+		return nil
+	}
+
 	var rules []Rule
 	for _, ing := range ingList {
 		for _, rule := range ing.Spec.Rules {

--- a/pkg/ingress/ssl_redirect_config.go
+++ b/pkg/ingress/ssl_redirect_config.go
@@ -1,0 +1,9 @@
+package ingress
+
+// SSLRedirectConfig contains configuration for SSLRedirect feature.
+type SSLRedirectConfig struct {
+	// The SSLPort to redirect to for all HTTP port
+	SSLPort int64
+	// The HTTP response code.
+	StatusCode string
+}


### PR DESCRIPTION
# add a new annotation "ssl-redirect" to simply the configuration for HTTP-HTTPS redirect

## What is the problem
1. The current solution (https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/tasks/ssl_redirect/) to configure HTTP→HTTPS redirect via AWSLoadBalancer is complicated and intrusive to customer’s Ingress rules.
2. The current solution (https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/tasks/ssl_redirect/) to configure HTTP→HTTPS redirect via AWSLoadBalancer is not AWS-config compatible.
    1. AWS Config is a AWS service that validates best practices on AWS resource configurations.
    2. with current solution, we’ll have a catch all rule(*path:/**) to do SSL-redirect instead of using the default rule per listener (which AWS config expects).
3. The current solution (https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/tasks/ssl_redirect/) to configure HTTP→HTTPS redirect is tricky, that relies on an implementation detail that the controller will ignore infinite redirect rules.
    1. when generate rules for port 80, the controller inserts the redirect-to-ssl rule as expected.
    2. when generate rules for port 443, the controller ignores the redirect-to-ssl rule as it will be a infinite redirect.

## What will be changed
We’ll introduce a new annotation called “alb.ingress.kubernetes.io/ssl-redirect” to do SSL redirection.
The value of alb.ingress.kubernetes.io/ssl-redirect is simply the SSL port to redirect to. e.g. alb.ingress.kubernetes.io/ssl-redirect: `443`

1. The port must be appears in the listen-port for Ingresses, and must be a HTTPS port.
2. All HTTP port for Ingresses will be redirect to this SSL port under *HTTP_301* redirect.

Note: 

1. currently ALB only supports *HTTP_301* or *HTTP_302* for ** redirect actions. And HTTP_301 is the preferred status_code for HTTP to HTTPS redirection. 
2. There are also a HTTP_308 status code can be used be achieve HTTP to HTTPS redirection. However, ALB currently don’t support it. If ALB supports it in the future, we can add a separate annotation like alb.ingress.kubernetes.io/ssl-redirect-status-code: HTTP_308 to further customize the behavior for advanced users.

Alternative designs considered:

1. we can allow specify both port and status code for the SSL redirect, like alb.ingress.kubernetes.io/ssl-redirect: '{"port":443, "status_code": "HTTP_301"}'
    1. pros: more flexible since we can have more settings like status_code.
    2. cons: more complicated to configure.

