### PR TITLE
Additional e2e tests for service

### DIFF
--- a/test/e2e/service/nlb_instance_target_test.go
+++ b/test/e2e/service/nlb_instance_target_test.go
@@ -3,11 +3,13 @@ package service
 import (
 	"context"
 	"fmt"
+	awssdk "github.com/aws/aws-sdk-go/aws"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework/http"
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework/utils"
+	"strings"
 )
 
 var _ = Describe("test k8s service reconciled by the aws load balancer controller", func() {
@@ -84,7 +86,7 @@ var _ = Describe("test k8s service reconciled by the aws load balancer controlle
 			})
 
 			By("enabling cross zone load balancing", func() {
-				err := stack.UpdateServiceAnnotation(ctx, tf, map[string]string{
+				err := stack.UpdateServiceAnnotations(ctx, tf, map[string]string{
 					"service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled": "true",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -97,7 +99,7 @@ var _ = Describe("test k8s service reconciled by the aws load balancer controlle
 			})
 
 			By("specifying load balancer tags", func() {
-				err := stack.UpdateServiceAnnotation(ctx, tf, map[string]string{
+				err := stack.UpdateServiceAnnotations(ctx, tf, map[string]string{
 					"service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags": "instance-mode=true, key1=value1",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -174,7 +176,7 @@ var _ = Describe("test k8s service reconciled by the aws load balancer controlle
 				Expect(err).NotTo(HaveOccurred())
 			})
 			By("specifying target group attributes annotation", func() {
-				err := stack.UpdateServiceAnnotation(ctx, tf, map[string]string{
+				err := stack.UpdateServiceAnnotations(ctx, tf, map[string]string{
 					"service.beta.kubernetes.io/aws-load-balancer-target-group-attributes": "preserve_client_ip.enabled=false, proxy_protocol_v2.enabled=true, deregistration_delay.timeout_seconds=120",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -186,6 +188,145 @@ var _ = Describe("test k8s service reconciled by the aws load balancer controlle
 						"deregistration_delay.timeout_seconds": "120",
 					})
 				}, utils.PollTimeoutShort, utils.PollIntervalMedium).Should(BeTrue())
+			})
+		})
+		It("should create TLS listeners", func() {
+			if len(tf.Options.CertificateARNs) == 0 {
+				Skip("Skipping tests, certificates not specified")
+			}
+			By("deploying stack", func() {
+				err := stack.Deploy(ctx, tf, map[string]string{
+					"service.beta.kubernetes.io/aws-load-balancer-ssl-cert": tf.Options.CertificateARNs,
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("checking service status for lb dns name", func() {
+				dnsName = stack.GetLoadBalancerIngressHostName()
+				Expect(dnsName).ToNot(BeEmpty())
+			})
+
+			By("querying AWS loadbalancer from the dns name", func() {
+				var err error
+				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(lbARN).ToNot(BeEmpty())
+			})
+			By("verifying AWS loadbalancer resources", func() {
+				err := verifyAWSLoadBalancerResources(ctx, tf, lbARN, LoadBalancerExpectation{
+					Type:       "network",
+					Scheme:     "internet-facing",
+					TargetType: "instance",
+					Listeners: map[string]string{
+						"80": "TLS",
+					},
+					TargetGroups: stack.resourceStack.getTargetGroupNodePortMap(),
+					NumTargets:   0,
+					TargetGroupHC: &TargetGroupHC{
+						Protocol:           "TCP",
+						Port:               "traffic-port",
+						Interval:           10,
+						Timeout:            10,
+						HealthyThreshold:   3,
+						UnhealthyThreshold: 3,
+					},
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("verifying listener certificates", func() {
+				expectedARNs := strings.Split(tf.Options.CertificateARNs, ",")
+				Eventually(func() bool {
+					return verifyLoadBalancerListenerCertificates(ctx, tf, lbARN, expectedARNs) == nil
+				}, utils.PollTimeoutShort, utils.PollIntervalMedium).Should(BeTrue())
+			})
+			By("removing first certificate from annotation and updating the service", func() {
+				certs := strings.Split(tf.Options.CertificateARNs, ",")[1:]
+				if len(certs) == 0 {
+					return
+				}
+				err := stack.UpdateServiceAnnotations(ctx, tf, map[string]string{
+					"service.beta.kubernetes.io/aws-load-balancer-ssl-cert": strings.Join(certs, ","),
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(func() bool {
+					return verifyLoadBalancerListenerCertificates(ctx, tf, lbARN, certs) == nil
+				}, utils.PollTimeoutShort, utils.PollIntervalMedium).Should(BeTrue())
+			})
+		})
+		It("should enable proxy protocol v2", func() {
+			By("deploying stack", func() {
+				err := stack.Deploy(ctx, tf, map[string]string{
+					"service.beta.kubernetes.io/aws-load-balancer-proxy-protocol": "*",
+				})
+				Expect(err).ToNot(HaveOccurred())
+				dnsName = stack.GetLoadBalancerIngressHostName()
+				Expect(dnsName).ToNot(BeEmpty())
+				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(lbARN).ToNot(BeEmpty())
+			})
+			By("verifying target group attributes", func() {
+				verified := verifyTargetGroupAttributes(ctx, tf, lbARN, map[string]string{
+					"proxy_protocol_v2.enabled": "true",
+				})
+				Expect(verified).To(BeTrue())
+			})
+			By("verifying precedence with target group attributes configuration", func() {
+				err := stack.UpdateServiceAnnotations(ctx, tf, map[string]string{
+					"service.beta.kubernetes.io/aws-load-balancer-target-group-attributes": "proxy_protocol_v2.enabled=false, deregistration_delay.timeout_seconds=120",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(func() bool {
+					return verifyTargetGroupAttributes(ctx, tf, lbARN, map[string]string{
+						"proxy_protocol_v2.enabled":            "true",
+						"deregistration_delay.timeout_seconds": "120",
+					})
+				}, utils.PollTimeoutShort, utils.PollIntervalMedium).Should(BeTrue())
+			})
+		})
+	})
+
+	Context("with NLB instance target configuration with target node labels", func() {
+		It("should add only the labelled nodes to the target group", func() {
+			By("deploying stack", func() {
+				err := stack.Deploy(ctx, tf, map[string]string{
+					"service.beta.kubernetes.io/aws-load-balancer-target-node-labels": "service.node.label/key1=value1",
+				})
+				Expect(err).ToNot(HaveOccurred())
+				dnsName = stack.GetLoadBalancerIngressHostName()
+				Expect(dnsName).ToNot(BeEmpty())
+				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(lbARN).ToNot(BeEmpty())
+			})
+			By("applying label to 1 worker node", func() {
+				nodes, err := stack.GetWorkerNodes(ctx, tf)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(nodes)).To(BeNumerically(">", 0))
+				err = stack.ApplyNodeLabels(ctx, tf, &nodes[0], map[string]string{"service.node.label/key1": "value1"})
+				Expect(err).ToNot(HaveOccurred())
+
+				targetGroups, err := tf.TGManager.GetTargetGroupsForLoadBalancer(ctx, lbARN)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(targetGroups)).To(Equal(1))
+				tgARN := awssdk.StringValue(targetGroups[0].TargetGroupArn)
+
+				err = verifyTargetGroupNumRegistered(ctx, tf, tgARN, 1)
+				Expect(err).ToNot(HaveOccurred())
+			})
+			By("removing target-node-labels annotation from the service", func() {
+				err := stack.DeleteServiceAnnotations(ctx, tf, []string{"service.beta.kubernetes.io/aws-load-balancer-target-node-labels"})
+				Expect(err).ToNot(HaveOccurred())
+
+				targetGroups, err := tf.TGManager.GetTargetGroupsForLoadBalancer(ctx, lbARN)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(targetGroups)).To(Equal(1))
+				tgARN := awssdk.StringValue(targetGroups[0].TargetGroupArn)
+
+				nodes, err := stack.GetWorkerNodes(ctx, tf)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = verifyTargetGroupNumRegistered(ctx, tf, tgARN, len(nodes))
+				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 	})

--- a/test/e2e/service/resource_stack.go
+++ b/test/e2e/service/resource_stack.go
@@ -65,6 +65,16 @@ func (s *resourceStack) UpdateServiceAnnotations(ctx context.Context, f *framewo
 	return nil
 }
 
+func (s *resourceStack) DeleteServiceAnnotations(ctx context.Context, f *framework.Framework, annotationKeys []string) error {
+	if err := s.removeServiceAnnotations(ctx, f, annotationKeys); err != nil {
+		return err
+	}
+	if err := s.waitUntilServiceReady(ctx, f); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (s *resourceStack) UpdateServiceTrafficPolicy(ctx context.Context, f *framework.Framework, trafficPolicy corev1.ServiceExternalTrafficPolicyType) error {
 	if err := s.updateServiceTrafficPolicy(ctx, f, trafficPolicy); err != nil {
 		return err
@@ -138,6 +148,15 @@ func (s *resourceStack) updateServiceAnnotations(ctx context.Context, f *framewo
 	oldSvc := s.svc.DeepCopy()
 	for key, value := range svcAnnotations {
 		s.svc.Annotations[key] = value
+	}
+	return s.updateService(ctx, f, oldSvc)
+}
+
+func (s *resourceStack) removeServiceAnnotations(ctx context.Context, f *framework.Framework, annotationKeys []string) error {
+	f.Logger.Info("removing service annotations", "svc", k8s.NamespacedName(s.svc))
+	oldSvc := s.svc.DeepCopy()
+	for _, key := range annotationKeys {
+		delete(s.svc.Annotations, key)
 	}
 	return s.updateService(ctx, f, oldSvc)
 }

--- a/test/framework/resources/aws/load_balancer.go
+++ b/test/framework/resources/aws/load_balancer.go
@@ -15,6 +15,7 @@ type LoadBalancerManager interface {
 	WaitUntilLoadBalancerAvailable(ctx context.Context, lbARN string) error
 	GetLoadBalancerFromARN(ctx context.Context, lbARN string) (*elbv2sdk.LoadBalancer, error)
 	GetLoadBalancerListeners(ctx context.Context, lbARN string) ([]*elbv2sdk.Listener, error)
+	GetLoadBalancerListenerCertificates(ctx context.Context, listnerARN string) ([]*elbv2sdk.Certificate, error)
 	GetLoadBalancerAttributes(ctx context.Context, lbARN string) ([]*elbv2sdk.LoadBalancerAttribute, error)
 	GetLoadBalancerTags(ctx context.Context, lbARN string) ([]*elbv2sdk.Tag, error)
 }
@@ -78,6 +79,12 @@ func (m *defaultLoadBalancerManager) GetLoadBalancerListeners(ctx context.Contex
 		return nil, err
 	}
 	return listeners.Listeners, nil
+}
+
+func (m *defaultLoadBalancerManager) GetLoadBalancerListenerCertificates(ctx context.Context, listnerARN string) ([]*elbv2sdk.Certificate, error) {
+	return m.elbv2Client.DescribeListenerCertificatesAsList(ctx, &elbv2sdk.DescribeListenerCertificatesInput{
+		ListenerArn: awssdk.String(listnerARN),
+	})
 }
 
 func (m *defaultLoadBalancerManager) GetLoadBalancerAttributes(ctx context.Context, lbARN string) ([]*elbv2sdk.LoadBalancerAttribute, error) {


### PR DESCRIPTION
Add the following e2e tests for service 
- TLS listeners multi-certificates
- edit certificate annotations, verify first certificate in the list is the default cert
- proxy protocol v2 annotation, targetgroup attributes
- target node labels for instance mode