### PR TITLE
feat: Add WatchIPBlocks and WatchInstanceFilters to TargetGroupBinding

### DIFF
--- a/config/crd/bases/elbv2.k8s.aws_targetgroupbindings.yaml
+++ b/config/crd/bases/elbv2.k8s.aws_targetgroupbindings.yaml
@@ -48,10 +48,14 @@ spec:
         description: TargetGroupBinding is the Schema for the TargetGroupBinding API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -59,28 +63,37 @@ spec:
             description: TargetGroupBindingSpec defines the desired state of TargetGroupBinding
             properties:
               networking:
-                description: networking provides the networking setup for ELBV2 LoadBalancer to access targets in TargetGroup.
+                description: networking provides the networking setup for ELBV2 LoadBalancer
+                  to access targets in TargetGroup.
                 properties:
                   ingress:
-                    description: List of ingress rules to allow ELBV2 LoadBalancer to access targets in TargetGroup.
+                    description: List of ingress rules to allow ELBV2 LoadBalancer
+                      to access targets in TargetGroup.
                     items:
                       properties:
                         from:
-                          description: List of peers which should be able to access the targets in TargetGroup. At least one NetworkingPeer should be specified.
+                          description: List of peers which should be able to access
+                            the targets in TargetGroup. At least one NetworkingPeer
+                            should be specified.
                           items:
-                            description: NetworkingPeer defines the source/destination peer for networking rules.
+                            description: NetworkingPeer defines the source/destination
+                              peer for networking rules.
                             properties:
                               ipBlock:
-                                description: IPBlock defines an IPBlock peer. If specified, none of the other fields can be set.
+                                description: IPBlock defines an IPBlock peer. If specified,
+                                  none of the other fields can be set.
                                 properties:
                                   cidr:
-                                    description: CIDR is the network CIDR. Both IPV4 or IPV6 CIDR are accepted.
+                                    description: CIDR is the network CIDR. Both IPV4
+                                      or IPV6 CIDR are accepted.
                                     type: string
                                 required:
                                 - cidr
                                 type: object
                               securityGroup:
-                                description: SecurityGroup defines a SecurityGroup peer. If specified, none of the other fields can be set.
+                                description: SecurityGroup defines a SecurityGroup
+                                  peer. If specified, none of the other fields can
+                                  be set.
                                 properties:
                                   groupID:
                                     description: GroupID is the EC2 SecurityGroupID.
@@ -91,17 +104,25 @@ spec:
                             type: object
                           type: array
                         ports:
-                          description: List of ports which should be made accessible on the targets in TargetGroup. If ports is empty or unspecified, it defaults to all ports with TCP.
+                          description: List of ports which should be made accessible
+                            on the targets in TargetGroup. If ports is empty or unspecified,
+                            it defaults to all ports with TCP.
                           items:
                             properties:
                               port:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: The port which traffic must match. When NodePort endpoints(instance TargetType) is used, this must be a numerical port. When Port endpoints(ip TargetType) is used, this can be either numerical or named port on pods. if port is unspecified, it defaults to all ports.
+                                description: The port which traffic must match. When
+                                  NodePort endpoints(instance TargetType) is used,
+                                  this must be a numerical port. When Port endpoints(ip
+                                  TargetType) is used, this can be either numerical
+                                  or named port on pods. if port is unspecified, it
+                                  defaults to all ports.
                                 x-kubernetes-int-or-string: true
                               protocol:
-                                description: The protocol which traffic must match. If protocol is unspecified, it defaults to TCP.
+                                description: The protocol which traffic must match.
+                                  If protocol is unspecified, it defaults to TCP.
                                 enum:
                                 - TCP
                                 - UDP
@@ -115,7 +136,8 @@ spec:
                     type: array
                 type: object
               serviceRef:
-                description: serviceRef is a reference to a Kubernetes Service and ServicePort.
+                description: serviceRef is a reference to a Kubernetes Service and
+                  ServicePort.
                 properties:
                   name:
                     description: Name is the name of the Service.
@@ -131,10 +153,12 @@ spec:
                 - port
                 type: object
               targetGroupARN:
-                description: targetGroupARN is the Amazon Resource Name (ARN) for the TargetGroup.
+                description: targetGroupARN is the Amazon Resource Name (ARN) for
+                  the TargetGroup.
                 type: string
               targetType:
-                description: targetType is the TargetType of TargetGroup. If unspecified, it will be automatically inferred.
+                description: targetType is the TargetType of TargetGroup. If unspecified,
+                  it will be automatically inferred.
                 enum:
                 - instance
                 - ip
@@ -160,10 +184,14 @@ spec:
         description: TargetGroupBinding is the Schema for the TargetGroupBinding API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -171,29 +199,39 @@ spec:
             description: TargetGroupBindingSpec defines the desired state of TargetGroupBinding
             properties:
               networking:
-                description: networking defines the networking rules to allow ELBV2 LoadBalancer to access targets in TargetGroup.
+                description: networking defines the networking rules to allow ELBV2
+                  LoadBalancer to access targets in TargetGroup.
                 properties:
                   ingress:
-                    description: List of ingress rules to allow ELBV2 LoadBalancer to access targets in TargetGroup.
+                    description: List of ingress rules to allow ELBV2 LoadBalancer
+                      to access targets in TargetGroup.
                     items:
-                      description: NetworkingIngressRule defines a particular set of traffic that is allowed to access TargetGroup's targets.
+                      description: NetworkingIngressRule defines a particular set
+                        of traffic that is allowed to access TargetGroup's targets.
                       properties:
                         from:
-                          description: List of peers which should be able to access the targets in TargetGroup. At least one NetworkingPeer should be specified.
+                          description: List of peers which should be able to access
+                            the targets in TargetGroup. At least one NetworkingPeer
+                            should be specified.
                           items:
-                            description: NetworkingPeer defines the source/destination peer for networking rules.
+                            description: NetworkingPeer defines the source/destination
+                              peer for networking rules.
                             properties:
                               ipBlock:
-                                description: IPBlock defines an IPBlock peer. If specified, none of the other fields can be set.
+                                description: IPBlock defines an IPBlock peer. If specified,
+                                  none of the other fields can be set.
                                 properties:
                                   cidr:
-                                    description: CIDR is the network CIDR. Both IPV4 or IPV6 CIDR are accepted.
+                                    description: CIDR is the network CIDR. Both IPV4
+                                      or IPV6 CIDR are accepted.
                                     type: string
                                 required:
                                 - cidr
                                 type: object
                               securityGroup:
-                                description: SecurityGroup defines a SecurityGroup peer. If specified, none of the other fields can be set.
+                                description: SecurityGroup defines a SecurityGroup
+                                  peer. If specified, none of the other fields can
+                                  be set.
                                 properties:
                                   groupID:
                                     description: GroupID is the EC2 SecurityGroupID.
@@ -204,18 +242,27 @@ spec:
                             type: object
                           type: array
                         ports:
-                          description: List of ports which should be made accessible on the targets in TargetGroup. If ports is empty or unspecified, it defaults to all ports with TCP.
+                          description: List of ports which should be made accessible
+                            on the targets in TargetGroup. If ports is empty or unspecified,
+                            it defaults to all ports with TCP.
                           items:
-                            description: NetworkingPort defines the port and protocol for networking rules.
+                            description: NetworkingPort defines the port and protocol
+                              for networking rules.
                             properties:
                               port:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: The port which traffic must match. When NodePort endpoints(instance TargetType) is used, this must be a numerical port. When Port endpoints(ip TargetType) is used, this can be either numerical or named port on pods. if port is unspecified, it defaults to all ports.
+                                description: The port which traffic must match. When
+                                  NodePort endpoints(instance TargetType) is used,
+                                  this must be a numerical port. When Port endpoints(ip
+                                  TargetType) is used, this can be either numerical
+                                  or named port on pods. if port is unspecified, it
+                                  defaults to all ports.
                                 x-kubernetes-int-or-string: true
                               protocol:
-                                description: The protocol which traffic must match. If protocol is unspecified, it defaults to TCP.
+                                description: The protocol which traffic must match.
+                                  If protocol is unspecified, it defaults to TCP.
                                 enum:
                                 - TCP
                                 - UDP
@@ -229,21 +276,32 @@ spec:
                     type: array
                 type: object
               nodeSelector:
-                description: node selector for instance type target groups to only register certain nodes
+                description: node selector for instance type target groups to only
+                  register certain nodes
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies to.
+                          description: key is the label key that the selector applies
+                            to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
                           items:
                             type: string
                           type: array
@@ -255,11 +313,16 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
                     type: object
                 type: object
               serviceRef:
-                description: serviceRef is a reference to a Kubernetes Service and ServicePort.
+                description: serviceRef is a reference to a Kubernetes Service and
+                  ServicePort.
                 properties:
                   name:
                     description: Name is the name of the Service.
@@ -275,10 +338,12 @@ spec:
                 - port
                 type: object
               targetGroupARN:
-                description: targetGroupARN is the Amazon Resource Name (ARN) for the TargetGroup.
+                description: targetGroupARN is the Amazon Resource Name (ARN) for
+                  the TargetGroup.
                 type: string
               targetType:
-                description: targetType is the TargetType of TargetGroup. If unspecified, it will be automatically inferred.
+                description: targetType is the TargetType of TargetGroup. If unspecified,
+                  it will be automatically inferred.
                 enum:
                 - instance
                 - ip

--- a/docs/deploy/configurations.md
+++ b/docs/deploy/configurations.md
@@ -85,7 +85,8 @@ Currently, you can set only 1 namespace to watch in this flag. See [this Kuberne
 |targetgroupbinding-max-concurrent-reconciles | int                       | 3               | Maximum number of concurrently running reconcile loops for targetGroupBinding |
 |watch-namespace                        | string                          |                 | Namespace the controller watches for updates to Kubernetes objects, If empty, all namespaces are watched. |
 |webhook-bind-port                      | int                             | 9443            | The TCP port the Webhook server binds to |
-
+|watch-ip-blocks                        | []string                        |                 | When using `TargetType: ip`, you can specify IP blocks in CIDR notation to only list (from AWS) ip targets that fall within their ranges. This is  useful when sharing a single target group among many `aws-load-balancer-controller` instances (for example across different clusters), so registration/deregistration of one controller does not affect other controllers. |
+|watch-instance-filters                 | []string                        |                 | When using `TargetType: instance`, you can specify filters to only list (from AWS) instance targets that match the specified filters. This is  useful when sharing a single target group among many `aws-load-balancer-controller` instances (for example across different clusters), so registration/deregistration of one controller does not affect other controllers. Please read [this reference](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html) for more information about these filters. |
 
 ### Default throttle config
 ```

--- a/docs/guide/targetgroupbinding/targetgroupbinding.md
+++ b/docs/guide/targetgroupbinding/targetgroupbinding.md
@@ -70,7 +70,6 @@ spec:
   ...
 ```
 
-
 ## Reference
 See the [reference](./spec.md) for TargetGroupBinding CR
 

--- a/main.go
+++ b/main.go
@@ -103,8 +103,10 @@ func main() {
 	sgManager := networking.NewDefaultSecurityGroupManager(cloud.EC2(), ctrl.Log)
 	sgReconciler := networking.NewDefaultSecurityGroupReconciler(sgManager, ctrl.Log)
 	subnetResolver := networking.NewDefaultSubnetsResolver(cloud.EC2(), cloud.VpcID(), controllerCFG.ClusterName, ctrl.Log.WithName("subnets-resolver"))
-	tgbResManager := targetgroupbinding.NewDefaultResourceManager(mgr.GetClient(), cloud.ELBV2(),
-		podInfoRepo, podENIResolver, nodeENIResolver, sgManager, sgReconciler, cloud.VpcID(), controllerCFG.ClusterName, ctrl.Log)
+	tgbResManager := targetgroupbinding.NewDefaultResourceManager(mgr.GetClient(), cloud.ELBV2(), cloud.EC2(),
+		podInfoRepo, podENIResolver, nodeENIResolver, sgManager, sgReconciler, cloud.VpcID(), controllerCFG.ClusterName,
+		controllerCFG.WatchIPBlocks, controllerCFG.WatchInstanceFilters, ctrl.Log)
+
 	ingGroupReconciler := ingress.NewGroupReconciler(cloud, mgr.GetClient(), mgr.GetEventRecorderFor("ingress"),
 		finalizerManager, sgManager, sgReconciler, subnetResolver,
 		controllerCFG, ctrl.Log.WithName("controllers").WithName("ingress"))

--- a/pkg/targetgroupbinding/targets_manager_test.go
+++ b/pkg/targetgroupbinding/targets_manager_test.go
@@ -2,11 +2,14 @@ package targetgroupbinding
 
 import (
 	"context"
+	"github.com/aws/aws-sdk-go/aws"
 	awssdk "github.com/aws/aws-sdk-go/aws"
+	ec2sdk "github.com/aws/aws-sdk-go/service/ec2"
 	elbv2sdk "github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/cache"
+	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
 	mock_services "sigs.k8s.io/aws-load-balancer-controller/mocks/aws/services"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sync"
@@ -545,6 +548,8 @@ func Test_cachedTargetsManager_DeregisterTargets(t *testing.T) {
 }
 
 func Test_cachedTargetsManager_ListTargets(t *testing.T) {
+	ipTargetType := elbv2api.TargetTypeIP
+
 	type describeTargetHealthWithContextCall struct {
 		req  *elbv2sdk.DescribeTargetHealthInput
 		resp *elbv2sdk.DescribeTargetHealthOutput
@@ -555,8 +560,9 @@ func Test_cachedTargetsManager_ListTargets(t *testing.T) {
 		targetsCache                         map[string][]TargetInfo
 	}
 	type args struct {
-		tgARN string
+		tgb *elbv2api.TargetGroupBinding
 	}
+
 	tests := []struct {
 		name             string
 		fields           fields
@@ -592,7 +598,12 @@ func Test_cachedTargetsManager_ListTargets(t *testing.T) {
 				targetsCache: nil,
 			},
 			args: args{
-				tgARN: "my-tg",
+				tgb: &elbv2api.TargetGroupBinding{
+					Spec: elbv2api.TargetGroupBindingSpec{
+						TargetGroupARN: "my-tg",
+						TargetType:     &ipTargetType,
+					},
+				},
 			},
 			want: []TargetInfo{
 				{
@@ -638,7 +649,12 @@ func Test_cachedTargetsManager_ListTargets(t *testing.T) {
 				},
 			},
 			args: args{
-				tgARN: "my-tg",
+				tgb: &elbv2api.TargetGroupBinding{
+					Spec: elbv2api.TargetGroupBindingSpec{
+						TargetGroupARN: "my-tg",
+						TargetType:     &ipTargetType,
+					},
+				},
 			},
 			want: []TargetInfo{
 				{
@@ -719,7 +735,12 @@ func Test_cachedTargetsManager_ListTargets(t *testing.T) {
 				},
 			},
 			args: args{
-				tgARN: "my-tg",
+				tgb: &elbv2api.TargetGroupBinding{
+					Spec: elbv2api.TargetGroupBindingSpec{
+						TargetGroupARN: "my-tg",
+						TargetType:     &ipTargetType,
+					},
+				},
 			},
 			want: []TargetInfo{
 				{
@@ -790,7 +811,7 @@ func Test_cachedTargetsManager_ListTargets(t *testing.T) {
 			}
 
 			ctx := context.Background()
-			got, err := m.ListTargets(ctx, tt.args.tgARN)
+			got, err := m.ListTargets(ctx, tt.args.tgb)
 			if tt.wantErr != nil {
 				assert.EqualError(t, err, tt.wantErr.Error())
 			} else {
@@ -809,6 +830,8 @@ func Test_cachedTargetsManager_ListTargets(t *testing.T) {
 }
 
 func Test_cachedTargetsManager_refreshUnhealthyTargets(t *testing.T) {
+	ipTargetType := elbv2api.TargetTypeIP
+
 	type describeTargetHealthWithContextCall struct {
 		req  *elbv2sdk.DescribeTargetHealthInput
 		resp *elbv2sdk.DescribeTargetHealthOutput
@@ -818,8 +841,8 @@ func Test_cachedTargetsManager_refreshUnhealthyTargets(t *testing.T) {
 		describeTargetHealthWithContextCalls []describeTargetHealthWithContextCall
 	}
 	type args struct {
-		tgARN         string
 		cachedTargets []TargetInfo
+		tgb           *elbv2api.TargetGroupBinding
 	}
 	tests := []struct {
 		name    string
@@ -834,7 +857,12 @@ func Test_cachedTargetsManager_refreshUnhealthyTargets(t *testing.T) {
 				describeTargetHealthWithContextCalls: nil,
 			},
 			args: args{
-				tgARN: "my-tg",
+				tgb: &elbv2api.TargetGroupBinding{
+					Spec: elbv2api.TargetGroupBindingSpec{
+						TargetGroupARN: "my-tg",
+						TargetType:     &ipTargetType,
+					},
+				},
 				cachedTargets: []TargetInfo{
 					{
 						Target: elbv2sdk.TargetDescription{
@@ -922,7 +950,12 @@ func Test_cachedTargetsManager_refreshUnhealthyTargets(t *testing.T) {
 				},
 			},
 			args: args{
-				tgARN: "my-tg",
+				tgb: &elbv2api.TargetGroupBinding{
+					Spec: elbv2api.TargetGroupBindingSpec{
+						TargetGroupARN: "my-tg",
+						TargetType:     &ipTargetType,
+					},
+				},
 				cachedTargets: []TargetInfo{
 					{
 						Target: elbv2sdk.TargetDescription{
@@ -1013,7 +1046,12 @@ func Test_cachedTargetsManager_refreshUnhealthyTargets(t *testing.T) {
 				},
 			},
 			args: args{
-				tgARN: "my-tg",
+				tgb: &elbv2api.TargetGroupBinding{
+					Spec: elbv2api.TargetGroupBindingSpec{
+						TargetGroupARN: "my-tg",
+						TargetType:     &ipTargetType,
+					},
+				},
 				cachedTargets: []TargetInfo{
 					{
 						Target: elbv2sdk.TargetDescription{
@@ -1123,7 +1161,12 @@ func Test_cachedTargetsManager_refreshUnhealthyTargets(t *testing.T) {
 				},
 			},
 			args: args{
-				tgARN: "my-tg",
+				tgb: &elbv2api.TargetGroupBinding{
+					Spec: elbv2api.TargetGroupBindingSpec{
+						TargetGroupARN: "my-tg",
+						TargetType:     &ipTargetType,
+					},
+				},
 				cachedTargets: []TargetInfo{
 					{
 						Target: elbv2sdk.TargetDescription{
@@ -1188,7 +1231,7 @@ func Test_cachedTargetsManager_refreshUnhealthyTargets(t *testing.T) {
 				elbv2Client: elbv2Client,
 			}
 			ctx := context.Background()
-			got, err := m.refreshUnhealthyTargets(ctx, tt.args.tgARN, tt.args.cachedTargets)
+			got, err := m.refreshUnhealthyTargets(ctx, tt.args.tgb, tt.args.cachedTargets)
 			if tt.wantErr != nil {
 				assert.EqualError(t, err, tt.wantErr.Error())
 			} else {
@@ -1200,18 +1243,29 @@ func Test_cachedTargetsManager_refreshUnhealthyTargets(t *testing.T) {
 }
 
 func Test_cachedTargetsManager_listTargetsFromAWS(t *testing.T) {
+	ipTargetType := elbv2api.TargetTypeIP
+	instanceTargetType := elbv2api.TargetTypeInstance
+
 	type describeTargetHealthWithContextCall struct {
 		req  *elbv2sdk.DescribeTargetHealthInput
 		resp *elbv2sdk.DescribeTargetHealthOutput
 		err  error
 	}
+	type describeInstancesAsListsCall struct {
+		req  *ec2sdk.DescribeInstancesInput
+		resp []*ec2sdk.Instance
+		err  error
+	}
 	type fields struct {
 		describeTargetHealthWithContextCalls []describeTargetHealthWithContextCall
+		describeInstancesAsListsCalls        []describeInstancesAsListsCall
 	}
 
 	type args struct {
-		tgARN   string
-		targets []elbv2sdk.TargetDescription
+		targets              []elbv2sdk.TargetDescription
+		tgb                  *elbv2api.TargetGroupBinding
+		watchIPBlocks        []string
+		watchInstanceFilters []string
 	}
 	tests := []struct {
 		name    string
@@ -1252,7 +1306,12 @@ func Test_cachedTargetsManager_listTargetsFromAWS(t *testing.T) {
 				},
 			},
 			args: args{
-				tgARN: "my-tg",
+				tgb: &elbv2api.TargetGroupBinding{
+					Spec: elbv2api.TargetGroupBindingSpec{
+						TargetGroupARN: "my-tg",
+						TargetType:     &ipTargetType,
+					},
+				},
 				targets: []elbv2sdk.TargetDescription{
 					{
 						Id:   awssdk.String("192.168.1.1"),
@@ -1310,7 +1369,12 @@ func Test_cachedTargetsManager_listTargetsFromAWS(t *testing.T) {
 				},
 			},
 			args: args{
-				tgARN:   "my-tg",
+				tgb: &elbv2api.TargetGroupBinding{
+					Spec: elbv2api.TargetGroupBindingSpec{
+						TargetGroupARN: "my-tg",
+						TargetType:     &ipTargetType,
+					},
+				},
 				targets: nil,
 			},
 			want: []TargetInfo{
@@ -1336,6 +1400,184 @@ func Test_cachedTargetsManager_listTargetsFromAWS(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "list with nil targets filtered by CIDRs",
+			fields: fields{
+				describeTargetHealthWithContextCalls: []describeTargetHealthWithContextCall{
+					{
+						req: &elbv2sdk.DescribeTargetHealthInput{
+							TargetGroupArn: awssdk.String("my-tg"),
+							Targets:        nil,
+						},
+						resp: &elbv2sdk.DescribeTargetHealthOutput{
+							TargetHealthDescriptions: []*elbv2sdk.TargetHealthDescription{
+								{
+									Target: &elbv2sdk.TargetDescription{
+										Id:   awssdk.String("10.10.1.1"),
+										Port: awssdk.Int64(8080),
+									},
+									TargetHealth: &elbv2sdk.TargetHealth{
+										Reason: awssdk.String(elbv2sdk.TargetHealthReasonEnumElbRegistrationInProgress),
+										State:  awssdk.String(elbv2sdk.TargetHealthStateEnumInitial),
+									},
+								},
+								{
+									Target: &elbv2sdk.TargetDescription{
+										Id:   awssdk.String("192.168.1.1"),
+										Port: awssdk.Int64(8080),
+									},
+									TargetHealth: &elbv2sdk.TargetHealth{
+										Reason: awssdk.String(elbv2sdk.TargetHealthReasonEnumElbRegistrationInProgress),
+										State:  awssdk.String(elbv2sdk.TargetHealthStateEnumInitial),
+									},
+								},
+								{
+									Target: &elbv2sdk.TargetDescription{
+										Id:   awssdk.String("192.168.1.2"),
+										Port: awssdk.Int64(8080),
+									},
+									TargetHealth: &elbv2sdk.TargetHealth{
+										Reason: awssdk.String(elbv2sdk.TargetHealthReasonEnumElbRegistrationInProgress),
+										State:  awssdk.String(elbv2sdk.TargetHealthStateEnumInitial),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				targets:       nil,
+				watchIPBlocks: []string{"192.168.1.0/24"},
+				tgb: &elbv2api.TargetGroupBinding{
+					Spec: elbv2api.TargetGroupBindingSpec{
+						TargetGroupARN: "my-tg",
+						TargetType:     &ipTargetType,
+					},
+				},
+			},
+			want: []TargetInfo{
+				{
+					Target: elbv2sdk.TargetDescription{
+						Id:   awssdk.String("192.168.1.1"),
+						Port: awssdk.Int64(8080),
+					},
+					TargetHealth: &elbv2sdk.TargetHealth{
+						Reason: awssdk.String(elbv2sdk.TargetHealthReasonEnumElbRegistrationInProgress),
+						State:  awssdk.String(elbv2sdk.TargetHealthStateEnumInitial),
+					},
+				},
+				{
+					Target: elbv2sdk.TargetDescription{
+						Id:   awssdk.String("192.168.1.2"),
+						Port: awssdk.Int64(8080),
+					},
+					TargetHealth: &elbv2sdk.TargetHealth{
+						Reason: awssdk.String(elbv2sdk.TargetHealthReasonEnumElbRegistrationInProgress),
+						State:  awssdk.String(elbv2sdk.TargetHealthStateEnumInitial),
+					},
+				},
+			},
+		},
+		{
+			name: "list with nil targets filtered by tags",
+			fields: fields{
+				describeInstancesAsListsCalls: []describeInstancesAsListsCall{
+					{
+						req: &ec2sdk.DescribeInstancesInput{
+							Filters: []*ec2sdk.Filter{
+								{
+									Name:   aws.String("tag:someTag"),
+									Values: []*string{aws.String("someValue")},
+								},
+							},
+						},
+						resp: []*ec2sdk.Instance{
+							{
+								InstanceId: awssdk.String("i-abcdefg2"),
+							},
+							{
+								InstanceId: awssdk.String("i-abcdefg3"),
+							},
+						},
+					},
+				},
+				describeTargetHealthWithContextCalls: []describeTargetHealthWithContextCall{
+					{
+						req: &elbv2sdk.DescribeTargetHealthInput{
+							TargetGroupArn: awssdk.String("my-tg"),
+							Targets:        nil,
+						},
+						resp: &elbv2sdk.DescribeTargetHealthOutput{
+							TargetHealthDescriptions: []*elbv2sdk.TargetHealthDescription{
+								{
+									Target: &elbv2sdk.TargetDescription{
+										Id:   awssdk.String("i-abcdefg1"),
+										Port: awssdk.Int64(8080),
+									},
+									TargetHealth: &elbv2sdk.TargetHealth{
+										Reason: awssdk.String(elbv2sdk.TargetHealthReasonEnumElbRegistrationInProgress),
+										State:  awssdk.String(elbv2sdk.TargetHealthStateEnumInitial),
+									},
+								},
+								{
+									Target: &elbv2sdk.TargetDescription{
+										Id:   awssdk.String("i-abcdefg2"),
+										Port: awssdk.Int64(8080),
+									},
+									TargetHealth: &elbv2sdk.TargetHealth{
+										Reason: awssdk.String(elbv2sdk.TargetHealthReasonEnumElbRegistrationInProgress),
+										State:  awssdk.String(elbv2sdk.TargetHealthStateEnumInitial),
+									},
+								},
+								{
+									Target: &elbv2sdk.TargetDescription{
+										Id:   awssdk.String("i-abcdefg3"),
+										Port: awssdk.Int64(8080),
+									},
+									TargetHealth: &elbv2sdk.TargetHealth{
+										Reason: awssdk.String(elbv2sdk.TargetHealthReasonEnumElbRegistrationInProgress),
+										State:  awssdk.String(elbv2sdk.TargetHealthStateEnumInitial),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				targets:              nil,
+				watchInstanceFilters: []string{"tag:someTag=someValue"},
+				tgb: &elbv2api.TargetGroupBinding{
+					Spec: elbv2api.TargetGroupBindingSpec{
+						TargetGroupARN: "my-tg",
+						TargetType:     &instanceTargetType,
+					},
+				},
+			},
+			want: []TargetInfo{
+				{
+					Target: elbv2sdk.TargetDescription{
+						Id:   awssdk.String("i-abcdefg2"),
+						Port: awssdk.Int64(8080),
+					},
+					TargetHealth: &elbv2sdk.TargetHealth{
+						Reason: awssdk.String(elbv2sdk.TargetHealthReasonEnumElbRegistrationInProgress),
+						State:  awssdk.String(elbv2sdk.TargetHealthStateEnumInitial),
+					},
+				},
+				{
+					Target: elbv2sdk.TargetDescription{
+						Id:   awssdk.String("i-abcdefg3"),
+						Port: awssdk.Int64(8080),
+					},
+					TargetHealth: &elbv2sdk.TargetHealth{
+						Reason: awssdk.String(elbv2sdk.TargetHealthReasonEnumElbRegistrationInProgress),
+						State:  awssdk.String(elbv2sdk.TargetHealthStateEnumInitial),
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1347,11 +1589,19 @@ func Test_cachedTargetsManager_listTargetsFromAWS(t *testing.T) {
 				elbv2Client.EXPECT().DescribeTargetHealthWithContext(gomock.Any(), call.req).Return(call.resp, call.err)
 			}
 
+			ec2Client := mock_services.NewMockEC2(ctrl)
+			for _, call := range tt.fields.describeInstancesAsListsCalls {
+				ec2Client.EXPECT().DescribeInstancesAsList(gomock.Any(), call.req).Return(call.resp, call.err)
+			}
+
 			m := &cachedTargetsManager{
-				elbv2Client: elbv2Client,
+				elbv2Client:          elbv2Client,
+				ec2Client:            ec2Client,
+				watchIPBlocks:        tt.args.watchIPBlocks,
+				watchInstanceFilters: tt.args.watchInstanceFilters,
 			}
 			ctx := context.Background()
-			got, err := m.listTargetsFromAWS(ctx, tt.args.tgARN, tt.args.targets)
+			got, err := m.listTargetsFromAWS(ctx, tt.args.tgb, tt.args.targets)
 			if tt.wantErr != nil {
 				assert.EqualError(t, err, tt.wantErr.Error())
 			} else {


### PR DESCRIPTION
### Introduction

This PR adds `WatchIPBlocks` and `WatchInstanceFilters` to `TargetGroupBinding`.

In our use case our product is deployed in multiple EKS clusters that are load balanced through a common ALB. When sharing a single target group among many `aws-load-balancer-controller` instances registration/deregistration of one controller affects other controllers. This PR makes a `TargetGroupBinding` to only care about a specific instance group or address space and leave the rest unmanaged.

### WatchIPBlocks

When using `TargetType: ip`, you can specify IP blocks in CIDR notation
to only list (from AWS) ip targets that fall within their ranges. This is 
useful when sharing a single target group among many `aws-load-balancer-controller`
instances (for example across different clusters), so registration/deregistration
of one controller does not affect other controllers.

```yaml
apiVersion: elbv2.k8s.aws/v1beta1
kind: TargetGroupBinding
metadata:
  name: my-tgb
spec:
  watchIPBlocks:
    - cidr: 10.1.1.0/24
    - cidr: 10.1.2.0/24
  ...
```

### WatchInstanceFilters

When using `TargetType: instance`, you can specify filters to only list
(from AWS) instance targets that match the specified filters. This is 
useful when sharing a single target group among many `aws-load-balancer-controller`
instances (for example across different clusters), so registration/deregistration
of one controller does not affect other controllers.

Please read [this reference](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html)
for more information about these filters.

```yaml
apiVersion: elbv2.k8s.aws/v1beta1
kind: TargetGroupBinding
metadata:
  name: my-tgb
spec:
  watchInstanceFilters:
    - name: "tag:someTag"
      values:
        - value1
        - value2
  ...
```
