### PR TITLE
Add a flag to set the default SSL Policy

### DIFF
--- a/controllers/ingress/group_controller.go
+++ b/controllers/ingress/group_controller.go
@@ -46,7 +46,8 @@ func NewGroupReconciler(cloud aws.Cloud, k8sClient client.Client, eventRecorder 
 		cloud.EC2(), cloud.ACM(),
 		annotationParser, subnetsResolver,
 		authConfigBuilder, enhancedBackendBuilder,
-		cloud.VpcID(), config.ClusterName, config.DefaultTags, logger)
+		cloud.VpcID(), config.ClusterName, config.DefaultTags,
+		config.DefaultSSLPolicy, logger)
 	stackMarshaller := deploy.NewDefaultStackMarshaller()
 	stackDeployer := deploy.NewDefaultStackDeployer(cloud, k8sClient, networkingSGManager, networkingSGReconciler,
 		config, ingressTagPrefix, logger)

--- a/controllers/service/service_controller.go
+++ b/controllers/service/service_controller.go
@@ -37,7 +37,7 @@ func NewServiceReconciler(cloud aws.Cloud, k8sClient client.Client, eventRecorde
 	config config.ControllerConfig, logger logr.Logger) *serviceReconciler {
 
 	annotationParser := annotations.NewSuffixAnnotationParser(serviceAnnotationPrefix)
-	modelBuilder := service.NewDefaultModelBuilder(annotationParser, subnetsResolver, config.ClusterName, config.DefaultTags)
+	modelBuilder := service.NewDefaultModelBuilder(annotationParser, subnetsResolver, config.ClusterName, config.DefaultTags, config.DefaultSSLPolicy)
 	stackMarshaller := deploy.NewDefaultStackMarshaller()
 	stackDeployer := deploy.NewDefaultStackDeployer(cloud, k8sClient, networkingSGManager, networkingSGReconciler, config, serviceTagPrefix, logger)
 	return &serviceReconciler{

--- a/docs/deploy/configurations.md
+++ b/docs/deploy/configurations.md
@@ -67,6 +67,7 @@ Currently, you can set only 1 namespace to watch in this flag. See [this Kuberne
 |aws-vpc-id                             | string                          | [instance metadata](#instance-metadata)    | AWS VPC ID for the Kubernetes cluster |
 |cluster-name                           | string                          |                 | Kubernetes cluster name|
 |default-tags                           | stringMap                       |                 | Default AWS Tags that will be applied to all AWS resources managed by this controller |
+|default-ssl-policy                     | string                          | ELBSecurityPolicy-2016-08 | Default SSL Policy that will be applied to all ingresses or services that do not have the SSL Policy annotation. |
 |enable-leader-election                 | boolean                         | true            | Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager. |
 |enable-pod-readiness-gate-inject       | boolean                         | true            | If enabled, targetHealth readiness gate will get injected to the pod spec for the matching endpoint pods. |
 |enable-shield                          | boolean                         | true            | Enable Shield addon for ALB |

--- a/pkg/config/controller_config.go
+++ b/pkg/config/controller_config.go
@@ -13,8 +13,10 @@ const (
 	flagDefaultTags                               = "default-tags"
 	flagServiceMaxConcurrentReconciles            = "service-max-concurrent-reconciles"
 	flagTargetGroupBindingMaxConcurrentReconciles = "targetgroupbinding-max-concurrent-reconciles"
+	flagDefaultSSLPolicy                          = "default-ssl-policy"
 	defaultLogLevel                               = "info"
 	defaultMaxConcurrentReconciles                = 3
+	defaultSSLPolicy                              = "ELBSecurityPolicy-2016-08"
 )
 
 // ControllerConfig contains the controller configuration
@@ -37,6 +39,10 @@ type ControllerConfig struct {
 	// Default AWS Tags that will be applied to all AWS resources managed by this controller.
 	DefaultTags map[string]string
 
+	// Default SSL Policy that will be applied to all ingresses or services that do not have
+	// the SSL Policy annotation.
+	DefaultSSLPolicy string
+
 	// Max concurrent reconcile loops for Service objects
 	ServiceMaxConcurrentReconciles int
 	// Max concurrent reconcile loops for TargetGroupBinding objects
@@ -54,6 +60,8 @@ func (cfg *ControllerConfig) BindFlags(fs *pflag.FlagSet) {
 		"Maximum number of concurrently running reconcile loops for service")
 	fs.IntVar(&cfg.TargetGroupBindingMaxConcurrentReconciles, flagTargetGroupBindingMaxConcurrentReconciles, defaultMaxConcurrentReconciles,
 		"Maximum number of concurrently running reconcile loops for targetGroupBinding")
+	fs.StringVar(&cfg.DefaultSSLPolicy, flagDefaultSSLPolicy, defaultSSLPolicy,
+		"Default SSL policy for load balancers listeners")
 
 	cfg.AWSConfig.BindFlags(fs)
 	cfg.RuntimeConfig.BindFlags(fs)

--- a/pkg/ingress/model_builder.go
+++ b/pkg/ingress/model_builder.go
@@ -35,7 +35,8 @@ func NewDefaultModelBuilder(k8sClient client.Client, eventRecorder record.EventR
 	ec2Client services.EC2, acmClient services.ACM,
 	annotationParser annotations.Parser, subnetsResolver networkingpkg.SubnetsResolver,
 	authConfigBuilder AuthConfigBuilder, enhancedBackendBuilder EnhancedBackendBuilder,
-	vpcID string, clusterName string, defaultTags map[string]string, logger logr.Logger) *defaultModelBuilder {
+	vpcID string, clusterName string, defaultTags map[string]string, defaultSSLPolicy string,
+	logger logr.Logger) *defaultModelBuilder {
 	certDiscovery := NewACMCertDiscovery(acmClient, logger)
 	ruleOptimizer := NewDefaultRuleOptimizer(logger)
 	return &defaultModelBuilder{
@@ -51,6 +52,7 @@ func NewDefaultModelBuilder(k8sClient client.Client, eventRecorder record.EventR
 		enhancedBackendBuilder: enhancedBackendBuilder,
 		ruleOptimizer:          ruleOptimizer,
 		defaultTags:            defaultTags,
+		defaultSSLPolicy:       defaultSSLPolicy,
 		logger:                 logger,
 	}
 }
@@ -73,6 +75,7 @@ type defaultModelBuilder struct {
 	enhancedBackendBuilder EnhancedBackendBuilder
 	ruleOptimizer          RuleOptimizer
 	defaultTags            map[string]string
+	defaultSSLPolicy       string
 
 	logger logr.Logger
 }
@@ -100,7 +103,7 @@ func (b *defaultModelBuilder) Build(ctx context.Context, ingGroup Group) (core.S
 		defaultTags:                               b.defaultTags,
 		defaultIPAddressType:                      elbv2model.IPAddressTypeIPV4,
 		defaultScheme:                             elbv2model.LoadBalancerSchemeInternal,
-		defaultSSLPolicy:                          "ELBSecurityPolicy-2016-08",
+		defaultSSLPolicy:                          b.defaultSSLPolicy,
 		defaultTargetType:                         elbv2model.TargetTypeInstance,
 		defaultBackendProtocol:                    elbv2model.ProtocolHTTP,
 		defaultBackendProtocolVersion:             elbv2model.ProtocolVersionHTTP1,

--- a/pkg/service/model_build_listener.go
+++ b/pkg/service/model_build_listener.go
@@ -93,7 +93,7 @@ func (t *defaultModelBuildTask) buildSSLNegotiationPolicy(_ context.Context) *st
 	if exists := t.annotationParser.ParseStringAnnotation(annotations.SvcLBSuffixSSLNegotiationPolicy, &rawSslPolicyStr, t.service.Annotations); exists {
 		return &rawSslPolicyStr
 	}
-	return nil
+	return &t.defaultSSLPolicy
 }
 
 func (t *defaultModelBuildTask) buildListenerCertificates(_ context.Context) []elbv2model.Certificate {

--- a/pkg/service/model_builder.go
+++ b/pkg/service/model_builder.go
@@ -27,12 +27,14 @@ type ModelBuilder interface {
 }
 
 // NewDefaultModelBuilder construct a new defaultModelBuilder
-func NewDefaultModelBuilder(annotationParser annotations.Parser, subnetsResolver networking.SubnetsResolver, clusterName string, defaultTags map[string]string) *defaultModelBuilder {
+func NewDefaultModelBuilder(annotationParser annotations.Parser, subnetsResolver networking.SubnetsResolver, clusterName string,
+	defaultTags map[string]string, defaultSSLPolicy string) *defaultModelBuilder {
 	return &defaultModelBuilder{
 		annotationParser: annotationParser,
 		subnetsResolver:  subnetsResolver,
 		clusterName:      clusterName,
 		defaultTags:      defaultTags,
+		defaultSSLPolicy: defaultSSLPolicy,
 	}
 }
 
@@ -43,6 +45,7 @@ type defaultModelBuilder struct {
 	subnetsResolver  networking.SubnetsResolver
 	clusterName      string
 	defaultTags      map[string]string
+	defaultSSLPolicy string
 }
 
 func (b *defaultModelBuilder) Build(ctx context.Context, service *corev1.Service) (core.Stack, *elbv2model.LoadBalancer, error) {
@@ -57,6 +60,7 @@ func (b *defaultModelBuilder) Build(ctx context.Context, service *corev1.Service
 		tgByResID: make(map[string]*elbv2model.TargetGroup),
 
 		defaultTags:                          b.defaultTags,
+		defaultSSLPolicy:                     b.defaultSSLPolicy,
 		defaultAccessLogS3Enabled:            false,
 		defaultAccessLogsS3Bucket:            "",
 		defaultAccessLogsS3Prefix:            "",
@@ -99,6 +103,7 @@ type defaultModelBuildTask struct {
 	ec2Subnets   []*ec2.Subnet
 
 	defaultTags                          map[string]string
+	defaultSSLPolicy                     string
 	defaultAccessLogS3Enabled            bool
 	defaultAccessLogsS3Bucket            string
 	defaultAccessLogsS3Prefix            string

--- a/pkg/service/model_builder_test.go
+++ b/pkg/service/model_builder_test.go
@@ -772,6 +772,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
              },
              "port":83,
              "protocol":"TLS",
+             "sslPolicy": "ELBSecurityPolicy-2016-08",
              "defaultActions":[
                 {
                    "type":"forward",
@@ -1682,7 +1683,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 			}
 
 			annotationParser := annotations.NewSuffixAnnotationParser("service.beta.kubernetes.io")
-			builder := NewDefaultModelBuilder(annotationParser, subnetsResolver, "my-cluster", nil)
+			builder := NewDefaultModelBuilder(annotationParser, subnetsResolver, "my-cluster", nil, "ELBSecurityPolicy-2016-08")
 			ctx := context.Background()
 			stack, _, err := builder.Build(ctx, tt.svc)
 			if tt.wantError {


### PR DESCRIPTION
The default SSL Policy is used when the SSL policy is not set by
annotations.