### PR TITLE
tolerate misconfiguration that references non-exists service or action

### DIFF
--- a/controllers/ingress/group_controller.go
+++ b/controllers/ingress/group_controller.go
@@ -40,7 +40,7 @@ func NewGroupReconciler(cloud aws.Cloud, k8sClient client.Client, eventRecorder 
 
 	annotationParser := annotations.NewSuffixAnnotationParser(annotations.AnnotationPrefixIngress)
 	authConfigBuilder := ingress.NewDefaultAuthConfigBuilder(annotationParser)
-	enhancedBackendBuilder := ingress.NewDefaultEnhancedBackendBuilder(annotationParser)
+	enhancedBackendBuilder := ingress.NewDefaultEnhancedBackendBuilder(k8sClient, annotationParser, authConfigBuilder)
 	referenceIndexer := ingress.NewDefaultReferenceIndexer(enhancedBackendBuilder, authConfigBuilder, logger)
 	modelBuilder := ingress.NewDefaultModelBuilder(k8sClient, eventRecorder,
 		cloud.EC2(), cloud.ACM(),

--- a/pkg/ingress/enhanced_backend_builder.go
+++ b/pkg/ingress/enhanced_backend_builder.go
@@ -3,33 +3,90 @@ package ingress
 import (
 	"context"
 	"fmt"
+	awssdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/algorithm"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
 	magicServicePortUseAnnotation = "use-annotation"
+
+	// the message body of fixed 503 response used when referencing a non-existent Kubernetes service as backend.
+	nonExistentBackendServiceMessageBody = "Backend service does not exist"
+	// the message body of fixed 503 response used when referencing a non-existent annotation Action as backend.
+	nonExistentBackendActionMessageBody = "Backend action does not exist"
+	// by default, we tolerate a missing backend service, and use a fixed 503 response instead.
+	defaultTolerateNonExistentBackendService = true
+	// by default, we tolerate a missing backend action, and use a fixed 503 response instead.
+	defaultTolerateNonExistentBackendAction = true
 )
 
-// An enhanced version of Ingress backend.
-// It contains additional routing conditions we parsed from annotations.
+// EnhancedBackend is an enhanced version of Ingress backend.
+// It contains additional routing conditions and authentication configurations we parsed from annotations.
 // Also, when magic string `use-annotation` is specified as backend, the actions will be parsed from annotations as well.
 type EnhancedBackend struct {
 	Conditions []RuleCondition
 	Action     Action
+	AuthConfig AuthConfig
 }
 
-// EnhancedBackendBuilder is capable of build  EnhancedBackend for Ingress backend.
+type EnhancedBackendBuildOptions struct {
+	// whether to load backend services
+	LoadBackendServices bool
+
+	// BackendServices contains all services referenced in Action, indexed by service's key.
+	// Note: we support to pass BackendServices during backend build, so that we can use the same service snapshot for same service during entire Ingress build process.
+	BackendServices map[types.NamespacedName]*corev1.Service
+
+	// whether to load auth configuration. when load authConfiguration, LoadBackendServices must be enabled as well.
+	LoadAuthConfig bool
+}
+
+type EnhancedBackendBuildOption func(opts *EnhancedBackendBuildOptions)
+
+func (opts *EnhancedBackendBuildOptions) ApplyOptions(options ...EnhancedBackendBuildOption) {
+	for _, option := range options {
+		option(opts)
+	}
+}
+
+// WithLoadBackendServices is a option that sets the WithLoadBackendServices and BackendServices.
+func WithLoadBackendServices(loadBackendServices bool, backendServices map[types.NamespacedName]*corev1.Service) EnhancedBackendBuildOption {
+	return func(opts *EnhancedBackendBuildOptions) {
+		opts.LoadBackendServices = loadBackendServices
+		opts.BackendServices = backendServices
+	}
+}
+
+// WithLoadAuthConfig is a option that sets the LoadAuthConfig.
+func WithLoadAuthConfig(loadAuthConfig bool) EnhancedBackendBuildOption {
+	return func(opts *EnhancedBackendBuildOptions) {
+		opts.LoadAuthConfig = loadAuthConfig
+	}
+}
+
+// EnhancedBackendBuilder is capable of build EnhancedBackend for Ingress backend.
 type EnhancedBackendBuilder interface {
-	Build(ctx context.Context, ing *networking.Ingress, backend networking.IngressBackend) (EnhancedBackend, error)
+	Build(ctx context.Context, ing *networking.Ingress, backend networking.IngressBackend, opts ...EnhancedBackendBuildOption) (EnhancedBackend, error)
 }
 
 // NewDefaultEnhancedBackendBuilder constructs new defaultEnhancedBackendBuilder.
-func NewDefaultEnhancedBackendBuilder(annotationParser annotations.Parser) *defaultEnhancedBackendBuilder {
+func NewDefaultEnhancedBackendBuilder(k8sClient client.Client, annotationParser annotations.Parser, authConfigBuilder AuthConfigBuilder) *defaultEnhancedBackendBuilder {
 	return &defaultEnhancedBackendBuilder{
-		annotationParser: annotationParser,
+		k8sClient:         k8sClient,
+		annotationParser:  annotationParser,
+		authConfigBuilder: authConfigBuilder,
+
+		tolerateNonExistentBackendService: defaultTolerateNonExistentBackendAction,
+		tolerateNonExistentBackendAction:  defaultTolerateNonExistentBackendService,
 	}
 }
 
@@ -37,10 +94,26 @@ var _ EnhancedBackendBuilder = &defaultEnhancedBackendBuilder{}
 
 // default implementation for defaultEnhancedBackendBuilder
 type defaultEnhancedBackendBuilder struct {
-	annotationParser annotations.Parser
+	k8sClient         client.Client
+	annotationParser  annotations.Parser
+	authConfigBuilder AuthConfigBuilder
+
+	// whether to tolerate misconfiguration that used a non-existent backend service.
+	// when tolerate, If a single backend service is used and it's non-existent, a fixed 503 response will be used instead.
+	tolerateNonExistentBackendService bool
+	// whether to tolerate misconfiguration that used a non-existent backend action.
+	// when tolerate, If the backend action annotation is non-existent, a fixed 503 response will be used instead.
+	tolerateNonExistentBackendAction bool
 }
 
-func (b *defaultEnhancedBackendBuilder) Build(ctx context.Context, ing *networking.Ingress, backend networking.IngressBackend) (EnhancedBackend, error) {
+func (b *defaultEnhancedBackendBuilder) Build(ctx context.Context, ing *networking.Ingress, backend networking.IngressBackend, opts ...EnhancedBackendBuildOption) (EnhancedBackend, error) {
+	buildOpts := EnhancedBackendBuildOptions{
+		LoadBackendServices: true,
+		LoadAuthConfig:      true,
+		BackendServices:     map[types.NamespacedName]*corev1.Service{},
+	}
+	buildOpts.ApplyOptions(opts...)
+
 	conditions, err := b.buildConditions(ctx, ing.Annotations, backend.ServiceName)
 	if err != nil {
 		return EnhancedBackend{}, err
@@ -56,9 +129,24 @@ func (b *defaultEnhancedBackendBuilder) Build(ctx context.Context, ing *networki
 		action = b.buildActionViaServiceAndServicePort(ctx, backend.ServiceName, backend.ServicePort)
 	}
 
+	var authCfg AuthConfig
+	if buildOpts.LoadBackendServices {
+		if err := b.loadBackendServices(ctx, &action, ing.Namespace, buildOpts.BackendServices); err != nil {
+			return EnhancedBackend{}, err
+		}
+
+		if buildOpts.LoadAuthConfig {
+			authCfg, err = b.buildAuthConfig(ctx, action, ing.Namespace, ing.Annotations, buildOpts.BackendServices)
+			if err != nil {
+				return EnhancedBackend{}, err
+			}
+		}
+	}
+
 	return EnhancedBackend{
 		Conditions: conditions,
 		Action:     action,
+		AuthConfig: authCfg,
 	}, nil
 }
 
@@ -77,7 +165,8 @@ func (b *defaultEnhancedBackendBuilder) buildConditions(_ context.Context, ingAn
 	return conditions, nil
 }
 
-func (b *defaultEnhancedBackendBuilder) buildActionViaAnnotation(_ context.Context, ingAnnotation map[string]string, svcName string) (Action, error) {
+// buildActionViaAnnotation will build the backend action specified via actions annotation.
+func (b *defaultEnhancedBackendBuilder) buildActionViaAnnotation(ctx context.Context, ingAnnotation map[string]string, svcName string) (Action, error) {
 	action := Action{}
 	annotationKey := fmt.Sprintf("actions.%v", svcName)
 	exists, err := b.annotationParser.ParseJSONAnnotation(annotationKey, &action, ingAnnotation)
@@ -85,40 +174,22 @@ func (b *defaultEnhancedBackendBuilder) buildActionViaAnnotation(_ context.Conte
 		return Action{}, err
 	}
 	if !exists {
+		if b.tolerateNonExistentBackendAction {
+			return b.build503ResponseAction(nonExistentBackendActionMessageBody), nil
+		}
 		return Action{}, errors.Errorf("missing %v configuration", annotationKey)
 	}
 	if err := action.validate(); err != nil {
 		return Action{}, err
 	}
-
-	// normalize forward action via TargetGroupARN.
-	if action.Type == ActionTypeForward && action.TargetGroupARN != nil {
-		action.ForwardConfig = &ForwardActionConfig{
-			TargetGroups: []TargetGroupTuple{
-				{
-					TargetGroupARN: action.TargetGroupARN,
-				},
-			},
-		}
-		action.TargetGroupARN = nil
-	}
-
-	// normalize servicePort to be int type if possible.
-	// this is for backwards-compatibility with old AWSALBIngressController, where ServicePort is defined as Type string.
-	if action.Type == ActionTypeForward && action.ForwardConfig != nil {
-		for _, tgt := range action.ForwardConfig.TargetGroups {
-			if tgt.ServicePort != nil {
-				normalizedSVCPort := intstr.Parse(tgt.ServicePort.String())
-				*tgt.ServicePort = normalizedSVCPort
-			}
-		}
-	}
-
+	b.normalizeSimplifiedSchemaForwardAction(ctx, &action)
+	b.normalizeServicePortForBackwardsCompatibility(ctx, &action)
 	return action, nil
 }
 
+// buildActionViaServiceAndServicePort will build the backend Action that forward to specified Kubernetes Service.
 func (b *defaultEnhancedBackendBuilder) buildActionViaServiceAndServicePort(_ context.Context, svcName string, svcPort intstr.IntOrString) Action {
-	return Action{
+	action := Action{
 		Type: ActionTypeForward,
 		ForwardConfig: &ForwardActionConfig{
 			TargetGroups: []TargetGroupTuple{
@@ -127,6 +198,98 @@ func (b *defaultEnhancedBackendBuilder) buildActionViaServiceAndServicePort(_ co
 					ServicePort: &svcPort,
 				},
 			},
+		},
+	}
+	return action
+}
+
+// normalizeSimplifiedSchemaForwardAction will normalize to the advanced schema for forward action to share common processing logic.
+// we support a simplified schema in action annotation when configure forward to a single TargetGroup.
+func (b *defaultEnhancedBackendBuilder) normalizeSimplifiedSchemaForwardAction(_ context.Context, action *Action) {
+	if action.Type == ActionTypeForward && action.TargetGroupARN != nil {
+		*action = Action{
+			Type: ActionTypeForward,
+			ForwardConfig: &ForwardActionConfig{
+				TargetGroups: []TargetGroupTuple{
+					{
+						TargetGroupARN: action.TargetGroupARN,
+					},
+				},
+			},
+		}
+	}
+}
+
+// normalizeServicePortForBackwardsCompatibility will normalize servicePort to be int type if possible.
+// this is for backwards-compatibility with old AWSALBIngressController, where ServicePort is defined as Type string.
+func (b *defaultEnhancedBackendBuilder) normalizeServicePortForBackwardsCompatibility(_ context.Context, action *Action) {
+	if action.Type == ActionTypeForward && action.ForwardConfig != nil {
+		for _, tgt := range action.ForwardConfig.TargetGroups {
+			if tgt.ServicePort != nil {
+				normalizedSVCPort := intstr.Parse(tgt.ServicePort.String())
+				*tgt.ServicePort = normalizedSVCPort
+			}
+		}
+	}
+}
+
+// loadBackendServices will load referenced backend services into backendServices.
+// when tolerateNonExistentBackendService==true, and forward to a single non-existent Kubernetes Service, a fixed 503 response instead.
+func (b *defaultEnhancedBackendBuilder) loadBackendServices(ctx context.Context, action *Action, namespace string,
+	backendServices map[types.NamespacedName]*corev1.Service) error {
+	if action.Type == ActionTypeForward && action.ForwardConfig != nil {
+		svcNames := sets.NewString()
+		for _, tgt := range action.ForwardConfig.TargetGroups {
+			if tgt.ServiceName != nil {
+				svcNames.Insert(awssdk.StringValue(tgt.ServiceName))
+			}
+		}
+		forwardToSingleSvc := (len(action.ForwardConfig.TargetGroups) == 1) && (svcNames.Len() == 1)
+		tolerateNonExistentBackendService := b.tolerateNonExistentBackendService && forwardToSingleSvc
+		for svcName := range svcNames {
+			svcKey := types.NamespacedName{Namespace: namespace, Name: svcName}
+			if _, ok := backendServices[svcKey]; ok {
+				continue
+			}
+
+			svc := &corev1.Service{}
+			if err := b.k8sClient.Get(ctx, svcKey, svc); err != nil {
+				if apierrors.IsNotFound(err) && tolerateNonExistentBackendService {
+					*action = b.build503ResponseAction(nonExistentBackendServiceMessageBody)
+					return nil
+				}
+				return err
+			}
+			backendServices[svcKey] = svc
+		}
+	}
+	return nil
+}
+
+func (b *defaultEnhancedBackendBuilder) buildAuthConfig(ctx context.Context, action Action, namespace string, ingAnnotation map[string]string, backendServices map[types.NamespacedName]*corev1.Service) (AuthConfig, error) {
+	svcAndIngAnnotations := ingAnnotation
+	// when forward to a single Service, the auth annotations on that Service will be merged in.
+	if action.Type == ActionTypeForward &&
+		action.ForwardConfig != nil &&
+		len(action.ForwardConfig.TargetGroups) == 1 &&
+		action.ForwardConfig.TargetGroups[0].ServiceName != nil {
+		svcName := awssdk.StringValue(action.ForwardConfig.TargetGroups[0].ServiceName)
+		svcKey := types.NamespacedName{Namespace: namespace, Name: svcName}
+		svc := backendServices[svcKey]
+		svcAndIngAnnotations = algorithm.MergeStringMap(svc.Annotations, svcAndIngAnnotations)
+	}
+
+	return b.authConfigBuilder.Build(ctx, svcAndIngAnnotations)
+}
+
+// build503ResponseAction generates a 503 fixed response action when forward to a single non-existent Kubernetes Service.
+func (b *defaultEnhancedBackendBuilder) build503ResponseAction(messageBody string) Action {
+	return Action{
+		Type: ActionTypeFixedResponse,
+		FixedResponseConfig: &FixedResponseActionConfig{
+			ContentType: awssdk.String("text/plain"),
+			StatusCode:  "503",
+			MessageBody: awssdk.String(messageBody),
 		},
 	}
 }

--- a/pkg/ingress/enhanced_backend_builder_test.go
+++ b/pkg/ingress/enhanced_backend_builder_test.go
@@ -6,37 +6,75 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/equality"
+	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"testing"
 )
 
 func Test_defaultEnhancedBackendBuilder_Build(t *testing.T) {
+	type env struct {
+		svcs []*corev1.Service
+	}
+	type fields struct {
+		tolerateNonExistentBackendService bool
+		tolerateNonExistentBackendAction  bool
+	}
 	type args struct {
 		ing     *networking.Ingress
 		backend networking.IngressBackend
+
+		loadBackendServices bool
+		loadAuthConfig      bool
+		backendServices     map[types.NamespacedName]*corev1.Service
+	}
+
+	svc1 := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "awesome-ns",
+			Name:      "svc-1",
+		},
 	}
 	portHTTP := intstr.FromString("http")
 	tests := []struct {
-		name    string
-		args    args
-		want    EnhancedBackend
-		wantErr error
+		name                string
+		env                 env
+		fields              fields
+		args                args
+		want                EnhancedBackend
+		wantBackendServices map[types.NamespacedName]*corev1.Service
+		wantErr             error
 	}{
 		{
 			name: "vanilla serviceBackend",
+			env: env{
+				svcs: []*corev1.Service{svc1},
+			},
+			fields: fields{
+				tolerateNonExistentBackendService: true,
+				tolerateNonExistentBackendAction:  true,
+			},
 			args: args{
 				ing: &networking.Ingress{
 					ObjectMeta: metav1.ObjectMeta{
+						Namespace:   "awesome-ns",
 						Annotations: map[string]string{},
 					},
 				},
 				backend: networking.IngressBackend{
-					ServiceName: "my-svc",
+					ServiceName: "svc-1",
 					ServicePort: portHTTP,
 				},
+				loadBackendServices: true,
+				loadAuthConfig:      true,
+				backendServices:     map[types.NamespacedName]*corev1.Service{},
 			},
 			want: EnhancedBackend{
 				Action: Action{
@@ -44,41 +82,51 @@ func Test_defaultEnhancedBackendBuilder_Build(t *testing.T) {
 					ForwardConfig: &ForwardActionConfig{
 						TargetGroups: []TargetGroupTuple{
 							{
-								ServiceName: awssdk.String("my-svc"),
+								ServiceName: awssdk.String("svc-1"),
 								ServicePort: &portHTTP,
 							},
 						},
 					},
 				},
+				AuthConfig: AuthConfig{
+					Type:                     AuthTypeNone,
+					OnUnauthenticatedRequest: "authenticate",
+					Scope:                    "openid",
+					SessionCookieName:        "AWSELBAuthSessionCookie",
+					SessionTimeout:           604800,
+				},
+			},
+			wantBackendServices: map[types.NamespacedName]*corev1.Service{
+				types.NamespacedName{Namespace: "awesome-ns", Name: "svc-1"}: svc1,
 			},
 		},
 		{
 			name: "vanilla serviceBackend with additional conditions",
+			env: env{
+				svcs: []*corev1.Service{svc1},
+			},
+			fields: fields{
+				tolerateNonExistentBackendService: true,
+				tolerateNonExistentBackendAction:  true,
+			},
 			args: args{
 				ing: &networking.Ingress{
 					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
 						Annotations: map[string]string{
-							"alb.ingress.kubernetes.io/conditions.my-svc": `[{"field":"http-header","httpHeaderConfig":{"httpHeaderName": "HeaderName", "values":["HeaderValue1", "HeaderValue2"]}}]`,
+							"alb.ingress.kubernetes.io/conditions.svc-1": `[{"field":"http-header","httpHeaderConfig":{"httpHeaderName": "HeaderName", "values":["HeaderValue1", "HeaderValue2"]}}]`,
 						},
 					},
 				},
 				backend: networking.IngressBackend{
-					ServiceName: "my-svc",
+					ServiceName: "svc-1",
 					ServicePort: portHTTP,
 				},
+				loadBackendServices: true,
+				loadAuthConfig:      true,
+				backendServices:     map[types.NamespacedName]*corev1.Service{},
 			},
 			want: EnhancedBackend{
-				Action: Action{
-					Type: ActionTypeForward,
-					ForwardConfig: &ForwardActionConfig{
-						TargetGroups: []TargetGroupTuple{
-							{
-								ServiceName: awssdk.String("my-svc"),
-								ServicePort: &portHTTP,
-							},
-						},
-					},
-				},
 				Conditions: []RuleCondition{
 					{
 						Field: RuleConditionFieldHTTPHeader,
@@ -88,22 +136,55 @@ func Test_defaultEnhancedBackendBuilder_Build(t *testing.T) {
 						},
 					},
 				},
+				Action: Action{
+					Type: ActionTypeForward,
+					ForwardConfig: &ForwardActionConfig{
+						TargetGroups: []TargetGroupTuple{
+							{
+								ServiceName: awssdk.String("svc-1"),
+								ServicePort: &portHTTP,
+							},
+						},
+					},
+				},
+				AuthConfig: AuthConfig{
+					Type:                     AuthTypeNone,
+					OnUnauthenticatedRequest: "authenticate",
+					Scope:                    "openid",
+					SessionCookieName:        "AWSELBAuthSessionCookie",
+					SessionTimeout:           604800,
+				},
+			},
+			wantBackendServices: map[types.NamespacedName]*corev1.Service{
+				types.NamespacedName{Namespace: "awesome-ns", Name: "svc-1"}: svc1,
 			},
 		},
 		{
-			name: "annotation-based serviceBackend",
+			name: "vanilla serviceBackend with additional auth configuration",
+			env: env{
+				svcs: []*corev1.Service{svc1},
+			},
+			fields: fields{
+				tolerateNonExistentBackendService: true,
+				tolerateNonExistentBackendAction:  true,
+			},
 			args: args{
 				ing: &networking.Ingress{
 					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
 						Annotations: map[string]string{
-							"alb.ingress.kubernetes.io/actions.fake-my-svc": `{"type":"forward","forwardConfig":{"targetGroups":[{"serviceName":"my-svc","servicePort":"http"}]}}`,
+							"alb.ingress.kubernetes.io/auth-type":        "cognito",
+							"alb.ingress.kubernetes.io/auth-idp-cognito": "{\"userPoolARN\":\"arn:aws:cognito-idp:us-west-2:xxx:userpool/xxx\",\"userPoolClientID\":\"my-clientID\",\"userPoolDomain\":\"my-domain\"}",
 						},
 					},
 				},
 				backend: networking.IngressBackend{
-					ServiceName: "fake-my-svc",
-					ServicePort: intstr.FromString("use-annotation"),
+					ServiceName: "svc-1",
+					ServicePort: portHTTP,
 				},
+				loadBackendServices: true,
+				loadAuthConfig:      true,
+				backendServices:     map[types.NamespacedName]*corev1.Service{},
 			},
 			want: EnhancedBackend{
 				Action: Action{
@@ -111,21 +192,202 @@ func Test_defaultEnhancedBackendBuilder_Build(t *testing.T) {
 					ForwardConfig: &ForwardActionConfig{
 						TargetGroups: []TargetGroupTuple{
 							{
-								ServiceName: awssdk.String("my-svc"),
+								ServiceName: awssdk.String("svc-1"),
+								ServicePort: &portHTTP,
+							},
+						},
+					},
+				},
+				AuthConfig: AuthConfig{
+					Type: AuthTypeCognito,
+					IDPConfigCognito: &AuthIDPConfigCognito{
+						UserPoolARN:      "arn:aws:cognito-idp:us-west-2:xxx:userpool/xxx",
+						UserPoolClientID: "my-clientID",
+						UserPoolDomain:   "my-domain",
+					},
+					OnUnauthenticatedRequest: "authenticate",
+					Scope:                    "openid",
+					SessionCookieName:        "AWSELBAuthSessionCookie",
+					SessionTimeout:           604800,
+				},
+			},
+			wantBackendServices: map[types.NamespacedName]*corev1.Service{
+				types.NamespacedName{Namespace: "awesome-ns", Name: "svc-1"}: svc1,
+			},
+		},
+		{
+			name: "vanilla serviceBackend - non-existent service and tolerateNonExistentBackendService==true",
+			env: env{
+				svcs: []*corev1.Service{svc1},
+			},
+			fields: fields{
+				tolerateNonExistentBackendService: true,
+				tolerateNonExistentBackendAction:  true,
+			},
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:   "awesome-ns",
+						Annotations: map[string]string{},
+					},
+				},
+				backend: networking.IngressBackend{
+					ServiceName: "svc-2",
+					ServicePort: portHTTP,
+				},
+				loadBackendServices: true,
+				loadAuthConfig:      true,
+				backendServices:     map[types.NamespacedName]*corev1.Service{},
+			},
+			want: EnhancedBackend{
+				Action: Action{
+					Type: ActionTypeFixedResponse,
+					FixedResponseConfig: &FixedResponseActionConfig{
+						ContentType: awssdk.String("text/plain"),
+						StatusCode:  "503",
+						MessageBody: awssdk.String(nonExistentBackendServiceMessageBody),
+					},
+				},
+				AuthConfig: AuthConfig{
+					Type:                     AuthTypeNone,
+					OnUnauthenticatedRequest: "authenticate",
+					Scope:                    "openid",
+					SessionCookieName:        "AWSELBAuthSessionCookie",
+					SessionTimeout:           604800,
+				},
+			},
+			wantBackendServices: map[types.NamespacedName]*corev1.Service{},
+		},
+		{
+			name: "vanilla serviceBackend - non-existent service and tolerateNonExistentBackendService==false",
+			env: env{
+				svcs: []*corev1.Service{svc1},
+			},
+			fields: fields{
+				tolerateNonExistentBackendService: false,
+				tolerateNonExistentBackendAction:  true,
+			},
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:   "awesome-ns",
+						Annotations: map[string]string{},
+					},
+				},
+				backend: networking.IngressBackend{
+					ServiceName: "svc-2",
+					ServicePort: portHTTP,
+				},
+				loadBackendServices: true,
+				loadAuthConfig:      true,
+				backendServices:     map[types.NamespacedName]*corev1.Service{},
+			},
+			wantErr: errors.New("services \"svc-2\" not found"),
+		},
+		{
+			name: "vanilla serviceBackend - non-existent service and tolerateNonExistentBackendService==false without loadBackendServices ",
+			env: env{
+				svcs: []*corev1.Service{svc1},
+			},
+			fields: fields{
+				tolerateNonExistentBackendService: false,
+				tolerateNonExistentBackendAction:  true,
+			},
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:   "awesome-ns",
+						Annotations: map[string]string{},
+					},
+				},
+				backend: networking.IngressBackend{
+					ServiceName: "svc-2",
+					ServicePort: portHTTP,
+				},
+				loadBackendServices: false,
+				loadAuthConfig:      false,
+				backendServices:     map[types.NamespacedName]*corev1.Service{},
+			},
+			want: EnhancedBackend{
+				Action: Action{
+					Type: ActionTypeForward,
+					ForwardConfig: &ForwardActionConfig{
+						TargetGroups: []TargetGroupTuple{
+							{
+								ServiceName: awssdk.String("svc-2"),
 								ServicePort: &portHTTP,
 							},
 						},
 					},
 				},
 			},
+			wantBackendServices: map[types.NamespacedName]*corev1.Service{},
 		},
 		{
-			name: "annotation-based with additional conditions",
+			name: "annotation-based serviceBackend",
+			env: env{
+				svcs: []*corev1.Service{svc1},
+			},
+			fields: fields{
+				tolerateNonExistentBackendService: true,
+				tolerateNonExistentBackendAction:  true,
+			},
 			args: args{
 				ing: &networking.Ingress{
 					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
 						Annotations: map[string]string{
-							"alb.ingress.kubernetes.io/actions.fake-my-svc":    `{"type":"forward","forwardConfig":{"targetGroups":[{"serviceName":"my-svc","servicePort":"http"}]}}`,
+							"alb.ingress.kubernetes.io/actions.fake-my-svc": `{"type":"forward","forwardConfig":{"targetGroups":[{"serviceName":"svc-1","servicePort":"http"}]}}`,
+						},
+					},
+				},
+				backend: networking.IngressBackend{
+					ServiceName: "fake-my-svc",
+					ServicePort: intstr.FromString("use-annotation"),
+				},
+				loadBackendServices: true,
+				loadAuthConfig:      true,
+				backendServices:     map[types.NamespacedName]*corev1.Service{},
+			},
+			want: EnhancedBackend{
+				Action: Action{
+					Type: ActionTypeForward,
+					ForwardConfig: &ForwardActionConfig{
+						TargetGroups: []TargetGroupTuple{
+							{
+								ServiceName: awssdk.String("svc-1"),
+								ServicePort: &portHTTP,
+							},
+						},
+					},
+				},
+				AuthConfig: AuthConfig{
+					Type:                     AuthTypeNone,
+					OnUnauthenticatedRequest: "authenticate",
+					Scope:                    "openid",
+					SessionCookieName:        "AWSELBAuthSessionCookie",
+					SessionTimeout:           604800,
+				},
+			},
+			wantBackendServices: map[types.NamespacedName]*corev1.Service{
+				types.NamespacedName{Namespace: "awesome-ns", Name: "svc-1"}: svc1,
+			},
+		},
+		{
+			name: "annotation-based with additional conditions",
+			env: env{
+				svcs: []*corev1.Service{svc1},
+			},
+			fields: fields{
+				tolerateNonExistentBackendService: true,
+				tolerateNonExistentBackendAction:  true,
+			},
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Annotations: map[string]string{
+							"alb.ingress.kubernetes.io/actions.fake-my-svc":    `{"type":"forward","forwardConfig":{"targetGroups":[{"serviceName":"svc-1","servicePort":"http"}]}}`,
 							"alb.ingress.kubernetes.io/conditions.fake-my-svc": `[{"field":"http-header","httpHeaderConfig":{"httpHeaderName": "HeaderName", "values":["HeaderValue1", "HeaderValue2"]}}]`,
 						},
 					},
@@ -134,19 +396,11 @@ func Test_defaultEnhancedBackendBuilder_Build(t *testing.T) {
 					ServiceName: "fake-my-svc",
 					ServicePort: intstr.FromString("use-annotation"),
 				},
+				loadBackendServices: true,
+				loadAuthConfig:      true,
+				backendServices:     map[types.NamespacedName]*corev1.Service{},
 			},
 			want: EnhancedBackend{
-				Action: Action{
-					Type: ActionTypeForward,
-					ForwardConfig: &ForwardActionConfig{
-						TargetGroups: []TargetGroupTuple{
-							{
-								ServiceName: awssdk.String("my-svc"),
-								ServicePort: &portHTTP,
-							},
-						},
-					},
-				},
 				Conditions: []RuleCondition{
 					{
 						Field: RuleConditionFieldHTTPHeader,
@@ -156,21 +410,189 @@ func Test_defaultEnhancedBackendBuilder_Build(t *testing.T) {
 						},
 					},
 				},
+				Action: Action{
+					Type: ActionTypeForward,
+					ForwardConfig: &ForwardActionConfig{
+						TargetGroups: []TargetGroupTuple{
+							{
+								ServiceName: awssdk.String("svc-1"),
+								ServicePort: &portHTTP,
+							},
+						},
+					},
+				},
+				AuthConfig: AuthConfig{
+					Type:                     AuthTypeNone,
+					OnUnauthenticatedRequest: "authenticate",
+					Scope:                    "openid",
+					SessionCookieName:        "AWSELBAuthSessionCookie",
+					SessionTimeout:           604800,
+				},
 			},
+			wantBackendServices: map[types.NamespacedName]*corev1.Service{
+				types.NamespacedName{Namespace: "awesome-ns", Name: "svc-1"}: svc1,
+			},
+		},
+		{
+			name: "annotation-based with additional auth configuration",
+			env: env{
+				svcs: []*corev1.Service{svc1},
+			},
+			fields: fields{
+				tolerateNonExistentBackendService: true,
+				tolerateNonExistentBackendAction:  true,
+			},
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Annotations: map[string]string{
+							"alb.ingress.kubernetes.io/actions.fake-my-svc": `{"type":"forward","forwardConfig":{"targetGroups":[{"serviceName":"svc-1","servicePort":"http"}]}}`,
+							"alb.ingress.kubernetes.io/auth-type":           "cognito",
+							"alb.ingress.kubernetes.io/auth-idp-cognito":    "{\"userPoolARN\":\"arn:aws:cognito-idp:us-west-2:xxx:userpool/xxx\",\"userPoolClientID\":\"my-clientID\",\"userPoolDomain\":\"my-domain\"}",
+						},
+					},
+				},
+				backend: networking.IngressBackend{
+					ServiceName: "fake-my-svc",
+					ServicePort: intstr.FromString("use-annotation"),
+				},
+				loadBackendServices: true,
+				loadAuthConfig:      true,
+				backendServices:     map[types.NamespacedName]*corev1.Service{},
+			},
+			want: EnhancedBackend{
+				Action: Action{
+					Type: ActionTypeForward,
+					ForwardConfig: &ForwardActionConfig{
+						TargetGroups: []TargetGroupTuple{
+							{
+								ServiceName: awssdk.String("svc-1"),
+								ServicePort: &portHTTP,
+							},
+						},
+					},
+				},
+				AuthConfig: AuthConfig{
+					Type: AuthTypeCognito,
+					IDPConfigCognito: &AuthIDPConfigCognito{
+						UserPoolARN:      "arn:aws:cognito-idp:us-west-2:xxx:userpool/xxx",
+						UserPoolClientID: "my-clientID",
+						UserPoolDomain:   "my-domain",
+					},
+					OnUnauthenticatedRequest: "authenticate",
+					Scope:                    "openid",
+					SessionCookieName:        "AWSELBAuthSessionCookie",
+					SessionTimeout:           604800,
+				},
+			},
+			wantBackendServices: map[types.NamespacedName]*corev1.Service{
+				types.NamespacedName{Namespace: "awesome-ns", Name: "svc-1"}: svc1,
+			},
+		},
+		{
+			name: "annotation-based serviceBackend - non-existent action and tolerateNonExistentBackendAction==true",
+			env: env{
+				svcs: []*corev1.Service{svc1},
+			},
+			fields: fields{
+				tolerateNonExistentBackendService: true,
+				tolerateNonExistentBackendAction:  true,
+			},
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:   "awesome-ns",
+						Annotations: map[string]string{},
+					},
+				},
+				backend: networking.IngressBackend{
+					ServiceName: "fake-my-svc",
+					ServicePort: intstr.FromString("use-annotation"),
+				},
+				loadBackendServices: true,
+				loadAuthConfig:      true,
+				backendServices:     map[types.NamespacedName]*corev1.Service{},
+			},
+			want: EnhancedBackend{
+				Action: Action{
+					Type: ActionTypeFixedResponse,
+					FixedResponseConfig: &FixedResponseActionConfig{
+						ContentType: awssdk.String("text/plain"),
+						StatusCode:  "503",
+						MessageBody: awssdk.String(nonExistentBackendActionMessageBody),
+					},
+				},
+				AuthConfig: AuthConfig{
+					Type:                     AuthTypeNone,
+					OnUnauthenticatedRequest: "authenticate",
+					Scope:                    "openid",
+					SessionCookieName:        "AWSELBAuthSessionCookie",
+					SessionTimeout:           604800,
+				},
+			},
+			wantBackendServices: map[types.NamespacedName]*corev1.Service{},
+		},
+		{
+			name: "annotation-based serviceBackend - non-existent action and tolerateNonExistentBackendAction==false",
+			env: env{
+				svcs: []*corev1.Service{svc1},
+			},
+			fields: fields{
+				tolerateNonExistentBackendService: true,
+				tolerateNonExistentBackendAction:  false,
+			},
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:   "awesome-ns",
+						Annotations: map[string]string{},
+					},
+				},
+				backend: networking.IngressBackend{
+					ServiceName: "fake-my-svc",
+					ServicePort: intstr.FromString("use-annotation"),
+				},
+				loadBackendServices: true,
+				loadAuthConfig:      true,
+				backendServices:     map[types.NamespacedName]*corev1.Service{},
+			},
+			wantErr: errors.New("missing actions.fake-my-svc configuration"),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			annotationParser := annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io")
-			b := &defaultEnhancedBackendBuilder{
-				annotationParser: annotationParser,
+			ctx := context.Background()
+			k8sSchema := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sSchema)
+			k8sClient := testclient.NewFakeClientWithScheme(k8sSchema)
+			for _, svc := range tt.env.svcs {
+				assert.NoError(t, k8sClient.Create(ctx, svc.DeepCopy()))
 			}
-			got, err := b.Build(context.Background(), tt.args.ing, tt.args.backend)
+
+			annotationParser := annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io")
+			authConfigBuilder := NewDefaultAuthConfigBuilder(annotationParser)
+			b := &defaultEnhancedBackendBuilder{
+				k8sClient:                         k8sClient,
+				annotationParser:                  annotationParser,
+				authConfigBuilder:                 authConfigBuilder,
+				tolerateNonExistentBackendService: tt.fields.tolerateNonExistentBackendService,
+				tolerateNonExistentBackendAction:  tt.fields.tolerateNonExistentBackendAction,
+			}
+
+			got, err := b.Build(context.Background(), tt.args.ing, tt.args.backend,
+				WithLoadBackendServices(tt.args.loadBackendServices, tt.args.backendServices),
+				WithLoadAuthConfig(tt.args.loadAuthConfig))
 			if tt.wantErr != nil {
 				assert.EqualError(t, err, tt.wantErr.Error())
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.want, got, "diff", cmp.Diff(tt.want, got))
+				if tt.args.loadBackendServices {
+					opt := equality.IgnoreFakeClientPopulatedFields()
+					assert.True(t, cmp.Equal(tt.wantBackendServices, tt.args.backendServices, opt),
+						"diff: %v", cmp.Diff(tt.wantBackendServices, tt.args.backendServices, opt))
+				}
 			}
 		})
 	}
@@ -809,6 +1231,512 @@ func Test_defaultEnhancedBackendBuilder_buildActionViaServiceAndServicePort(t *t
 			b := &defaultEnhancedBackendBuilder{}
 			got := b.buildActionViaServiceAndServicePort(context.Background(), tt.args.svcName, tt.args.svcPort)
 
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_defaultEnhancedBackendBuilder_loadBackendServices(t *testing.T) {
+	port80 := intstr.FromInt(80)
+	svc1 := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "awesome-ns",
+			Name:      "svc-1",
+			Annotations: map[string]string{
+				"version": "2",
+			},
+		},
+	}
+	svc1_v1 := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "awesome-ns",
+			Name:      "svc-1",
+			Annotations: map[string]string{
+				"version": "1",
+			},
+		},
+	}
+	svc2 := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "awesome-ns",
+			Name:      "svc-2",
+		},
+	}
+
+	type env struct {
+		svcs []*corev1.Service
+	}
+	type fields struct {
+		tolerateNonExistentBackendService bool
+	}
+	type args struct {
+		action          *Action
+		namespace       string
+		backendServices map[types.NamespacedName]*corev1.Service
+	}
+	tests := []struct {
+		name                string
+		env                 env
+		fields              fields
+		args                args
+		wantAction          Action
+		wantBackendServices map[types.NamespacedName]*corev1.Service
+		wantErr             error
+	}{
+		{
+			name: "forward to a single exists service",
+			env: env{
+				svcs: []*corev1.Service{svc1, svc2},
+			},
+			fields: fields{
+				tolerateNonExistentBackendService: true,
+			},
+			args: args{
+				action: &Action{
+					Type: ActionTypeForward,
+					ForwardConfig: &ForwardActionConfig{
+						TargetGroups: []TargetGroupTuple{
+							{
+								ServiceName: awssdk.String("svc-1"),
+								ServicePort: &port80,
+							},
+						},
+					},
+				},
+				namespace:       "awesome-ns",
+				backendServices: map[types.NamespacedName]*corev1.Service{},
+			},
+			wantAction: Action{
+				Type: ActionTypeForward,
+				ForwardConfig: &ForwardActionConfig{
+					TargetGroups: []TargetGroupTuple{
+						{
+							ServiceName: awssdk.String("svc-1"),
+							ServicePort: &port80,
+						},
+					},
+				},
+			},
+			wantBackendServices: map[types.NamespacedName]*corev1.Service{
+				types.NamespacedName{Namespace: "awesome-ns", Name: "svc-1"}: svc1,
+			},
+		},
+		{
+			name: "forward to multiple exists service",
+			env: env{
+				svcs: []*corev1.Service{svc1, svc2},
+			},
+			fields: fields{
+				tolerateNonExistentBackendService: true,
+			},
+			args: args{
+				action: &Action{
+					Type: ActionTypeForward,
+					ForwardConfig: &ForwardActionConfig{
+						TargetGroups: []TargetGroupTuple{
+							{
+								ServiceName: awssdk.String("svc-1"),
+								ServicePort: &port80,
+							},
+							{
+								ServiceName: awssdk.String("svc-2"),
+								ServicePort: &port80,
+							},
+						},
+					},
+				},
+				namespace:       "awesome-ns",
+				backendServices: map[types.NamespacedName]*corev1.Service{},
+			},
+			wantAction: Action{
+				Type: ActionTypeForward,
+				ForwardConfig: &ForwardActionConfig{
+					TargetGroups: []TargetGroupTuple{
+						{
+							ServiceName: awssdk.String("svc-1"),
+							ServicePort: &port80,
+						},
+						{
+							ServiceName: awssdk.String("svc-2"),
+							ServicePort: &port80,
+						},
+					},
+				},
+			},
+			wantBackendServices: map[types.NamespacedName]*corev1.Service{
+				types.NamespacedName{Namespace: "awesome-ns", Name: "svc-1"}: svc1,
+				types.NamespacedName{Namespace: "awesome-ns", Name: "svc-2"}: svc2,
+			},
+		},
+		{
+			name: "forward to multiple exists service - svc1 has older snapshot",
+			env: env{
+				svcs: []*corev1.Service{svc1, svc2},
+			},
+			fields: fields{
+				tolerateNonExistentBackendService: true,
+			},
+			args: args{
+				action: &Action{
+					Type: ActionTypeForward,
+					ForwardConfig: &ForwardActionConfig{
+						TargetGroups: []TargetGroupTuple{
+							{
+								ServiceName: awssdk.String("svc-1"),
+								ServicePort: &port80,
+							},
+							{
+								ServiceName: awssdk.String("svc-2"),
+								ServicePort: &port80,
+							},
+						},
+					},
+				},
+				namespace: "awesome-ns",
+				backendServices: map[types.NamespacedName]*corev1.Service{
+					types.NamespacedName{Namespace: "awesome-ns", Name: "svc-1"}: svc1_v1,
+				},
+			},
+			wantAction: Action{
+				Type: ActionTypeForward,
+				ForwardConfig: &ForwardActionConfig{
+					TargetGroups: []TargetGroupTuple{
+						{
+							ServiceName: awssdk.String("svc-1"),
+							ServicePort: &port80,
+						},
+						{
+							ServiceName: awssdk.String("svc-2"),
+							ServicePort: &port80,
+						},
+					},
+				},
+			},
+			wantBackendServices: map[types.NamespacedName]*corev1.Service{
+				types.NamespacedName{Namespace: "awesome-ns", Name: "svc-1"}: svc1_v1,
+				types.NamespacedName{Namespace: "awesome-ns", Name: "svc-2"}: svc2,
+			},
+		},
+		{
+			name: "forward to a single non-existent service - tolerateNonExistentBackendService == true",
+			env: env{
+				svcs: []*corev1.Service{},
+			},
+			fields: fields{
+				tolerateNonExistentBackendService: true,
+			},
+			args: args{
+				action: &Action{
+					Type: ActionTypeForward,
+					ForwardConfig: &ForwardActionConfig{
+						TargetGroups: []TargetGroupTuple{
+							{
+								ServiceName: awssdk.String("svc-1"),
+								ServicePort: &port80,
+							},
+						},
+					},
+				},
+				namespace:       "awesome-ns",
+				backendServices: map[types.NamespacedName]*corev1.Service{},
+			},
+			wantAction: Action{
+				Type: ActionTypeFixedResponse,
+				FixedResponseConfig: &FixedResponseActionConfig{
+					ContentType: awssdk.String("text/plain"),
+					StatusCode:  "503",
+					MessageBody: awssdk.String(nonExistentBackendServiceMessageBody),
+				},
+			},
+			wantBackendServices: map[types.NamespacedName]*corev1.Service{},
+		},
+		{
+			name: "forward to a single non-existent service - tolerateNonExistentBackendService == false",
+			env: env{
+				svcs: []*corev1.Service{},
+			},
+			fields: fields{
+				tolerateNonExistentBackendService: false,
+			},
+			args: args{
+				action: &Action{
+					Type: ActionTypeForward,
+					ForwardConfig: &ForwardActionConfig{
+						TargetGroups: []TargetGroupTuple{
+							{
+								ServiceName: awssdk.String("svc-1"),
+								ServicePort: &port80,
+							},
+						},
+					},
+				},
+				namespace:       "awesome-ns",
+				backendServices: map[types.NamespacedName]*corev1.Service{},
+			},
+			wantErr: errors.New("services \"svc-1\" not found"),
+		},
+		{
+			name: "forward to multiple services, one of them is non-existent - tolerateNonExistentBackendService == true",
+			env: env{
+				svcs: []*corev1.Service{svc1},
+			},
+			fields: fields{
+				tolerateNonExistentBackendService: true,
+			},
+			args: args{
+				action: &Action{
+					Type: ActionTypeForward,
+					ForwardConfig: &ForwardActionConfig{
+						TargetGroups: []TargetGroupTuple{
+							{
+								ServiceName: awssdk.String("svc-1"),
+								ServicePort: &port80,
+							},
+							{
+								ServiceName: awssdk.String("svc-2"),
+								ServicePort: &port80,
+							},
+						},
+					},
+				},
+				namespace:       "awesome-ns",
+				backendServices: map[types.NamespacedName]*corev1.Service{},
+			},
+			wantErr: errors.New("services \"svc-2\" not found"),
+		},
+		{
+			name: "load for fixed response action is noop",
+			fields: fields{
+				tolerateNonExistentBackendService: true,
+			},
+			args: args{
+				action: &Action{
+					Type: ActionTypeFixedResponse,
+					FixedResponseConfig: &FixedResponseActionConfig{
+						ContentType: awssdk.String("text/plain"),
+						StatusCode:  "404",
+					},
+				},
+				namespace:       "awesome-ns",
+				backendServices: map[types.NamespacedName]*corev1.Service{},
+			},
+			wantAction: Action{
+				Type: ActionTypeFixedResponse,
+				FixedResponseConfig: &FixedResponseActionConfig{
+					ContentType: awssdk.String("text/plain"),
+					StatusCode:  "404",
+				},
+			},
+			wantBackendServices: map[types.NamespacedName]*corev1.Service{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			k8sSchema := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sSchema)
+			k8sClient := testclient.NewFakeClientWithScheme(k8sSchema)
+			for _, svc := range tt.env.svcs {
+				assert.NoError(t, k8sClient.Create(ctx, svc.DeepCopy()))
+			}
+
+			b := &defaultEnhancedBackendBuilder{
+				k8sClient:                         k8sClient,
+				tolerateNonExistentBackendService: tt.fields.tolerateNonExistentBackendService,
+			}
+			err := b.loadBackendServices(ctx, tt.args.action, tt.args.namespace, tt.args.backendServices)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantAction, *tt.args.action)
+				opt := equality.IgnoreFakeClientPopulatedFields()
+				assert.True(t, cmp.Equal(tt.wantBackendServices, tt.args.backendServices, opt),
+					"diff: %v", cmp.Diff(tt.wantBackendServices, tt.args.backendServices, opt))
+			}
+		})
+	}
+}
+
+func Test_defaultEnhancedBackendBuilder_buildAuthConfig(t *testing.T) {
+	port80 := intstr.FromInt(80)
+	type args struct {
+		action          Action
+		namespace       string
+		ingAnnotation   map[string]string
+		backendServices map[types.NamespacedName]*corev1.Service
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    AuthConfig
+		wantErr error
+	}{
+		{
+			name: "forward action with single targetGroup will load authConfig from Ingress & Service",
+			args: args{
+				action: Action{
+					Type: ActionTypeForward,
+					ForwardConfig: &ForwardActionConfig{
+						TargetGroups: []TargetGroupTuple{
+							{
+								ServiceName: awssdk.String("my-svc"),
+								ServicePort: &port80,
+							},
+						},
+					},
+				},
+				namespace: "awesome-ns",
+				ingAnnotation: map[string]string{
+					"alb.ingress.kubernetes.io/auth-type":        "cognito",
+					"alb.ingress.kubernetes.io/auth-idp-cognito": "{\"userPoolARN\":\"arn:aws:cognito-idp:us-west-2:xxx:userpool/xxx\",\"userPoolClientID\":\"my-clientID\",\"userPoolDomain\":\"my-domain\"}",
+				},
+				backendServices: map[types.NamespacedName]*corev1.Service{
+					types.NamespacedName{Namespace: "awesome-ns", Name: "my-svc"}: {
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"alb.ingress.kubernetes.io/auth-type": "none",
+							},
+						},
+					},
+				},
+			},
+			want: AuthConfig{
+				Type: AuthTypeNone,
+				IDPConfigCognito: &AuthIDPConfigCognito{
+					UserPoolARN:      "arn:aws:cognito-idp:us-west-2:xxx:userpool/xxx",
+					UserPoolClientID: "my-clientID",
+					UserPoolDomain:   "my-domain",
+				},
+				OnUnauthenticatedRequest: "authenticate",
+				Scope:                    "openid",
+				SessionCookieName:        "AWSELBAuthSessionCookie",
+				SessionTimeout:           604800,
+			},
+		},
+		{
+			name: "forward action with multiple targetGroup will load authConfig from Ingress",
+			args: args{
+				action: Action{
+					Type: ActionTypeForward,
+					ForwardConfig: &ForwardActionConfig{
+						TargetGroups: []TargetGroupTuple{
+							{
+								TargetGroupARN: awssdk.String("my-tg-arn"),
+							},
+							{
+								ServiceName: awssdk.String("my-svc"),
+								ServicePort: &port80,
+							},
+						},
+					},
+				},
+				namespace: "awesome-ns",
+				ingAnnotation: map[string]string{
+					"alb.ingress.kubernetes.io/auth-type":        "cognito",
+					"alb.ingress.kubernetes.io/auth-idp-cognito": "{\"userPoolARN\":\"arn:aws:cognito-idp:us-west-2:xxx:userpool/xxx\",\"userPoolClientID\":\"my-clientID\",\"userPoolDomain\":\"my-domain\"}",
+				},
+				backendServices: map[types.NamespacedName]*corev1.Service{
+					types.NamespacedName{Namespace: "awesome-ns", Name: "my-svc"}: {
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"alb.ingress.kubernetes.io/auth-type": "none",
+							},
+						},
+					},
+				},
+			},
+			want: AuthConfig{
+				Type: AuthTypeCognito,
+				IDPConfigCognito: &AuthIDPConfigCognito{
+					UserPoolARN:      "arn:aws:cognito-idp:us-west-2:xxx:userpool/xxx",
+					UserPoolClientID: "my-clientID",
+					UserPoolDomain:   "my-domain",
+				},
+				OnUnauthenticatedRequest: "authenticate",
+				Scope:                    "openid",
+				SessionCookieName:        "AWSELBAuthSessionCookie",
+				SessionTimeout:           604800,
+			},
+		},
+		{
+			name: "fixed response action will load authConfig from Ingress",
+			args: args{
+				action: Action{
+					Type: ActionTypeFixedResponse,
+					FixedResponseConfig: &FixedResponseActionConfig{
+						ContentType: awssdk.String("text/plain"),
+						StatusCode:  "404",
+					},
+				},
+				namespace: "awesome-ns",
+				ingAnnotation: map[string]string{
+					"alb.ingress.kubernetes.io/auth-type":        "cognito",
+					"alb.ingress.kubernetes.io/auth-idp-cognito": "{\"userPoolARN\":\"arn:aws:cognito-idp:us-west-2:xxx:userpool/xxx\",\"userPoolClientID\":\"my-clientID\",\"userPoolDomain\":\"my-domain\"}",
+				},
+				backendServices: map[types.NamespacedName]*corev1.Service{},
+			},
+			want: AuthConfig{
+				Type: AuthTypeCognito,
+				IDPConfigCognito: &AuthIDPConfigCognito{
+					UserPoolARN:      "arn:aws:cognito-idp:us-west-2:xxx:userpool/xxx",
+					UserPoolClientID: "my-clientID",
+					UserPoolDomain:   "my-domain",
+				},
+				OnUnauthenticatedRequest: "authenticate",
+				Scope:                    "openid",
+				SessionCookieName:        "AWSELBAuthSessionCookie",
+				SessionTimeout:           604800,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			annotationParser := annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io")
+			authConfigBuilder := NewDefaultAuthConfigBuilder(annotationParser)
+			b := &defaultEnhancedBackendBuilder{
+				annotationParser:  annotationParser,
+				authConfigBuilder: authConfigBuilder,
+			}
+			got, err := b.buildAuthConfig(context.Background(), tt.args.action, tt.args.namespace, tt.args.ingAnnotation, tt.args.backendServices)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func Test_defaultEnhancedBackendBuilder_build503ResponseAction(t *testing.T) {
+	type args struct {
+		messageBody string
+	}
+	tests := []struct {
+		name string
+		args args
+		want Action
+	}{
+		{
+			name: "non-existent service",
+			args: args{
+				messageBody: "Backend service does not exist",
+			},
+			want: Action{
+				Type: ActionTypeFixedResponse,
+				FixedResponseConfig: &FixedResponseActionConfig{
+					ContentType: awssdk.String("text/plain"),
+					StatusCode:  "503",
+					MessageBody: awssdk.String("Backend service does not exist"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &defaultEnhancedBackendBuilder{}
+			got := b.build503ResponseAction(tt.args.messageBody)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/ingress/model_build_listener.go
+++ b/pkg/ingress/model_build_listener.go
@@ -76,7 +76,9 @@ func (t *defaultModelBuildTask) buildListenerDefaultActions(ctx context.Context,
 		return nil, errors.Errorf("multiple ingress defined default backend: %v", ingKeys)
 	}
 	ing := ingsWithDefaultBackend[0]
-	enhancedBackend, err := t.enhancedBackendBuilder.Build(ctx, ing, *ing.Spec.Backend)
+	enhancedBackend, err := t.enhancedBackendBuilder.Build(ctx, ing, *ing.Spec.Backend,
+		WithLoadBackendServices(true, t.backendServices),
+		WithLoadAuthConfig(true))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ingress/model_build_listener_rules.go
+++ b/pkg/ingress/model_build_listener_rules.go
@@ -24,7 +24,9 @@ func (t *defaultModelBuildTask) buildListenerRules(ctx context.Context, lsARN co
 				continue
 			}
 			for _, path := range rule.HTTP.Paths {
-				enhancedBackend, err := t.enhancedBackendBuilder.Build(ctx, ing, path.Backend)
+				enhancedBackend, err := t.enhancedBackendBuilder.Build(ctx, ing, path.Backend,
+					WithLoadBackendServices(true, t.backendServices),
+					WithLoadAuthConfig(true))
 				if err != nil {
 					return errors.Wrapf(err, "ingress: %v", k8s.NamespacedName(ing))
 				}

--- a/pkg/ingress/model_builder.go
+++ b/pkg/ingress/model_builder.go
@@ -6,6 +6,7 @@ import (
 	elbv2sdk "github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -116,8 +117,9 @@ func (b *defaultModelBuilder) Build(ctx context.Context, ingGroup Group) (core.S
 		defaultHealthCheckMatcherHTTPCode:         "200",
 		defaultHealthCheckMatcherGRPCCode:         "12",
 
-		loadBalancer: nil,
-		tgByResID:    make(map[string]*elbv2model.TargetGroup),
+		loadBalancer:    nil,
+		tgByResID:       make(map[string]*elbv2model.TargetGroup),
+		backendServices: make(map[types.NamespacedName]*corev1.Service),
 	}
 	if err := task.run(ctx); err != nil {
 		return nil, nil, err
@@ -160,9 +162,10 @@ type defaultModelBuildTask struct {
 	defaultHealthCheckMatcherHTTPCode         string
 	defaultHealthCheckMatcherGRPCCode         string
 
-	loadBalancer *elbv2model.LoadBalancer
-	managedSG    *ec2model.SecurityGroup
-	tgByResID    map[string]*elbv2model.TargetGroup
+	loadBalancer    *elbv2model.LoadBalancer
+	managedSG       *ec2model.SecurityGroup
+	tgByResID       map[string]*elbv2model.TargetGroup
+	backendServices map[types.NamespacedName]*corev1.Service
 }
 
 func (t *defaultModelBuildTask) run(ctx context.Context) error {

--- a/pkg/ingress/model_builder_test.go
+++ b/pkg/ingress/model_builder_test.go
@@ -1860,7 +1860,7 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 			certDiscovery := NewMockCertDiscovery(ctrl)
 			annotationParser := annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io")
 			authConfigBuilder := NewDefaultAuthConfigBuilder(annotationParser)
-			enhancedBackendBuilder := NewDefaultEnhancedBackendBuilder(annotationParser)
+			enhancedBackendBuilder := NewDefaultEnhancedBackendBuilder(k8sClient, annotationParser, authConfigBuilder)
 			ruleOptimizer := NewDefaultRuleOptimizer(&log.NullLogger{})
 
 			stackMarshaller := deploy.NewDefaultStackMarshaller()

--- a/pkg/ingress/reference_indexer.go
+++ b/pkg/ingress/reference_indexer.go
@@ -55,7 +55,10 @@ func (i *defaultReferenceIndexer) BuildServiceRefIndexes(ctx context.Context, in
 
 	serviceNames := sets.NewString()
 	for _, backend := range backends {
-		enhancedBackend, err := i.enhancedBackendBuilder.Build(ctx, ing, backend)
+		enhancedBackend, err := i.enhancedBackendBuilder.Build(ctx, ing, backend,
+			WithLoadBackendServices(false, nil),
+			WithLoadAuthConfig(false),
+		)
 		if err != nil {
 			i.logger.Error(err, "failed to build Ingress indexes",
 				"indexKey", IndexKeyServiceRefName)

--- a/pkg/ingress/reference_indexer_test.go
+++ b/pkg/ingress/reference_indexer_test.go
@@ -251,7 +251,7 @@ func Test_defaultReferenceIndexer_BuildServiceRefIndexes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			annotationParser := annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io")
 			authConfigBuilder := NewDefaultAuthConfigBuilder(annotationParser)
-			enhancedBackendBuilder := NewDefaultEnhancedBackendBuilder(annotationParser)
+			enhancedBackendBuilder := NewDefaultEnhancedBackendBuilder(nil, annotationParser, nil)
 			i := &defaultReferenceIndexer{
 				enhancedBackendBuilder: enhancedBackendBuilder,
 				authConfigBuilder:      authConfigBuilder,
@@ -302,7 +302,7 @@ func Test_defaultReferenceIndexer_BuildSecretRefIndexes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			annotationParser := annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io")
 			authConfigBuilder := NewDefaultAuthConfigBuilder(annotationParser)
-			enhancedBackendBuilder := NewDefaultEnhancedBackendBuilder(annotationParser)
+			enhancedBackendBuilder := NewDefaultEnhancedBackendBuilder(nil, annotationParser, nil)
 			i := &defaultReferenceIndexer{
 				enhancedBackendBuilder: enhancedBackendBuilder,
 				authConfigBuilder:      authConfigBuilder,


### PR DESCRIPTION
[**Behavior change**] This PR will tolerate misconfiguration that references non-exists service or action with following rules.
1. If a non-exists service is referenced as backend, a fixed 503 response will be used with message "Backend service does not exist"
2. If a non-exists action annotation is referenced as backend, a fixed 503 response will be used with message "Backend action does not exist"
3. If the action annotation forward to a single non-exists service, a fixed 503 response will be used with message "Backend service does not exist"

We do above behave change, so that a single misconfigured IngressRule didn't block entire Ingress or IngressGroup reconciliation.

Note to reviewer:
1. This PR also have a tiny refactor for below benefits:
    1. make sure to use the same service snapshot for same service during entire Ingress build process. (e.g. a service might get updated while the Ingress model build in progress)
    2. we build authCfg within enhancedModel builder, so that the action builder didn't need to care how authCfg should be extracted. (In the future, we might have our own CRD for backend to leverage [resource-bacd](https://kubernetes.io/docs/concepts/services-networking/ingress/#resource-backend)
 2. We have `tolerateNonExistentBackendService` and `tolerateNonExistentBackendAction` configuration, but we don't expose it for users in this version. (we might expose them in future releases if there are valid user cases that requires it).
