### PR TITLE
set default log level to info

### DIFF
--- a/main.go
+++ b/main.go
@@ -191,7 +191,7 @@ func getLoggerWithLogLevel(logLevel string) logr.Logger {
 	case "debug":
 		zapLevel = zapraw.NewAtomicLevelAt(zapraw.DebugLevel)
 	default:
-		zapLevel = zapraw.NewAtomicLevelAt(zapraw.DebugLevel)
+		zapLevel = zapraw.NewAtomicLevelAt(zapraw.InfoLevel)
 	}
 
 	logger := zap.New(zap.UseDevMode(false),


### PR DESCRIPTION
Fixes #1820

The log level gets set to debug by default if the command line `log-level` flag is anything but info or debug. This is confusing to the end users since the default value for the command line flag is info. If the log level passed from the command line is not recognized, revert to the default.