### PR TITLE
Fixed an issue where mergedTLSCerts would be sorted.

### DIFF
--- a/pkg/deploy/elbv2/listener_manager_test.go
+++ b/pkg/deploy/elbv2/listener_manager_test.go
@@ -66,6 +66,60 @@ func Test_isSDKListenerSettingsDrifted(t *testing.T) {
 			},
 		},
 		{
+			name: "listener hasn't drifted if multiple acm specified",
+			args: args{
+				lsSpec: elbv2model.ListenerSpec{
+					Port:       80,
+					Protocol:   elbv2model.ProtocolHTTPS,
+					SSLPolicy:  awssdk.String("ELBSecurityPolicy-FS-1-2-Res-2019-08"),
+					ALPNPolicy: []string{"HTTP2Preferred"},
+					Certificates: []elbv2model.Certificate{
+						{
+							CertificateARN: awssdk.String("cert-arn1"),
+						},
+						{
+							CertificateARN: awssdk.String("cert-arn2"),
+						},
+					},
+				},
+				sdkLS: &elbv2sdk.Listener{
+					Port:     awssdk.Int64(80),
+					Protocol: awssdk.String("HTTPS"),
+					Certificates: []*elbv2sdk.Certificate{
+						{
+							CertificateArn: awssdk.String("cert-arn1"),
+							IsDefault:      awssdk.Bool(true),
+						},
+					},
+					DefaultActions: []*elbv2sdk.Action{
+						{
+							Type: awssdk.String("fixed-response"),
+							FixedResponseConfig: &elbv2sdk.FixedResponseActionConfig{
+								StatusCode: awssdk.String("404"),
+							},
+						},
+					},
+					SslPolicy:  awssdk.String("ELBSecurityPolicy-FS-1-2-Res-2019-08"),
+					AlpnPolicy: awssdk.StringSlice([]string{"HTTP2Preferred"}),
+				},
+				desiredDefaultCerts: []*elbv2sdk.Certificate{
+					{
+						CertificateArn: awssdk.String("cert-arn1"),
+						IsDefault:      awssdk.Bool(true),
+					},
+				},
+				desiredDefaultActions: []*elbv2sdk.Action{
+					{
+						Type: awssdk.String("fixed-response"),
+						FixedResponseConfig: &elbv2sdk.FixedResponseActionConfig{
+							StatusCode: awssdk.String("404"),
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
 			name: "Ignore ALPN configuration if not specified in model",
 			args: args{
 				lsSpec: elbv2model.ListenerSpec{

--- a/pkg/deploy/elbv2/listener_manager_test.go
+++ b/pkg/deploy/elbv2/listener_manager_test.go
@@ -117,7 +117,6 @@ func Test_isSDKListenerSettingsDrifted(t *testing.T) {
 					},
 				},
 			},
-			want: false,
 		},
 		{
 			name: "Ignore ALPN configuration if not specified in model",

--- a/pkg/ingress/model_build_listener.go
+++ b/pkg/ingress/model_build_listener.go
@@ -78,7 +78,7 @@ func (t *defaultModelBuildTask) buildListenerDefaultActions(ctx context.Context,
 	return t.buildActions(ctx, protocol, ing, enhancedBackend)
 }
 
-// the listen port config for specific Ingress's port
+// the listen port config for specific listener port.
 type listenPortConfig struct {
 	protocol       elbv2model.Protocol
 	inboundCIDRv4s []string

--- a/pkg/ingress/model_builder.go
+++ b/pkg/ingress/model_builder.go
@@ -232,7 +232,7 @@ func (t *defaultModelBuildTask) mergeListenPortConfigs(_ context.Context, listen
 	var mergedSSLPolicyProvider *types.NamespacedName
 	var mergedSSLPolicy *string
 
-	mergedTLSCerts := sets.NewString()
+	var mergedTLSCerts []string
 
 	for ingKey, cfg := range listenPortConfigByIngress {
 		if mergedProtocolProvider == nil {
@@ -267,7 +267,7 @@ func (t *defaultModelBuildTask) mergeListenPortConfigs(_ context.Context, listen
 					*mergedSSLPolicyProvider, awssdk.StringValue(mergedSSLPolicy), ingKey, awssdk.StringValue(cfg.sslPolicy))
 			}
 		}
-		mergedTLSCerts.Insert(cfg.tlsCerts...)
+		mergedTLSCerts = append(mergedTLSCerts, cfg.tlsCerts...)
 	}
 
 	if len(mergedInboundCIDRv4s) == 0 && len(mergedInboundCIDRv6s) == 0 {
@@ -283,7 +283,7 @@ func (t *defaultModelBuildTask) mergeListenPortConfigs(_ context.Context, listen
 		inboundCIDRv4s: mergedInboundCIDRv4s.List(),
 		inboundCIDRv6s: mergedInboundCIDRv6s.List(),
 		sslPolicy:      mergedSSLPolicy,
-		tlsCerts:       mergedTLSCerts.UnsortedList(),
+		tlsCerts:       mergedTLSCerts,
 	}, nil
 }
 

--- a/pkg/ingress/model_builder.go
+++ b/pkg/ingress/model_builder.go
@@ -283,7 +283,7 @@ func (t *defaultModelBuildTask) mergeListenPortConfigs(_ context.Context, listen
 		inboundCIDRv4s: mergedInboundCIDRv4s.List(),
 		inboundCIDRv6s: mergedInboundCIDRv6s.List(),
 		sslPolicy:      mergedSSLPolicy,
-		tlsCerts:       mergedTLSCerts.List(),
+		tlsCerts:       mergedTLSCerts.UnsortedList(),
 	}, nil
 }
 

--- a/pkg/ingress/model_builder_test.go
+++ b/pkg/ingress/model_builder_test.go
@@ -1054,9 +1054,9 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 			args: args{
 				ingGroup: Group{
 					ID: GroupID{Namespace: "ns-1", Name: "ing-1"},
-					Members: []*networking.Ingress{
+					Members: []ClassifiedIngress{
 						{
-							ObjectMeta: metav1.ObjectMeta{
+							Ing: &networking.Ingress{ObjectMeta: metav1.ObjectMeta{
 								Namespace: "ns-1",
 								Name:      "ing-1",
 								Annotations: map[string]string{
@@ -1064,41 +1064,42 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 									"alb.ingress.kubernetes.io/certificate-arn": "arn:aws:acm:us-east-1:9999999:certificate/22222222,arn:aws:acm:us-east-1:9999999:certificate/33333333,arn:aws:acm:us-east-1:9999999:certificate/11111111,,arn:aws:acm:us-east-1:9999999:certificate/11111111",
 								},
 							},
-							Spec: networking.IngressSpec{
-								Rules: []networking.IngressRule{
-									{
-										Host: "app-1.example.com",
-										IngressRuleValue: networking.IngressRuleValue{
-											HTTP: &networking.HTTPIngressRuleValue{
-												Paths: []networking.HTTPIngressPath{
-													{
-														Path: "/svc-1",
-														Backend: networking.IngressBackend{
-															ServiceName: ns_1_svc_1.Name,
-															ServicePort: intstr.FromString("http"),
+								Spec: networking.IngressSpec{
+									Rules: []networking.IngressRule{
+										{
+											Host: "app-1.example.com",
+											IngressRuleValue: networking.IngressRuleValue{
+												HTTP: &networking.HTTPIngressRuleValue{
+													Paths: []networking.HTTPIngressPath{
+														{
+															Path: "/svc-1",
+															Backend: networking.IngressBackend{
+																ServiceName: ns_1_svc_1.Name,
+																ServicePort: intstr.FromString("http"),
+															},
 														},
-													},
-													{
-														Path: "/svc-2",
-														Backend: networking.IngressBackend{
-															ServiceName: ns_1_svc_2.Name,
-															ServicePort: intstr.FromString("http"),
+														{
+															Path: "/svc-2",
+															Backend: networking.IngressBackend{
+																ServiceName: ns_1_svc_2.Name,
+																ServicePort: intstr.FromString("http"),
+															},
 														},
 													},
 												},
 											},
 										},
-									},
-									{
-										Host: "app-2.example.com",
-										IngressRuleValue: networking.IngressRuleValue{
-											HTTP: &networking.HTTPIngressRuleValue{
-												Paths: []networking.HTTPIngressPath{
-													{
-														Path: "/svc-3",
-														Backend: networking.IngressBackend{
-															ServiceName: ns_1_svc_3.Name,
-															ServicePort: intstr.FromString("https"),
+										{
+											Host: "app-2.example.com",
+											IngressRuleValue: networking.IngressRuleValue{
+												HTTP: &networking.HTTPIngressRuleValue{
+													Paths: []networking.HTTPIngressPath{
+														{
+															Path: "/svc-3",
+															Backend: networking.IngressBackend{
+																ServiceName: ns_1_svc_3.Name,
+																ServicePort: intstr.FromString("https"),
+															},
 														},
 													},
 												},
@@ -1147,9 +1148,6 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 						},
 						{
                         "certificateARN": "arn:aws:acm:us-east-1:9999999:certificate/33333333"
-						},
-						{
-                        "certificateARN": "arn:aws:acm:us-east-1:9999999:certificate/11111111"
 						},
 						{
                         "certificateARN": "arn:aws:acm:us-east-1:9999999:certificate/11111111"
@@ -1880,6 +1878,8 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 				enhancedBackendBuilder: enhancedBackendBuilder,
 				ruleOptimizer:          ruleOptimizer,
 				logger:                 &log.NullLogger{},
+
+				defaultSSLPolicy: "ELBSecurityPolicy-2016-08",
 			}
 
 			gotStack, _, err := b.Build(context.Background(), tt.args.ingGroup)

--- a/pkg/ingress/model_builder_test.go
+++ b/pkg/ingress/model_builder_test.go
@@ -1061,7 +1061,7 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 								Name:      "ing-1",
 								Annotations: map[string]string{
 									"alb.ingress.kubernetes.io/scheme":          "internet-facing",
-									"alb.ingress.kubernetes.io/certificate-arn": "arn:aws:acm:us-east-1:9999999:certificate/22222222,arn:aws:acm:us-east-1:9999999:certificate/33333333,arn:aws:acm:us-east-1:9999999:certificate/11111111",
+									"alb.ingress.kubernetes.io/certificate-arn": "arn:aws:acm:us-east-1:9999999:certificate/22222222,arn:aws:acm:us-east-1:9999999:certificate/33333333,arn:aws:acm:us-east-1:9999999:certificate/11111111,,arn:aws:acm:us-east-1:9999999:certificate/11111111",
 								},
 							},
 							Spec: networking.IngressSpec{
@@ -1147,6 +1147,9 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 						},
 						{
                         "certificateARN": "arn:aws:acm:us-east-1:9999999:certificate/33333333"
+						},
+						{
+                        "certificateARN": "arn:aws:acm:us-east-1:9999999:certificate/11111111"
 						},
 						{
                         "certificateARN": "arn:aws:acm:us-east-1:9999999:certificate/11111111"


### PR DESCRIPTION
# Description
- Added model builder using multiple certificate cases.
- I changed to use Unsorted List because the order of certificate list changes even though I want to default certificate in the order of annotation.
    - https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/9776d298fddc1bb7fe9245510467d2507580ec96/docs/guide/ingress/annotation.md#ssl 

## Issue
- https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/1836