### PR TITLE
Updating the default resource tag documentation to reference the correct tag name

### DIFF
--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -678,7 +678,7 @@ Custom attributes to LoadBalancers and TargetGroups can be controlled with follo
 ## Resource Tags
 AWS Load Balancer Controller will automatically apply following tags to AWS resources(ALB/TargetGroups/SecurityGroups) created.
 
-- `ingress.k8s.aws/cluster: ${clusterName}`
+- `elbv2.k8s.aws/cluster: ${clusterName}`
 - `ingress.k8s.aws/stack: ${stackID}`
 - `ingress.k8s.aws/resource: ${resourceID}`
 


### PR DESCRIPTION
**Context**
Fixes: #1886
Issue filed pointing out the error in the docs: https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/1886

**Testing**
Took a look locally and it looked good.