### PR TITLE
Add support for specifying the load balancer's name via annotation

### DIFF
--- a/pkg/annotations/constants.go
+++ b/pkg/annotations/constants.go
@@ -49,6 +49,7 @@ const (
 	SvcLBSuffixLoadBalancerType              = "aws-load-balancer-type"
 	SvcLBSuffixInternal                      = "aws-load-balancer-internal"
 	SvcLBSuffixIPAddressType                 = "aws-load-balancer-ip-address-type"
+	SvcLBSuffixLoadBalancerName              = "aws-load-balancer-name"
 	SvcLBSuffixProxyProtocol                 = "aws-load-balancer-proxy-protocol"
 	SvcLBSuffixAccessLogEnabled              = "aws-load-balancer-access-log-enabled"
 	SvcLBSuffixAccessLogS3BucketName         = "aws-load-balancer-access-log-s3-bucket-name"

--- a/pkg/service/model_build_load_balancer.go
+++ b/pkg/service/model_build_load_balancer.go
@@ -231,6 +231,10 @@ func (t *defaultModelBuildTask) buildLoadBalancerAttributes(_ context.Context) (
 var invalidLoadBalancerNamePattern = regexp.MustCompile("[[:^alnum:]]")
 
 func (t *defaultModelBuildTask) buildLoadBalancerName(_ context.Context, scheme elbv2model.LoadBalancerScheme) string {
+	var name string
+	if exists := t.annotationParser.ParseStringAnnotation(annotations.SvcLBSuffixLoadBalancerName, &name, t.service.Annotations); exists {
+		return name
+	}
 	uuidHash := sha256.New()
 	_, _ = uuidHash.Write([]byte(t.clusterName))
 	_, _ = uuidHash.Write([]byte(t.service.UID))


### PR DESCRIPTION
This adds a new "aws-load-balancer-name" annotation that can be used to specify the associated load balancer's name, overriding the default name format.

Some implementation notes:
* This doesn't perform any input validation on the annotation value to ensure it matches the allowed naming format. I'm happy to add this but didnt see validation on any other annotation value strings.
* Adding or updating the annotation on existing ingresses has no effect once a load balancer already exists.
* This doesn't modify target group names. I was wondering if another annotation would be accepted for specifying target group names. Given the one-to-many relationship of k8s Services to target groups, the annotation could be a stringMap of service ports to target group names, something like:
```yaml
service.beta.kubernetes.io/aws-target-group-name: "{\"80\": \"target-group-1\", \"443\": \"target-group-2\"}"
```

fixes https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/1483