### PR TITLE
Change check for remove regacy readiness gate

### DIFF
--- a/pkg/inject/pod_readiness_gate.go
+++ b/pkg/inject/pod_readiness_gate.go
@@ -38,14 +38,17 @@ func (m *PodReadinessGate) Mutate(ctx context.Context, pod *corev1.Pod) error {
 	if !m.config.EnablePodReadinessGateInject {
 		return nil
 	}
-	// legacy readiness gates are removed for maintaining backwards compatibility.
-	m.removeLegacyTargetHealthReadinessGates(ctx, pod)
 
 	// see https://github.com/kubernetes/kubernetes/issues/88282 and https://github.com/kubernetes/kubernetes/issues/76680
 	req := webhook.ContextGetAdmissionRequest(ctx)
 	targetHealthCondTypes, err := m.computeTargetHealthReadinessGateConditionTypes(ctx, req.Namespace, pod)
 	if err != nil {
 		return err
+	}
+
+	if len(targetHealthCondTypes) > 0 {
+		// legacy readiness gates are removed for maintaining backwards compatibility.
+		m.removeLegacyTargetHealthReadinessGates(ctx, pod)
 	}
 
 	for _, condType := range targetHealthCondTypes {


### PR DESCRIPTION
https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/1782

If `targetHealthCondTypes` is empty, target pod is out of the control of v2, so `recagy rediness gate` is not should not be removed.