### PR TITLE
add support for IngressClassParams's group settings

### DIFF
--- a/pkg/ingress/class.go
+++ b/pkg/ingress/class.go
@@ -5,10 +5,17 @@ import (
 	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
 )
 
+// ClassifiedIngress is Ingress with it's associated IngressClass Configuration
+type ClassifiedIngress struct {
+	Ing            *networking.Ingress
+	IngClassConfig ClassConfiguration
+}
+
 // ClassConfiguration contains configurations for IngressClass
 type ClassConfiguration struct {
 	// The IngressClass for Ingress if any.
 	IngClass *networking.IngressClass
+
 	// The IngressClassParams for Ingress if any.
 	IngClassParams *elbv2api.IngressClassParams
 }

--- a/pkg/ingress/class_loader.go
+++ b/pkg/ingress/class_loader.go
@@ -27,6 +27,7 @@ var ErrInvalidIngressClass = errors.New("invalid ingress class")
 
 // ClassLoader loads IngressClass configurations for Ingress.
 type ClassLoader interface {
+	// Load loads the ClassConfiguration for Ingress with IngressClassName.
 	Load(ctx context.Context, ing *networking.Ingress) (ClassConfiguration, error)
 }
 
@@ -44,7 +45,7 @@ type defaultClassLoader struct {
 
 func (l *defaultClassLoader) Load(ctx context.Context, ing *networking.Ingress) (ClassConfiguration, error) {
 	if ing.Spec.IngressClassName == nil {
-		return ClassConfiguration{}, nil
+		return ClassConfiguration{}, fmt.Errorf("%w: %v", ErrInvalidIngressClass, "spec.ingressClassName is nil")
 	}
 
 	ingClassKey := types.NamespacedName{Name: *ing.Spec.IngressClassName}

--- a/pkg/ingress/class_loader_test.go
+++ b/pkg/ingress/class_loader_test.go
@@ -59,8 +59,7 @@ func Test_defaultClassLoader_Load(t *testing.T) {
 					},
 				},
 			},
-			want:    ClassConfiguration{},
-			wantErr: nil,
+			wantErr: errors.New("invalid ingress class: spec.ingressClassName is nil"),
 		},
 		{
 			name: "when IngressClass not found",

--- a/pkg/ingress/finalizer_test.go
+++ b/pkg/ingress/finalizer_test.go
@@ -22,7 +22,7 @@ func Test_defaultFinalizerManager_AddGroupFinalizer(t *testing.T) {
 	}
 	type args struct {
 		groupID GroupID
-		ingList []*networking.Ingress
+		members []ClassifiedIngress
 	}
 
 	tests := []struct {
@@ -70,27 +70,31 @@ func Test_defaultFinalizerManager_AddGroupFinalizer(t *testing.T) {
 					Namespace: "",
 					Name:      "awesome-group",
 				},
-				ingList: []*networking.Ingress{
+				members: []ClassifiedIngress{
 					{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: "namespace",
-							Name:      "ingress-a",
-							Annotations: map[string]string{
-								"kubernetes.io/ingress.class":          "alb",
-								"alb.ingress.kubernetes.io/group.name": "awesome-group",
+						Ing: &networking.Ingress{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "namespace",
+								Name:      "ingress-a",
+								Annotations: map[string]string{
+									"kubernetes.io/ingress.class":          "alb",
+									"alb.ingress.kubernetes.io/group.name": "awesome-group",
+								},
+								ResourceVersion: "0001",
 							},
-							ResourceVersion: "0001",
 						},
 					},
 					{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: "namespace",
-							Name:      "ingress-b",
-							Annotations: map[string]string{
-								"kubernetes.io/ingress.class":          "alb",
-								"alb.ingress.kubernetes.io/group.name": "awesome-group",
+						Ing: &networking.Ingress{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "namespace",
+								Name:      "ingress-b",
+								Annotations: map[string]string{
+									"kubernetes.io/ingress.class":          "alb",
+									"alb.ingress.kubernetes.io/group.name": "awesome-group",
+								},
+								ResourceVersion: "0001",
 							},
-							ResourceVersion: "0001",
 						},
 					},
 				},
@@ -121,15 +125,17 @@ func Test_defaultFinalizerManager_AddGroupFinalizer(t *testing.T) {
 					Namespace: "namespace",
 					Name:      "ingress-as",
 				},
-				ingList: []*networking.Ingress{
+				members: []ClassifiedIngress{
 					{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: "namespace",
-							Name:      "ingress-a",
-							Annotations: map[string]string{
-								"kubernetes.io/ingress.class": "alb",
+						Ing: &networking.Ingress{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "namespace",
+								Name:      "ingress-a",
+								Annotations: map[string]string{
+									"kubernetes.io/ingress.class": "alb",
+								},
+								ResourceVersion: "0001",
 							},
-							ResourceVersion: "0001",
 						},
 					},
 				},
@@ -161,15 +167,17 @@ func Test_defaultFinalizerManager_AddGroupFinalizer(t *testing.T) {
 					Namespace: "namespace",
 					Name:      "ingress-as",
 				},
-				ingList: []*networking.Ingress{
+				members: []ClassifiedIngress{
 					{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: "namespace",
-							Name:      "ingress-a",
-							Annotations: map[string]string{
-								"kubernetes.io/ingress.class": "alb",
+						Ing: &networking.Ingress{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "namespace",
+								Name:      "ingress-a",
+								Annotations: map[string]string{
+									"kubernetes.io/ingress.class": "alb",
+								},
+								ResourceVersion: "0001",
 							},
-							ResourceVersion: "0001",
 						},
 					},
 				},
@@ -188,7 +196,7 @@ func Test_defaultFinalizerManager_AddGroupFinalizer(t *testing.T) {
 			}
 
 			manager := NewDefaultFinalizerManager(k8sFinalizerManager)
-			err := manager.AddGroupFinalizer(context.Background(), tt.args.groupID, tt.args.ingList...)
+			err := manager.AddGroupFinalizer(context.Background(), tt.args.groupID, tt.args.members)
 			if tt.wantErr == nil {
 				assert.NoError(t, err)
 			} else {
@@ -208,8 +216,8 @@ func Test_defaultFinalizerManager_RemoveGroupFinalizer(t *testing.T) {
 		removeFinalizersCalls []removeFinalizersCall
 	}
 	type args struct {
-		groupID GroupID
-		ingList []*networking.Ingress
+		groupID         GroupID
+		inactiveMembers []*networking.Ingress
 	}
 
 	tests := []struct {
@@ -257,7 +265,7 @@ func Test_defaultFinalizerManager_RemoveGroupFinalizer(t *testing.T) {
 					Namespace: "",
 					Name:      "awesome-group",
 				},
-				ingList: []*networking.Ingress{
+				inactiveMembers: []*networking.Ingress{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Namespace: "namespace",
@@ -308,7 +316,7 @@ func Test_defaultFinalizerManager_RemoveGroupFinalizer(t *testing.T) {
 					Namespace: "namespace",
 					Name:      "ingress-as",
 				},
-				ingList: []*networking.Ingress{
+				inactiveMembers: []*networking.Ingress{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Namespace: "namespace",
@@ -348,7 +356,7 @@ func Test_defaultFinalizerManager_RemoveGroupFinalizer(t *testing.T) {
 					Namespace: "namespace",
 					Name:      "ingress-as",
 				},
-				ingList: []*networking.Ingress{
+				inactiveMembers: []*networking.Ingress{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Namespace: "namespace",
@@ -375,7 +383,7 @@ func Test_defaultFinalizerManager_RemoveGroupFinalizer(t *testing.T) {
 			}
 
 			manager := NewDefaultFinalizerManager(k8sFinalizerManager)
-			err := manager.RemoveGroupFinalizer(context.Background(), tt.args.groupID, tt.args.ingList...)
+			err := manager.RemoveGroupFinalizer(context.Background(), tt.args.groupID, tt.args.inactiveMembers)
 			if tt.wantErr == nil {
 				assert.NoError(t, err)
 			} else {

--- a/pkg/ingress/group.go
+++ b/pkg/ingress/group.go
@@ -12,7 +12,9 @@ import (
 type GroupID types.NamespacedName
 
 // IsExplicit tests whether this is an explicit group.
-// Explicit groups are defined by annotation on Ingress: `group.name`
+// Explicit groups are defined by either:
+//	* annotation on Ingress: `group.name`
+//  * field on associated IngressClassParams: `group.name`
 func (groupID GroupID) IsExplicit() bool {
 	return groupID.Namespace == ""
 }
@@ -52,13 +54,13 @@ func DecodeGroupIDFromReconcileRequest(request ctrl.Request) GroupID {
 // It's our customization for Kubernetes's Ingress Spec, an Ingress group represents an "LoadBalancer",
 // where each member Ingress defines rules for that LoadBalancer.
 // There are two types of group: explicit and implicit.
-// Explicit groups are defined by annotation on Ingress: `group.name`
-// Implicit groups are for ingresses without `group.name`, each ingress become a standalone group of itself.
+// Explicit groups are defined by either annotation(group.name) on Ingress or field(group.name) on associated IngressClassParams
+// Implicit groups are for ingresses without explicit group, each ingress become a standalone group of itself.
 type Group struct {
 	ID GroupID
 
 	// Members are Ingresses that is belong to this group.
-	Members []*networking.Ingress
+	Members []ClassifiedIngress
 
 	// InactiveMembers are Ingresses that no longer belong to this group, but still hold the finalizers.
 	InactiveMembers []*networking.Ingress

--- a/pkg/ingress/group_loader.go
+++ b/pkg/ingress/group_loader.go
@@ -4,10 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1beta1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 	"regexp"
@@ -15,6 +12,7 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sort"
+	"strings"
 )
 
 const (
@@ -31,26 +29,29 @@ var (
 
 	// err represents that ingress group is invalid.
 	errInvalidIngressGroup = errors.New("invalid ingress group")
-	// err represents that ingress class is invalid.
-	errInvalidIngressClass = errors.New("invalid ingress class")
 )
 
 // GroupLoader loads Ingress groups.
 type GroupLoader interface {
-	// FindGroupID returns the IngressGroup's ID or nil if it doesn't belong to any group.
-	FindGroupID(ctx context.Context, ing *networking.Ingress) (*GroupID, error)
-
 	// Load returns an Ingress group given groupID.
 	Load(ctx context.Context, groupID GroupID) (Group, error)
+
+	// LoadGroupIDIfAny loads the groupID for Ingress if Ingress belong to any IngressGroup.
+	// Ingresses that is not managed by this controller or in deletion state won't have a groupID.
+	LoadGroupIDIfAny(ctx context.Context, ing *networking.Ingress) (*GroupID, error)
+
+	// LoadGroupIDsPendingFinalization returns groupIDs that have associated finalizer on Ingress.
+	LoadGroupIDsPendingFinalization(ctx context.Context, ing *networking.Ingress) []GroupID
 }
 
 // NewDefaultGroupLoader constructs new GroupLoader instance.
-func NewDefaultGroupLoader(client client.Client, eventRecorder record.EventRecorder, annotationParser annotations.Parser, classAnnotationMatcher ClassAnnotationMatcher, manageIngressesWithoutIngressClass bool) *defaultGroupLoader {
+func NewDefaultGroupLoader(client client.Client, eventRecorder record.EventRecorder, annotationParser annotations.Parser, classLoader ClassLoader, classAnnotationMatcher ClassAnnotationMatcher, manageIngressesWithoutIngressClass bool) *defaultGroupLoader {
 	return &defaultGroupLoader{
 		client:           client,
 		eventRecorder:    eventRecorder,
 		annotationParser: annotationParser,
 
+		classLoader:                        classLoader,
 		classAnnotationMatcher:             classAnnotationMatcher,
 		manageIngressesWithoutIngressClass: manageIngressesWithoutIngressClass,
 	}
@@ -64,33 +65,15 @@ type defaultGroupLoader struct {
 	eventRecorder    record.EventRecorder
 	annotationParser annotations.Parser
 
+	// classLoader loads IngressClass configurations for Ingress.
+	classLoader ClassLoader
+
 	// classAnnotationMatcher checks whether ingresses with "kubernetes.io/ingress.class" annotation should be managed.
 	classAnnotationMatcher ClassAnnotationMatcher
+
 	// manageIngressesWithoutIngressClass specifies whether ingresses without "kubernetes.io/ingress.class" annotation
 	// and "spec.ingressClassName" should be managed or not.
 	manageIngressesWithoutIngressClass bool
-}
-
-func (m *defaultGroupLoader) FindGroupID(ctx context.Context, ing *networking.Ingress) (*GroupID, error) {
-	matchesIngressClass, err := m.matchesIngressClass(ctx, ing)
-	if err != nil {
-		return nil, err
-	}
-	if !matchesIngressClass {
-		return nil, nil
-	}
-
-	groupName := ""
-	if exists := m.annotationParser.ParseStringAnnotation(annotations.IngressSuffixGroupName, &groupName, ing.Annotations); exists {
-		if err := validateGroupName(groupName); err != nil {
-			return nil, fmt.Errorf("%w: %v", errInvalidIngressGroup, err.Error())
-		}
-		groupID := NewGroupIDForExplicitGroup(groupName)
-		return &groupID, nil
-	}
-
-	groupID := NewGroupIDForImplicitGroup(k8s.NamespacedName(ing))
-	return &groupID, nil
 }
 
 func (m *defaultGroupLoader) Load(ctx context.Context, groupID GroupID) (Group, error) {
@@ -99,25 +82,27 @@ func (m *defaultGroupLoader) Load(ctx context.Context, groupID GroupID) (Group, 
 		return Group{}, err
 	}
 
-	var members []*networking.Ingress
+	var members []ClassifiedIngress
 	var inactiveMembers []*networking.Ingress
 	finalizer := buildGroupFinalizer(groupID)
 	for index := range ingList.Items {
 		ing := &ingList.Items[index]
-		isGroupMember, err := m.isGroupMember(ctx, groupID, ing)
+		classifiedIngress, isGroupMember, err := m.isGroupMember(ctx, groupID, ing)
 		if err != nil {
 			return Group{}, errors.Wrapf(err, "ingress: %v", k8s.NamespacedName(ing))
 		}
 		if isGroupMember {
-			members = append(members, ing)
+			members = append(members, classifiedIngress)
 		} else if m.containsGroupFinalizer(groupID, finalizer, ing) {
 			inactiveMembers = append(inactiveMembers, ing)
 		}
 	}
-	sortedMembers, err := m.sortGroupMembers(ctx, members)
+
+	sortedMembers, err := m.sortGroupMembers(members)
 	if err != nil {
 		return Group{}, err
 	}
+
 	return Group{
 		ID:              groupID,
 		Members:         sortedMembers,
@@ -125,64 +110,129 @@ func (m *defaultGroupLoader) Load(ctx context.Context, groupID GroupID) (Group, 
 	}, nil
 }
 
-// matchesIngressClass tests whether provided Ingress are matched by this group loader.
-func (m *defaultGroupLoader) matchesIngressClass(ctx context.Context, ing *networking.Ingress) (bool, error) {
-	var matchesIngressClassResults []bool
+func (m *defaultGroupLoader) LoadGroupIDIfAny(ctx context.Context, ing *networking.Ingress) (*GroupID, error) {
+	_, groupID, err := m.loadGroupIDIfAnyHelper(ctx, ing)
+	return groupID, err
+}
+
+func (m *defaultGroupLoader) LoadGroupIDsPendingFinalization(_ context.Context, ing *networking.Ingress) []GroupID {
+	var groupIDs []GroupID
+	for _, finalizer := range ing.GetFinalizers() {
+		if finalizer == implicitGroupFinalizer {
+			groupIDs = append(groupIDs, NewGroupIDForImplicitGroup(k8s.NamespacedName(ing)))
+		} else if strings.HasPrefix(finalizer, explicitGroupFinalizerPrefix) {
+			groupName := finalizer[len(explicitGroupFinalizerPrefix):]
+			groupIDs = append(groupIDs, NewGroupIDForExplicitGroup(groupName))
+		}
+	}
+	return groupIDs
+}
+
+// isGroupMember checks whether specified Ingress is member of specific IngressGroup.
+// If it's group member, a valid ClassifiedIngress will be returned as well.
+// NOTE: this function should only error out when it's not certain whether the specified ingress is group member. (e.g. due to APIServer failures).
+func (m *defaultGroupLoader) isGroupMember(ctx context.Context, groupID GroupID, ing *networking.Ingress) (ClassifiedIngress, bool, error) {
+	classifiedIngress, ingGroupID, err := m.loadGroupIDIfAnyHelper(ctx, ing)
+	if err != nil {
+		if errors.Is(err, ErrInvalidIngressClass) || errors.Is(err, errInvalidIngressGroup) {
+			return ClassifiedIngress{}, false, nil
+		}
+		return ClassifiedIngress{}, false, err
+	}
+	if ingGroupID == nil {
+		return ClassifiedIngress{}, false, nil
+	}
+	groupIDMatches := groupID == *ingGroupID
+	return classifiedIngress, groupIDMatches, nil
+}
+
+// loadGroupIDIfAnyHelper loads the groupID for Ingress if Ingress belong to any IngressGroup, along with the ClassifiedIngress object.
+func (m *defaultGroupLoader) loadGroupIDIfAnyHelper(ctx context.Context, ing *networking.Ingress) (ClassifiedIngress, *GroupID, error) {
+	// Ingress no longer belong to any IngressGroup when it's been deleted.
+	if !ing.DeletionTimestamp.IsZero() {
+		return ClassifiedIngress{}, nil, nil
+	}
+	classifiedIngress, matchesIngressClass, err := m.classifyIngress(ctx, ing)
+	if err != nil {
+		return ClassifiedIngress{}, nil, err
+	}
+	if !matchesIngressClass {
+		return ClassifiedIngress{}, nil, nil
+	}
+
+	groupID, err := m.loadGroupID(classifiedIngress)
+	if err != nil {
+		return ClassifiedIngress{}, nil, err
+	}
+	return classifiedIngress, &groupID, nil
+}
+
+// classifyIngress will classify the Ingress resource and returns whether it should be managed by this controller, along with the ClassifiedIngress object.
+func (m *defaultGroupLoader) classifyIngress(ctx context.Context, ing *networking.Ingress) (ClassifiedIngress, bool, error) {
+	// the "kubernetes.io/ingress.class" annotation takes higher priority than "ingressClassName" field
 	if ingClassAnnotation, exists := ing.Annotations[annotations.IngressClass]; exists {
-		matchesIngressClass := m.classAnnotationMatcher.Matches(ingClassAnnotation)
-		matchesIngressClassResults = append(matchesIngressClassResults, matchesIngressClass)
+		if matchesIngressClass := m.classAnnotationMatcher.Matches(ingClassAnnotation); matchesIngressClass {
+			return ClassifiedIngress{
+				Ing:            ing,
+				IngClassConfig: ClassConfiguration{},
+			}, true, nil
+		}
+		return ClassifiedIngress{
+			Ing:            ing,
+			IngClassConfig: ClassConfiguration{},
+		}, false, nil
 	}
 
 	if ing.Spec.IngressClassName != nil {
-		matchesIngressClass, err := m.matchesIngressClassName(ctx, *ing.Spec.IngressClassName)
+		ingClassConfig, err := m.classLoader.Load(ctx, ing)
 		if err != nil {
-			return false, err
+			return ClassifiedIngress{
+				Ing:            ing,
+				IngClassConfig: ClassConfiguration{},
+			}, false, err
 		}
-		matchesIngressClassResults = append(matchesIngressClassResults, matchesIngressClass)
+
+		if matchesIngressClass := ingClassConfig.IngClass != nil && ingClassConfig.IngClass.Spec.Controller == ingressClassControllerALB; matchesIngressClass {
+			return ClassifiedIngress{
+				Ing:            ing,
+				IngClassConfig: ingClassConfig,
+			}, true, nil
+		}
+		return ClassifiedIngress{
+			Ing:            ing,
+			IngClassConfig: ingClassConfig,
+		}, false, nil
 	}
 
-	if len(matchesIngressClassResults) == 2 {
-		if matchesIngressClassResults[0] != matchesIngressClassResults[1] {
-			m.eventRecorder.Event(ing, corev1.EventTypeWarning, k8s.IngressEventReasonConflictingIngressClass, "conflicting values for IngressClass by `spec.IngressClass` and `kubernetes.io/ingress.class` annotation")
-		}
-		return matchesIngressClassResults[0], nil
-	}
-	if len(matchesIngressClassResults) == 1 {
-		return matchesIngressClassResults[0], nil
-	}
-
-	return m.manageIngressesWithoutIngressClass, nil
+	return ClassifiedIngress{
+		Ing:            ing,
+		IngClassConfig: ClassConfiguration{},
+	}, m.manageIngressesWithoutIngressClass, nil
 }
 
-// matchesIngressClassName tests whether provided ingClassName are matched by this group loader.
-func (m *defaultGroupLoader) matchesIngressClassName(ctx context.Context, ingClassName string) (bool, error) {
-	ingClassKey := types.NamespacedName{Name: ingClassName}
-	ingClass := &networking.IngressClass{}
-	if err := m.client.Get(ctx, ingClassKey, ingClass); err != nil {
-		if apierrors.IsNotFound(err) {
-			return false, fmt.Errorf("%w: %v", errInvalidIngressClass, err.Error())
+// loadGroupID loads the groupID for classified Ingress.
+func (m *defaultGroupLoader) loadGroupID(classifiedIng ClassifiedIngress) (GroupID, error) {
+	// the "group" settings in associated IngClassParams takes higher priority than "group.name" annotation on Ingresses.
+	if classifiedIng.IngClassConfig.IngClassParams != nil && classifiedIng.IngClassConfig.IngClassParams.Spec.Group != nil {
+		groupName := classifiedIng.IngClassConfig.IngClassParams.Spec.Group.Name
+		if err := validateGroupName(groupName); err != nil {
+			return GroupID{}, fmt.Errorf("%w: %v", errInvalidIngressGroup, err.Error())
 		}
-		return false, err
+		groupID := NewGroupIDForExplicitGroup(groupName)
+		return groupID, nil
 	}
-	matchesIngressClass := ingClass.Spec.Controller == ingressClassControllerALB
-	return matchesIngressClass, nil
-}
 
-// isGroupMember checks whether an ingress is member of a Ingress group
-func (m *defaultGroupLoader) isGroupMember(ctx context.Context, groupID GroupID, ing *networking.Ingress) (bool, error) {
-	ingGroupID, err := m.FindGroupID(ctx, ing)
-	if err != nil {
-		if errors.Is(err, errInvalidIngressGroup) || errors.Is(err, errInvalidIngressClass) {
-			return false, nil
+	groupName := ""
+	if exists := m.annotationParser.ParseStringAnnotation(annotations.IngressSuffixGroupName, &groupName, classifiedIng.Ing.Annotations); exists {
+		if err := validateGroupName(groupName); err != nil {
+			return GroupID{}, fmt.Errorf("%w: %v", errInvalidIngressGroup, err.Error())
 		}
-		return false, err
+		groupID := NewGroupIDForExplicitGroup(groupName)
+		return groupID, nil
 	}
 
-	if ingGroupID == nil || (*ingGroupID) != groupID {
-		return false, nil
-	}
-
-	return ing.DeletionTimestamp.IsZero(), nil
+	groupID := NewGroupIDForImplicitGroup(k8s.NamespacedName(classifiedIng.Ing))
+	return groupID, nil
 }
 
 func (m *defaultGroupLoader) containsGroupFinalizer(groupID GroupID, finalizer string, ing *networking.Ingress) bool {
@@ -194,9 +244,9 @@ func (m *defaultGroupLoader) containsGroupFinalizer(groupID GroupID, finalizer s
 	return ingImplicitGroupID == groupID && k8s.HasFinalizer(ing, finalizer)
 }
 
-type ingressWithOrder struct {
-	ingress *networking.Ingress
-	order   int64
+type groupMemberWithOrder struct {
+	member ClassifiedIngress
+	order  int64
 }
 
 // sortGroupMembers will sort Ingresses within Ingress group in ascending order.
@@ -204,23 +254,23 @@ type ingressWithOrder struct {
 // * explicit denote the order via "group.order" annotation.(It's an error if two Ingress have same explicit order)
 // * implicit denote the order of ${defaultGroupOrder}.
 // If two Ingress are of same order, they are sorted by lexical order of their full-qualified name.
-func (m *defaultGroupLoader) sortGroupMembers(ctx context.Context, members []*networking.Ingress) ([]*networking.Ingress, error) {
+func (m *defaultGroupLoader) sortGroupMembers(members []ClassifiedIngress) ([]ClassifiedIngress, error) {
 	if len(members) == 0 {
 		return nil, nil
 	}
 
-	ingressWithOrderList := make([]ingressWithOrder, 0, len(members))
+	groupMemberWithOrderList := make([]groupMemberWithOrder, 0, len(members))
 	explicitOrders := sets.NewInt64()
-	for _, ing := range members {
+	for _, member := range members {
 		var order = defaultGroupOrder
-		exists, err := m.annotationParser.ParseInt64Annotation(annotations.IngressSuffixGroupOrder, &order, ing.Annotations)
+		exists, err := m.annotationParser.ParseInt64Annotation(annotations.IngressSuffixGroupOrder, &order, member.Ing.Annotations)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to load Ingress group order for ingress: %v", k8s.NamespacedName(ing))
+			return nil, errors.Wrapf(err, "failed to load Ingress group order for ingress: %v", k8s.NamespacedName(member.Ing))
 		}
 		if exists {
 			if order < minGroupOrder || order > maxGroupOder {
 				return nil, errors.Errorf("explicit Ingress group order must be within [%v:%v], Ingress: %v, order: %v",
-					minGroupOrder, maxGroupOder, k8s.NamespacedName(ing), order)
+					minGroupOrder, maxGroupOder, k8s.NamespacedName(member.Ing), order)
 			}
 			if explicitOrders.Has(order) {
 				return nil, errors.Errorf("conflict Ingress group order: %v", order)
@@ -228,26 +278,26 @@ func (m *defaultGroupLoader) sortGroupMembers(ctx context.Context, members []*ne
 			explicitOrders.Insert(order)
 		}
 
-		ingressWithOrderList = append(ingressWithOrderList, ingressWithOrder{ingress: ing, order: order})
+		groupMemberWithOrderList = append(groupMemberWithOrderList, groupMemberWithOrder{member: member, order: order})
 	}
 
-	sort.Slice(ingressWithOrderList, func(i, j int) bool {
-		orderI := ingressWithOrderList[i].order
-		orderJ := ingressWithOrderList[j].order
+	sort.Slice(groupMemberWithOrderList, func(i, j int) bool {
+		orderI := groupMemberWithOrderList[i].order
+		orderJ := groupMemberWithOrderList[j].order
 		if orderI != orderJ {
 			return orderI < orderJ
 		}
 
-		nameI := k8s.NamespacedName(ingressWithOrderList[i].ingress).String()
-		nameJ := k8s.NamespacedName(ingressWithOrderList[j].ingress).String()
+		nameI := k8s.NamespacedName(groupMemberWithOrderList[i].member.Ing).String()
+		nameJ := k8s.NamespacedName(groupMemberWithOrderList[j].member.Ing).String()
 		return nameI < nameJ
 	})
 
-	sortedIngresses := make([]*networking.Ingress, 0, len(ingressWithOrderList))
-	for _, item := range ingressWithOrderList {
-		sortedIngresses = append(sortedIngresses, item.ingress)
+	sortedMembers := make([]ClassifiedIngress, 0, len(groupMemberWithOrderList))
+	for _, item := range groupMemberWithOrderList {
+		sortedMembers = append(sortedMembers, item.member)
 	}
-	return sortedIngresses, nil
+	return sortedMembers, nil
 }
 
 // validateGroupName validates whether Ingress group name is valid

--- a/pkg/ingress/group_loader_test.go
+++ b/pkg/ingress/group_loader_test.go
@@ -4,1063 +4,1280 @@ import (
 	"context"
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/record"
+	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
 	mock_client "sigs.k8s.io/aws-load-balancer-controller/mocks/controller-runtime/client"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/equality"
 	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"testing"
+	"time"
 )
 
-func Test_defaultGroupLoader_FindGroupID(t *testing.T) {
+func Test_defaultGroupLoader_Load(t *testing.T) {
+	now := metav1.Date(2021, 03, 28, 11, 11, 11, 0, time.UTC)
+	ingClassA := &networking.IngressClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ing-class-a",
+		},
+		Spec: networking.IngressClassSpec{
+			Controller: "ingress.k8s.aws/alb",
+			Parameters: &corev1.TypedLocalObjectReference{
+				APIGroup: awssdk.String("elbv2.k8s.aws"),
+				Kind:     "IngressClassParams",
+				Name:     "ing-class-a-params",
+			},
+		},
+	}
+	ingClassAParams := &elbv2api.IngressClassParams{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ing-class-a-params",
+		},
+		Spec: elbv2api.IngressClassParamsSpec{
+			Group: &elbv2api.IngressGroup{
+				Name: "awesome-group",
+			},
+		},
+	}
+
+	ingClassB := &networking.IngressClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ing-class-b",
+		},
+		Spec: networking.IngressClassSpec{
+			Controller: "ingress.k8s.aws/alb",
+			Parameters: &corev1.TypedLocalObjectReference{
+				APIGroup: awssdk.String("elbv2.k8s.aws"),
+				Kind:     "IngressClassParams",
+				Name:     "ing-class-b-params",
+			},
+		},
+	}
+
+	ingClassBParams := &elbv2api.IngressClassParams{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ing-class-b-params",
+		},
+		Spec: elbv2api.IngressClassParamsSpec{
+			Group: &elbv2api.IngressGroup{
+				Name: "awesome-group",
+			},
+		},
+	}
+
+	ingClassC := &networking.IngressClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ing-class-c",
+		},
+		Spec: networking.IngressClassSpec{
+			Controller: "ingress.k8s.aws/alb",
+			Parameters: &corev1.TypedLocalObjectReference{
+				APIGroup: awssdk.String("elbv2.k8s.aws"),
+				Kind:     "IngressClassParams",
+				Name:     "ing-class-c-params",
+			},
+		},
+	}
+
+	ingClassCParams := &elbv2api.IngressClassParams{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ing-class-c-params",
+		},
+		Spec: elbv2api.IngressClassParamsSpec{
+			Group: &elbv2api.IngressGroup{
+				Name: "another-group",
+			},
+		},
+	}
+
+	ingClassD := &networking.IngressClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ing-class-d",
+		},
+		Spec: networking.IngressClassSpec{
+			Controller: "ingress.k8s.aws/alb",
+		},
+	}
+
+	ing1 := &networking.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ing-ns",
+			Name:      "ing-1",
+		},
+		Spec: networking.IngressSpec{
+			IngressClassName: awssdk.String(ingClassA.Name),
+		},
+	}
+
+	ing1BeenDeletedWithoutFinalizer := &networking.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         "ing-ns",
+			Name:              "ing-1",
+			DeletionTimestamp: &now,
+		},
+		Spec: networking.IngressSpec{
+			IngressClassName: awssdk.String(ingClassA.Name),
+		},
+	}
+	ing1BeenDeletedWithFinalizer := &networking.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ing-ns",
+			Name:      "ing-1",
+			Finalizers: []string{
+				"group.ingress.k8s.aws/awesome-group",
+			},
+			DeletionTimestamp: &now,
+		},
+		Spec: networking.IngressSpec{
+			IngressClassName: awssdk.String(ingClassA.Name),
+		},
+	}
+	ing1WithHighGroupOrder := &networking.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ing-ns",
+			Name:      "ing-1",
+			Annotations: map[string]string{
+				"alb.ingress.kubernetes.io/group.order": "100",
+			},
+		},
+		Spec: networking.IngressSpec{
+			IngressClassName: awssdk.String(ingClassA.Name),
+		},
+	}
+
+	ing2 := &networking.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ing-ns",
+			Name:      "ing-2",
+		},
+		Spec: networking.IngressSpec{
+			IngressClassName: awssdk.String(ingClassB.Name),
+		},
+	}
+	ing3 := &networking.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ing-ns",
+			Name:      "ing-3",
+		},
+		Spec: networking.IngressSpec{
+			IngressClassName: awssdk.String(ingClassC.Name),
+		},
+	}
+	ing4 := &networking.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ing-ns",
+			Name:      "ing-4",
+		},
+		Spec: networking.IngressSpec{
+			IngressClassName: awssdk.String(ingClassD.Name),
+		},
+	}
+	ing5 := &networking.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ing-ns",
+			Name:      "ing-5",
+			Annotations: map[string]string{
+				"alb.ingress.kubernetes.io/group.name": "awesome-group",
+			},
+		},
+		Spec: networking.IngressSpec{
+			IngressClassName: awssdk.String(ingClassD.Name),
+		},
+	}
+	ing5WithImplicitGroupFinalizer := &networking.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ing-ns",
+			Name:      "ing-5",
+			Annotations: map[string]string{
+				"alb.ingress.kubernetes.io/group.name": "awesome-group",
+			},
+			Finalizers: []string{
+				"ingress.k8s.aws/resources",
+			},
+		},
+		Spec: networking.IngressSpec{
+			IngressClassName: awssdk.String(ingClassD.Name),
+		},
+	}
+
+	ing6 := &networking.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ing-ns",
+			Name:      "ing-6",
+			Annotations: map[string]string{
+				"kubernetes.io/ingress.class": "alb",
+			},
+		},
+	}
+	ing6BeenDeletedWithoutFinalizer := &networking.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ing-ns",
+			Name:      "ing-6",
+			Annotations: map[string]string{
+				"kubernetes.io/ingress.class": "alb",
+			},
+			DeletionTimestamp: &now,
+		},
+	}
+	ing6BeenDeletedWithFinalizer := &networking.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ing-ns",
+			Name:      "ing-6",
+			Annotations: map[string]string{
+				"kubernetes.io/ingress.class": "alb",
+			},
+			Finalizers: []string{
+				"ingress.k8s.aws/resources",
+			},
+			DeletionTimestamp: &now,
+		},
+	}
+	ing7 := &networking.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ing-ns",
+			Name:      "ing-7",
+			Annotations: map[string]string{
+				"kubernetes.io/ingress.class":          "alb",
+				"alb.ingress.kubernetes.io/group.name": "awesome-group",
+			},
+		},
+	}
+	ing7WithImplicitGroupFinalizer := &networking.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ing-ns",
+			Name:      "ing-7",
+			Annotations: map[string]string{
+				"kubernetes.io/ingress.class":          "alb",
+				"alb.ingress.kubernetes.io/group.name": "awesome-group",
+			},
+			Finalizers: []string{
+				"ingress.k8s.aws/resources",
+			},
+		},
+	}
+
+	type env struct {
+		ingClassList       []*networking.IngressClass
+		ingClassParamsList []*elbv2api.IngressClassParams
+		ingList            []*networking.Ingress
+	}
+	type args struct {
+		groupID GroupID
+	}
 	tests := []struct {
 		name    string
-		ing     *networking.Ingress
-		want    *GroupID
+		env     env
+		args    args
+		want    Group
 		wantErr error
 	}{
 		{
-			name: "explicit group",
-			ing: &networking.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "namespace",
-					Name:      "ingress",
-					Annotations: map[string]string{
-						"kubernetes.io/ingress.class":          "alb",
-						"alb.ingress.kubernetes.io/group.name": "awesome-group",
-					},
+			name: "load explicit group(awesome-group)",
+			env: env{
+				ingClassList: []*networking.IngressClass{
+					ingClassA, ingClassB, ingClassC, ingClassD,
+				},
+				ingClassParamsList: []*elbv2api.IngressClassParams{
+					ingClassAParams, ingClassBParams, ingClassCParams,
+				},
+				ingList: []*networking.Ingress{
+					ing1, ing2, ing3, ing4, ing5, ing6, ing7,
 				},
 			},
-			want: &GroupID{
-				Namespace: "",
-				Name:      "awesome-group",
+			args: args{
+				groupID: GroupID{Name: "awesome-group"},
+			},
+			want: Group{
+				ID: GroupID{Name: "awesome-group"},
+				Members: []ClassifiedIngress{
+					{
+						Ing: ing1,
+						IngClassConfig: ClassConfiguration{
+							IngClass:       ingClassA,
+							IngClassParams: ingClassAParams,
+						},
+					},
+					{
+						Ing: ing2,
+						IngClassConfig: ClassConfiguration{
+							IngClass:       ingClassB,
+							IngClassParams: ingClassBParams,
+						},
+					},
+					{
+						Ing: ing5,
+						IngClassConfig: ClassConfiguration{
+							IngClass: ingClassD,
+						},
+					},
+					{
+						Ing:            ing7,
+						IngClassConfig: ClassConfiguration{},
+					},
+				},
+				InactiveMembers: nil,
 			},
 		},
 		{
-			name: "implicit group",
-			ing: &networking.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "namespace",
-					Name:      "ingress",
-					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": "alb",
-					},
+			name: "load explicit group(awesome-group) - ing-1 been deleted with finalizer",
+			env: env{
+				ingClassList: []*networking.IngressClass{
+					ingClassA, ingClassB, ingClassC, ingClassD,
+				},
+				ingClassParamsList: []*elbv2api.IngressClassParams{
+					ingClassAParams, ingClassBParams, ingClassCParams,
+				},
+				ingList: []*networking.Ingress{
+					ing1BeenDeletedWithFinalizer, ing2, ing3, ing4, ing5, ing6, ing7,
 				},
 			},
-			want: &GroupID{
-				Namespace: "namespace",
-				Name:      "ingress",
+			args: args{
+				groupID: GroupID{Name: "awesome-group"},
+			},
+			want: Group{
+				ID: GroupID{Name: "awesome-group"},
+				Members: []ClassifiedIngress{
+					{
+						Ing: ing2,
+						IngClassConfig: ClassConfiguration{
+							IngClass:       ingClassB,
+							IngClassParams: ingClassBParams,
+						},
+					},
+					{
+						Ing: ing5,
+						IngClassConfig: ClassConfiguration{
+							IngClass: ingClassD,
+						},
+					},
+					{
+						Ing:            ing7,
+						IngClassConfig: ClassConfiguration{},
+					},
+				},
+				InactiveMembers: []*networking.Ingress{
+					ing1BeenDeletedWithFinalizer,
+				},
 			},
 		},
 		{
-			name: "ingress class mismatch",
-			ing: &networking.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "namespace",
-					Name:      "ingress",
-					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": "nginx",
+			name: "load explicit group(awesome-group) - ing-1 been deleted without finalizer",
+			env: env{
+				ingClassList: []*networking.IngressClass{
+					ingClassA, ingClassB, ingClassC, ingClassD,
+				},
+				ingClassParamsList: []*elbv2api.IngressClassParams{
+					ingClassAParams, ingClassBParams, ingClassCParams,
+				},
+				ingList: []*networking.Ingress{
+					ing1BeenDeletedWithoutFinalizer, ing2, ing3, ing4, ing5, ing6, ing7,
+				},
+			},
+			args: args{
+				groupID: GroupID{Name: "awesome-group"},
+			},
+			want: Group{
+				ID: GroupID{Name: "awesome-group"},
+				Members: []ClassifiedIngress{
+					{
+						Ing: ing2,
+						IngClassConfig: ClassConfiguration{
+							IngClass:       ingClassB,
+							IngClassParams: ingClassBParams,
+						},
+					},
+					{
+						Ing: ing5,
+						IngClassConfig: ClassConfiguration{
+							IngClass: ingClassD,
+						},
+					},
+					{
+						Ing:            ing7,
+						IngClassConfig: ClassConfiguration{},
+					},
+				},
+				InactiveMembers: nil,
+			},
+		},
+		{
+			name: "load explicit group(awesome-group) - ing-1 have explicit high group order",
+			env: env{
+				ingClassList: []*networking.IngressClass{
+					ingClassA, ingClassB, ingClassC, ingClassD,
+				},
+				ingClassParamsList: []*elbv2api.IngressClassParams{
+					ingClassAParams, ingClassBParams, ingClassCParams,
+				},
+				ingList: []*networking.Ingress{
+					ing1WithHighGroupOrder, ing2, ing3, ing4, ing5, ing6, ing7,
+				},
+			},
+			args: args{
+				groupID: GroupID{Name: "awesome-group"},
+			},
+			want: Group{
+				ID: GroupID{Name: "awesome-group"},
+				Members: []ClassifiedIngress{
+					{
+						Ing: ing2,
+						IngClassConfig: ClassConfiguration{
+							IngClass:       ingClassB,
+							IngClassParams: ingClassBParams,
+						},
+					},
+					{
+						Ing: ing5,
+						IngClassConfig: ClassConfiguration{
+							IngClass: ingClassD,
+						},
+					},
+					{
+						Ing:            ing7,
+						IngClassConfig: ClassConfiguration{},
+					},
+					{
+						Ing: ing1WithHighGroupOrder,
+						IngClassConfig: ClassConfiguration{
+							IngClass:       ingClassA,
+							IngClassParams: ingClassAParams,
+						},
+					},
+				},
+				InactiveMembers: nil,
+			},
+		},
+		{
+			name: "load implicit group(ing-ns/ing-4)",
+			env: env{
+				ingClassList: []*networking.IngressClass{
+					ingClassA, ingClassB, ingClassC, ingClassD,
+				},
+				ingClassParamsList: []*elbv2api.IngressClassParams{
+					ingClassAParams, ingClassBParams, ingClassCParams,
+				},
+				ingList: []*networking.Ingress{
+					ing1, ing2, ing3, ing4, ing5, ing6, ing7,
+				},
+			},
+			args: args{
+				groupID: GroupID{Namespace: "ing-ns", Name: "ing-4"},
+			},
+			want: Group{
+				ID: GroupID{Namespace: "ing-ns", Name: "ing-4"},
+				Members: []ClassifiedIngress{
+					{
+						Ing: ing4,
+						IngClassConfig: ClassConfiguration{
+							IngClass: ingClassD,
+						},
+					},
+				},
+				InactiveMembers: nil,
+			},
+		},
+		{
+			name: "load implicit group(ing-ns/ing-6)",
+			env: env{
+				ingClassList: []*networking.IngressClass{
+					ingClassA, ingClassB, ingClassC, ingClassD,
+				},
+				ingClassParamsList: []*elbv2api.IngressClassParams{
+					ingClassAParams, ingClassBParams, ingClassCParams,
+				},
+				ingList: []*networking.Ingress{
+					ing1, ing2, ing3, ing4, ing5, ing6, ing7,
+				},
+			},
+			args: args{
+				groupID: GroupID{Namespace: "ing-ns", Name: "ing-6"},
+			},
+			want: Group{
+				ID: GroupID{Namespace: "ing-ns", Name: "ing-6"},
+				Members: []ClassifiedIngress{
+					{
+						Ing:            ing6,
+						IngClassConfig: ClassConfiguration{},
+					},
+				},
+				InactiveMembers: nil,
+			},
+		},
+		{
+			name: "load implicit group(ing-ns/ing-6) - ing-6 been deleted without finalizer",
+			env: env{
+				ingClassList: []*networking.IngressClass{
+					ingClassA, ingClassB, ingClassC, ingClassD,
+				},
+				ingClassParamsList: []*elbv2api.IngressClassParams{
+					ingClassAParams, ingClassBParams, ingClassCParams,
+				},
+				ingList: []*networking.Ingress{
+					ing1, ing2, ing3, ing4, ing5, ing6BeenDeletedWithoutFinalizer, ing7,
+				},
+			},
+			args: args{
+				groupID: GroupID{Namespace: "ing-ns", Name: "ing-6"},
+			},
+			want: Group{
+				ID:              GroupID{Namespace: "ing-ns", Name: "ing-6"},
+				Members:         nil,
+				InactiveMembers: nil,
+			},
+		},
+		{
+			name: "load implicit group(ing-ns/ing-6) - ing-6 been deleted with finalizer",
+			env: env{
+				ingClassList: []*networking.IngressClass{
+					ingClassA, ingClassB, ingClassC, ingClassD,
+				},
+				ingClassParamsList: []*elbv2api.IngressClassParams{
+					ingClassAParams, ingClassBParams, ingClassCParams,
+				},
+				ingList: []*networking.Ingress{
+					ing1, ing2, ing3, ing4, ing5, ing6BeenDeletedWithFinalizer, ing7,
+				},
+			},
+			args: args{
+				groupID: GroupID{Namespace: "ing-ns", Name: "ing-6"},
+			},
+			want: Group{
+				ID:              GroupID{Namespace: "ing-ns", Name: "ing-6"},
+				Members:         nil,
+				InactiveMembers: []*networking.Ingress{ing6BeenDeletedWithFinalizer},
+			},
+		},
+		{
+			name: "load implicit group(ing-ns/ing-7) - ing-7 without implicit group finalizer",
+			env: env{
+				ingClassList: []*networking.IngressClass{
+					ingClassA, ingClassB, ingClassC, ingClassD,
+				},
+				ingClassParamsList: []*elbv2api.IngressClassParams{
+					ingClassAParams, ingClassBParams, ingClassCParams,
+				},
+				ingList: []*networking.Ingress{
+					ing1, ing2, ing3, ing4, ing5, ing6, ing7,
+				},
+			},
+			args: args{
+				groupID: GroupID{Namespace: "ing-ns", Name: "ing-7"},
+			},
+			want: Group{
+				ID:              GroupID{Namespace: "ing-ns", Name: "ing-7"},
+				Members:         nil,
+				InactiveMembers: nil,
+			},
+		},
+		{
+			name: "load implicit group(ing-ns/ing-7) - ing-7 with implicit group finalizer",
+			env: env{
+				ingClassList: []*networking.IngressClass{
+					ingClassA, ingClassB, ingClassC, ingClassD,
+				},
+				ingClassParamsList: []*elbv2api.IngressClassParams{
+					ingClassAParams, ingClassBParams, ingClassCParams,
+				},
+				ingList: []*networking.Ingress{
+					ing1, ing2, ing3, ing4, ing5WithImplicitGroupFinalizer, ing6, ing7WithImplicitGroupFinalizer,
+				},
+			},
+			args: args{
+				groupID: GroupID{Namespace: "ing-ns", Name: "ing-7"},
+			},
+			want: Group{
+				ID:      GroupID{Namespace: "ing-ns", Name: "ing-7"},
+				Members: nil,
+				InactiveMembers: []*networking.Ingress{
+					ing7WithImplicitGroupFinalizer,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			k8sSchema := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sSchema)
+			elbv2api.AddToScheme(k8sSchema)
+			k8sClient := testclient.NewFakeClientWithScheme(k8sSchema)
+			for _, ingClass := range tt.env.ingClassList {
+				assert.NoError(t, k8sClient.Create(context.Background(), ingClass.DeepCopy()))
+			}
+			for _, ingClassParams := range tt.env.ingClassParamsList {
+				assert.NoError(t, k8sClient.Create(context.Background(), ingClassParams.DeepCopy()))
+			}
+			for _, ing := range tt.env.ingList {
+				assert.NoError(t, k8sClient.Create(context.Background(), ing.DeepCopy()))
+			}
+
+			annotationParser := annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io")
+			classLoader := NewDefaultClassLoader(k8sClient)
+			classAnnotationMatcher := NewDefaultClassAnnotationMatcher("alb")
+			m := &defaultGroupLoader{
+				client:                             k8sClient,
+				annotationParser:                   annotationParser,
+				classLoader:                        classLoader,
+				classAnnotationMatcher:             classAnnotationMatcher,
+				manageIngressesWithoutIngressClass: false,
+			}
+			got, err := m.Load(context.Background(), tt.args.groupID)
+			if tt.wantErr != nil {
+				assert.Equal(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				opt := cmp.Options{
+					equality.IgnoreFakeClientPopulatedFields(),
+				}
+				assert.True(t, cmp.Equal(tt.want, got, opt),
+					"diff: %v", cmp.Diff(tt.want, got, opt))
+			}
+		})
+	}
+}
+
+func Test_defaultGroupLoader_LoadGroupIDsPendingFinalization(t *testing.T) {
+	type args struct {
+		ing *networking.Ingress
+	}
+	tests := []struct {
+		name string
+		args args
+		want []GroupID
+	}{
+		{
+			name: "one finalizer for explicit group",
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+						Finalizers: []string{
+							"group.ingress.k8s.aws/awesome-group",
+						},
+					},
+				},
+			},
+			want: []GroupID{
+				{
+					Name: "awesome-group",
+				},
+			},
+		},
+		{
+			name: "one finalizer for implicit group",
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+						Finalizers: []string{
+							"ingress.k8s.aws/resources",
+						},
+					},
+				},
+			},
+			want: []GroupID{
+				{
+					Namespace: "ing-ns",
+					Name:      "ing-name",
+				},
+			},
+		},
+		{
+			name: "one finalizer for explicit group",
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+						Finalizers: []string{
+							"group.ingress.k8s.aws/awesome-group",
+						},
+					},
+				},
+			},
+			want: []GroupID{
+				{
+					Name: "awesome-group",
+				},
+			},
+		},
+		{
+			name: "multiple finalizer for IngressGroups",
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+						Finalizers: []string{
+							"group.ingress.k8s.aws/awesome-group-1",
+							"group.ingress.k8s.aws/awesome-group-2",
+							"ingress.k8s.aws/resources",
+							"some-group/some-finalizer",
+						},
+					},
+				},
+			},
+			want: []GroupID{
+				{
+					Name: "awesome-group-1",
+				},
+				{
+					Name: "awesome-group-2",
+				},
+				{
+					Namespace: "ing-ns",
+					Name:      "ing-name",
+				},
+			},
+		},
+		{
+			name: "no finalizer",
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Finalizers: nil,
 					},
 				},
 			},
 			want: nil,
 		},
 		{
-			name: "invalid group name",
-			ing: &networking.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "namespace",
-					Name:      "ingress",
-					Annotations: map[string]string{
-						"kubernetes.io/ingress.class":          "alb",
-						"alb.ingress.kubernetes.io/group.name": "a$b",
+			name: "no finalizer for IngressGroups",
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Finalizers: []string{
+							"some-group/some-finalizer",
+						},
 					},
 				},
 			},
-			want:    nil,
-			wantErr: errors.New(`invalid ingress group: groupName must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character`),
+			want: nil,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-
-			client := mock_client.NewMockClient(ctrl)
-			annotationParser := annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io")
-			m := &defaultGroupLoader{
-				client:                             client,
-				annotationParser:                   annotationParser,
-				classAnnotationMatcher:             NewDefaultClassAnnotationMatcher(ingressClassALB),
-				manageIngressesWithoutIngressClass: false,
-			}
-			got, err := m.FindGroupID(context.Background(), tt.ing)
+			m := &defaultGroupLoader{}
+			got := m.LoadGroupIDsPendingFinalization(context.Background(), tt.args.ing)
 			assert.Equal(t, tt.want, got)
-			if tt.wantErr == nil {
-				assert.NoError(t, err)
-			} else {
-				assert.EqualError(t, err, tt.wantErr.Error())
-			}
-		})
-	}
-}
-
-func Test_defaultGroupLoader_Load(t *testing.T) {
-	now := metav1.Now()
-
-	type listIngressesCall struct {
-		ingList networking.IngressList
-		err     error
-	}
-
-	tests := []struct {
-		name              string
-		groupID           GroupID
-		listIngressesCall *listIngressesCall
-		want              Group
-		wantErr           error
-	}{
-		{
-			name: "explicit group",
-			groupID: GroupID{
-				Namespace: "",
-				Name:      "awesome-group",
-			},
-			listIngressesCall: &listIngressesCall{
-				ingList: networking.IngressList{
-					Items: []networking.Ingress{
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: "namespace",
-								Name:      "ingress-a",
-								Annotations: map[string]string{
-									"kubernetes.io/ingress.class":          "alb",
-									"alb.ingress.kubernetes.io/group.name": "awesome-group",
-								},
-							},
-						},
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: "namespace",
-								Name:      "ingress-b",
-								Annotations: map[string]string{
-									"kubernetes.io/ingress.class":          "alb",
-									"alb.ingress.kubernetes.io/group.name": "awesome-group",
-								},
-							},
-						},
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: "namespace",
-								Name:      "ingress-c",
-								Annotations: map[string]string{
-									"kubernetes.io/ingress.class":          "alb",
-									"alb.ingress.kubernetes.io/group.name": "cool-group",
-								},
-							},
-						},
-					},
-				},
-			},
-			want: Group{
-				ID: GroupID{
-					Namespace: "",
-					Name:      "awesome-group",
-				},
-				Members: []*networking.Ingress{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: "namespace",
-							Name:      "ingress-a",
-							Annotations: map[string]string{
-								"kubernetes.io/ingress.class":          "alb",
-								"alb.ingress.kubernetes.io/group.name": "awesome-group",
-							},
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: "namespace",
-							Name:      "ingress-b",
-							Annotations: map[string]string{
-								"kubernetes.io/ingress.class":          "alb",
-								"alb.ingress.kubernetes.io/group.name": "awesome-group",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "explicit group - deleted Ingress without finalizer",
-			groupID: GroupID{
-				Namespace: "",
-				Name:      "awesome-group",
-			},
-			listIngressesCall: &listIngressesCall{
-				ingList: networking.IngressList{
-					Items: []networking.Ingress{
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: "namespace",
-								Name:      "ingress-a",
-								Annotations: map[string]string{
-									"kubernetes.io/ingress.class":          "alb",
-									"alb.ingress.kubernetes.io/group.name": "awesome-group",
-								},
-							},
-						},
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: "namespace",
-								Name:      "ingress-b",
-								Annotations: map[string]string{
-									"kubernetes.io/ingress.class":          "alb",
-									"alb.ingress.kubernetes.io/group.name": "awesome-group",
-								},
-								DeletionTimestamp: &now,
-							},
-						},
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: "namespace",
-								Name:      "ingress-c",
-								Annotations: map[string]string{
-									"kubernetes.io/ingress.class":          "alb",
-									"alb.ingress.kubernetes.io/group.name": "cool-group",
-								},
-							},
-						},
-					},
-				},
-			},
-			want: Group{
-				ID: GroupID{
-					Namespace: "",
-					Name:      "awesome-group",
-				},
-				Members: []*networking.Ingress{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: "namespace",
-							Name:      "ingress-a",
-							Annotations: map[string]string{
-								"kubernetes.io/ingress.class":          "alb",
-								"alb.ingress.kubernetes.io/group.name": "awesome-group",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "explicit group - deleted Ingress with finalizer",
-			groupID: GroupID{
-				Namespace: "",
-				Name:      "awesome-group",
-			},
-			listIngressesCall: &listIngressesCall{
-				ingList: networking.IngressList{
-					Items: []networking.Ingress{
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: "namespace",
-								Name:      "ingress-a",
-								Annotations: map[string]string{
-									"kubernetes.io/ingress.class":          "alb",
-									"alb.ingress.kubernetes.io/group.name": "awesome-group",
-								},
-							},
-						},
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: "namespace",
-								Name:      "ingress-b",
-								Annotations: map[string]string{
-									"kubernetes.io/ingress.class":          "alb",
-									"alb.ingress.kubernetes.io/group.name": "awesome-group",
-								},
-								Finalizers:        []string{"group.ingress.k8s.aws/awesome-group"},
-								DeletionTimestamp: &now,
-							},
-						},
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: "namespace",
-								Name:      "ingress-c",
-								Annotations: map[string]string{
-									"kubernetes.io/ingress.class":          "alb",
-									"alb.ingress.kubernetes.io/group.name": "cool-group",
-								},
-							},
-						},
-					},
-				},
-			},
-			want: Group{
-				ID: GroupID{
-					Namespace: "",
-					Name:      "awesome-group",
-				},
-				Members: []*networking.Ingress{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: "namespace",
-							Name:      "ingress-a",
-							Annotations: map[string]string{
-								"kubernetes.io/ingress.class":          "alb",
-								"alb.ingress.kubernetes.io/group.name": "awesome-group",
-							},
-						},
-					},
-				},
-				InactiveMembers: []*networking.Ingress{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: "namespace",
-							Name:      "ingress-b",
-							Annotations: map[string]string{
-								"kubernetes.io/ingress.class":          "alb",
-								"alb.ingress.kubernetes.io/group.name": "awesome-group",
-							},
-							Finalizers:        []string{"group.ingress.k8s.aws/awesome-group"},
-							DeletionTimestamp: &now,
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "implicit group",
-			groupID: GroupID{
-				Namespace: "namespace",
-				Name:      "ingress-a",
-			},
-			listIngressesCall: &listIngressesCall{
-				ingList: networking.IngressList{
-					Items: []networking.Ingress{
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: "namespace",
-								Name:      "ingress-a",
-								Annotations: map[string]string{
-									"kubernetes.io/ingress.class": "alb",
-								},
-							},
-						},
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: "namespace",
-								Name:      "ingress-c",
-								Annotations: map[string]string{
-									"kubernetes.io/ingress.class": "alb",
-								},
-							},
-						},
-					},
-				},
-			},
-			want: Group{
-				ID: GroupID{
-					Namespace: "namespace",
-					Name:      "ingress-a",
-				},
-				Members: []*networking.Ingress{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: "namespace",
-							Name:      "ingress-a",
-							Annotations: map[string]string{
-								"kubernetes.io/ingress.class": "alb",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "implicit group - deleted Ingress without finalizer",
-			groupID: GroupID{
-				Namespace: "namespace",
-				Name:      "ingress-a",
-			},
-			listIngressesCall: &listIngressesCall{
-				ingList: networking.IngressList{
-					Items: []networking.Ingress{
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: "namespace",
-								Name:      "ingress-a",
-								Annotations: map[string]string{
-									"kubernetes.io/ingress.class": "alb",
-								},
-								DeletionTimestamp: &now,
-							},
-						},
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: "namespace",
-								Name:      "ingress-c",
-								Annotations: map[string]string{
-									"kubernetes.io/ingress.class": "alb",
-								},
-							},
-						},
-					},
-				},
-			},
-			want: Group{
-				ID: GroupID{
-					Namespace: "namespace",
-					Name:      "ingress-a",
-				},
-				Members:         nil,
-				InactiveMembers: nil,
-			},
-		},
-		{
-			name: "implicit group - deleted Ingress with finalizer",
-			groupID: GroupID{
-				Namespace: "namespace",
-				Name:      "ingress-a",
-			},
-			listIngressesCall: &listIngressesCall{
-				ingList: networking.IngressList{
-					Items: []networking.Ingress{
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: "namespace",
-								Name:      "ingress-a",
-								Annotations: map[string]string{
-									"kubernetes.io/ingress.class": "alb",
-								},
-								Finalizers:        []string{"ingress.k8s.aws/resources"},
-								DeletionTimestamp: &now,
-							},
-						},
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: "namespace",
-								Name:      "ingress-c",
-								Annotations: map[string]string{
-									"kubernetes.io/ingress.class": "alb",
-								},
-								Finalizers: []string{"ingress.k8s.aws/resources"},
-							},
-						},
-					},
-				},
-			},
-			want: Group{
-				ID: GroupID{
-					Namespace: "namespace",
-					Name:      "ingress-a",
-				},
-				Members: nil,
-				InactiveMembers: []*networking.Ingress{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: "namespace",
-							Name:      "ingress-a",
-							Annotations: map[string]string{
-								"kubernetes.io/ingress.class": "alb",
-							},
-							Finalizers:        []string{"ingress.k8s.aws/resources"},
-							DeletionTimestamp: &now,
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "implicit group - joined explicit group without finalizer",
-			groupID: GroupID{
-				Namespace: "namespace",
-				Name:      "ingress-a",
-			},
-			listIngressesCall: &listIngressesCall{
-				ingList: networking.IngressList{
-					Items: []networking.Ingress{
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: "namespace",
-								Name:      "ingress-a",
-								Annotations: map[string]string{
-									"kubernetes.io/ingress.class":          "alb",
-									"alb.ingress.kubernetes.io/group.name": "awesome-group",
-								},
-							},
-						},
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: "namespace",
-								Name:      "ingress-c",
-								Annotations: map[string]string{
-									"kubernetes.io/ingress.class": "alb",
-								},
-							},
-						},
-					},
-				},
-			},
-			want: Group{
-				ID: GroupID{
-					Namespace: "namespace",
-					Name:      "ingress-a",
-				},
-				Members:         nil,
-				InactiveMembers: nil,
-			},
-		},
-		{
-			name: "implicit group - joined explicit group with finalizer",
-			groupID: GroupID{
-				Namespace: "namespace",
-				Name:      "ingress-a",
-			},
-			listIngressesCall: &listIngressesCall{
-				ingList: networking.IngressList{
-					Items: []networking.Ingress{
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: "namespace",
-								Name:      "ingress-a",
-								Annotations: map[string]string{
-									"kubernetes.io/ingress.class":          "alb",
-									"alb.ingress.kubernetes.io/group.name": "awesome-group",
-								},
-								Finalizers: []string{"ingress.k8s.aws/resources"},
-							},
-						},
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: "namespace",
-								Name:      "ingress-c",
-								Annotations: map[string]string{
-									"kubernetes.io/ingress.class": "alb",
-								},
-								Finalizers: []string{"ingress.k8s.aws/resources"},
-							},
-						},
-					},
-				},
-			},
-			want: Group{
-				ID: GroupID{
-					Namespace: "namespace",
-					Name:      "ingress-a",
-				},
-				Members: nil,
-				InactiveMembers: []*networking.Ingress{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: "namespace",
-							Name:      "ingress-a",
-							Annotations: map[string]string{
-								"kubernetes.io/ingress.class":          "alb",
-								"alb.ingress.kubernetes.io/group.name": "awesome-group",
-							},
-							Finalizers: []string{"ingress.k8s.aws/resources"},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-
-			client := mock_client.NewMockClient(ctrl)
-			annotationParser := annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io")
-			m := &defaultGroupLoader{
-				client:                             client,
-				annotationParser:                   annotationParser,
-				classAnnotationMatcher:             NewDefaultClassAnnotationMatcher(ingressClassALB),
-				manageIngressesWithoutIngressClass: false,
-			}
-			if tt.listIngressesCall != nil {
-				client.EXPECT().List(gomock.Any(), gomock.Any()).SetArg(1, tt.listIngressesCall.ingList).Return(tt.listIngressesCall.err)
-			}
-			got, err := m.Load(context.Background(), tt.groupID)
-			if tt.wantErr != nil {
-				assert.EqualError(t, err, tt.wantErr.Error())
-			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, tt.want, got)
-			}
-		})
-	}
-}
-
-func Test_defaultGroupLoader_matchesIngressClass(t *testing.T) {
-	type env struct {
-		ingClasses []*networking.IngressClass
-	}
-	type fields struct {
-		ingressClass                       string
-		manageIngressesWithoutIngressClass bool
-	}
-	tests := []struct {
-		name    string
-		env     env
-		fields  fields
-		ing     *networking.Ingress
-		want    bool
-		wantErr error
-	}{
-		{
-			name: "desire empty ingress class and no ingress class specified",
-			fields: fields{
-				ingressClass:                       "",
-				manageIngressesWithoutIngressClass: true,
-			},
-			ing: &networking.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{},
-				},
-			},
-			want: true,
-		},
-		{
-			name: "desire empty ingress class and alb ingress class specified",
-			fields: fields{
-				ingressClass:                       "",
-				manageIngressesWithoutIngressClass: true,
-			},
-			ing: &networking.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": "alb",
-					},
-				},
-			},
-			want: true,
-		},
-		{
-			name: "desire empty ingress class but another ingress class specified",
-			fields: fields{
-				ingressClass:                       "",
-				manageIngressesWithoutIngressClass: true,
-			},
-			ing: &networking.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": "nginx",
-					},
-				},
-			},
-			want: false,
-		},
-		{
-			name: "desire alb ingress class and alb ingress class specified",
-			fields: fields{
-				ingressClass:                       "alb",
-				manageIngressesWithoutIngressClass: false,
-			},
-			ing: &networking.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": "alb",
-					},
-				},
-			},
-			want: true,
-		},
-		{
-			name: "desire alb ingress class but no ingress class specified",
-			fields: fields{
-				ingressClass:                       "alb",
-				manageIngressesWithoutIngressClass: false,
-			},
-			ing: &networking.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{},
-				},
-			},
-			want: false,
-		},
-		{
-			name: "desire alb ingress class but another ingress class specified",
-			fields: fields{
-				ingressClass:                       "alb",
-				manageIngressesWithoutIngressClass: false,
-			},
-			ing: &networking.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": "nginx",
-					},
-				},
-			},
-			want: false,
-		},
-		{
-			name: "ingressClass exists and matches alb controller",
-			env: env{
-				ingClasses: []*networking.IngressClass{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "my-ing-class",
-						},
-						Spec: networking.IngressClassSpec{
-							Controller: "ingress.k8s.aws/alb",
-						},
-					},
-				},
-			},
-			fields: fields{
-				ingressClass:                       "alb",
-				manageIngressesWithoutIngressClass: false,
-			},
-			ing: &networking.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{},
-				},
-				Spec: networking.IngressSpec{
-					IngressClassName: awssdk.String("my-ing-class"),
-				},
-			},
-			want: true,
-		},
-		{
-			name: "ingressClass exists and matches another controller",
-			env: env{
-				ingClasses: []*networking.IngressClass{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "my-ing-class",
-						},
-						Spec: networking.IngressClassSpec{
-							Controller: "kubernetes.io/nginx",
-						},
-					},
-				},
-			},
-			fields: fields{
-				ingressClass:                       "alb",
-				manageIngressesWithoutIngressClass: false,
-			},
-			ing: &networking.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{},
-				},
-				Spec: networking.IngressSpec{
-					IngressClassName: awssdk.String("my-ing-class"),
-				},
-			},
-			want: false,
-		},
-		{
-			name: "matches alb ingress class via both annotation and spec.ingressClassName",
-			env: env{
-				ingClasses: []*networking.IngressClass{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "my-ing-class",
-						},
-						Spec: networking.IngressClassSpec{
-							Controller: "ingress.k8s.aws/alb",
-						},
-					},
-				},
-			},
-			fields: fields{
-				ingressClass:                       "alb",
-				manageIngressesWithoutIngressClass: false,
-			},
-			ing: &networking.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": "alb",
-					},
-				},
-				Spec: networking.IngressSpec{
-					IngressClassName: awssdk.String("my-ing-class"),
-				},
-			},
-			want: true,
-		},
-		{
-			name: "matches alb ingress class via annotation but not via spec.ingressClassName",
-			env: env{
-				ingClasses: []*networking.IngressClass{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "my-ing-class",
-						},
-						Spec: networking.IngressClassSpec{
-							Controller: "kubernetes.io/nginx",
-						},
-					},
-				},
-			},
-			fields: fields{
-				ingressClass:                       "alb",
-				manageIngressesWithoutIngressClass: false,
-			},
-			ing: &networking.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": "alb",
-					},
-				},
-				Spec: networking.IngressSpec{
-					IngressClassName: awssdk.String("my-ing-class"),
-				},
-			},
-			want: true,
-		},
-		{
-			name: "matches alb ingress class via spec.ingressClassName but not via annotation",
-			env: env{
-				ingClasses: []*networking.IngressClass{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "my-ing-class",
-						},
-						Spec: networking.IngressClassSpec{
-							Controller: "ingress.k8s.aws/alb",
-						},
-					},
-				},
-			},
-			fields: fields{
-				ingressClass:                       "alb",
-				manageIngressesWithoutIngressClass: false,
-			},
-			ing: &networking.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": "nginx",
-					},
-				},
-				Spec: networking.IngressSpec{
-					IngressClassName: awssdk.String("my-ing-class"),
-				},
-			},
-			want: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
-			k8sSchema := runtime.NewScheme()
-			clientgoscheme.AddToScheme(k8sSchema)
-			k8sClient := testclient.NewFakeClientWithScheme(k8sSchema)
-			for _, ingClass := range tt.env.ingClasses {
-				assert.NoError(t, k8sClient.Create(ctx, ingClass.DeepCopy()))
-			}
-
-			m := &defaultGroupLoader{
-				client:                             k8sClient,
-				eventRecorder:                      record.NewFakeRecorder(10),
-				classAnnotationMatcher:             NewDefaultClassAnnotationMatcher(tt.fields.ingressClass),
-				manageIngressesWithoutIngressClass: tt.fields.manageIngressesWithoutIngressClass,
-			}
-			got, err := m.matchesIngressClass(ctx, tt.ing)
-			if tt.wantErr != nil {
-				assert.EqualError(t, err, tt.wantErr.Error())
-			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, tt.want, got)
-			}
-		})
-	}
-}
-
-func Test_defaultGroupLoader_matchesIngressClassName(t *testing.T) {
-	type env struct {
-		ingClasses []*networking.IngressClass
-	}
-	type args struct {
-		ingClassName string
-	}
-	tests := []struct {
-		name    string
-		env     env
-		args    args
-		want    bool
-		wantErr error
-	}{
-		{
-			name: "ingressClass exists and matches controller",
-			env: env{
-				ingClasses: []*networking.IngressClass{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "my-ing-class",
-						},
-						Spec: networking.IngressClassSpec{
-							Controller: "ingress.k8s.aws/alb",
-						},
-					},
-				},
-			},
-			args: args{
-				ingClassName: "my-ing-class",
-			},
-			want: true,
-		},
-		{
-			name: "ingressClass exists and mismatches controller",
-			env: env{
-				ingClasses: []*networking.IngressClass{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "my-ing-class",
-						},
-						Spec: networking.IngressClassSpec{
-							Controller: "kubernetes.io/nginx",
-						},
-					},
-				},
-			},
-			args: args{
-				ingClassName: "my-ing-class",
-			},
-			want: false,
-		},
-		{
-			name: "ingressClass doesn't exists",
-			env: env{
-				ingClasses: nil,
-			},
-			args: args{
-				ingClassName: "my-ing-class",
-			},
-			want:    false,
-			wantErr: errors.New("invalid ingress class: ingressclasses.networking.k8s.io \"my-ing-class\" not found"),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
-			k8sSchema := runtime.NewScheme()
-			clientgoscheme.AddToScheme(k8sSchema)
-			k8sClient := testclient.NewFakeClientWithScheme(k8sSchema)
-			for _, ingClass := range tt.env.ingClasses {
-				assert.NoError(t, k8sClient.Create(ctx, ingClass.DeepCopy()))
-			}
-
-			m := &defaultGroupLoader{
-				client: k8sClient,
-			}
-			got, err := m.matchesIngressClassName(ctx, tt.args.ingClassName)
-			if tt.wantErr != nil {
-				assert.EqualError(t, err, tt.wantErr.Error())
-			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, tt.want, got)
-			}
 		})
 	}
 }
 
 func Test_defaultGroupLoader_isGroupMember(t *testing.T) {
 	now := metav1.Now()
-	tests := []struct {
-		name    string
+	type env struct {
+		ingClassList       []*networking.IngressClass
+		ingClassParamsList []*elbv2api.IngressClassParams
+	}
+	type args struct {
 		groupID GroupID
 		ing     *networking.Ingress
-		want    bool
-		wantErr error
+	}
+	tests := []struct {
+		name              string
+		env               env
+		args              args
+		wantClassifiedIng ClassifiedIngress
+		wantIsGroupMember bool
+		wantErr           error
 	}{
 		{
-			name: "explicit group member",
-			groupID: GroupID{
-				Namespace: "",
-				Name:      "awesome-group",
-			},
-			ing: &networking.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "namespace",
-					Name:      "ingress",
-					Annotations: map[string]string{
-						"kubernetes.io/ingress.class":          "alb",
-						"alb.ingress.kubernetes.io/group.name": "awesome-group",
+			name: "ingress is member of explicit group - groupID match with groupName from IngressClassParams",
+			env: env{
+				ingClassList: []*networking.IngressClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ing-class",
+						},
+						Spec: networking.IngressClassSpec{
+							Controller: "ingress.k8s.aws/alb",
+							Parameters: &corev1.TypedLocalObjectReference{
+								APIGroup: awssdk.String("elbv2.k8s.aws"),
+								Kind:     "IngressClassParams",
+								Name:     "ing-class-params",
+							},
+						},
+					},
+				},
+				ingClassParamsList: []*elbv2api.IngressClassParams{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ing-class-params",
+						},
+						Spec: elbv2api.IngressClassParamsSpec{
+							Group: &elbv2api.IngressGroup{
+								Name: "awesome-group",
+							},
+						},
 					},
 				},
 			},
-			want: true,
-		},
-		{
-			name: "implicit group member",
-			groupID: GroupID{
-				Namespace: "namespace",
-				Name:      "ingress",
-			},
-			ing: &networking.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "namespace",
-					Name:      "ingress",
-					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": "alb",
+			args: args{
+				groupID: GroupID{Name: "awesome-group"},
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: awssdk.String("ing-class"),
 					},
 				},
 			},
-			want: true,
-		},
-		{
-			name: "deleted ingress is no longer member",
-			groupID: GroupID{
-				Namespace: "namespace",
-				Name:      "ingress",
-			},
-			ing: &networking.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "namespace",
-					Name:      "ingress",
-					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": "alb",
+			wantClassifiedIng: ClassifiedIngress{
+				Ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
 					},
-					DeletionTimestamp: &now,
-				},
-			},
-			want: false,
-		},
-		{
-			name: "invalid group name",
-			groupID: GroupID{
-				Namespace: "namespace",
-				Name:      "ingress",
-			},
-			ing: &networking.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "namespace",
-					Name:      "ingress",
-					Annotations: map[string]string{
-						"kubernetes.io/ingress.class":          "alb",
-						"alb.ingress.kubernetes.io/group.name": "a$b",
+					Spec: networking.IngressSpec{
+						IngressClassName: awssdk.String("ing-class"),
 					},
 				},
+				IngClassConfig: ClassConfiguration{
+					IngClass: &networking.IngressClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ing-class",
+						},
+						Spec: networking.IngressClassSpec{
+							Controller: "ingress.k8s.aws/alb",
+							Parameters: &corev1.TypedLocalObjectReference{
+								APIGroup: awssdk.String("elbv2.k8s.aws"),
+								Kind:     "IngressClassParams",
+								Name:     "ing-class-params",
+							},
+						},
+					},
+					IngClassParams: &elbv2api.IngressClassParams{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ing-class-params",
+						},
+						Spec: elbv2api.IngressClassParamsSpec{
+							Group: &elbv2api.IngressGroup{
+								Name: "awesome-group",
+							},
+						},
+					},
+				},
 			},
-			want: false,
+			wantIsGroupMember: true,
 		},
 		{
-			name: "invalid ingress class",
-			groupID: GroupID{
-				Namespace: "namespace",
-				Name:      "ingress",
-			},
-			ing: &networking.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "namespace",
-					Name:      "ingress",
+			name: "ingress isn't member of explicit group - groupID mismatch with groupName from IngressClassParams",
+			env: env{
+				ingClassList: []*networking.IngressClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ing-class",
+						},
+						Spec: networking.IngressClassSpec{
+							Controller: "ingress.k8s.aws/alb",
+							Parameters: &corev1.TypedLocalObjectReference{
+								APIGroup: awssdk.String("elbv2.k8s.aws"),
+								Kind:     "IngressClassParams",
+								Name:     "ing-class-params",
+							},
+						},
+					},
 				},
-				Spec: networking.IngressSpec{
-					IngressClassName: awssdk.String("my-class"),
+				ingClassParamsList: []*elbv2api.IngressClassParams{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ing-class-params",
+						},
+						Spec: elbv2api.IngressClassParamsSpec{
+							Group: &elbv2api.IngressGroup{
+								Name: "awesome-group",
+							},
+						},
+					},
 				},
 			},
-			want: false,
+			args: args{
+				groupID: GroupID{Name: "another-group"},
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: awssdk.String("ing-class"),
+					},
+				},
+			},
+			wantClassifiedIng: ClassifiedIngress{
+				Ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: awssdk.String("ing-class"),
+					},
+				},
+				IngClassConfig: ClassConfiguration{
+					IngClass: &networking.IngressClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ing-class",
+						},
+						Spec: networking.IngressClassSpec{
+							Controller: "ingress.k8s.aws/alb",
+							Parameters: &corev1.TypedLocalObjectReference{
+								APIGroup: awssdk.String("elbv2.k8s.aws"),
+								Kind:     "IngressClassParams",
+								Name:     "ing-class-params",
+							},
+						},
+					},
+					IngClassParams: &elbv2api.IngressClassParams{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ing-class-params",
+						},
+						Spec: elbv2api.IngressClassParamsSpec{
+							Group: &elbv2api.IngressGroup{
+								Name: "awesome-group",
+							},
+						},
+					},
+				},
+			},
+			wantIsGroupMember: false,
+		},
+		{
+			name: "ingress is member of explicit group - groupID match with groupName from annotation",
+			args: args{
+				groupID: GroupID{Name: "awesome-group"},
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+						Annotations: map[string]string{
+							"kubernetes.io/ingress.class":          "alb",
+							"alb.ingress.kubernetes.io/group.name": "awesome-group",
+						},
+					},
+				},
+			},
+			wantClassifiedIng: ClassifiedIngress{
+				Ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+						Annotations: map[string]string{
+							"kubernetes.io/ingress.class":          "alb",
+							"alb.ingress.kubernetes.io/group.name": "awesome-group",
+						},
+					},
+				},
+				IngClassConfig: ClassConfiguration{},
+			},
+			wantIsGroupMember: true,
+		},
+		{
+			name: "ingress isn't member of explicit group - groupID mismatch with groupName from annotation",
+			args: args{
+				groupID: GroupID{Name: "another-group"},
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+						Annotations: map[string]string{
+							"kubernetes.io/ingress.class":          "alb",
+							"alb.ingress.kubernetes.io/group.name": "awesome-group",
+						},
+					},
+				},
+			},
+			wantClassifiedIng: ClassifiedIngress{
+				Ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+						Annotations: map[string]string{
+							"kubernetes.io/ingress.class":          "alb",
+							"alb.ingress.kubernetes.io/group.name": "awesome-group",
+						},
+					},
+				},
+				IngClassConfig: ClassConfiguration{},
+			},
+			wantIsGroupMember: false,
+		},
+		{
+			name: "ingress is member of implicit group - with ingressClassName",
+			env: env{
+				ingClassList: []*networking.IngressClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ing-class",
+						},
+						Spec: networking.IngressClassSpec{
+							Controller: "ingress.k8s.aws/alb",
+							Parameters: &corev1.TypedLocalObjectReference{
+								APIGroup: awssdk.String("elbv2.k8s.aws"),
+								Kind:     "IngressClassParams",
+								Name:     "ing-class-params",
+							},
+						},
+					},
+				},
+				ingClassParamsList: []*elbv2api.IngressClassParams{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ing-class-params",
+						},
+						Spec: elbv2api.IngressClassParamsSpec{
+							Group: nil,
+						},
+					},
+				},
+			},
+			args: args{
+				groupID: GroupID{Namespace: "ing-ns", Name: "ing-name"},
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: awssdk.String("ing-class"),
+					},
+				},
+			},
+			wantClassifiedIng: ClassifiedIngress{
+				Ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: awssdk.String("ing-class"),
+					},
+				},
+				IngClassConfig: ClassConfiguration{
+					IngClass: &networking.IngressClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ing-class",
+						},
+						Spec: networking.IngressClassSpec{
+							Controller: "ingress.k8s.aws/alb",
+							Parameters: &corev1.TypedLocalObjectReference{
+								APIGroup: awssdk.String("elbv2.k8s.aws"),
+								Kind:     "IngressClassParams",
+								Name:     "ing-class-params",
+							},
+						},
+					},
+					IngClassParams: &elbv2api.IngressClassParams{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ing-class-params",
+						},
+						Spec: elbv2api.IngressClassParamsSpec{
+							Group: nil,
+						},
+					},
+				},
+			},
+			wantIsGroupMember: true,
+		},
+		{
+			name: "ingress isn't member of implicit group - with ingressClassName",
+			env: env{
+				ingClassList: []*networking.IngressClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ing-class",
+						},
+						Spec: networking.IngressClassSpec{
+							Controller: "ingress.k8s.aws/alb",
+							Parameters: &corev1.TypedLocalObjectReference{
+								APIGroup: awssdk.String("elbv2.k8s.aws"),
+								Kind:     "IngressClassParams",
+								Name:     "ing-class-params",
+							},
+						},
+					},
+				},
+				ingClassParamsList: []*elbv2api.IngressClassParams{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ing-class-params",
+						},
+						Spec: elbv2api.IngressClassParamsSpec{
+							Group: nil,
+						},
+					},
+				},
+			},
+			args: args{
+				groupID: GroupID{Namespace: "ing-ns", Name: "another-ing-name"},
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: awssdk.String("ing-class"),
+					},
+				},
+			},
+			wantClassifiedIng: ClassifiedIngress{
+				Ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: awssdk.String("ing-class"),
+					},
+				},
+				IngClassConfig: ClassConfiguration{
+					IngClass: &networking.IngressClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ing-class",
+						},
+						Spec: networking.IngressClassSpec{
+							Controller: "ingress.k8s.aws/alb",
+							Parameters: &corev1.TypedLocalObjectReference{
+								APIGroup: awssdk.String("elbv2.k8s.aws"),
+								Kind:     "IngressClassParams",
+								Name:     "ing-class-params",
+							},
+						},
+					},
+					IngClassParams: &elbv2api.IngressClassParams{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ing-class-params",
+						},
+						Spec: elbv2api.IngressClassParamsSpec{
+							Group: nil,
+						},
+					},
+				},
+			},
+			wantIsGroupMember: false,
+		},
+		{
+			name: "ingress is member of implicit group - with ingressClass annotation",
+			args: args{
+				groupID: GroupID{Namespace: "ing-ns", Name: "ing-name"},
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+						Annotations: map[string]string{
+							"kubernetes.io/ingress.class": "alb",
+						},
+					},
+				},
+			},
+			wantClassifiedIng: ClassifiedIngress{
+				Ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+						Annotations: map[string]string{
+							"kubernetes.io/ingress.class": "alb",
+						},
+					},
+				},
+				IngClassConfig: ClassConfiguration{},
+			},
+			wantIsGroupMember: true,
+		},
+		{
+			name: "ingress isn't member of implicit group - with ingressClass annotation",
+			args: args{
+				groupID: GroupID{Namespace: "ing-ns", Name: "another-ing-name"},
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+						Annotations: map[string]string{
+							"kubernetes.io/ingress.class": "alb",
+						},
+					},
+				},
+			},
+			wantClassifiedIng: ClassifiedIngress{
+				Ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+						Annotations: map[string]string{
+							"kubernetes.io/ingress.class": "alb",
+						},
+					},
+				},
+				IngClassConfig: ClassConfiguration{},
+			},
+			wantIsGroupMember: false,
+		},
+		{
+			name: "ingress isn't member of a explicit group - invalid IngressClass",
+			args: args{
+				groupID: GroupID{Name: "awesome-group"},
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: awssdk.String("ingress-class-non-exists"),
+					},
+				},
+			},
+			wantClassifiedIng: ClassifiedIngress{},
+			wantIsGroupMember: false,
+		},
+		{
+			name: "ingress isn't member of a explicit group - invalid IngressGroup",
+			args: args{
+				groupID: GroupID{Name: "awesome-group"},
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+						Annotations: map[string]string{
+							"kubernetes.io/ingress.class":          "alb",
+							"alb.ingress.kubernetes.io/group.name": "awesome-group$",
+						},
+					},
+				},
+			},
+			wantClassifiedIng: ClassifiedIngress{},
+			wantIsGroupMember: false,
+		},
+		{
+			name: "ingress isn't member of a explicit group - ingress-been-deleted",
+			args: args{
+				groupID: GroupID{Name: "awesome-group"},
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+						Annotations: map[string]string{
+							"kubernetes.io/ingress.class":          "alb",
+							"alb.ingress.kubernetes.io/group.name": "awesome-group",
+						},
+						DeletionTimestamp: &now,
+					},
+				},
+			},
+			wantClassifiedIng: ClassifiedIngress{},
+			wantIsGroupMember: false,
 		},
 	}
 	for _, tt := range tests {
@@ -1070,16 +1287,854 @@ func Test_defaultGroupLoader_isGroupMember(t *testing.T) {
 
 			k8sSchema := runtime.NewScheme()
 			clientgoscheme.AddToScheme(k8sSchema)
+			elbv2api.AddToScheme(k8sSchema)
 			k8sClient := testclient.NewFakeClientWithScheme(k8sSchema)
+			for _, ingClass := range tt.env.ingClassList {
+				assert.NoError(t, k8sClient.Create(context.Background(), ingClass.DeepCopy()))
+			}
+			for _, ingClassParams := range tt.env.ingClassParamsList {
+				assert.NoError(t, k8sClient.Create(context.Background(), ingClassParams.DeepCopy()))
+			}
+
 			annotationParser := annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io")
+			classLoader := NewDefaultClassLoader(k8sClient)
+			classAnnotationMatcher := NewDefaultClassAnnotationMatcher("alb")
 			m := &defaultGroupLoader{
 				client:                             k8sClient,
-				eventRecorder:                      record.NewFakeRecorder(10),
 				annotationParser:                   annotationParser,
-				classAnnotationMatcher:             NewDefaultClassAnnotationMatcher(ingressClassALB),
+				classLoader:                        classLoader,
+				classAnnotationMatcher:             classAnnotationMatcher,
 				manageIngressesWithoutIngressClass: false,
 			}
-			got, err := m.isGroupMember(context.Background(), tt.groupID, tt.ing)
+
+			gotClassifiedIng, gotIsGroupMember, err := m.isGroupMember(context.Background(), tt.args.groupID, tt.args.ing)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				opt := cmp.Options{
+					equality.IgnoreFakeClientPopulatedFields(),
+				}
+				assert.True(t, cmp.Equal(tt.wantClassifiedIng, gotClassifiedIng, opt),
+					"diff: %v", cmp.Diff(tt.wantClassifiedIng, gotClassifiedIng, opt))
+				assert.Equal(t, tt.wantIsGroupMember, gotIsGroupMember)
+			}
+		})
+	}
+}
+
+func Test_defaultGroupLoader_loadGroupIDIfAnyHelper(t *testing.T) {
+	now := metav1.Now()
+	awesomeGroupID := GroupID{Name: "awesome-group"}
+	ingImplicitGroupID := GroupID{Namespace: "ing-ns", Name: "ing-name"}
+
+	type env struct {
+		ingClassList       []*networking.IngressClass
+		ingClassParamsList []*elbv2api.IngressClassParams
+	}
+
+	type args struct {
+		ing *networking.Ingress
+	}
+	tests := []struct {
+		name              string
+		env               env
+		args              args
+		wantClassifiedIng ClassifiedIngress
+		wantGroupID       *GroupID
+		wantErr           error
+	}{
+		{
+			name: "ingress no longer belong to any IngressGroup when it's been deleted",
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+						Annotations: map[string]string{
+							"kubernetes.io/ingress.class": "alb",
+						},
+						DeletionTimestamp: &now,
+					},
+				},
+			},
+			wantClassifiedIng: ClassifiedIngress{},
+			wantGroupID:       nil,
+			wantErr:           nil,
+		},
+		{
+			name: "ingress specified groupID via IngressClassParams",
+			env: env{
+				ingClassList: []*networking.IngressClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ing-class",
+						},
+						Spec: networking.IngressClassSpec{
+							Controller: "ingress.k8s.aws/alb",
+							Parameters: &corev1.TypedLocalObjectReference{
+								APIGroup: awssdk.String("elbv2.k8s.aws"),
+								Kind:     "IngressClassParams",
+								Name:     "ing-class-params",
+							},
+						},
+					},
+				},
+				ingClassParamsList: []*elbv2api.IngressClassParams{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ing-class-params",
+						},
+						Spec: elbv2api.IngressClassParamsSpec{
+							Group: &elbv2api.IngressGroup{
+								Name: "awesome-group",
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: awssdk.String("ing-class"),
+					},
+				},
+			},
+			wantClassifiedIng: ClassifiedIngress{
+				Ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: awssdk.String("ing-class"),
+					},
+				},
+				IngClassConfig: ClassConfiguration{
+					IngClass: &networking.IngressClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ing-class",
+						},
+						Spec: networking.IngressClassSpec{
+							Controller: "ingress.k8s.aws/alb",
+							Parameters: &corev1.TypedLocalObjectReference{
+								APIGroup: awssdk.String("elbv2.k8s.aws"),
+								Kind:     "IngressClassParams",
+								Name:     "ing-class-params",
+							},
+						},
+					},
+					IngClassParams: &elbv2api.IngressClassParams{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ing-class-params",
+						},
+						Spec: elbv2api.IngressClassParamsSpec{
+							Group: &elbv2api.IngressGroup{
+								Name: "awesome-group",
+							},
+						},
+					},
+				},
+			},
+			wantGroupID: &awesomeGroupID,
+			wantErr:     nil,
+		},
+		{
+			name: "ingress specified groupID via annotation",
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+						Annotations: map[string]string{
+							"kubernetes.io/ingress.class":          "alb",
+							"alb.ingress.kubernetes.io/group.name": "awesome-group",
+						},
+					},
+				},
+			},
+			wantClassifiedIng: ClassifiedIngress{
+				Ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+						Annotations: map[string]string{
+							"kubernetes.io/ingress.class":          "alb",
+							"alb.ingress.kubernetes.io/group.name": "awesome-group",
+						},
+					},
+				},
+				IngClassConfig: ClassConfiguration{},
+			},
+			wantGroupID: &awesomeGroupID,
+			wantErr:     nil,
+		},
+		{
+			name: "ingress defaults to have implicit groupID",
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+						Annotations: map[string]string{
+							"kubernetes.io/ingress.class": "alb",
+						},
+					},
+				},
+			},
+			wantClassifiedIng: ClassifiedIngress{
+				Ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+						Annotations: map[string]string{
+							"kubernetes.io/ingress.class": "alb",
+						},
+					},
+				},
+				IngClassConfig: ClassConfiguration{},
+			},
+			wantGroupID: &ingImplicitGroupID,
+			wantErr:     nil,
+		},
+		{
+			name: "ingress failed to be classified",
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: awssdk.String("ing-class"),
+					},
+				},
+			},
+			wantClassifiedIng: ClassifiedIngress{},
+			wantGroupID:       nil,
+			wantErr:           errors.New("invalid ingress class: ingressclasses.networking.k8s.io \"ing-class\" not found"),
+		},
+		{
+			name: "ingress isn't matched by controller's class",
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+						Annotations: map[string]string{
+							"kubernetes.io/ingress.class": "nginx",
+						},
+					},
+				},
+			},
+			wantClassifiedIng: ClassifiedIngress{},
+			wantGroupID:       nil,
+			wantErr:           nil,
+		},
+		{
+			name: "ingress's groupID is invalid",
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+						Annotations: map[string]string{
+							"kubernetes.io/ingress.class":          "alb",
+							"alb.ingress.kubernetes.io/group.name": "awesome-group$",
+						},
+					},
+				},
+			},
+			wantClassifiedIng: ClassifiedIngress{},
+			wantGroupID:       nil,
+			wantErr:           errors.New("invalid ingress group: groupName must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			k8sSchema := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sSchema)
+			elbv2api.AddToScheme(k8sSchema)
+			k8sClient := testclient.NewFakeClientWithScheme(k8sSchema)
+			for _, ingClass := range tt.env.ingClassList {
+				assert.NoError(t, k8sClient.Create(context.Background(), ingClass.DeepCopy()))
+			}
+			for _, ingClassParams := range tt.env.ingClassParamsList {
+				assert.NoError(t, k8sClient.Create(context.Background(), ingClassParams.DeepCopy()))
+			}
+
+			annotationParser := annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io")
+			classLoader := NewDefaultClassLoader(k8sClient)
+			classAnnotationMatcher := NewDefaultClassAnnotationMatcher("alb")
+			m := &defaultGroupLoader{
+				client:                             k8sClient,
+				annotationParser:                   annotationParser,
+				classLoader:                        classLoader,
+				classAnnotationMatcher:             classAnnotationMatcher,
+				manageIngressesWithoutIngressClass: false,
+			}
+			gotClassifiedIng, gotGroupID, err := m.loadGroupIDIfAnyHelper(context.Background(), tt.args.ing)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				opt := cmp.Options{
+					equality.IgnoreFakeClientPopulatedFields(),
+				}
+				assert.True(t, cmp.Equal(tt.wantClassifiedIng, gotClassifiedIng, opt),
+					"diff: %v", cmp.Diff(tt.wantClassifiedIng, gotClassifiedIng, opt))
+				assert.Equal(t, tt.wantGroupID, gotGroupID)
+			}
+		})
+	}
+}
+
+func Test_defaultGroupLoader_classifyIngress(t *testing.T) {
+	type env struct {
+		ingClassList []*networking.IngressClass
+	}
+	type fields struct {
+		ingressClass                       string
+		manageIngressesWithoutIngressClass bool
+	}
+	type args struct {
+		ing *networking.Ingress
+	}
+	tests := []struct {
+		name                    string
+		env                     env
+		fields                  fields
+		args                    args
+		wantClassifiedIng       ClassifiedIngress
+		wantIngressClassMatches bool
+		wantErr                 error
+	}{
+		{
+			name: "class specified via annotation - matches",
+			fields: fields{
+				ingressClass: "alb",
+			},
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+						Annotations: map[string]string{
+							"kubernetes.io/ingress.class": "alb",
+						},
+					},
+				},
+			},
+			wantClassifiedIng: ClassifiedIngress{
+				Ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+						Annotations: map[string]string{
+							"kubernetes.io/ingress.class": "alb",
+						},
+					},
+				},
+				IngClassConfig: ClassConfiguration{},
+			},
+			wantIngressClassMatches: true,
+		},
+		{
+			name: "class specified via annotation - mismatches",
+			fields: fields{
+				ingressClass: "alb",
+			},
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+						Annotations: map[string]string{
+							"kubernetes.io/ingress.class": "nginx",
+						},
+					},
+				},
+			},
+			wantClassifiedIng: ClassifiedIngress{
+				Ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+						Annotations: map[string]string{
+							"kubernetes.io/ingress.class": "nginx",
+						},
+					},
+				},
+				IngClassConfig: ClassConfiguration{},
+			},
+			wantIngressClassMatches: false,
+		},
+		{
+			name: "class specified via ingressClassName - matches",
+			env: env{
+				ingClassList: []*networking.IngressClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ing-class",
+						},
+						Spec: networking.IngressClassSpec{
+							Controller: "ingress.k8s.aws/alb",
+						},
+					},
+				},
+			},
+			fields: fields{
+				ingressClass: "alb",
+			},
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:   "ing-ns",
+						Name:        "ing-name",
+						Annotations: map[string]string{},
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: awssdk.String("ing-class"),
+					},
+				},
+			},
+			wantClassifiedIng: ClassifiedIngress{
+				Ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:   "ing-ns",
+						Name:        "ing-name",
+						Annotations: map[string]string{},
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: awssdk.String("ing-class"),
+					},
+				},
+				IngClassConfig: ClassConfiguration{
+					IngClass: &networking.IngressClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ing-class",
+						},
+						Spec: networking.IngressClassSpec{
+							Controller: "ingress.k8s.aws/alb",
+						},
+					},
+				},
+			},
+			wantIngressClassMatches: true,
+		},
+		{
+			name: "class specified via both annotation & ingressClassName - annotation takes priority",
+			env: env{
+				ingClassList: []*networking.IngressClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ing-class",
+						},
+						Spec: networking.IngressClassSpec{
+							Controller: "ingress.k8s.aws/alb",
+						},
+					},
+				},
+			},
+			fields: fields{
+				ingressClass: "alb",
+			},
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+						Annotations: map[string]string{
+							"kubernetes.io/ingress.class": "alb",
+						},
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: awssdk.String("ing-class"),
+					},
+				},
+			},
+			wantClassifiedIng: ClassifiedIngress{
+				Ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ing-ns",
+						Name:      "ing-name",
+						Annotations: map[string]string{
+							"kubernetes.io/ingress.class": "alb",
+						},
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: awssdk.String("ing-class"),
+					},
+				},
+				IngClassConfig: ClassConfiguration{},
+			},
+			wantIngressClassMatches: true,
+		},
+		{
+			name: "class specified via ingressClassName - mismatches",
+			env: env{
+				ingClassList: []*networking.IngressClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ing-class",
+						},
+						Spec: networking.IngressClassSpec{
+							Controller: "some.other/nginx",
+						},
+					},
+				},
+			},
+			fields: fields{
+				ingressClass: "alb",
+			},
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:   "ing-ns",
+						Name:        "ing-name",
+						Annotations: map[string]string{},
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: awssdk.String("ing-class"),
+					},
+				},
+			},
+			wantClassifiedIng: ClassifiedIngress{
+				Ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:   "ing-ns",
+						Name:        "ing-name",
+						Annotations: map[string]string{},
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: awssdk.String("ing-class"),
+					},
+				},
+				IngClassConfig: ClassConfiguration{
+					IngClass: &networking.IngressClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ing-class",
+						},
+						Spec: networking.IngressClassSpec{
+							Controller: "some.other/nginx",
+						},
+					},
+				},
+			},
+			wantIngressClassMatches: false,
+		},
+		{
+			name: "class specified via ingressClassName - ingressClass not found",
+			env: env{
+				ingClassList: []*networking.IngressClass{},
+			},
+			fields: fields{
+				ingressClass: "alb",
+			},
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:   "ing-ns",
+						Name:        "ing-name",
+						Annotations: map[string]string{},
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: awssdk.String("ing-class"),
+					},
+				},
+			},
+			wantClassifiedIng: ClassifiedIngress{
+				Ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:   "ing-ns",
+						Name:        "ing-name",
+						Annotations: map[string]string{},
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: awssdk.String("ing-class"),
+					},
+				},
+				IngClassConfig: ClassConfiguration{},
+			},
+			wantErr: errors.New("invalid ingress class: ingressclasses.networking.k8s.io \"ing-class\" not found"),
+		},
+		{
+			name: "no class specified - manageIngressesWithoutIngressClass is set",
+			fields: fields{
+				ingressClass:                       "",
+				manageIngressesWithoutIngressClass: true,
+			},
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:   "ing-ns",
+						Name:        "ing-name",
+						Annotations: map[string]string{},
+					},
+				},
+			},
+			wantClassifiedIng: ClassifiedIngress{
+				Ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:   "ing-ns",
+						Name:        "ing-name",
+						Annotations: map[string]string{},
+					},
+				},
+				IngClassConfig: ClassConfiguration{},
+			},
+			wantIngressClassMatches: true,
+		},
+		{
+			name: "no class specified - manageIngressesWithoutIngressClass isn't set",
+			fields: fields{
+				ingressClass:                       "",
+				manageIngressesWithoutIngressClass: false,
+			},
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:   "ing-ns",
+						Name:        "ing-name",
+						Annotations: map[string]string{},
+					},
+				},
+			},
+			wantClassifiedIng: ClassifiedIngress{
+				Ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:   "ing-ns",
+						Name:        "ing-name",
+						Annotations: map[string]string{},
+					},
+				},
+				IngClassConfig: ClassConfiguration{},
+			},
+			wantIngressClassMatches: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			k8sSchema := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sSchema)
+			elbv2api.AddToScheme(k8sSchema)
+			k8sClient := testclient.NewFakeClientWithScheme(k8sSchema)
+			for _, ingClass := range tt.env.ingClassList {
+				assert.NoError(t, k8sClient.Create(context.Background(), ingClass.DeepCopy()))
+			}
+
+			annotationParser := annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io")
+			classLoader := NewDefaultClassLoader(k8sClient)
+			classAnnotationMatcher := NewDefaultClassAnnotationMatcher(tt.fields.ingressClass)
+			m := &defaultGroupLoader{
+				client:                             k8sClient,
+				annotationParser:                   annotationParser,
+				classLoader:                        classLoader,
+				classAnnotationMatcher:             classAnnotationMatcher,
+				manageIngressesWithoutIngressClass: tt.fields.manageIngressesWithoutIngressClass,
+			}
+
+			gotClassifiedIng, gotIngressClassMatches, err := m.classifyIngress(context.Background(), tt.args.ing)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				opt := cmp.Options{
+					equality.IgnoreFakeClientPopulatedFields(),
+				}
+				assert.True(t, cmp.Equal(tt.wantClassifiedIng, gotClassifiedIng, opt),
+					"diff: %v", cmp.Diff(tt.wantClassifiedIng, gotClassifiedIng, opt))
+				assert.Equal(t, tt.wantIngressClassMatches, gotIngressClassMatches)
+			}
+		})
+	}
+}
+
+func Test_defaultGroupLoader_loadGroupID(t *testing.T) {
+	type args struct {
+		classifiedIng ClassifiedIngress
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    GroupID
+		wantErr error
+	}{
+		{
+			name: "groupName specified via Ingress annotation",
+			args: args{
+				classifiedIng: ClassifiedIngress{
+					Ing: &networking.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "ing-ns",
+							Name:      "ing-name",
+							Annotations: map[string]string{
+								"alb.ingress.kubernetes.io/group.name": "awesome-group",
+							},
+						},
+					},
+				},
+			},
+			want: GroupID{Name: "awesome-group"},
+		},
+		{
+			name: "groupName specified via Ingress annotation - but invalid",
+			args: args{
+				classifiedIng: ClassifiedIngress{
+					Ing: &networking.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "ing-ns",
+							Name:      "ing-name",
+							Annotations: map[string]string{
+								"alb.ingress.kubernetes.io/group.name": "awesome-group$",
+							},
+						},
+					},
+				},
+			},
+			wantErr: errors.New("invalid ingress group: groupName must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character"),
+		},
+		{
+			name: "groupName specified via IngressClassParams",
+			args: args{
+				classifiedIng: ClassifiedIngress{
+					Ing: &networking.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace:   "ing-ns",
+							Name:        "ing-name",
+							Annotations: map[string]string{},
+						},
+					},
+					IngClassConfig: ClassConfiguration{
+						IngClassParams: &elbv2api.IngressClassParams{
+							Spec: elbv2api.IngressClassParamsSpec{
+								Group: &elbv2api.IngressGroup{
+									Name: "awesome-group",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: GroupID{Name: "awesome-group"},
+		},
+		{
+			name: "groupName specified via IngressClassParams - but invalid",
+			args: args{
+				classifiedIng: ClassifiedIngress{
+					Ing: &networking.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace:   "ing-ns",
+							Name:        "ing-name",
+							Annotations: map[string]string{},
+						},
+					},
+					IngClassConfig: ClassConfiguration{
+						IngClassParams: &elbv2api.IngressClassParams{
+							Spec: elbv2api.IngressClassParamsSpec{
+								Group: &elbv2api.IngressGroup{
+									Name: "awesome-group$",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: errors.New("invalid ingress group: groupName must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character"),
+		},
+		{
+			name: "groupName specified via both Ingress annotation & IngressClassParams",
+			args: args{
+				classifiedIng: ClassifiedIngress{
+					Ing: &networking.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "ing-ns",
+							Name:      "ing-name",
+							Annotations: map[string]string{
+								"alb.ingress.kubernetes.io/group.name": "awesome-group-via-anno",
+							},
+						},
+					},
+					IngClassConfig: ClassConfiguration{
+						IngClassParams: &elbv2api.IngressClassParams{
+							Spec: elbv2api.IngressClassParamsSpec{
+								Group: &elbv2api.IngressGroup{
+									Name: "awesome-group-via-params",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: GroupID{Name: "awesome-group-via-params"},
+		},
+		{
+			name: "groupName specified via both Ingress annotation & IngressClassParams",
+			args: args{
+				classifiedIng: ClassifiedIngress{
+					Ing: &networking.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "ing-ns",
+							Name:      "ing-name",
+							Annotations: map[string]string{
+								"alb.ingress.kubernetes.io/group.name": "awesome-group-via-anno",
+							},
+						},
+					},
+					IngClassConfig: ClassConfiguration{
+						IngClassParams: &elbv2api.IngressClassParams{
+							Spec: elbv2api.IngressClassParamsSpec{
+								Group: &elbv2api.IngressGroup{
+									Name: "awesome-group-via-params",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: GroupID{Name: "awesome-group-via-params"},
+		},
+		{
+			name: "groupName not specified",
+			args: args{
+				classifiedIng: ClassifiedIngress{
+					Ing: &networking.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace:   "ing-ns",
+							Name:        "ing-name",
+							Annotations: map[string]string{},
+						},
+					},
+					IngClassConfig: ClassConfiguration{
+						IngClassParams: &elbv2api.IngressClassParams{
+							Spec: elbv2api.IngressClassParamsSpec{
+								Group: nil,
+							},
+						},
+					},
+				},
+			},
+			want: GroupID{Namespace: "ing-ns", Name: "ing-name"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			annotationParser := annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io")
+			m := &defaultGroupLoader{
+				annotationParser: annotationParser,
+			}
+			got, err := m.loadGroupID(tt.args.classifiedIng)
 			if tt.wantErr != nil {
 				assert.EqualError(t, err, tt.wantErr.Error())
 			} else {
@@ -1265,72 +2320,84 @@ func Test_defaultGroupLoader_containsGroupFinalizer(t *testing.T) {
 func Test_defaultGroupLoader_sortGroupMembers(t *testing.T) {
 	tests := []struct {
 		name    string
-		members []*networking.Ingress
-		want    []*networking.Ingress
+		members []ClassifiedIngress
+		want    []ClassifiedIngress
 		wantErr error
 	}{
 		{
 			name: "sort implicitly sorted Ingresses",
-			members: []*networking.Ingress{
+			members: []ClassifiedIngress{
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "namespace",
-						Name:      "ingress-c",
-						Annotations: map[string]string{
-							"kubernetes.io/ingress.class":          "alb",
-							"alb.ingress.kubernetes.io/group.name": "awesome-group",
+					Ing: &networking.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "namespace",
+							Name:      "ingress-c",
+							Annotations: map[string]string{
+								"kubernetes.io/ingress.class":          "alb",
+								"alb.ingress.kubernetes.io/group.name": "awesome-group",
+							},
 						},
 					},
 				},
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "namespace",
-						Name:      "ingress-b",
-						Annotations: map[string]string{
-							"kubernetes.io/ingress.class":          "alb",
-							"alb.ingress.kubernetes.io/group.name": "awesome-group",
+					Ing: &networking.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "namespace",
+							Name:      "ingress-b",
+							Annotations: map[string]string{
+								"kubernetes.io/ingress.class":          "alb",
+								"alb.ingress.kubernetes.io/group.name": "awesome-group",
+							},
 						},
 					},
 				},
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "namespace",
-						Name:      "ingress-a",
-						Annotations: map[string]string{
-							"kubernetes.io/ingress.class":          "alb",
-							"alb.ingress.kubernetes.io/group.name": "awesome-group",
+					Ing: &networking.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "namespace",
+							Name:      "ingress-a",
+							Annotations: map[string]string{
+								"kubernetes.io/ingress.class":          "alb",
+								"alb.ingress.kubernetes.io/group.name": "awesome-group",
+							},
 						},
 					},
 				},
 			},
-			want: []*networking.Ingress{
+			want: []ClassifiedIngress{
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "namespace",
-						Name:      "ingress-a",
-						Annotations: map[string]string{
-							"kubernetes.io/ingress.class":          "alb",
-							"alb.ingress.kubernetes.io/group.name": "awesome-group",
+					Ing: &networking.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "namespace",
+							Name:      "ingress-a",
+							Annotations: map[string]string{
+								"kubernetes.io/ingress.class":          "alb",
+								"alb.ingress.kubernetes.io/group.name": "awesome-group",
+							},
 						},
 					},
 				},
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "namespace",
-						Name:      "ingress-b",
-						Annotations: map[string]string{
-							"kubernetes.io/ingress.class":          "alb",
-							"alb.ingress.kubernetes.io/group.name": "awesome-group",
+					Ing: &networking.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "namespace",
+							Name:      "ingress-b",
+							Annotations: map[string]string{
+								"kubernetes.io/ingress.class":          "alb",
+								"alb.ingress.kubernetes.io/group.name": "awesome-group",
+							},
 						},
 					},
 				},
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "namespace",
-						Name:      "ingress-c",
-						Annotations: map[string]string{
-							"kubernetes.io/ingress.class":          "alb",
-							"alb.ingress.kubernetes.io/group.name": "awesome-group",
+					Ing: &networking.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "namespace",
+							Name:      "ingress-c",
+							Annotations: map[string]string{
+								"kubernetes.io/ingress.class":          "alb",
+								"alb.ingress.kubernetes.io/group.name": "awesome-group",
+							},
 						},
 					},
 				},
@@ -1338,72 +2405,84 @@ func Test_defaultGroupLoader_sortGroupMembers(t *testing.T) {
 		},
 		{
 			name: "sort explicitly sorted Ingresses",
-			members: []*networking.Ingress{
+			members: []ClassifiedIngress{
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "namespace",
-						Name:      "ingress-a",
-						Annotations: map[string]string{
-							"kubernetes.io/ingress.class":           "alb",
-							"alb.ingress.kubernetes.io/group.name":  "awesome-group",
-							"alb.ingress.kubernetes.io/group.order": "3",
+					Ing: &networking.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "namespace",
+							Name:      "ingress-a",
+							Annotations: map[string]string{
+								"kubernetes.io/ingress.class":           "alb",
+								"alb.ingress.kubernetes.io/group.name":  "awesome-group",
+								"alb.ingress.kubernetes.io/group.order": "3",
+							},
 						},
 					},
 				},
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "namespace",
-						Name:      "ingress-b",
-						Annotations: map[string]string{
-							"kubernetes.io/ingress.class":           "alb",
-							"alb.ingress.kubernetes.io/group.name":  "awesome-group",
-							"alb.ingress.kubernetes.io/group.order": "2",
+					Ing: &networking.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "namespace",
+							Name:      "ingress-b",
+							Annotations: map[string]string{
+								"kubernetes.io/ingress.class":           "alb",
+								"alb.ingress.kubernetes.io/group.name":  "awesome-group",
+								"alb.ingress.kubernetes.io/group.order": "2",
+							},
 						},
 					},
 				},
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "namespace",
-						Name:      "ingress-c",
-						Annotations: map[string]string{
-							"kubernetes.io/ingress.class":           "alb",
-							"alb.ingress.kubernetes.io/group.name":  "awesome-group",
-							"alb.ingress.kubernetes.io/group.order": "1",
+					Ing: &networking.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "namespace",
+							Name:      "ingress-c",
+							Annotations: map[string]string{
+								"kubernetes.io/ingress.class":           "alb",
+								"alb.ingress.kubernetes.io/group.name":  "awesome-group",
+								"alb.ingress.kubernetes.io/group.order": "1",
+							},
 						},
 					},
 				},
 			},
-			want: []*networking.Ingress{
+			want: []ClassifiedIngress{
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "namespace",
-						Name:      "ingress-c",
-						Annotations: map[string]string{
-							"kubernetes.io/ingress.class":           "alb",
-							"alb.ingress.kubernetes.io/group.name":  "awesome-group",
-							"alb.ingress.kubernetes.io/group.order": "1",
+					Ing: &networking.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "namespace",
+							Name:      "ingress-c",
+							Annotations: map[string]string{
+								"kubernetes.io/ingress.class":           "alb",
+								"alb.ingress.kubernetes.io/group.name":  "awesome-group",
+								"alb.ingress.kubernetes.io/group.order": "1",
+							},
 						},
 					},
 				},
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "namespace",
-						Name:      "ingress-b",
-						Annotations: map[string]string{
-							"kubernetes.io/ingress.class":           "alb",
-							"alb.ingress.kubernetes.io/group.name":  "awesome-group",
-							"alb.ingress.kubernetes.io/group.order": "2",
+					Ing: &networking.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "namespace",
+							Name:      "ingress-b",
+							Annotations: map[string]string{
+								"kubernetes.io/ingress.class":           "alb",
+								"alb.ingress.kubernetes.io/group.name":  "awesome-group",
+								"alb.ingress.kubernetes.io/group.order": "2",
+							},
 						},
 					},
 				},
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "namespace",
-						Name:      "ingress-a",
-						Annotations: map[string]string{
-							"kubernetes.io/ingress.class":           "alb",
-							"alb.ingress.kubernetes.io/group.name":  "awesome-group",
-							"alb.ingress.kubernetes.io/group.order": "3",
+					Ing: &networking.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "namespace",
+							Name:      "ingress-a",
+							Annotations: map[string]string{
+								"kubernetes.io/ingress.class":           "alb",
+								"alb.ingress.kubernetes.io/group.name":  "awesome-group",
+								"alb.ingress.kubernetes.io/group.order": "3",
+							},
 						},
 					},
 				},
@@ -1411,68 +2490,80 @@ func Test_defaultGroupLoader_sortGroupMembers(t *testing.T) {
 		},
 		{
 			name: "sort explicitly & implicitly sorted Ingresses",
-			members: []*networking.Ingress{
+			members: []ClassifiedIngress{
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "namespace",
-						Name:      "ingress-a",
-						Annotations: map[string]string{
-							"kubernetes.io/ingress.class":           "alb",
-							"alb.ingress.kubernetes.io/group.name":  "awesome-group",
-							"alb.ingress.kubernetes.io/group.order": "1",
+					Ing: &networking.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "namespace",
+							Name:      "ingress-a",
+							Annotations: map[string]string{
+								"kubernetes.io/ingress.class":           "alb",
+								"alb.ingress.kubernetes.io/group.name":  "awesome-group",
+								"alb.ingress.kubernetes.io/group.order": "1",
+							},
 						},
 					},
 				},
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "namespace",
-						Name:      "ingress-b",
-						Annotations: map[string]string{
-							"kubernetes.io/ingress.class":          "alb",
-							"alb.ingress.kubernetes.io/group.name": "awesome-group",
+					Ing: &networking.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "namespace",
+							Name:      "ingress-b",
+							Annotations: map[string]string{
+								"kubernetes.io/ingress.class":          "alb",
+								"alb.ingress.kubernetes.io/group.name": "awesome-group",
+							},
 						},
 					},
 				},
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "namespace",
-						Name:      "ingress-c",
-						Annotations: map[string]string{
-							"kubernetes.io/ingress.class":          "alb",
-							"alb.ingress.kubernetes.io/group.name": "awesome-group",
+					Ing: &networking.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "namespace",
+							Name:      "ingress-c",
+							Annotations: map[string]string{
+								"kubernetes.io/ingress.class":          "alb",
+								"alb.ingress.kubernetes.io/group.name": "awesome-group",
+							},
 						},
 					},
 				},
 			},
-			want: []*networking.Ingress{
+			want: []ClassifiedIngress{
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "namespace",
-						Name:      "ingress-b",
-						Annotations: map[string]string{
-							"kubernetes.io/ingress.class":          "alb",
-							"alb.ingress.kubernetes.io/group.name": "awesome-group",
+					Ing: &networking.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "namespace",
+							Name:      "ingress-b",
+							Annotations: map[string]string{
+								"kubernetes.io/ingress.class":          "alb",
+								"alb.ingress.kubernetes.io/group.name": "awesome-group",
+							},
 						},
 					},
 				},
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "namespace",
-						Name:      "ingress-c",
-						Annotations: map[string]string{
-							"kubernetes.io/ingress.class":          "alb",
-							"alb.ingress.kubernetes.io/group.name": "awesome-group",
+					Ing: &networking.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "namespace",
+							Name:      "ingress-c",
+							Annotations: map[string]string{
+								"kubernetes.io/ingress.class":          "alb",
+								"alb.ingress.kubernetes.io/group.name": "awesome-group",
+							},
 						},
 					},
 				},
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "namespace",
-						Name:      "ingress-a",
-						Annotations: map[string]string{
-							"kubernetes.io/ingress.class":           "alb",
-							"alb.ingress.kubernetes.io/group.name":  "awesome-group",
-							"alb.ingress.kubernetes.io/group.order": "1",
+					Ing: &networking.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "namespace",
+							Name:      "ingress-a",
+							Annotations: map[string]string{
+								"kubernetes.io/ingress.class":           "alb",
+								"alb.ingress.kubernetes.io/group.name":  "awesome-group",
+								"alb.ingress.kubernetes.io/group.order": "1",
+							},
 						},
 					},
 				},
@@ -1480,24 +2571,28 @@ func Test_defaultGroupLoader_sortGroupMembers(t *testing.T) {
 		},
 		{
 			name: "sort single Ingress",
-			members: []*networking.Ingress{
+			members: []ClassifiedIngress{
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "namespace",
-						Name:      "ingress",
-						Annotations: map[string]string{
-							"kubernetes.io/ingress.class": "alb",
+					Ing: &networking.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "namespace",
+							Name:      "ingress",
+							Annotations: map[string]string{
+								"kubernetes.io/ingress.class": "alb",
+							},
 						},
 					},
 				},
 			},
-			want: []*networking.Ingress{
+			want: []ClassifiedIngress{
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "namespace",
-						Name:      "ingress",
-						Annotations: map[string]string{
-							"kubernetes.io/ingress.class": "alb",
+					Ing: &networking.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "namespace",
+							Name:      "ingress",
+							Annotations: map[string]string{
+								"kubernetes.io/ingress.class": "alb",
+							},
 						},
 					},
 				},
@@ -1505,14 +2600,16 @@ func Test_defaultGroupLoader_sortGroupMembers(t *testing.T) {
 		},
 		{
 			name: "invalid group order format",
-			members: []*networking.Ingress{
+			members: []ClassifiedIngress{
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "namespace",
-						Name:      "ingress",
-						Annotations: map[string]string{
-							"kubernetes.io/ingress.class":           "alb",
-							"alb.ingress.kubernetes.io/group.order": "x",
+					Ing: &networking.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "namespace",
+							Name:      "ingress",
+							Annotations: map[string]string{
+								"kubernetes.io/ingress.class":           "alb",
+								"alb.ingress.kubernetes.io/group.order": "x",
+							},
 						},
 					},
 				},
@@ -1522,14 +2619,16 @@ func Test_defaultGroupLoader_sortGroupMembers(t *testing.T) {
 		},
 		{
 			name: "invalid group order range",
-			members: []*networking.Ingress{
+			members: []ClassifiedIngress{
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "namespace",
-						Name:      "ingress",
-						Annotations: map[string]string{
-							"kubernetes.io/ingress.class":           "alb",
-							"alb.ingress.kubernetes.io/group.order": "1001",
+					Ing: &networking.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "namespace",
+							Name:      "ingress",
+							Annotations: map[string]string{
+								"kubernetes.io/ingress.class":           "alb",
+								"alb.ingress.kubernetes.io/group.order": "1001",
+							},
 						},
 					},
 				},
@@ -1539,26 +2638,30 @@ func Test_defaultGroupLoader_sortGroupMembers(t *testing.T) {
 		},
 		{
 			name: "two ingress shouldn't have same explicit order",
-			members: []*networking.Ingress{
+			members: []ClassifiedIngress{
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "namespace",
-						Name:      "ingress-a",
-						Annotations: map[string]string{
-							"kubernetes.io/ingress.class":           "alb",
-							"alb.ingress.kubernetes.io/group.name":  "awesome-group",
-							"alb.ingress.kubernetes.io/group.order": "42",
+					Ing: &networking.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "namespace",
+							Name:      "ingress-a",
+							Annotations: map[string]string{
+								"kubernetes.io/ingress.class":           "alb",
+								"alb.ingress.kubernetes.io/group.name":  "awesome-group",
+								"alb.ingress.kubernetes.io/group.order": "42",
+							},
 						},
 					},
 				},
 				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "namespace",
-						Name:      "ingress-b",
-						Annotations: map[string]string{
-							"kubernetes.io/ingress.class":           "alb",
-							"alb.ingress.kubernetes.io/group.name":  "awesome-group",
-							"alb.ingress.kubernetes.io/group.order": "42",
+					Ing: &networking.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "namespace",
+							Name:      "ingress-b",
+							Annotations: map[string]string{
+								"kubernetes.io/ingress.class":           "alb",
+								"alb.ingress.kubernetes.io/group.name":  "awesome-group",
+								"alb.ingress.kubernetes.io/group.order": "42",
+							},
 						},
 					},
 				},
@@ -1580,7 +2683,7 @@ func Test_defaultGroupLoader_sortGroupMembers(t *testing.T) {
 				classAnnotationMatcher:             NewDefaultClassAnnotationMatcher(ingressClassALB),
 				manageIngressesWithoutIngressClass: false,
 			}
-			got, err := m.sortGroupMembers(context.Background(), tt.members)
+			got, err := m.sortGroupMembers(tt.members)
 			assert.Equal(t, tt.want, got)
 			if tt.wantErr == nil {
 				assert.NoError(t, err)

--- a/pkg/ingress/model_build_load_balancer.go
+++ b/pkg/ingress/model_build_load_balancer.go
@@ -98,9 +98,9 @@ func (t *defaultModelBuildTask) buildLoadBalancerName(_ context.Context, scheme 
 
 func (t *defaultModelBuildTask) buildLoadBalancerScheme(_ context.Context) (elbv2model.LoadBalancerScheme, error) {
 	explicitSchemes := sets.String{}
-	for _, ing := range t.ingGroup.Members {
+	for _, member := range t.ingGroup.Members {
 		rawSchema := ""
-		if exists := t.annotationParser.ParseStringAnnotation(annotations.IngressSuffixScheme, &rawSchema, ing.Annotations); !exists {
+		if exists := t.annotationParser.ParseStringAnnotation(annotations.IngressSuffixScheme, &rawSchema, member.Ing.Annotations); !exists {
 			continue
 		}
 		explicitSchemes.Insert(rawSchema)
@@ -125,9 +125,9 @@ func (t *defaultModelBuildTask) buildLoadBalancerScheme(_ context.Context) (elbv
 // buildLoadBalancerIPAddressType builds the LoadBalancer IPAddressType.
 func (t *defaultModelBuildTask) buildLoadBalancerIPAddressType(_ context.Context) (elbv2model.IPAddressType, error) {
 	explicitIPAddressTypes := sets.NewString()
-	for _, ing := range t.ingGroup.Members {
+	for _, member := range t.ingGroup.Members {
 		rawIPAddressType := ""
-		if exists := t.annotationParser.ParseStringAnnotation(annotations.IngressSuffixIPAddressType, &rawIPAddressType, ing.Annotations); !exists {
+		if exists := t.annotationParser.ParseStringAnnotation(annotations.IngressSuffixIPAddressType, &rawIPAddressType, member.Ing.Annotations); !exists {
 			continue
 		}
 		explicitIPAddressTypes.Insert(rawIPAddressType)
@@ -151,9 +151,9 @@ func (t *defaultModelBuildTask) buildLoadBalancerIPAddressType(_ context.Context
 
 func (t *defaultModelBuildTask) buildLoadBalancerSubnetMappings(ctx context.Context, scheme elbv2model.LoadBalancerScheme) ([]elbv2model.SubnetMapping, error) {
 	var explicitSubnetNameOrIDsList [][]string
-	for _, ing := range t.ingGroup.Members {
+	for _, member := range t.ingGroup.Members {
 		var rawSubnetNameOrIDs []string
-		if exists := t.annotationParser.ParseStringSliceAnnotation(annotations.IngressSuffixSubnets, &rawSubnetNameOrIDs, ing.Annotations); !exists {
+		if exists := t.annotationParser.ParseStringSliceAnnotation(annotations.IngressSuffixSubnets, &rawSubnetNameOrIDs, member.Ing.Annotations); !exists {
 			continue
 		}
 		explicitSubnetNameOrIDsList = append(explicitSubnetNameOrIDsList, rawSubnetNameOrIDs)
@@ -189,9 +189,9 @@ func (t *defaultModelBuildTask) buildLoadBalancerSubnetMappings(ctx context.Cont
 
 func (t *defaultModelBuildTask) buildLoadBalancerSecurityGroups(ctx context.Context, listenPortConfigByPort map[int64]listenPortConfig, ipAddressType elbv2model.IPAddressType) ([]core.StringToken, error) {
 	var explicitSGNameOrIDsList [][]string
-	for _, ing := range t.ingGroup.Members {
+	for _, member := range t.ingGroup.Members {
 		var rawSGNameOrIDs []string
-		if exists := t.annotationParser.ParseStringSliceAnnotation(annotations.IngressSuffixSecurityGroups, &rawSGNameOrIDs, ing.Annotations); !exists {
+		if exists := t.annotationParser.ParseStringSliceAnnotation(annotations.IngressSuffixSecurityGroups, &rawSGNameOrIDs, member.Ing.Annotations); !exists {
 			continue
 		}
 		explicitSGNameOrIDsList = append(explicitSGNameOrIDsList, rawSGNameOrIDs)
@@ -224,14 +224,14 @@ func (t *defaultModelBuildTask) buildLoadBalancerSecurityGroups(ctx context.Cont
 
 func (t *defaultModelBuildTask) buildLoadBalancerCOIPv4Pool(_ context.Context) (*string, error) {
 	explicitCOIPv4Pools := sets.NewString()
-	for _, ing := range t.ingGroup.Members {
+	for _, member := range t.ingGroup.Members {
 		rawCOIPv4Pool := ""
-		if exists := t.annotationParser.ParseStringAnnotation(annotations.IngressSuffixCustomerOwnedIPv4Pool, &rawCOIPv4Pool, ing.Annotations); !exists {
+		if exists := t.annotationParser.ParseStringAnnotation(annotations.IngressSuffixCustomerOwnedIPv4Pool, &rawCOIPv4Pool, member.Ing.Annotations); !exists {
 			continue
 		}
 		if len(rawCOIPv4Pool) == 0 {
 			return nil, errors.Errorf("cannot use empty value for %s annotation, ingress: %v",
-				annotations.IngressSuffixCustomerOwnedIPv4Pool, k8s.NamespacedName(ing))
+				annotations.IngressSuffixCustomerOwnedIPv4Pool, k8s.NamespacedName(member.Ing))
 		}
 		explicitCOIPv4Pools.Insert(rawCOIPv4Pool)
 	}
@@ -249,9 +249,9 @@ func (t *defaultModelBuildTask) buildLoadBalancerCOIPv4Pool(_ context.Context) (
 
 func (t *defaultModelBuildTask) buildLoadBalancerAttributes(_ context.Context) ([]elbv2model.LoadBalancerAttribute, error) {
 	mergedAttributes := make(map[string]string)
-	for _, ing := range t.ingGroup.Members {
+	for _, member := range t.ingGroup.Members {
 		var rawAttributes map[string]string
-		if _, err := t.annotationParser.ParseStringMapAnnotation(annotations.IngressSuffixLoadBalancerAttributes, &rawAttributes, ing.Annotations); err != nil {
+		if _, err := t.annotationParser.ParseStringMapAnnotation(annotations.IngressSuffixLoadBalancerAttributes, &rawAttributes, member.Ing.Annotations); err != nil {
 			return nil, err
 		}
 		for attrKey, attrValue := range rawAttributes {
@@ -273,9 +273,9 @@ func (t *defaultModelBuildTask) buildLoadBalancerAttributes(_ context.Context) (
 
 func (t *defaultModelBuildTask) buildLoadBalancerTags(_ context.Context) (map[string]string, error) {
 	annotationTags := make(map[string]string)
-	for _, ing := range t.ingGroup.Members {
+	for _, member := range t.ingGroup.Members {
 		var rawTags map[string]string
-		if _, err := t.annotationParser.ParseStringMapAnnotation(annotations.IngressSuffixTags, &rawTags, ing.Annotations); err != nil {
+		if _, err := t.annotationParser.ParseStringMapAnnotation(annotations.IngressSuffixTags, &rawTags, member.Ing.Annotations); err != nil {
 			return nil, err
 		}
 		for tagKey, tagValue := range rawTags {

--- a/pkg/ingress/model_build_load_balancer_addons.go
+++ b/pkg/ingress/model_build_load_balancer_addons.go
@@ -26,9 +26,9 @@ func (t *defaultModelBuildTask) buildLoadBalancerAddOns(ctx context.Context, lbA
 
 func (t *defaultModelBuildTask) buildWAFv2WebACLAssociation(_ context.Context, lbARN core.StringToken) (*wafv2model.WebACLAssociation, error) {
 	explicitWebACLARNs := sets.NewString()
-	for _, ing := range t.ingGroup.Members {
+	for _, member := range t.ingGroup.Members {
 		rawWebACLARN := ""
-		if exists := t.annotationParser.ParseStringAnnotation(annotations.IngressSuffixWAFv2ACLARN, &rawWebACLARN, ing.Annotations); exists {
+		if exists := t.annotationParser.ParseStringAnnotation(annotations.IngressSuffixWAFv2ACLARN, &rawWebACLARN, member.Ing.Annotations); exists {
 			explicitWebACLARNs.Insert(rawWebACLARN)
 		}
 	}
@@ -51,11 +51,11 @@ func (t *defaultModelBuildTask) buildWAFv2WebACLAssociation(_ context.Context, l
 
 func (t *defaultModelBuildTask) buildWAFRegionalWebACLAssociation(_ context.Context, lbARN core.StringToken) (*wafregionalmodel.WebACLAssociation, error) {
 	explicitWebACLIDs := sets.NewString()
-	for _, ing := range t.ingGroup.Members {
+	for _, member := range t.ingGroup.Members {
 		rawWebACLARN := ""
-		if exists := t.annotationParser.ParseStringAnnotation(annotations.IngressSuffixWAFACLID, &rawWebACLARN, ing.Annotations); exists {
+		if exists := t.annotationParser.ParseStringAnnotation(annotations.IngressSuffixWAFACLID, &rawWebACLARN, member.Ing.Annotations); exists {
 			explicitWebACLIDs.Insert(rawWebACLARN)
-		} else if exists := t.annotationParser.ParseStringAnnotation(annotations.IngressSuffixWebACLID, &rawWebACLARN, ing.Annotations); exists {
+		} else if exists := t.annotationParser.ParseStringAnnotation(annotations.IngressSuffixWebACLID, &rawWebACLARN, member.Ing.Annotations); exists {
 			explicitWebACLIDs.Insert(rawWebACLARN)
 		}
 	}
@@ -78,9 +78,9 @@ func (t *defaultModelBuildTask) buildWAFRegionalWebACLAssociation(_ context.Cont
 
 func (t *defaultModelBuildTask) buildShieldProtection(_ context.Context, lbARN core.StringToken) (*shieldmodel.Protection, error) {
 	explicitEnableProtections := make(map[bool]struct{})
-	for _, ing := range t.ingGroup.Members {
+	for _, member := range t.ingGroup.Members {
 		rawEnableProtection := false
-		exists, err := t.annotationParser.ParseBoolAnnotation(annotations.IngressSuffixShieldAdvancedProtection, &rawEnableProtection, ing.Annotations)
+		exists, err := t.annotationParser.ParseBoolAnnotation(annotations.IngressSuffixShieldAdvancedProtection, &rawEnableProtection, member.Ing.Annotations)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ingress/model_build_load_balancer_test.go
+++ b/pkg/ingress/model_build_load_balancer_test.go
@@ -25,12 +25,14 @@ func Test_defaultModelBuildTask_buildLoadBalancerCOIPv4Pool(t *testing.T) {
 			name: "COIPv4 not configured on standalone Ingress",
 			fields: fields{
 				ingGroup: Group{
-					Members: []*networking.Ingress{
+					Members: []ClassifiedIngress{
 						{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace:   "awesome-ns",
-								Name:        "ing-1",
-								Annotations: map[string]string{},
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace:   "awesome-ns",
+									Name:        "ing-1",
+									Annotations: map[string]string{},
+								},
 							},
 						},
 					},
@@ -42,13 +44,15 @@ func Test_defaultModelBuildTask_buildLoadBalancerCOIPv4Pool(t *testing.T) {
 			name: "COIPv4 configured on standalone Ingress",
 			fields: fields{
 				ingGroup: Group{
-					Members: []*networking.Ingress{
+					Members: []ClassifiedIngress{
 						{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: "awesome-ns",
-								Name:      "ing-1",
-								Annotations: map[string]string{
-									"alb.ingress.kubernetes.io/customer-owned-ipv4-pool": "my-ip-pool",
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "awesome-ns",
+									Name:      "ing-1",
+									Annotations: map[string]string{
+										"alb.ingress.kubernetes.io/customer-owned-ipv4-pool": "my-ip-pool",
+									},
 								},
 							},
 						},
@@ -61,13 +65,15 @@ func Test_defaultModelBuildTask_buildLoadBalancerCOIPv4Pool(t *testing.T) {
 			name: "specified empty COIPv4 on standalone Ingress",
 			fields: fields{
 				ingGroup: Group{
-					Members: []*networking.Ingress{
+					Members: []ClassifiedIngress{
 						{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: "awesome-ns",
-								Name:      "ing-1",
-								Annotations: map[string]string{
-									"alb.ingress.kubernetes.io/customer-owned-ipv4-pool": "",
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "awesome-ns",
+									Name:      "ing-1",
+									Annotations: map[string]string{
+										"alb.ingress.kubernetes.io/customer-owned-ipv4-pool": "",
+									},
 								},
 							},
 						},
@@ -80,19 +86,23 @@ func Test_defaultModelBuildTask_buildLoadBalancerCOIPv4Pool(t *testing.T) {
 			name: "COIPv4 not configured on all Ingresses among IngressGroup",
 			fields: fields{
 				ingGroup: Group{
-					Members: []*networking.Ingress{
+					Members: []ClassifiedIngress{
 						{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace:   "awesome-ns",
-								Name:        "ing-1",
-								Annotations: map[string]string{},
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace:   "awesome-ns",
+									Name:        "ing-1",
+									Annotations: map[string]string{},
+								},
 							},
 						},
 						{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace:   "awesome-ns",
-								Name:        "ing-2",
-								Annotations: map[string]string{},
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace:   "awesome-ns",
+									Name:        "ing-2",
+									Annotations: map[string]string{},
+								},
 							},
 						},
 					},
@@ -104,21 +114,25 @@ func Test_defaultModelBuildTask_buildLoadBalancerCOIPv4Pool(t *testing.T) {
 			name: "COIPv4 configured on one Ingress among IngressGroup",
 			fields: fields{
 				ingGroup: Group{
-					Members: []*networking.Ingress{
+					Members: []ClassifiedIngress{
 						{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: "awesome-ns",
-								Name:      "ing-1",
-								Annotations: map[string]string{
-									"alb.ingress.kubernetes.io/customer-owned-ipv4-pool": "my-ip-pool",
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "awesome-ns",
+									Name:      "ing-1",
+									Annotations: map[string]string{
+										"alb.ingress.kubernetes.io/customer-owned-ipv4-pool": "my-ip-pool",
+									},
 								},
 							},
 						},
 						{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace:   "awesome-ns",
-								Name:        "ing-2",
-								Annotations: map[string]string{},
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace:   "awesome-ns",
+									Name:        "ing-2",
+									Annotations: map[string]string{},
+								},
 							},
 						},
 					},
@@ -130,22 +144,26 @@ func Test_defaultModelBuildTask_buildLoadBalancerCOIPv4Pool(t *testing.T) {
 			name: "COIPv4 configured on multiple Ingresses among IngressGroup - with same value",
 			fields: fields{
 				ingGroup: Group{
-					Members: []*networking.Ingress{
+					Members: []ClassifiedIngress{
 						{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: "awesome-ns",
-								Name:      "ing-1",
-								Annotations: map[string]string{
-									"alb.ingress.kubernetes.io/customer-owned-ipv4-pool": "my-ip-pool",
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "awesome-ns",
+									Name:      "ing-1",
+									Annotations: map[string]string{
+										"alb.ingress.kubernetes.io/customer-owned-ipv4-pool": "my-ip-pool",
+									},
 								},
 							},
 						},
 						{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: "awesome-ns",
-								Name:      "ing-2",
-								Annotations: map[string]string{
-									"alb.ingress.kubernetes.io/customer-owned-ipv4-pool": "my-ip-pool",
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "awesome-ns",
+									Name:      "ing-2",
+									Annotations: map[string]string{
+										"alb.ingress.kubernetes.io/customer-owned-ipv4-pool": "my-ip-pool",
+									},
 								},
 							},
 						},
@@ -158,22 +176,26 @@ func Test_defaultModelBuildTask_buildLoadBalancerCOIPv4Pool(t *testing.T) {
 			name: "COIPv4 configured on multiple Ingress among IngressGroup - with different value",
 			fields: fields{
 				ingGroup: Group{
-					Members: []*networking.Ingress{
+					Members: []ClassifiedIngress{
 						{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: "awesome-ns",
-								Name:      "ing-1",
-								Annotations: map[string]string{
-									"alb.ingress.kubernetes.io/customer-owned-ipv4-pool": "my-ip-pool",
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "awesome-ns",
+									Name:      "ing-1",
+									Annotations: map[string]string{
+										"alb.ingress.kubernetes.io/customer-owned-ipv4-pool": "my-ip-pool",
+									},
 								},
 							},
 						},
 						{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: "awesome-ns",
-								Name:      "ing-2",
-								Annotations: map[string]string{
-									"alb.ingress.kubernetes.io/customer-owned-ipv4-pool": "my-another-pool",
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "awesome-ns",
+									Name:      "ing-2",
+									Annotations: map[string]string{
+										"alb.ingress.kubernetes.io/customer-owned-ipv4-pool": "my-another-pool",
+									},
 								},
 							},
 						},
@@ -216,15 +238,19 @@ func Test_defaultModelBuildTask_buildLoadBalancerTags(t *testing.T) {
 			name: "empty default tags, no tags annotation",
 			fields: fields{
 				ingGroup: Group{
-					Members: []*networking.Ingress{
+					Members: []ClassifiedIngress{
 						{
-							ObjectMeta: metav1.ObjectMeta{
-								Annotations: map[string]string{},
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Annotations: map[string]string{},
+								},
 							},
 						},
 						{
-							ObjectMeta: metav1.ObjectMeta{
-								Annotations: map[string]string{},
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Annotations: map[string]string{},
+								},
 							},
 						},
 					},
@@ -237,18 +263,22 @@ func Test_defaultModelBuildTask_buildLoadBalancerTags(t *testing.T) {
 			name: "empty default tags, non-empty tags annotation",
 			fields: fields{
 				ingGroup: Group{
-					Members: []*networking.Ingress{
+					Members: []ClassifiedIngress{
 						{
-							ObjectMeta: metav1.ObjectMeta{
-								Annotations: map[string]string{
-									"alb.ingress.kubernetes.io/tags": "k1=v1",
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Annotations: map[string]string{
+										"alb.ingress.kubernetes.io/tags": "k1=v1",
+									},
 								},
 							},
 						},
 						{
-							ObjectMeta: metav1.ObjectMeta{
-								Annotations: map[string]string{
-									"alb.ingress.kubernetes.io/tags": "k2=v2",
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Annotations: map[string]string{
+										"alb.ingress.kubernetes.io/tags": "k2=v2",
+									},
 								},
 							},
 						},
@@ -265,15 +295,19 @@ func Test_defaultModelBuildTask_buildLoadBalancerTags(t *testing.T) {
 			name: "non-empty default tags, empty tags annotation",
 			fields: fields{
 				ingGroup: Group{
-					Members: []*networking.Ingress{
+					Members: []ClassifiedIngress{
 						{
-							ObjectMeta: metav1.ObjectMeta{
-								Annotations: map[string]string{},
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Annotations: map[string]string{},
+								},
 							},
 						},
 						{
-							ObjectMeta: metav1.ObjectMeta{
-								Annotations: map[string]string{},
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Annotations: map[string]string{},
+								},
 							},
 						},
 					},
@@ -292,18 +326,22 @@ func Test_defaultModelBuildTask_buildLoadBalancerTags(t *testing.T) {
 			name: "non-empty default tags, non-empty tags annotation",
 			fields: fields{
 				ingGroup: Group{
-					Members: []*networking.Ingress{
+					Members: []ClassifiedIngress{
 						{
-							ObjectMeta: metav1.ObjectMeta{
-								Annotations: map[string]string{
-									"alb.ingress.kubernetes.io/tags": "k1=v1,k3=v3a",
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Annotations: map[string]string{
+										"alb.ingress.kubernetes.io/tags": "k1=v1,k3=v3a",
+									},
 								},
 							},
 						},
 						{
-							ObjectMeta: metav1.ObjectMeta{
-								Annotations: map[string]string{
-									"alb.ingress.kubernetes.io/tags": "k2=v2",
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Annotations: map[string]string{
+										"alb.ingress.kubernetes.io/tags": "k2=v2",
+									},
 								},
 							},
 						},
@@ -325,18 +363,22 @@ func Test_defaultModelBuildTask_buildLoadBalancerTags(t *testing.T) {
 			name: "empty default tags, conflicting tags annotation",
 			fields: fields{
 				ingGroup: Group{
-					Members: []*networking.Ingress{
+					Members: []ClassifiedIngress{
 						{
-							ObjectMeta: metav1.ObjectMeta{
-								Annotations: map[string]string{
-									"alb.ingress.kubernetes.io/tags": "k1=v1,k3=v3a",
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Annotations: map[string]string{
+										"alb.ingress.kubernetes.io/tags": "k1=v1,k3=v3a",
+									},
 								},
 							},
 						},
 						{
-							ObjectMeta: metav1.ObjectMeta{
-								Annotations: map[string]string{
-									"alb.ingress.kubernetes.io/tags": "k2=v2,k3=v3b",
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Annotations: map[string]string{
+										"alb.ingress.kubernetes.io/tags": "k2=v2,k3=v3b",
+									},
 								},
 							},
 						},

--- a/pkg/ingress/model_build_managed_sg.go
+++ b/pkg/ingress/model_build_managed_sg.go
@@ -63,9 +63,9 @@ func (t *defaultModelBuildTask) buildManagedSecurityGroupName(_ context.Context)
 
 func (t *defaultModelBuildTask) buildManagedSecurityGroupTags(_ context.Context) (map[string]string, error) {
 	annotationTags := make(map[string]string)
-	for _, ing := range t.ingGroup.Members {
+	for _, member := range t.ingGroup.Members {
 		var rawTags map[string]string
-		if _, err := t.annotationParser.ParseStringMapAnnotation(annotations.IngressSuffixTags, &rawTags, ing.Annotations); err != nil {
+		if _, err := t.annotationParser.ParseStringMapAnnotation(annotations.IngressSuffixTags, &rawTags, member.Ing.Annotations); err != nil {
 			return nil, err
 		}
 		for tagKey, tagValue := range rawTags {

--- a/pkg/ingress/model_build_managed_sg_test.go
+++ b/pkg/ingress/model_build_managed_sg_test.go
@@ -25,15 +25,19 @@ func Test_defaultModelBuildTask_buildManagedSecurityGroupTags(t *testing.T) {
 			name: "empty default tags, no tags annotation",
 			fields: fields{
 				ingGroup: Group{
-					Members: []*networking.Ingress{
+					Members: []ClassifiedIngress{
 						{
-							ObjectMeta: metav1.ObjectMeta{
-								Annotations: map[string]string{},
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Annotations: map[string]string{},
+								},
 							},
 						},
 						{
-							ObjectMeta: metav1.ObjectMeta{
-								Annotations: map[string]string{},
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Annotations: map[string]string{},
+								},
 							},
 						},
 					},
@@ -46,18 +50,22 @@ func Test_defaultModelBuildTask_buildManagedSecurityGroupTags(t *testing.T) {
 			name: "empty default tags, non-empty tags annotation",
 			fields: fields{
 				ingGroup: Group{
-					Members: []*networking.Ingress{
+					Members: []ClassifiedIngress{
 						{
-							ObjectMeta: metav1.ObjectMeta{
-								Annotations: map[string]string{
-									"alb.ingress.kubernetes.io/tags": "k1=v1",
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Annotations: map[string]string{
+										"alb.ingress.kubernetes.io/tags": "k1=v1",
+									},
 								},
 							},
 						},
 						{
-							ObjectMeta: metav1.ObjectMeta{
-								Annotations: map[string]string{
-									"alb.ingress.kubernetes.io/tags": "k2=v2",
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Annotations: map[string]string{
+										"alb.ingress.kubernetes.io/tags": "k2=v2",
+									},
 								},
 							},
 						},
@@ -74,15 +82,19 @@ func Test_defaultModelBuildTask_buildManagedSecurityGroupTags(t *testing.T) {
 			name: "non-empty default tags, empty tags annotation",
 			fields: fields{
 				ingGroup: Group{
-					Members: []*networking.Ingress{
+					Members: []ClassifiedIngress{
 						{
-							ObjectMeta: metav1.ObjectMeta{
-								Annotations: map[string]string{},
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Annotations: map[string]string{},
+								},
 							},
 						},
 						{
-							ObjectMeta: metav1.ObjectMeta{
-								Annotations: map[string]string{},
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Annotations: map[string]string{},
+								},
 							},
 						},
 					},
@@ -101,18 +113,22 @@ func Test_defaultModelBuildTask_buildManagedSecurityGroupTags(t *testing.T) {
 			name: "non-empty default tags, non-empty tags annotation",
 			fields: fields{
 				ingGroup: Group{
-					Members: []*networking.Ingress{
+					Members: []ClassifiedIngress{
 						{
-							ObjectMeta: metav1.ObjectMeta{
-								Annotations: map[string]string{
-									"alb.ingress.kubernetes.io/tags": "k1=v1,k3=v3a",
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Annotations: map[string]string{
+										"alb.ingress.kubernetes.io/tags": "k1=v1,k3=v3a",
+									},
 								},
 							},
 						},
 						{
-							ObjectMeta: metav1.ObjectMeta{
-								Annotations: map[string]string{
-									"alb.ingress.kubernetes.io/tags": "k2=v2",
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Annotations: map[string]string{
+										"alb.ingress.kubernetes.io/tags": "k2=v2",
+									},
 								},
 							},
 						},
@@ -134,18 +150,22 @@ func Test_defaultModelBuildTask_buildManagedSecurityGroupTags(t *testing.T) {
 			name: "empty default tags, conflicting tags annotation",
 			fields: fields{
 				ingGroup: Group{
-					Members: []*networking.Ingress{
+					Members: []ClassifiedIngress{
 						{
-							ObjectMeta: metav1.ObjectMeta{
-								Annotations: map[string]string{
-									"alb.ingress.kubernetes.io/tags": "k1=v1,k3=v3a",
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Annotations: map[string]string{
+										"alb.ingress.kubernetes.io/tags": "k1=v1,k3=v3a",
+									},
 								},
 							},
 						},
 						{
-							ObjectMeta: metav1.ObjectMeta{
-								Annotations: map[string]string{
-									"alb.ingress.kubernetes.io/tags": "k2=v2,k3=v3b",
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Annotations: map[string]string{
+										"alb.ingress.kubernetes.io/tags": "k2=v2,k3=v3b",
+									},
 								},
 							},
 						},

--- a/pkg/ingress/model_builder_test.go
+++ b/pkg/ingress/model_builder_test.go
@@ -158,47 +158,48 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 			args: args{
 				ingGroup: Group{
 					ID: GroupID{Namespace: "ns-1", Name: "ing-1"},
-					Members: []*networking.Ingress{
+					Members: []ClassifiedIngress{
 						{
-							ObjectMeta: metav1.ObjectMeta{
+							Ing: &networking.Ingress{ObjectMeta: metav1.ObjectMeta{
 								Namespace: "ns-1",
 								Name:      "ing-1",
 							},
-							Spec: networking.IngressSpec{
-								Rules: []networking.IngressRule{
-									{
-										Host: "app-1.example.com",
-										IngressRuleValue: networking.IngressRuleValue{
-											HTTP: &networking.HTTPIngressRuleValue{
-												Paths: []networking.HTTPIngressPath{
-													{
-														Path: "/svc-1",
-														Backend: networking.IngressBackend{
-															ServiceName: ns_1_svc_1.Name,
-															ServicePort: intstr.FromString("http"),
+								Spec: networking.IngressSpec{
+									Rules: []networking.IngressRule{
+										{
+											Host: "app-1.example.com",
+											IngressRuleValue: networking.IngressRuleValue{
+												HTTP: &networking.HTTPIngressRuleValue{
+													Paths: []networking.HTTPIngressPath{
+														{
+															Path: "/svc-1",
+															Backend: networking.IngressBackend{
+																ServiceName: ns_1_svc_1.Name,
+																ServicePort: intstr.FromString("http"),
+															},
 														},
-													},
-													{
-														Path: "/svc-2",
-														Backend: networking.IngressBackend{
-															ServiceName: ns_1_svc_2.Name,
-															ServicePort: intstr.FromString("http"),
+														{
+															Path: "/svc-2",
+															Backend: networking.IngressBackend{
+																ServiceName: ns_1_svc_2.Name,
+																ServicePort: intstr.FromString("http"),
+															},
 														},
 													},
 												},
 											},
 										},
-									},
-									{
-										Host: "app-2.example.com",
-										IngressRuleValue: networking.IngressRuleValue{
-											HTTP: &networking.HTTPIngressRuleValue{
-												Paths: []networking.HTTPIngressPath{
-													{
-														Path: "/svc-3",
-														Backend: networking.IngressBackend{
-															ServiceName: ns_1_svc_3.Name,
-															ServicePort: intstr.FromString("https"),
+										{
+											Host: "app-2.example.com",
+											IngressRuleValue: networking.IngressRuleValue{
+												HTTP: &networking.HTTPIngressRuleValue{
+													Paths: []networking.HTTPIngressPath{
+														{
+															Path: "/svc-3",
+															Backend: networking.IngressBackend{
+																ServiceName: ns_1_svc_3.Name,
+																ServicePort: intstr.FromString("https"),
+															},
 														},
 													},
 												},
@@ -604,50 +605,51 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 			args: args{
 				ingGroup: Group{
 					ID: GroupID{Namespace: "ns-1", Name: "ing-1"},
-					Members: []*networking.Ingress{
+					Members: []ClassifiedIngress{
 						{
-							ObjectMeta: metav1.ObjectMeta{
+							Ing: &networking.Ingress{ObjectMeta: metav1.ObjectMeta{
 								Namespace: "ns-1",
 								Name:      "ing-1",
 								Annotations: map[string]string{
 									"alb.ingress.kubernetes.io/scheme": "internet-facing",
 								},
 							},
-							Spec: networking.IngressSpec{
-								Rules: []networking.IngressRule{
-									{
-										Host: "app-1.example.com",
-										IngressRuleValue: networking.IngressRuleValue{
-											HTTP: &networking.HTTPIngressRuleValue{
-												Paths: []networking.HTTPIngressPath{
-													{
-														Path: "/svc-1",
-														Backend: networking.IngressBackend{
-															ServiceName: ns_1_svc_1.Name,
-															ServicePort: intstr.FromString("http"),
+								Spec: networking.IngressSpec{
+									Rules: []networking.IngressRule{
+										{
+											Host: "app-1.example.com",
+											IngressRuleValue: networking.IngressRuleValue{
+												HTTP: &networking.HTTPIngressRuleValue{
+													Paths: []networking.HTTPIngressPath{
+														{
+															Path: "/svc-1",
+															Backend: networking.IngressBackend{
+																ServiceName: ns_1_svc_1.Name,
+																ServicePort: intstr.FromString("http"),
+															},
 														},
-													},
-													{
-														Path: "/svc-2",
-														Backend: networking.IngressBackend{
-															ServiceName: ns_1_svc_2.Name,
-															ServicePort: intstr.FromString("http"),
+														{
+															Path: "/svc-2",
+															Backend: networking.IngressBackend{
+																ServiceName: ns_1_svc_2.Name,
+																ServicePort: intstr.FromString("http"),
+															},
 														},
 													},
 												},
 											},
 										},
-									},
-									{
-										Host: "app-2.example.com",
-										IngressRuleValue: networking.IngressRuleValue{
-											HTTP: &networking.HTTPIngressRuleValue{
-												Paths: []networking.HTTPIngressPath{
-													{
-														Path: "/svc-3",
-														Backend: networking.IngressBackend{
-															ServiceName: ns_1_svc_3.Name,
-															ServicePort: intstr.FromString("https"),
+										{
+											Host: "app-2.example.com",
+											IngressRuleValue: networking.IngressRuleValue{
+												HTTP: &networking.HTTPIngressRuleValue{
+													Paths: []networking.HTTPIngressPath{
+														{
+															Path: "/svc-3",
+															Backend: networking.IngressBackend{
+																ServiceName: ns_1_svc_3.Name,
+																ServicePort: intstr.FromString("https"),
+															},
 														},
 													},
 												},
@@ -1053,31 +1055,32 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 			args: args{
 				ingGroup: Group{
 					ID: GroupID{Namespace: "ns-1", Name: "ing-1"},
-					Members: []*networking.Ingress{
+					Members: []ClassifiedIngress{
 						{
-							ObjectMeta: metav1.ObjectMeta{
+							Ing: &networking.Ingress{ObjectMeta: metav1.ObjectMeta{
 								Namespace: "ns-1",
 								Name:      "ing-1",
 							},
-							Spec: networking.IngressSpec{
-								Rules: []networking.IngressRule{
-									{
-										Host: "app-1.example.com",
-										IngressRuleValue: networking.IngressRuleValue{
-											HTTP: &networking.HTTPIngressRuleValue{
-												Paths: []networking.HTTPIngressPath{
-													{
-														Path: "/svc-1-name",
-														Backend: networking.IngressBackend{
-															ServiceName: ns_1_svc_1.Name,
-															ServicePort: intstr.FromString("http"),
+								Spec: networking.IngressSpec{
+									Rules: []networking.IngressRule{
+										{
+											Host: "app-1.example.com",
+											IngressRuleValue: networking.IngressRuleValue{
+												HTTP: &networking.HTTPIngressRuleValue{
+													Paths: []networking.HTTPIngressPath{
+														{
+															Path: "/svc-1-name",
+															Backend: networking.IngressBackend{
+																ServiceName: ns_1_svc_1.Name,
+																ServicePort: intstr.FromString("http"),
+															},
 														},
-													},
-													{
-														Path: "/svc-1-port",
-														Backend: networking.IngressBackend{
-															ServiceName: ns_1_svc_1.Name,
-															ServicePort: intstr.FromInt(80),
+														{
+															Path: "/svc-1-port",
+															Backend: networking.IngressBackend{
+																ServiceName: ns_1_svc_1.Name,
+																ServicePort: intstr.FromInt(80),
+															},
 														},
 													},
 												},
@@ -1447,24 +1450,25 @@ func Test_defaultModelBuildTask_buildSSLRedirectConfig(t *testing.T) {
 			fields: fields{
 				ingGroup: Group{
 					ID: GroupID{Namespace: "ns-1", Name: "ing-1"},
-					Members: []*networking.Ingress{
+					Members: []ClassifiedIngress{
 						{
-							ObjectMeta: metav1.ObjectMeta{
+							Ing: &networking.Ingress{ObjectMeta: metav1.ObjectMeta{
 								Namespace: "ns-1",
 								Name:      "ing-1",
 							},
-							Spec: networking.IngressSpec{
-								Rules: []networking.IngressRule{
-									{
-										Host: "app-1.example.com",
-										IngressRuleValue: networking.IngressRuleValue{
-											HTTP: &networking.HTTPIngressRuleValue{
-												Paths: []networking.HTTPIngressPath{
-													{
-														Path: "/svc-1",
-														Backend: networking.IngressBackend{
-															ServiceName: "svc-1",
-															ServicePort: intstr.FromString("http"),
+								Spec: networking.IngressSpec{
+									Rules: []networking.IngressRule{
+										{
+											Host: "app-1.example.com",
+											IngressRuleValue: networking.IngressRuleValue{
+												HTTP: &networking.HTTPIngressRuleValue{
+													Paths: []networking.HTTPIngressPath{
+														{
+															Path: "/svc-1",
+															Backend: networking.IngressBackend{
+																ServiceName: "svc-1",
+																ServicePort: intstr.FromString("http"),
+															},
 														},
 													},
 												},
@@ -1495,27 +1499,28 @@ func Test_defaultModelBuildTask_buildSSLRedirectConfig(t *testing.T) {
 			fields: fields{
 				ingGroup: Group{
 					ID: GroupID{Namespace: "ns-1", Name: "ing-1"},
-					Members: []*networking.Ingress{
+					Members: []ClassifiedIngress{
 						{
-							ObjectMeta: metav1.ObjectMeta{
+							Ing: &networking.Ingress{ObjectMeta: metav1.ObjectMeta{
 								Namespace: "ns-1",
 								Name:      "ing-1",
 								Annotations: map[string]string{
 									"alb.ingress.kubernetes.io/ssl-redirect": "443",
 								},
 							},
-							Spec: networking.IngressSpec{
-								Rules: []networking.IngressRule{
-									{
-										Host: "app-1.example.com",
-										IngressRuleValue: networking.IngressRuleValue{
-											HTTP: &networking.HTTPIngressRuleValue{
-												Paths: []networking.HTTPIngressPath{
-													{
-														Path: "/svc-1",
-														Backend: networking.IngressBackend{
-															ServiceName: "svc-1",
-															ServicePort: intstr.FromString("http"),
+								Spec: networking.IngressSpec{
+									Rules: []networking.IngressRule{
+										{
+											Host: "app-1.example.com",
+											IngressRuleValue: networking.IngressRuleValue{
+												HTTP: &networking.HTTPIngressRuleValue{
+													Paths: []networking.HTTPIngressPath{
+														{
+															Path: "/svc-1",
+															Backend: networking.IngressBackend{
+																ServiceName: "svc-1",
+																ServicePort: intstr.FromString("http"),
+															},
 														},
 													},
 												},
@@ -1549,27 +1554,28 @@ func Test_defaultModelBuildTask_buildSSLRedirectConfig(t *testing.T) {
 			fields: fields{
 				ingGroup: Group{
 					ID: GroupID{Namespace: "ns-1", Name: "ing-1"},
-					Members: []*networking.Ingress{
+					Members: []ClassifiedIngress{
 						{
-							ObjectMeta: metav1.ObjectMeta{
+							Ing: &networking.Ingress{ObjectMeta: metav1.ObjectMeta{
 								Namespace: "ns-1",
 								Name:      "ing-1",
 								Annotations: map[string]string{
 									"alb.ingress.kubernetes.io/ssl-redirect": "8443",
 								},
 							},
-							Spec: networking.IngressSpec{
-								Rules: []networking.IngressRule{
-									{
-										Host: "app-1.example.com",
-										IngressRuleValue: networking.IngressRuleValue{
-											HTTP: &networking.HTTPIngressRuleValue{
-												Paths: []networking.HTTPIngressPath{
-													{
-														Path: "/svc-1",
-														Backend: networking.IngressBackend{
-															ServiceName: "svc-1",
-															ServicePort: intstr.FromString("http"),
+								Spec: networking.IngressSpec{
+									Rules: []networking.IngressRule{
+										{
+											Host: "app-1.example.com",
+											IngressRuleValue: networking.IngressRuleValue{
+												HTTP: &networking.HTTPIngressRuleValue{
+													Paths: []networking.HTTPIngressPath{
+														{
+															Path: "/svc-1",
+															Backend: networking.IngressBackend{
+																ServiceName: "svc-1",
+																ServicePort: intstr.FromString("http"),
+															},
 														},
 													},
 												},
@@ -1600,27 +1606,28 @@ func Test_defaultModelBuildTask_buildSSLRedirectConfig(t *testing.T) {
 			fields: fields{
 				ingGroup: Group{
 					ID: GroupID{Namespace: "ns-1", Name: "ing-1"},
-					Members: []*networking.Ingress{
+					Members: []ClassifiedIngress{
 						{
-							ObjectMeta: metav1.ObjectMeta{
+							Ing: &networking.Ingress{ObjectMeta: metav1.ObjectMeta{
 								Namespace: "ns-1",
 								Name:      "ing-1",
 								Annotations: map[string]string{
 									"alb.ingress.kubernetes.io/ssl-redirect": "80",
 								},
 							},
-							Spec: networking.IngressSpec{
-								Rules: []networking.IngressRule{
-									{
-										Host: "app-1.example.com",
-										IngressRuleValue: networking.IngressRuleValue{
-											HTTP: &networking.HTTPIngressRuleValue{
-												Paths: []networking.HTTPIngressPath{
-													{
-														Path: "/svc-1",
-														Backend: networking.IngressBackend{
-															ServiceName: "svc-1",
-															ServicePort: intstr.FromString("http"),
+								Spec: networking.IngressSpec{
+									Rules: []networking.IngressRule{
+										{
+											Host: "app-1.example.com",
+											IngressRuleValue: networking.IngressRuleValue{
+												HTTP: &networking.HTTPIngressRuleValue{
+													Paths: []networking.HTTPIngressPath{
+														{
+															Path: "/svc-1",
+															Backend: networking.IngressBackend{
+																ServiceName: "svc-1",
+																ServicePort: intstr.FromString("http"),
+															},
 														},
 													},
 												},
@@ -1651,24 +1658,25 @@ func Test_defaultModelBuildTask_buildSSLRedirectConfig(t *testing.T) {
 			fields: fields{
 				ingGroup: Group{
 					ID: GroupID{Namespace: "", Name: "awesome-group"},
-					Members: []*networking.Ingress{
+					Members: []ClassifiedIngress{
 						{
-							ObjectMeta: metav1.ObjectMeta{
+							Ing: &networking.Ingress{ObjectMeta: metav1.ObjectMeta{
 								Namespace: "ns-1",
 								Name:      "ing-1",
 							},
-							Spec: networking.IngressSpec{
-								Rules: []networking.IngressRule{
-									{
-										Host: "app-1.example.com",
-										IngressRuleValue: networking.IngressRuleValue{
-											HTTP: &networking.HTTPIngressRuleValue{
-												Paths: []networking.HTTPIngressPath{
-													{
-														Path: "/svc-1",
-														Backend: networking.IngressBackend{
-															ServiceName: "svc-1",
-															ServicePort: intstr.FromString("http"),
+								Spec: networking.IngressSpec{
+									Rules: []networking.IngressRule{
+										{
+											Host: "app-1.example.com",
+											IngressRuleValue: networking.IngressRuleValue{
+												HTTP: &networking.HTTPIngressRuleValue{
+													Paths: []networking.HTTPIngressPath{
+														{
+															Path: "/svc-1",
+															Backend: networking.IngressBackend{
+																ServiceName: "svc-1",
+																ServicePort: intstr.FromString("http"),
+															},
 														},
 													},
 												},
@@ -1679,22 +1687,23 @@ func Test_defaultModelBuildTask_buildSSLRedirectConfig(t *testing.T) {
 							},
 						},
 						{
-							ObjectMeta: metav1.ObjectMeta{
+							Ing: &networking.Ingress{ObjectMeta: metav1.ObjectMeta{
 								Namespace: "ns-2",
 								Name:      "ing-2",
 							},
-							Spec: networking.IngressSpec{
-								Rules: []networking.IngressRule{
-									{
-										Host: "app-2.example.com",
-										IngressRuleValue: networking.IngressRuleValue{
-											HTTP: &networking.HTTPIngressRuleValue{
-												Paths: []networking.HTTPIngressPath{
-													{
-														Path: "/svc-2",
-														Backend: networking.IngressBackend{
-															ServiceName: "svc-2",
-															ServicePort: intstr.FromString("http"),
+								Spec: networking.IngressSpec{
+									Rules: []networking.IngressRule{
+										{
+											Host: "app-2.example.com",
+											IngressRuleValue: networking.IngressRuleValue{
+												HTTP: &networking.HTTPIngressRuleValue{
+													Paths: []networking.HTTPIngressPath{
+														{
+															Path: "/svc-2",
+															Backend: networking.IngressBackend{
+																ServiceName: "svc-2",
+																ServicePort: intstr.FromString("http"),
+															},
 														},
 													},
 												},
@@ -1725,27 +1734,28 @@ func Test_defaultModelBuildTask_buildSSLRedirectConfig(t *testing.T) {
 			fields: fields{
 				ingGroup: Group{
 					ID: GroupID{Namespace: "", Name: "awesome-group"},
-					Members: []*networking.Ingress{
+					Members: []ClassifiedIngress{
 						{
-							ObjectMeta: metav1.ObjectMeta{
+							Ing: &networking.Ingress{ObjectMeta: metav1.ObjectMeta{
 								Namespace: "ns-1",
 								Name:      "ing-1",
 								Annotations: map[string]string{
 									"alb.ingress.kubernetes.io/ssl-redirect": "443",
 								},
 							},
-							Spec: networking.IngressSpec{
-								Rules: []networking.IngressRule{
-									{
-										Host: "app-1.example.com",
-										IngressRuleValue: networking.IngressRuleValue{
-											HTTP: &networking.HTTPIngressRuleValue{
-												Paths: []networking.HTTPIngressPath{
-													{
-														Path: "/svc-1",
-														Backend: networking.IngressBackend{
-															ServiceName: "svc-1",
-															ServicePort: intstr.FromString("http"),
+								Spec: networking.IngressSpec{
+									Rules: []networking.IngressRule{
+										{
+											Host: "app-1.example.com",
+											IngressRuleValue: networking.IngressRuleValue{
+												HTTP: &networking.HTTPIngressRuleValue{
+													Paths: []networking.HTTPIngressPath{
+														{
+															Path: "/svc-1",
+															Backend: networking.IngressBackend{
+																ServiceName: "svc-1",
+																ServicePort: intstr.FromString("http"),
+															},
 														},
 													},
 												},
@@ -1756,22 +1766,23 @@ func Test_defaultModelBuildTask_buildSSLRedirectConfig(t *testing.T) {
 							},
 						},
 						{
-							ObjectMeta: metav1.ObjectMeta{
+							Ing: &networking.Ingress{ObjectMeta: metav1.ObjectMeta{
 								Namespace: "ns-2",
 								Name:      "ing-2",
 							},
-							Spec: networking.IngressSpec{
-								Rules: []networking.IngressRule{
-									{
-										Host: "app-2.example.com",
-										IngressRuleValue: networking.IngressRuleValue{
-											HTTP: &networking.HTTPIngressRuleValue{
-												Paths: []networking.HTTPIngressPath{
-													{
-														Path: "/svc-2",
-														Backend: networking.IngressBackend{
-															ServiceName: "svc-2",
-															ServicePort: intstr.FromString("http"),
+								Spec: networking.IngressSpec{
+									Rules: []networking.IngressRule{
+										{
+											Host: "app-2.example.com",
+											IngressRuleValue: networking.IngressRuleValue{
+												HTTP: &networking.HTTPIngressRuleValue{
+													Paths: []networking.HTTPIngressPath{
+														{
+															Path: "/svc-2",
+															Backend: networking.IngressBackend{
+																ServiceName: "svc-2",
+																ServicePort: intstr.FromString("http"),
+															},
 														},
 													},
 												},
@@ -1805,27 +1816,28 @@ func Test_defaultModelBuildTask_buildSSLRedirectConfig(t *testing.T) {
 			fields: fields{
 				ingGroup: Group{
 					ID: GroupID{Namespace: "", Name: "awesome-group"},
-					Members: []*networking.Ingress{
+					Members: []ClassifiedIngress{
 						{
-							ObjectMeta: metav1.ObjectMeta{
+							Ing: &networking.Ingress{ObjectMeta: metav1.ObjectMeta{
 								Namespace: "ns-1",
 								Name:      "ing-1",
 								Annotations: map[string]string{
 									"alb.ingress.kubernetes.io/ssl-redirect": "443",
 								},
 							},
-							Spec: networking.IngressSpec{
-								Rules: []networking.IngressRule{
-									{
-										Host: "app-1.example.com",
-										IngressRuleValue: networking.IngressRuleValue{
-											HTTP: &networking.HTTPIngressRuleValue{
-												Paths: []networking.HTTPIngressPath{
-													{
-														Path: "/svc-1",
-														Backend: networking.IngressBackend{
-															ServiceName: "svc-1",
-															ServicePort: intstr.FromString("http"),
+								Spec: networking.IngressSpec{
+									Rules: []networking.IngressRule{
+										{
+											Host: "app-1.example.com",
+											IngressRuleValue: networking.IngressRuleValue{
+												HTTP: &networking.HTTPIngressRuleValue{
+													Paths: []networking.HTTPIngressPath{
+														{
+															Path: "/svc-1",
+															Backend: networking.IngressBackend{
+																ServiceName: "svc-1",
+																ServicePort: intstr.FromString("http"),
+															},
 														},
 													},
 												},
@@ -1836,25 +1848,26 @@ func Test_defaultModelBuildTask_buildSSLRedirectConfig(t *testing.T) {
 							},
 						},
 						{
-							ObjectMeta: metav1.ObjectMeta{
+							Ing: &networking.Ingress{ObjectMeta: metav1.ObjectMeta{
 								Namespace: "ns-2",
 								Name:      "ing-2",
 								Annotations: map[string]string{
 									"alb.ingress.kubernetes.io/ssl-redirect": "443",
 								},
 							},
-							Spec: networking.IngressSpec{
-								Rules: []networking.IngressRule{
-									{
-										Host: "app-2.example.com",
-										IngressRuleValue: networking.IngressRuleValue{
-											HTTP: &networking.HTTPIngressRuleValue{
-												Paths: []networking.HTTPIngressPath{
-													{
-														Path: "/svc-2",
-														Backend: networking.IngressBackend{
-															ServiceName: "svc-2",
-															ServicePort: intstr.FromString("http"),
+								Spec: networking.IngressSpec{
+									Rules: []networking.IngressRule{
+										{
+											Host: "app-2.example.com",
+											IngressRuleValue: networking.IngressRuleValue{
+												HTTP: &networking.HTTPIngressRuleValue{
+													Paths: []networking.HTTPIngressPath{
+														{
+															Path: "/svc-2",
+															Backend: networking.IngressBackend{
+																ServiceName: "svc-2",
+																ServicePort: intstr.FromString("http"),
+															},
 														},
 													},
 												},
@@ -1888,27 +1901,28 @@ func Test_defaultModelBuildTask_buildSSLRedirectConfig(t *testing.T) {
 			fields: fields{
 				ingGroup: Group{
 					ID: GroupID{Namespace: "", Name: "awesome-group"},
-					Members: []*networking.Ingress{
+					Members: []ClassifiedIngress{
 						{
-							ObjectMeta: metav1.ObjectMeta{
+							Ing: &networking.Ingress{ObjectMeta: metav1.ObjectMeta{
 								Namespace: "ns-1",
 								Name:      "ing-1",
 								Annotations: map[string]string{
 									"alb.ingress.kubernetes.io/ssl-redirect": "443",
 								},
 							},
-							Spec: networking.IngressSpec{
-								Rules: []networking.IngressRule{
-									{
-										Host: "app-1.example.com",
-										IngressRuleValue: networking.IngressRuleValue{
-											HTTP: &networking.HTTPIngressRuleValue{
-												Paths: []networking.HTTPIngressPath{
-													{
-														Path: "/svc-1",
-														Backend: networking.IngressBackend{
-															ServiceName: "svc-1",
-															ServicePort: intstr.FromString("http"),
+								Spec: networking.IngressSpec{
+									Rules: []networking.IngressRule{
+										{
+											Host: "app-1.example.com",
+											IngressRuleValue: networking.IngressRuleValue{
+												HTTP: &networking.HTTPIngressRuleValue{
+													Paths: []networking.HTTPIngressPath{
+														{
+															Path: "/svc-1",
+															Backend: networking.IngressBackend{
+																ServiceName: "svc-1",
+																ServicePort: intstr.FromString("http"),
+															},
 														},
 													},
 												},
@@ -1919,25 +1933,26 @@ func Test_defaultModelBuildTask_buildSSLRedirectConfig(t *testing.T) {
 							},
 						},
 						{
-							ObjectMeta: metav1.ObjectMeta{
+							Ing: &networking.Ingress{ObjectMeta: metav1.ObjectMeta{
 								Namespace: "ns-2",
 								Name:      "ing-2",
 								Annotations: map[string]string{
 									"alb.ingress.kubernetes.io/ssl-redirect": "8443",
 								},
 							},
-							Spec: networking.IngressSpec{
-								Rules: []networking.IngressRule{
-									{
-										Host: "app-2.example.com",
-										IngressRuleValue: networking.IngressRuleValue{
-											HTTP: &networking.HTTPIngressRuleValue{
-												Paths: []networking.HTTPIngressPath{
-													{
-														Path: "/svc-2",
-														Backend: networking.IngressBackend{
-															ServiceName: "svc-2",
-															ServicePort: intstr.FromString("http"),
+								Spec: networking.IngressSpec{
+									Rules: []networking.IngressRule{
+										{
+											Host: "app-2.example.com",
+											IngressRuleValue: networking.IngressRuleValue{
+												HTTP: &networking.HTTPIngressRuleValue{
+													Paths: []networking.HTTPIngressPath{
+														{
+															Path: "/svc-2",
+															Backend: networking.IngressBackend{
+																ServiceName: "svc-2",
+																ServicePort: intstr.FromString("http"),
+															},
 														},
 													},
 												},

--- a/webhooks/networking/ingress_validator.go
+++ b/webhooks/networking/ingress_validator.go
@@ -135,9 +135,11 @@ func (v *ingressValidator) checkGroupNameAnnotationUsage(ing *networking.Ingress
 }
 
 func (v *ingressValidator) checkIngressClassUsage(ctx context.Context, ing *networking.Ingress) error {
-	_, err := v.classLoader.Load(ctx, ing)
-	if err != nil {
-		return err
+	if ing.Spec.IngressClassName != nil {
+		_, err := v.classLoader.Load(ctx, ing)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/webhooks/networking/ingress_validator_test.go
+++ b/webhooks/networking/ingress_validator_test.go
@@ -479,8 +479,7 @@ func Test_ingressValidator_checkIngressClassUsage(t *testing.T) {
 	}
 
 	type args struct {
-		ing            *networking.Ingress
-		ingClassParams *elbv2api.IngressClassParams
+		ing *networking.Ingress
 	}
 	tests := []struct {
 		name    string
@@ -488,6 +487,22 @@ func Test_ingressValidator_checkIngressClassUsage(t *testing.T) {
 		args    args
 		wantErr error
 	}{
+		{
+			name: "IngressClassName isn't specified",
+			env:  env{},
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Name:      "awesome-ing",
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: nil,
+					},
+				},
+			},
+			wantErr: nil,
+		},
 		{
 			name: "IngressClass didn't exists",
 			env:  env{},


### PR DESCRIPTION
# This PR adds support for IngressClassParams's group settings.

The group settings in IngressClassParams takes higher priority than "alb.ingress.kubernetes.io/group.name" annotation.

The IngressGroup membership designation algorithm runs as follows:
* When Ingress is associated with IngressClass resource
   * when IngressClass references an IngressClassParams resource
      * when "group" is set in IngressClassParams, Ingress will belong to specified IngressGroup identified by "group.name" field in IngressClassParams.
       * when "group" is not set in IngressClassParams, Ingress will follow same logic for IngressGroup membership designation as "When Ingress is not associated with IngressClass resource"
    * when IngressClass didn't references an IngressClassParams resource, Ingress will follow same logic for IngressGroup membership designation as "When Ingress is not associated with IngressClass resource"
* When Ingress is not associated with IngressClass resource. (e.g. have `kubernetes.io/ingress.class` defined)
     * when "alb.ingress.kubernetes.io/group.name" annotation presents, Ingress will belong to specified IngressGroup identified by the annotation value
     * when "alb.ingress.kubernetes.io/group.name" annotation not presents, Ingress will not belong to any explicit IngressGroup. (or Ingress belong to a implicit IngressGroup consisted with itself only)
  

Additional Notes:  
- `kubernetes.io/ingress.class` annotation takes higher priority than "spec.ingressClassName" field on Ingress. If `kubernetes.io/ingress.class` annotation is set, then `spec.ingressClassName` field will be ignored. 
-  Before this PR, the code will issue a warning if both `kubernetes.io/ingress.class` annotation and `spec.ingressClassName` field is set and contains inconsistent value. Such warning logic is removed along this PR since later Kubernetes version have built-in validations that enforce only one of them can be set on Ingress.
- If Cluster admins wants to prevents users from set IngressGroups with "alb.ingress.kubernetes.io/group.name" annotation, they can leverage "--disable-ingress-group-name-annotation=true" introduced in [PR-1849](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/1849)

# Test done:
* UTs
* Ingress creation with explicit group
* Ingress creation with implicit group
* Ingress updates by change from explicit group to implicit group
* Ingress updates by change from implicit group to explicit group

See [PR-1849](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/1849) for overall design.
Other PRs:
- https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/1902