### PR TITLE
Initial VPC Endpoint Service (Private Link) Interface

### DIFF
--- a/pkg/annotations/constants.go
+++ b/pkg/annotations/constants.go
@@ -81,4 +81,8 @@ const (
 	SvcLBSuffixTargetNodeLabels              = "aws-load-balancer-target-node-labels"
 	SvcLBSuffixLoadBalancerAttributes        = "aws-load-balancer-attributes"
 	SvcLBSuffixManageSGRules                 = "aws-load-balancer-manage-backend-security-group-rules"
+
+	SvcLBSuffixEndpointServiceAcceptanceRequired = "aws-load-balancer-endpoint-service-acceptance-required"
+	SvcLBSuffixEndpointServiceAllowedPrincipals  = "aws-load-balancer-endpoint-service-allowed-principals"
+	SvcLBSuffixEndpointServicePrivateDNSName     = "aws-load-balancer-endpoint-service-private-dns-name"
 )

--- a/pkg/config/addons_config.go
+++ b/pkg/config/addons_config.go
@@ -3,10 +3,11 @@ package config
 import "github.com/spf13/pflag"
 
 const (
-	flagWAFEnabled    = "enable-waf"
-	flagWAFV2Enabled  = "enable-wafv2"
-	flagShieldEnabled = "enable-shield"
-	defaultEnabled    = true
+	flagWAFEnabled             = "enable-waf"
+	flagWAFV2Enabled           = "enable-wafv2"
+	flagShieldEnabled          = "enable-shield"
+	flagEndpointServiceEnabled = "enable-endpoint-service"
+	defaultEnabled             = true
 )
 
 // AddonsConfig contains configuration for the addon features
@@ -17,6 +18,8 @@ type AddonsConfig struct {
 	WAFV2Enabled bool
 	// Shield addon for ALB
 	ShieldEnabled bool
+	// Endpoint Service addon for NLB
+	EndpointServiceEnabled bool
 }
 
 // BindFlags binds the command line flags to the fields in the config object
@@ -24,4 +27,5 @@ func (f *AddonsConfig) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&f.WAFEnabled, flagWAFEnabled, defaultEnabled, "Enable WAF addon for ALB")
 	fs.BoolVar(&f.WAFV2Enabled, flagWAFV2Enabled, defaultEnabled, "Enable WAF V2 addon for ALB")
 	fs.BoolVar(&f.ShieldEnabled, flagShieldEnabled, defaultEnabled, "Enable Shield addon for ALB")
+	fs.BoolVar(&f.EndpointServiceEnabled, flagEndpointServiceEnabled, defaultEnabled, "Enable VPC Endpoint Service addon for NLB")
 }

--- a/pkg/deploy/ec2/endpoint_service_manager.go
+++ b/pkg/deploy/ec2/endpoint_service_manager.go
@@ -1,0 +1,45 @@
+package ec2
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/services"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/tracking"
+	ec2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/ec2"
+)
+
+// abstraction around endpoint service operations for EC2.
+type EndpointServiceManager interface {
+	// ReconcileTags will reconcile tags on resources.
+	ReconcileTags(ctx context.Context, resID string, desiredTags map[string]string, opts ...ReconcileTagsOption) error
+
+	// ListEndpointServices returns VPC Endpoint Services that matches any of the tagging requirements.
+	ListEndpointServices(ctx context.Context, tagFilters ...tracking.TagFilter) ([]ec2model.VPCEndpointService, error)
+}
+
+// NewdefaultEndpointServiceManager constructs new defaultEndpointServiceManager.
+func NewDefaultEndpointServiceManager(ec2Client services.EC2, vpcID string, logger logr.Logger) *defaultEndpointServiceManager {
+	return &defaultEndpointServiceManager{
+		ec2Client: ec2Client,
+		vpcID:     vpcID,
+		logger:    logger,
+	}
+}
+
+var _ EndpointServiceManager = &defaultEndpointServiceManager{}
+
+// default implementation for EndpointServiceManager.
+type defaultEndpointServiceManager struct {
+	ec2Client services.EC2
+	vpcID     string
+	logger    logr.Logger
+}
+
+func (m *defaultEndpointServiceManager) ReconcileTags(ctx context.Context, resID string, desiredTags map[string]string, opts ...ReconcileTagsOption) error {
+	return nil
+}
+
+func (m *defaultEndpointServiceManager) ListEndpointServices(ctx context.Context, tagFilters ...tracking.TagFilter) ([]ec2model.VPCEndpointService, error) {
+	return nil, nil
+}

--- a/pkg/deploy/ec2/endpoint_service_synthesizer.go
+++ b/pkg/deploy/ec2/endpoint_service_synthesizer.go
@@ -1,0 +1,43 @@
+package ec2
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/services"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/tracking"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/core"
+)
+
+// NewEndpointServiceSynthesizer constructs new endpointServiceSynthesizer.
+func NewEndpointServiceSynthesizer(ec2Client services.EC2, trackingProvider tracking.Provider, taggingManager TaggingManager,
+	esManager EndpointServiceManager, vpcID string, logger logr.Logger, stack core.Stack) *endpointServiceSynthesizer {
+	return &endpointServiceSynthesizer{
+		ec2Client:        ec2Client,
+		trackingProvider: trackingProvider,
+		taggingManager:   taggingManager,
+		esManager:        esManager,
+		vpcID:            vpcID,
+		logger:           logger,
+		stack:            stack,
+	}
+}
+
+type endpointServiceSynthesizer struct {
+	ec2Client        services.EC2
+	trackingProvider tracking.Provider
+	taggingManager   TaggingManager
+	esManager        EndpointServiceManager
+	vpcID            string
+	logger           logr.Logger
+
+	stack core.Stack
+}
+
+func (s *endpointServiceSynthesizer) Synthesize(ctx context.Context) error {
+	return nil
+}
+
+func (s *endpointServiceSynthesizer) PostSynthesize(ctx context.Context) error {
+	return nil
+}

--- a/pkg/model/ec2/vpc_endpoint_service.go
+++ b/pkg/model/ec2/vpc_endpoint_service.go
@@ -1,0 +1,71 @@
+package ec2
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/core"
+)
+
+var _ core.Resource = &VPCEndpointService{}
+
+// VPCEndpointService represents a VPC Endpoint Service.
+type VPCEndpointService struct {
+	core.ResourceMeta `json:"-"`
+
+	//  desired state of VPCEndpointService
+	Spec VPCEndpointServiceSpec `json:"spec"`
+
+	// observed state of VPCEndpointService
+	Status *VPCEndpointServiceStatus `json:"status,omitempty"`
+}
+
+// NewVPCEndpointService constructs new VPCEndpointService resource.
+func NewVPCEndpointService(stack core.Stack, id string, spec VPCEndpointServiceSpec) *VPCEndpointService {
+	es := &VPCEndpointService{
+		ResourceMeta: core.NewResourceMeta(stack, "AWS::EC2::VPCEndpointService", id),
+		Spec:         spec,
+		Status:       nil,
+	}
+	stack.AddResource(es)
+	return es
+}
+
+// SetStatus sets the VPCEndpointService's status
+func (es *VPCEndpointService) SetStatus(status VPCEndpointServiceStatus) {
+	es.Status = &status
+}
+
+// ServiceID returns a token for this VPCEndpointService's serviceID.
+func (es *VPCEndpointService) ServiceID() core.StringToken {
+	return core.NewResourceFieldStringToken(es, "status/serviceID",
+		func(ctx context.Context, res core.Resource, fieldPath string) (s string, err error) {
+			es := res.(*VPCEndpointService)
+			if es.Status == nil {
+				return "", errors.Errorf("VPCEndpointService is not fulfilled yet: %v", es.ID())
+			}
+			return es.Status.ServiceID, nil
+		},
+	)
+}
+
+// VPCEndpointServiceSpec defines the desired state of VPCEndpointService
+type VPCEndpointServiceSpec struct {
+	// whether requests from service consumers to create an endpoint to the service must be accepted
+	AcceptanceRequired *bool `json:"acceptance_required"`
+
+	NetworkLoadBalancerArns []string `json:"network_load_balancer_arns"`
+
+	PrivateDNSName *string `json:"private_dns_name"`
+
+	// +optional
+	Tags map[string]string `json:"tags,omitempty"`
+}
+
+// VPCEndpointServiceStatus defines the observed state of VPCEndpointService
+type VPCEndpointServiceStatus struct {
+	// The ID of the endpoint service.
+	ServiceID string `json:"serviceID"`
+
+	BaseEndpointDnsNames []string `json:"base_endpoint_dns_names"`
+}

--- a/pkg/networking/vpc_endpoint_service_info.go
+++ b/pkg/networking/vpc_endpoint_service_info.go
@@ -1,0 +1,41 @@
+package networking
+
+import (
+	awssdk "github.com/aws/aws-sdk-go/aws"
+	ec2sdk "github.com/aws/aws-sdk-go/service/ec2"
+)
+
+// VPCEndpointServiceInfo wraps necessary information about an Endpoint Service.
+type VPCEndpointServiceInfo struct {
+	// The ID of the endpoint service.
+	ServiceID string
+
+	// whether requests from service consumers to create an endpoint to the service must be accepted
+	AcceptanceRequired bool
+
+	NetworkLoadBalancerArns []string
+
+	PrivateDNSName *string
+
+	BaseEndpointDnsNames []string
+	// +optional
+	Tags map[string]string
+}
+
+// NewRawVPCEndpointServiceInfo constructs new VPCEndpointServiceInfo with raw ec2SDK's ServiceConfiguration object.
+func NewRawVPCEndpointServiceInfo(sdkES *ec2sdk.ServiceConfiguration) VPCEndpointServiceInfo {
+	esID := awssdk.StringValue(sdkES.ServiceId)
+
+	tags := make(map[string]string, len(sdkES.Tags))
+	for _, tag := range sdkES.Tags {
+		tags[awssdk.StringValue(tag.Key)] = awssdk.StringValue(tag.Value)
+	}
+	return VPCEndpointServiceInfo{
+		ServiceID:               esID,
+		AcceptanceRequired:      awssdk.BoolValue(sdkES.AcceptanceRequired),
+		NetworkLoadBalancerArns: awssdk.StringValueSlice(sdkES.NetworkLoadBalancerArns),
+		PrivateDNSName:          sdkES.PrivateDnsName,
+		BaseEndpointDnsNames:    awssdk.StringValueSlice(sdkES.BaseEndpointDnsNames),
+		Tags:                    tags,
+	}
+}

--- a/pkg/networking/vpc_endpoint_service_manager.go
+++ b/pkg/networking/vpc_endpoint_service_manager.go
@@ -1,0 +1,63 @@
+package networking
+
+import (
+	"context"
+
+	ec2sdk "github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/services"
+)
+
+type FetchVPCESInfoOptions struct {
+	// whether to ignore cache and reload Endpoint Service Info from AWS directly.
+	ReloadIgnoringCache bool
+}
+
+// Apply FetchVPCESInfoOption options
+func (opts *FetchVPCESInfoOptions) ApplyOptions(options ...FetchVPCESInfoOption) {
+	for _, option := range options {
+		option(opts)
+	}
+}
+
+type FetchVPCESInfoOption func(opts *FetchVPCESInfoOptions)
+
+// WithReloadIgnoringCache is a option that sets the ReloadIgnoringCache to true.
+func WithVPCESReloadIgnoringCache() FetchVPCESInfoOption {
+	return func(opts *FetchVPCESInfoOptions) {
+		opts.ReloadIgnoringCache = true
+	}
+}
+
+// VPCEndpointServiceManager is an abstraction around EC2's VPC Endpoint Service API.
+type VPCEndpointServiceManager interface {
+	// FetchVPCESInfosByID will fetch VPCEndpointServiceInfo with EndpointService IDs.
+	FetchVPCESInfosByID(ctx context.Context, esIDs []string, opts ...FetchVPCESInfoOption) (map[string]VPCEndpointServiceInfo, error)
+
+	// FetchVPCESInfosByRequest will fetch VPCEndpointServiceInfo with raw DescribeVpcEndpointServiceConfigurationsInput request.
+	FetchVPCESInfosByRequest(ctx context.Context, req *ec2sdk.DescribeVpcEndpointServiceConfigurationsInput) (map[string]VPCEndpointServiceInfo, error)
+}
+
+// NewDefaultVPCEndpointServiceManager constructs new defaultVPCEndpointServiceManager.
+func NewDefaultVPCEndpointServiceManager(ec2Client services.EC2, logger logr.Logger) *defaultVPCEndpointServiceManager {
+	return &defaultVPCEndpointServiceManager{
+		ec2Client: ec2Client,
+		logger:    logger,
+	}
+}
+
+var _ VPCEndpointServiceManager = &defaultVPCEndpointServiceManager{}
+
+// default implementation for VPCEndpointServiceManager
+type defaultVPCEndpointServiceManager struct {
+	ec2Client services.EC2
+	logger    logr.Logger
+}
+
+func (m *defaultVPCEndpointServiceManager) FetchVPCESInfosByID(ctx context.Context, esIDs []string, opts ...FetchVPCESInfoOption) (map[string]VPCEndpointServiceInfo, error) {
+	return nil, nil
+}
+
+func (m *defaultVPCEndpointServiceManager) FetchVPCESInfosByRequest(ctx context.Context, req *ec2sdk.DescribeVpcEndpointServiceConfigurationsInput) (map[string]VPCEndpointServiceInfo, error) {
+	return nil, nil
+}

--- a/pkg/service/model_build_endpoint_service.go
+++ b/pkg/service/model_build_endpoint_service.go
@@ -1,0 +1,13 @@
+package service
+
+import (
+	"context"
+)
+
+func (t *defaultModelBuildTask) buildEndpointService(ctx context.Context) error {
+	// return early if endpoint service annotations arent present
+
+	// otherwise parse the annotations and create endpoint service via pkg/model/ec2.NewVPCEndpointService
+	// which adds the resource to the core.stack
+	return nil
+}

--- a/pkg/service/model_builder.go
+++ b/pkg/service/model_builder.go
@@ -112,6 +112,9 @@ func (b *defaultModelBuilder) Build(ctx context.Context, service *corev1.Service
 		defaultHealthCheckTimeoutForInstanceModeLocal:            6,
 		defaultHealthCheckHealthyThresholdForInstanceModeLocal:   2,
 		defaultHealthCheckUnhealthyThresholdForInstanceModeLocal: 2,
+
+		defaultEndpointServiceAcceptanceRequired: true,
+		defaultEndpointServicePrivateDnsName:     "",
 	}
 
 	if err := task.run(ctx); err != nil {
@@ -169,6 +172,10 @@ type defaultModelBuildTask struct {
 	defaultHealthCheckTimeoutForInstanceModeLocal            int64
 	defaultHealthCheckHealthyThresholdForInstanceModeLocal   int64
 	defaultHealthCheckUnhealthyThresholdForInstanceModeLocal int64
+
+	// Default VPC Endpoint Service settings
+	defaultEndpointServiceAcceptanceRequired bool
+	defaultEndpointServicePrivateDnsName     string
 }
 
 func (t *defaultModelBuildTask) run(ctx context.Context) error {
@@ -202,6 +209,10 @@ func (t *defaultModelBuildTask) buildModel(ctx context.Context) error {
 		return err
 	}
 	err = t.buildListeners(ctx, scheme)
+	if err != nil {
+		return err
+	}
+	err = t.buildEndpointService(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This adds a stubbed interface for VPC Endpoint Service support. This was mostly copied from the security group implementation since I view them as similar auxiliary resources to the main loadbalancer/listener/targetgroup resource types.

A few discussion topics and notes for the future implementation:
* Should the controller detach other NLBs or GWLBs besides the Service's NLB?
* I haven't checked whether Endpoint Services are supported in all regions and partitions, but I anticipate the new addon CLI flag should be sufficient if not.
* EndpointServices can't be deleted if they're currently used by an interface Endpoint in another VPC, should this block the finalizer on k8s Service deletion?
* We'll want to decide on how to expose the DNS verification information (record name, type, and value). If we choose to use annotations, I believe this would be the first case of the controller writing annotations back to the resource so we would need to think through the implications of doing so. If we can define the records in a way compatible with external-dns that would be ideal.
* I plan on including the same tags as on the NLB itself and using them in the tagging filter of `DescribeVpcEndpointServiceConfigurations` to find existing endpoint services.
* The [AWS docs](https://docs.aws.amazon.com/vpc/latest/privatelink/endpoint-service-overview.html) recommend exposing Endpoint Services in all AZs of the region which requires the NLB be configured for a subnet in every AZ, this is probably worth mentioning in the docs.


ref: https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/1859