### PR TITLE
add aws-region / aws-vpc-id args in deployment

### DIFF
--- a/docs/install/v2_1_2_full.yaml
+++ b/docs/install/v2_1_2_full.yaml
@@ -485,6 +485,8 @@ spec:
         - args:
             - --cluster-name=your-cluster-name
             - --ingress-class=alb
+            - --aws-region=eks-vpc-region
+            - --aws-vpc-id=eks-vpc-id
           image: amazon/aws-alb-ingress-controller:v2.1.2
           livenessProbe:
             failureThreshold: 2

--- a/docs/install/v2_1_3_full.yaml
+++ b/docs/install/v2_1_3_full.yaml
@@ -485,6 +485,8 @@ spec:
         - args:
             - --cluster-name=your-cluster-name
             - --ingress-class=alb
+            - --aws-region=eks-vpc-region
+            - --aws-vpc-id=eks-vpc-id
           image: amazon/aws-alb-ingress-controller:v2.1.3
           livenessProbe:
             failureThreshold: 2


### PR DESCRIPTION
when nodegroup IMDS disabled, args `--aws-region` and `--aws-vpc-id` is required