### PR TITLE
Fix new tagging ARNs in aws-cn IAM policy

### DIFF
--- a/docs/install/iam_policy_cn.json
+++ b/docs/install/iam_policy_cn.json
@@ -159,10 +159,10 @@
                 "elasticloadbalancing:RemoveTags"
             ],
             "Resource": [
-                "arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*",
-                "arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*",
-                "arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
-                "arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
+                "arn:aws-cn:elasticloadbalancing:*:*:listener/net/*/*/*",
+                "arn:aws-cn:elasticloadbalancing:*:*:listener/app/*/*/*",
+                "arn:aws-cn:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
+                "arn:aws-cn:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
             ]
         },
         {


### PR DESCRIPTION
Followup to https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/1887

This policy JSON is for AWS China which requires using the aws-cn partition (as evidenced by the other ARNs in the policy document)