### PR TITLE
add validating webhook for ingress_class_params

### DIFF
--- a/main.go
+++ b/main.go
@@ -141,7 +141,7 @@ func main() {
 	corewebhook.NewPodMutator(podReadinessGateInjector).SetupWithManager(mgr)
 	elbv2webhook.NewTargetGroupBindingMutator(cloud.ELBV2(), ctrl.Log).SetupWithManager(mgr)
 	elbv2webhook.NewTargetGroupBindingValidator(ctrl.Log).SetupWithManager(mgr)
-	networkingwebhook.NewIngressValidator(controllerCFG.IngressConfig, ctrl.Log).SetupWithManager(mgr)
+	networkingwebhook.NewIngressValidator(mgr.GetClient(), controllerCFG.IngressConfig, ctrl.Log).SetupWithManager(mgr)
 	//+kubebuilder:scaffold:builder
 
 	stopChan := ctrl.SetupSignalHandler()

--- a/pkg/ingress/class.go
+++ b/pkg/ingress/class.go
@@ -1,0 +1,14 @@
+package ingress
+
+import (
+	networking "k8s.io/api/networking/v1beta1"
+	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
+)
+
+// ClassConfiguration contains configurations for IngressClass
+type ClassConfiguration struct {
+	// The IngressClass for Ingress if any.
+	IngClass *networking.IngressClass
+	// The IngressClassParams for Ingress if any.
+	IngClassParams *elbv2api.IngressClassParams
+}

--- a/pkg/ingress/class_loader.go
+++ b/pkg/ingress/class_loader.go
@@ -1,0 +1,111 @@
+package ingress
+
+import (
+	"context"
+	"fmt"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	networking "k8s.io/api/networking/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// the controller name used in IngressClass for ALB.
+	ingressClassControllerALB = "ingress.k8s.aws/alb"
+	// the Kind for IngressClassParams CRD.
+	ingressClassParamsKind = "IngressClassParams"
+)
+
+// ErrInvalidIngressClass is an sentinel error that represents the IngressClass configuration for Ingress is invalid.
+var ErrInvalidIngressClass = errors.New("invalid ingress class")
+
+// ClassLoader loads IngressClass configurations for Ingress.
+type ClassLoader interface {
+	Load(ctx context.Context, ing *networking.Ingress) (ClassConfiguration, error)
+}
+
+// NewDefaultClassLoader constructs new defaultClassLoader instance.
+func NewDefaultClassLoader(client client.Client) *defaultClassLoader {
+	return &defaultClassLoader{
+		client: client,
+	}
+}
+
+// default implementation for ClassLoader
+type defaultClassLoader struct {
+	client client.Client
+}
+
+func (l *defaultClassLoader) Load(ctx context.Context, ing *networking.Ingress) (ClassConfiguration, error) {
+	if ing.Spec.IngressClassName == nil {
+		return ClassConfiguration{}, nil
+	}
+
+	ingClassKey := types.NamespacedName{Name: *ing.Spec.IngressClassName}
+	ingClass := &networking.IngressClass{}
+	if err := l.client.Get(ctx, ingClassKey, ingClass); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ClassConfiguration{}, fmt.Errorf("%w: %v", ErrInvalidIngressClass, err.Error())
+		}
+		return ClassConfiguration{}, err
+	}
+	if ingClass.Spec.Controller != ingressClassControllerALB || ingClass.Spec.Parameters == nil {
+		return ClassConfiguration{
+			IngClass: ingClass,
+		}, nil
+	}
+
+	if ingClass.Spec.Parameters.APIGroup == nil ||
+		(*ingClass.Spec.Parameters.APIGroup) != elbv2api.GroupVersion.Group ||
+		ingClass.Spec.Parameters.Kind != ingressClassParamsKind {
+		return ClassConfiguration{}, fmt.Errorf("%w: IngressClass %v references unknown parameters", ErrInvalidIngressClass, ingClass.Name)
+	}
+	ingClassParamsKey := types.NamespacedName{Name: ingClass.Spec.Parameters.Name}
+	ingClassParams := &elbv2api.IngressClassParams{}
+	if err := l.client.Get(ctx, ingClassParamsKey, ingClassParams); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ClassConfiguration{}, fmt.Errorf("%w: %v", ErrInvalidIngressClass, err.Error())
+		}
+		return ClassConfiguration{}, err
+	}
+	if err := l.validateIngressClassParamsNamespaceRestriction(ctx, ing, ingClassParams); err != nil {
+		return ClassConfiguration{}, fmt.Errorf("%w: %v", ErrInvalidIngressClass, err.Error())
+	}
+
+	return ClassConfiguration{
+		IngClass:       ingClass,
+		IngClassParams: ingClassParams,
+	}, nil
+}
+
+func (l *defaultClassLoader) validateIngressClassParamsNamespaceRestriction(ctx context.Context, ing *networking.Ingress, ingClassParams *elbv2api.IngressClassParams) error {
+	// when namespaceSelector is empty, it matches every namespace
+	if ingClassParams.Spec.NamespaceSelector == nil {
+		return nil
+	}
+
+	ingNamespace := ing.Namespace
+	// see https://github.com/kubernetes/kubernetes/issues/88282 and https://github.com/kubernetes/kubernetes/issues/76680
+	if admissionReq := webhook.ContextGetAdmissionRequest(ctx); admissionReq != nil {
+		ingNamespace = admissionReq.Namespace
+	}
+	ingNSKey := types.NamespacedName{Name: ingNamespace}
+	ingNS := &corev1.Namespace{}
+	if err := l.client.Get(ctx, ingNSKey, ingNS); err != nil {
+		return err
+	}
+	selector, err := metav1.LabelSelectorAsSelector(ingClassParams.Spec.NamespaceSelector)
+	if err != nil {
+		return err
+	}
+	if !selector.Matches(labels.Set(ingNS.Labels)) {
+		return errors.Errorf("namespaceSelector of IngressClassParams %v mismatch", ingClassParams.Name)
+	}
+	return nil
+}

--- a/pkg/ingress/class_loader_test.go
+++ b/pkg/ingress/class_loader_test.go
@@ -1,0 +1,709 @@
+package ingress
+
+import (
+	"context"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	networking "k8s.io/api/networking/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/equality"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/webhook"
+	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"testing"
+)
+
+func Test_defaultClassLoader_Load(t *testing.T) {
+	type env struct {
+		nsList             []*corev1.Namespace
+		ingClassList       []*networking.IngressClass
+		ingClassParamsList []*elbv2api.IngressClassParams
+	}
+	type args struct {
+		ing *networking.Ingress
+	}
+	tests := []struct {
+		name    string
+		env     env
+		args    args
+		want    ClassConfiguration
+		wantErr error
+	}{
+		{
+			name: "when IngressClassName unspecified",
+			env: env{
+				nsList: []*corev1.Namespace{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "awesome-ns",
+						},
+					},
+				},
+			},
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Name:      "awesome-ing",
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: nil,
+					},
+				},
+			},
+			want:    ClassConfiguration{},
+			wantErr: nil,
+		},
+		{
+			name: "when IngressClass not found",
+			env: env{
+				nsList: []*corev1.Namespace{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "awesome-ns",
+						},
+					},
+				},
+			},
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Name:      "awesome-ing",
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: aws.String("awesome-class"),
+					},
+				},
+			},
+			wantErr: errors.New("invalid ingress class: ingressclasses.networking.k8s.io \"awesome-class\" not found"),
+		},
+		{
+			name: "when IngressClass found and belong to other controller",
+			env: env{
+				nsList: []*corev1.Namespace{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "awesome-ns",
+						},
+					},
+				},
+				ingClassList: []*networking.IngressClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "awesome-class",
+						},
+						Spec: networking.IngressClassSpec{
+							Controller: "some-other-controller",
+							Parameters: &corev1.TypedLocalObjectReference{
+								Kind: "IngressClassParams",
+								Name: "awesome-class-config",
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Name:      "awesome-ing",
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: aws.String("awesome-class"),
+					},
+				},
+			},
+			want: ClassConfiguration{
+				IngClass: &networking.IngressClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "awesome-class",
+					},
+					Spec: networking.IngressClassSpec{
+						Controller: "some-other-controller",
+						Parameters: &corev1.TypedLocalObjectReference{
+							Kind: "IngressClassParams",
+							Name: "awesome-class-config",
+						},
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "when IngressClass is ALB - without IngressClassParams",
+			env: env{
+				nsList: []*corev1.Namespace{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "awesome-ns",
+						},
+					},
+				},
+				ingClassList: []*networking.IngressClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "awesome-class",
+						},
+						Spec: networking.IngressClassSpec{
+							Controller: "ingress.k8s.aws/alb",
+							Parameters: nil,
+						},
+					},
+				},
+			},
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Name:      "awesome-ing",
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: aws.String("awesome-class"),
+					},
+				},
+			},
+			want: ClassConfiguration{
+				IngClass: &networking.IngressClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "awesome-class",
+					},
+					Spec: networking.IngressClassSpec{
+						Controller: "ingress.k8s.aws/alb",
+						Parameters: nil,
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "when IngressClass is ALB - with invalid IngressClassParams - empty APIGroup",
+			env: env{
+				nsList: []*corev1.Namespace{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "awesome-ns",
+						},
+					},
+				},
+				ingClassList: []*networking.IngressClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "awesome-class",
+						},
+						Spec: networking.IngressClassSpec{
+							Controller: "ingress.k8s.aws/alb",
+							Parameters: &corev1.TypedLocalObjectReference{
+								Kind: "IngressClassParams",
+								Name: "awesome-class-params",
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Name:      "awesome-ing",
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: aws.String("awesome-class"),
+					},
+				},
+			},
+			wantErr: errors.New("invalid ingress class: IngressClass awesome-class references unknown parameters"),
+		},
+		{
+			name: "when IngressClass is ALB - with invalid IngressClassParams - unknown APIGroup",
+			env: env{
+				nsList: []*corev1.Namespace{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "awesome-ns",
+						},
+					},
+				},
+				ingClassList: []*networking.IngressClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "awesome-class",
+						},
+						Spec: networking.IngressClassSpec{
+							Controller: "ingress.k8s.aws/alb",
+							Parameters: &corev1.TypedLocalObjectReference{
+								APIGroup: aws.String("some.other.group/v1"),
+								Kind:     "IngressClassParams",
+								Name:     "awesome-class-params",
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Name:      "awesome-ing",
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: aws.String("awesome-class"),
+					},
+				},
+			},
+			wantErr: errors.New("invalid ingress class: IngressClass awesome-class references unknown parameters"),
+		},
+		{
+			name: "when IngressClass is ALB - with invalid IngressClassParams - unknown Kind",
+			env: env{
+				nsList: []*corev1.Namespace{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "awesome-ns",
+						},
+					},
+				},
+				ingClassList: []*networking.IngressClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "awesome-class",
+						},
+						Spec: networking.IngressClassSpec{
+							Controller: "ingress.k8s.aws/alb",
+							Parameters: &corev1.TypedLocalObjectReference{
+								APIGroup: aws.String("elbv2.k8s.aws"),
+								Kind:     "SomeOtherKind",
+								Name:     "awesome-class-params",
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Name:      "awesome-ing",
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: aws.String("awesome-class"),
+					},
+				},
+			},
+			wantErr: errors.New("invalid ingress class: IngressClass awesome-class references unknown parameters"),
+		},
+		{
+			name: "when IngressClass is ALB - with invalid IngressClassParams - non-exists",
+			env: env{
+				nsList: []*corev1.Namespace{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "awesome-ns",
+						},
+					},
+				},
+				ingClassList: []*networking.IngressClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "awesome-class",
+						},
+						Spec: networking.IngressClassSpec{
+							Controller: "ingress.k8s.aws/alb",
+							Parameters: &corev1.TypedLocalObjectReference{
+								APIGroup: aws.String("elbv2.k8s.aws"),
+								Kind:     "IngressClassParams",
+								Name:     "awesome-class-params",
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Name:      "awesome-ing",
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: aws.String("awesome-class"),
+					},
+				},
+			},
+			wantErr: errors.New("invalid ingress class: ingressclassparamses.elbv2.k8s.aws \"awesome-class-params\" not found"),
+		},
+		{
+			name: "when IngressClass is ALB - with invalid IngressClassParams - namespaceSelector mismatch",
+			env: env{
+				nsList: []*corev1.Namespace{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "awesome-ns",
+							Labels: map[string]string{
+								"team": "another-team",
+							},
+						},
+					},
+				},
+				ingClassList: []*networking.IngressClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "awesome-class",
+						},
+						Spec: networking.IngressClassSpec{
+							Controller: "ingress.k8s.aws/alb",
+							Parameters: &corev1.TypedLocalObjectReference{
+								APIGroup: aws.String("elbv2.k8s.aws"),
+								Kind:     "IngressClassParams",
+								Name:     "awesome-class-params",
+							},
+						},
+					},
+				},
+				ingClassParamsList: []*elbv2api.IngressClassParams{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "awesome-class-params",
+						},
+						Spec: elbv2api.IngressClassParamsSpec{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"team": "awesome-team",
+								},
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Name:      "awesome-ing",
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: aws.String("awesome-class"),
+					},
+				},
+			},
+			wantErr: errors.New("invalid ingress class: namespaceSelector of IngressClassParams awesome-class-params mismatch"),
+		},
+		{
+			name: "when IngressClass is ALB - with valid IngressClassParams",
+			env: env{
+				nsList: []*corev1.Namespace{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "awesome-ns",
+							Labels: map[string]string{
+								"team": "awesome-team",
+							},
+						},
+					},
+				},
+				ingClassList: []*networking.IngressClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "awesome-class",
+						},
+						Spec: networking.IngressClassSpec{
+							Controller: "ingress.k8s.aws/alb",
+							Parameters: &corev1.TypedLocalObjectReference{
+								APIGroup: aws.String("elbv2.k8s.aws"),
+								Kind:     "IngressClassParams",
+								Name:     "awesome-class-params",
+							},
+						},
+					},
+				},
+				ingClassParamsList: []*elbv2api.IngressClassParams{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "awesome-class-params",
+						},
+						Spec: elbv2api.IngressClassParamsSpec{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"team": "awesome-team",
+								},
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Name:      "awesome-ing",
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: aws.String("awesome-class"),
+					},
+				},
+			},
+			want: ClassConfiguration{
+				IngClass: &networking.IngressClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "awesome-class",
+					},
+					Spec: networking.IngressClassSpec{
+						Controller: "ingress.k8s.aws/alb",
+						Parameters: &corev1.TypedLocalObjectReference{
+							APIGroup: aws.String("elbv2.k8s.aws"),
+							Kind:     "IngressClassParams",
+							Name:     "awesome-class-params",
+						},
+					},
+				},
+				IngClassParams: &elbv2api.IngressClassParams{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "awesome-class-params",
+					},
+					Spec: elbv2api.IngressClassParamsSpec{
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"team": "awesome-team",
+							},
+						},
+					},
+				},
+			},
+			wantErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			ctx := context.Background()
+			k8sSchema := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sSchema)
+			elbv2api.AddToScheme(k8sSchema)
+			k8sClient := testclient.NewFakeClientWithScheme(k8sSchema)
+			for _, ns := range tt.env.nsList {
+				assert.NoError(t, k8sClient.Create(ctx, ns.DeepCopy()))
+			}
+			for _, ingClass := range tt.env.ingClassList {
+				assert.NoError(t, k8sClient.Create(ctx, ingClass.DeepCopy()))
+			}
+			for _, ingClassParams := range tt.env.ingClassParamsList {
+				assert.NoError(t, k8sClient.Create(ctx, ingClassParams.DeepCopy()))
+			}
+
+			l := &defaultClassLoader{
+				client: k8sClient,
+			}
+			got, err := l.Load(ctx, tt.args.ing)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				opt := cmp.Options{
+					equality.IgnoreFakeClientPopulatedFields(),
+				}
+				assert.True(t, cmp.Equal(tt.want, got, opt),
+					"diff: %v", cmp.Diff(tt.want, got, opt))
+			}
+		})
+	}
+}
+
+func Test_defaultClassLoader_validateIngressClassParamsNamespaceRestriction(t *testing.T) {
+	type env struct {
+		nsList []*corev1.Namespace
+	}
+	type args struct {
+		admissionReq   *admission.Request
+		ing            *networking.Ingress
+		ingClassParams *elbv2api.IngressClassParams
+	}
+	tests := []struct {
+		name    string
+		env     env
+		args    args
+		wantErr error
+	}{
+		{
+			name: "when ingressClassParams have empty namespaceSelector",
+			env: env{
+				nsList: []*corev1.Namespace{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "awesome-ns",
+						},
+					},
+				},
+			},
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "my-ns",
+						Name:      "awesome-ns",
+					},
+				},
+				ingClassParams: &elbv2api.IngressClassParams{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "awesome-class",
+					},
+					Spec: elbv2api.IngressClassParamsSpec{
+						NamespaceSelector: nil,
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "when ingressClassParams have nonempty namespaceSelector - matches Ingress's namespace [without admission request]",
+			env: env{
+				nsList: []*corev1.Namespace{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "awesome-ns",
+							Labels: map[string]string{
+								"team": "awesome-team",
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				admissionReq: nil,
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Name:      "awesome-ing",
+					},
+				},
+				ingClassParams: &elbv2api.IngressClassParams{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "awesome-class",
+					},
+					Spec: elbv2api.IngressClassParamsSpec{
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"team": "awesome-team",
+							},
+						},
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "when ingressClassParams have nonempty namespaceSelector - matches Ingress's namespace [with admission request]",
+			env: env{
+				nsList: []*corev1.Namespace{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "awesome-ns",
+							Labels: map[string]string{
+								"team": "awesome-team",
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				admissionReq: &admission.Request{
+					AdmissionRequest: admissionv1beta1.AdmissionRequest{
+						Namespace: "awesome-ns",
+					},
+				},
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "",
+						Name:      "awesome-ing",
+					},
+				},
+				ingClassParams: &elbv2api.IngressClassParams{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "awesome-class",
+					},
+					Spec: elbv2api.IngressClassParamsSpec{
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"team": "awesome-team",
+							},
+						},
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "when ingressClassParams have nonempty namespaceSelector - mismatches Ingress's namespace",
+			env: env{
+				nsList: []*corev1.Namespace{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "awesome-ns",
+							Labels: map[string]string{
+								"team": "another-team",
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				admissionReq: nil,
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Name:      "awesome-ing",
+					},
+				},
+				ingClassParams: &elbv2api.IngressClassParams{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "awesome-class",
+					},
+					Spec: elbv2api.IngressClassParamsSpec{
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"team": "awesome-team",
+							},
+						},
+					},
+				},
+			},
+			wantErr: errors.New("namespaceSelector of IngressClassParams awesome-class mismatch"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			ctx := context.Background()
+			k8sSchema := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sSchema)
+			elbv2api.AddToScheme(k8sSchema)
+			k8sClient := testclient.NewFakeClientWithScheme(k8sSchema)
+			for _, ns := range tt.env.nsList {
+				assert.NoError(t, k8sClient.Create(ctx, ns.DeepCopy()))
+			}
+
+			l := &defaultClassLoader{
+				client: k8sClient,
+			}
+			if tt.args.admissionReq != nil {
+				ctx = webhook.ContextWithAdmissionRequest(ctx, *tt.args.admissionReq)
+			}
+			err := l.validateIngressClassParamsNamespaceRestriction(ctx, tt.args.ing, tt.args.ingClassParams)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/ingress/group_loader.go
+++ b/pkg/ingress/group_loader.go
@@ -22,8 +22,6 @@ const (
 	minGroupOrder      int64 = 1
 	maxGroupOder       int64 = 1000
 	maxGroupNameLength int   = 63
-	// the controller name used in IngressClass for ALB.
-	ingressClassControllerALB = "ingress.k8s.aws/alb"
 )
 
 var (

--- a/webhooks/networking/ingress_validator_test.go
+++ b/webhooks/networking/ingress_validator_test.go
@@ -1,12 +1,20 @@
 package networking
 
 import (
+	"context"
+	awssdk "github.com/aws/aws-sdk-go/aws"
+	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/ingress"
+	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"testing"
 )
@@ -454,6 +462,205 @@ func Test_ingressValidator_checkGroupNameAnnotationUsage(t *testing.T) {
 				logger:                        &log.NullLogger{},
 			}
 			err := v.checkGroupNameAnnotationUsage(tt.args.ing, tt.args.oldIng)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_ingressValidator_checkIngressClassUsage(t *testing.T) {
+	type env struct {
+		nsList             []*corev1.Namespace
+		ingClassList       []*networking.IngressClass
+		ingClassParamsList []*elbv2api.IngressClassParams
+	}
+
+	type args struct {
+		ing            *networking.Ingress
+		ingClassParams *elbv2api.IngressClassParams
+	}
+	tests := []struct {
+		name    string
+		env     env
+		args    args
+		wantErr error
+	}{
+		{
+			name: "IngressClass didn't exists",
+			env:  env{},
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Name:      "awesome-ing",
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: awssdk.String("awesome-class"),
+					},
+				},
+			},
+			wantErr: errors.New("invalid ingress class: ingressclasses.networking.k8s.io \"awesome-class\" not found"),
+		},
+		{
+			name: "IngressClass exists but IngressClassParams unspecified",
+			env: env{
+				ingClassList: []*networking.IngressClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "awesome-class",
+						},
+					},
+				},
+			},
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Name:      "awesome-ing",
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: awssdk.String("awesome-class"),
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "IngressClass exists and IngressClassParams exists, and namespaceSelector mismatches",
+			env: env{
+				nsList: []*corev1.Namespace{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "awesome-ns",
+							Labels: map[string]string{
+								"team": "another-team",
+							},
+						},
+					},
+				},
+				ingClassList: []*networking.IngressClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "awesome-class",
+						},
+						Spec: networking.IngressClassSpec{
+							Controller: "ingress.k8s.aws/alb",
+							Parameters: &corev1.TypedLocalObjectReference{
+								APIGroup: awssdk.String("elbv2.k8s.aws"),
+								Kind:     "IngressClassParams",
+								Name:     "awesome-class-params",
+							},
+						},
+					},
+				},
+				ingClassParamsList: []*elbv2api.IngressClassParams{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "awesome-class-params",
+						},
+						Spec: elbv2api.IngressClassParamsSpec{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"team": "awesome-team",
+								},
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Name:      "awesome-ing",
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: awssdk.String("awesome-class"),
+					},
+				},
+			},
+			wantErr: errors.New("invalid ingress class: namespaceSelector of IngressClassParams awesome-class-params mismatch"),
+		},
+		{
+			name: "IngressClass exists and IngressClassParams exists, and namespaceSelector matches",
+			env: env{
+				nsList: []*corev1.Namespace{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "awesome-ns",
+							Labels: map[string]string{
+								"team": "awesome-team",
+							},
+						},
+					},
+				},
+				ingClassList: []*networking.IngressClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "awesome-class",
+						},
+						Spec: networking.IngressClassSpec{
+							Controller: "ingress.k8s.aws/alb",
+							Parameters: &corev1.TypedLocalObjectReference{
+								APIGroup: awssdk.String("elbv2.k8s.aws"),
+								Kind:     "IngressClassParams",
+								Name:     "awesome-class-params",
+							},
+						},
+					},
+				},
+				ingClassParamsList: []*elbv2api.IngressClassParams{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "awesome-class-params",
+						},
+						Spec: elbv2api.IngressClassParamsSpec{
+							NamespaceSelector: nil,
+						},
+					},
+				},
+			},
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Name:      "awesome-ing",
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: awssdk.String("awesome-class"),
+					},
+				},
+			},
+			wantErr: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			ctx := context.Background()
+			k8sSchema := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sSchema)
+			elbv2api.AddToScheme(k8sSchema)
+			k8sClient := testclient.NewFakeClientWithScheme(k8sSchema)
+			for _, ns := range tt.env.nsList {
+				assert.NoError(t, k8sClient.Create(ctx, ns.DeepCopy()))
+			}
+			for _, ingClass := range tt.env.ingClassList {
+				assert.NoError(t, k8sClient.Create(ctx, ingClass.DeepCopy()))
+			}
+			for _, ingClassParams := range tt.env.ingClassParamsList {
+				assert.NoError(t, k8sClient.Create(ctx, ingClassParams.DeepCopy()))
+			}
+
+			v := &ingressValidator{
+				classLoader: ingress.NewDefaultClassLoader(k8sClient),
+			}
+			err := v.checkIngressClassUsage(ctx, tt.args.ing)
 			if tt.wantErr != nil {
 				assert.EqualError(t, err, tt.wantErr.Error())
 			} else {


### PR DESCRIPTION
This PR adds additional checks in Ingress's validationWebhook to check IngressClass configurations.
1. If IngressClass is not found, the validation webhook will fail
2. If IngressClass is ALB and refers a unknown or non-exists parameters resource, the validation webhook will fail
3. If IngressClass is ALB and refers a IngressClassParams with namespace selector and didn't match Ingress's namespace, the validation webhook will fail

See [PR-1849](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/1849) for overall design.

# Test done:
1. UTs
2. Tests for various cases in UT:
    * ```admission webhook "vingress.elbv2.k8s.aws" denied the request: namespaceSelector of IngressClassParams my-class-params mismatch```
    * ```admission webhook "vingress.elbv2.k8s.aws" denied the request: invalid ingress class: IngressClassParams.elbv2.k8s.aws "my-class-params" not found```