### PR TITLE
Update nlb target type annotation

### DIFF
--- a/controllers/service/eventhandlers/service_events.go
+++ b/controllers/service/eventhandlers/service_events.go
@@ -65,8 +65,8 @@ func (h *enqueueRequestsForServiceEvent) isServiceSupported(service *corev1.Serv
 	}
 	var lbTargetType string
 	_ = h.annotationParser.ParseStringAnnotation(annotations.SvcLBSuffixTargetType, &lbTargetType, service.Annotations)
-	if lbType == svcpkg.LoadBalancerTypeExternal && (lbTargetType == svcpkg.LoadBalancerTargetTypeNLBIP ||
-		lbTargetType == svcpkg.LoadBalancerTargetTypeNLBInstance) {
+	if lbType == svcpkg.LoadBalancerTypeExternal && (lbTargetType == svcpkg.LoadBalancerTargetTypeIP ||
+		lbTargetType == svcpkg.LoadBalancerTargetTypeInstance) {
 		return true
 	}
 	return false

--- a/pkg/annotations/constants.go
+++ b/pkg/annotations/constants.go
@@ -49,10 +49,11 @@ const (
 	// prefixes service.beta.kubernetes.io, service.kubernetes.io
 	SvcLBSuffixSourceRanges                  = "load-balancer-source-ranges"
 	SvcLBSuffixLoadBalancerType              = "aws-load-balancer-type"
-	SvcLBSuffixInternal                      = "aws-load-balancer-internal"
-	SvcLBSuffixIPAddressType                 = "aws-load-balancer-ip-address-type"
+	SvcLBSuffixTargetType                    = "aws-load-balancer-nlb-target-type"
 	SvcLBSuffixLoadBalancerName              = "aws-load-balancer-name"
+	SvcLBSuffixInternal                      = "aws-load-balancer-internal"
 	SvcLBSuffixProxyProtocol                 = "aws-load-balancer-proxy-protocol"
+	SvcLBSuffixIPAddressType                 = "aws-load-balancer-ip-address-type"
 	SvcLBSuffixAccessLogEnabled              = "aws-load-balancer-access-log-enabled"
 	SvcLBSuffixAccessLogS3BucketName         = "aws-load-balancer-access-log-s3-bucket-name"
 	SvcLBSuffixAccessLogS3BucketPrefix       = "aws-load-balancer-access-log-s3-bucket-prefix"
@@ -74,6 +75,5 @@ const (
 	SvcLBSuffixTargetGroupAttributes         = "aws-load-balancer-target-group-attributes"
 	SvcLBSuffixSubnets                       = "aws-load-balancer-subnets"
 	SvcLBSuffixALPNPolicy                    = "aws-load-balancer-alpn-policy"
-	SvcLBSuffixTargetType                    = "aws-load-balancer-target-type"
 	SvcLBSuffixTargetNodeLabels              = "aws-load-balancer-target-node-labels"
 )

--- a/pkg/ingress/model_build_target_group_test.go
+++ b/pkg/ingress/model_build_target_group_test.go
@@ -614,7 +614,7 @@ func Test_defaultModelBuildTask_buildTargetGroupBindingNodeSelector(t *testing.T
 						},
 					},
 				},
-				svc: &corev1.Service{},
+				svc:        &corev1.Service{},
 				targetType: elbv2model.TargetTypeInstance,
 			},
 			wantErr: errors.New("failed to parse stringMap annotation, alb.ingress.kubernetes.io/target-node-labels: key1"),

--- a/pkg/service/model_build_target_group.go
+++ b/pkg/service/model_build_target_group.go
@@ -325,10 +325,10 @@ func (t *defaultModelBuildTask) buildTargetType(_ context.Context) (elbv2model.T
 	_ = t.annotationParser.ParseStringAnnotation(annotations.SvcLBSuffixLoadBalancerType, &lbType, t.service.Annotations)
 	var lbTargetType string
 	_ = t.annotationParser.ParseStringAnnotation(annotations.SvcLBSuffixTargetType, &lbTargetType, t.service.Annotations)
-	if lbType == LoadBalancerTargetTypeNLBIP || (lbType == LoadBalancerTypeExternal && lbTargetType == LoadBalancerTargetTypeNLBIP) {
+	if lbType == LoadBalancerTypeNLBIP || (lbType == LoadBalancerTypeExternal && lbTargetType == LoadBalancerTargetTypeIP) {
 		return elbv2model.TargetTypeIP, nil
 	}
-	if lbType == LoadBalancerTypeExternal && lbTargetType == LoadBalancerTargetTypeNLBInstance {
+	if lbType == LoadBalancerTypeExternal && lbTargetType == LoadBalancerTargetTypeInstance {
 		return elbv2model.TargetTypeInstance, nil
 	}
 	return "", errors.Errorf("unsupported target type \"%v\" for load balancer type \"%v\"", lbTargetType, lbType)

--- a/pkg/service/model_build_target_group_test.go
+++ b/pkg/service/model_build_target_group_test.go
@@ -966,8 +966,8 @@ func Test_defaultModelBuilder_buildTargetType(t *testing.T) {
 			svc: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"service.beta.kubernetes.io/aws-load-balancer-type":        "external",
-						"service.beta.kubernetes.io/aws-load-balancer-target-type": "nlb-instance",
+						"service.beta.kubernetes.io/aws-load-balancer-type":            "external",
+						"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "instance",
 					},
 				},
 			},
@@ -978,8 +978,8 @@ func Test_defaultModelBuilder_buildTargetType(t *testing.T) {
 			svc: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"service.beta.kubernetes.io/aws-load-balancer-type":        "external",
-						"service.beta.kubernetes.io/aws-load-balancer-target-type": "nlb-ip",
+						"service.beta.kubernetes.io/aws-load-balancer-type":            "external",
+						"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "ip",
 					},
 				},
 			},
@@ -1001,8 +1001,8 @@ func Test_defaultModelBuilder_buildTargetType(t *testing.T) {
 			svc: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"service.beta.kubernetes.io/aws-load-balancer-type":        "external",
-						"service.beta.kubernetes.io/aws-load-balancer-target-type": "unknown",
+						"service.beta.kubernetes.io/aws-load-balancer-type":            "external",
+						"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "unknown",
 					},
 				},
 			},

--- a/pkg/service/model_builder.go
+++ b/pkg/service/model_builder.go
@@ -14,10 +14,10 @@ import (
 )
 
 const (
-	LoadBalancerTypeNLBIP             = "nlb-ip"
-	LoadBalancerTypeExternal          = "external"
-	LoadBalancerTargetTypeNLBIP       = "nlb-ip"
-	LoadBalancerTargetTypeNLBInstance = "nlb-instance"
+	LoadBalancerTypeNLBIP          = "nlb-ip"
+	LoadBalancerTypeExternal       = "external"
+	LoadBalancerTargetTypeIP       = "ip"
+	LoadBalancerTargetTypeInstance = "instance"
 )
 
 // ModelBuilder builds the model stack for the service resource.

--- a/pkg/service/model_builder_test.go
+++ b/pkg/service/model_builder_test.go
@@ -1022,8 +1022,8 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 					Name:      "service-deleted",
 					Namespace: "doesnt-exist",
 					Annotations: map[string]string{
-						"service.beta.kubernetes.io/aws-load-balancer-type":        "external",
-						"service.beta.kubernetes.io/aws-load-balancer-target-type": "nlb-ip",
+						"service.beta.kubernetes.io/aws-load-balancer-type":            "external",
+						"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "ip",
 					},
 					DeletionTimestamp: &metav1.Time{
 						Time: time.Now(),
@@ -1044,8 +1044,8 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 					Name:      "instance-mode",
 					Namespace: "default",
 					Annotations: map[string]string{
-						"service.beta.kubernetes.io/aws-load-balancer-type":        "external",
-						"service.beta.kubernetes.io/aws-load-balancer-target-type": "nlb-instance",
+						"service.beta.kubernetes.io/aws-load-balancer-type":            "external",
+						"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "instance",
 					},
 					UID: "2dc098f0-ae33-4378-af7b-83e2a0424495",
 				},
@@ -1352,8 +1352,8 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 					Name:      "traffic-local",
 					Namespace: "app",
 					Annotations: map[string]string{
-						"service.beta.kubernetes.io/aws-load-balancer-type":        "external",
-						"service.beta.kubernetes.io/aws-load-balancer-target-type": "nlb-instance",
+						"service.beta.kubernetes.io/aws-load-balancer-type":            "external",
+						"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "instance",
 					},
 					UID: "2dc098f0-ae33-4378-af7b-83e2a0424495",
 				},

--- a/test/e2e/service/nlb_instance_target.go
+++ b/test/e2e/service/nlb_instance_target.go
@@ -95,8 +95,8 @@ func (s *NLBInstanceTestStack) buildServiceSpec(ctx context.Context, annotations
 		ObjectMeta: metav1.ObjectMeta{
 			Name: defaultName,
 			Annotations: map[string]string{
-				"service.beta.kubernetes.io/aws-load-balancer-type":        "external",
-				"service.beta.kubernetes.io/aws-load-balancer-target-type": "nlb-instance",
+				"service.beta.kubernetes.io/aws-load-balancer-type":            "external",
+				"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "instance",
 			},
 		},
 		Spec: corev1.ServiceSpec{

--- a/test/e2e/service/nlb_ip_target_test.go
+++ b/test/e2e/service/nlb_ip_target_test.go
@@ -303,7 +303,7 @@ var _ = Describe("k8s service reconciled by the aws load balancer", func() {
 	})
 	Context("NLB IP Load Balancer with name", func() {
 		var (
-			svc *corev1.Service
+			svc    *corev1.Service
 			lbName string
 		)
 		BeforeEach(func() {


### PR DESCRIPTION
Use the following annotation for NLB target type determination 
```
service.beta.kubernetes.io/aws-load-balancer-nlb-target-type
```
The valid values are `ip` and `instance`.

This makes the annotation consistent with ALB.