### PR TITLE
support for annotation aws-load-balancer-ip-target-label

### DIFF
--- a/pkg/annotations/constants.go
+++ b/pkg/annotations/constants.go
@@ -77,4 +77,5 @@ const (
 	SvcLBSuffixSubnets                       = "aws-load-balancer-subnets"
 	SvcLBSuffixALPNPolicy                    = "aws-load-balancer-alpn-policy"
 	SvcLBSuffixTargetNodeLabels              = "aws-load-balancer-target-node-labels"
+	SvcLBSuffixIPTargetLabel			     = "aws-load-balancer-ip-target-label"
 )

--- a/pkg/backend/endpoint_resolver_test.go
+++ b/pkg/backend/endpoint_resolver_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/equality"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -796,6 +797,7 @@ func Test_defaultEndpointResolver_ResolvePodEndpoints(t *testing.T) {
 				k8sClient:   k8sClient,
 				podInfoRepo: podInfoRepo,
 				logger:      &log.NullLogger{},
+				annotationParser: annotations.NewSuffixAnnotationParser(serviceAnnotationPrefix),
 			}
 			got, gotContainsPotentialReadyEndpoints, err := r.ResolvePodEndpoints(ctx, tt.args.svcKey, tt.args.port, tt.args.opts...)
 			if tt.wantErr != nil {

--- a/pkg/k8s/pod_info.go
+++ b/pkg/k8s/pod_info.go
@@ -22,6 +22,7 @@ type PodInfo struct {
 	ReadinessGates []corev1.PodReadinessGate
 	Conditions     []corev1.PodCondition
 	PodIP          string
+	PodLabels	   map[string]string
 
 	ENIInfos []PodENIInfo
 }
@@ -102,6 +103,7 @@ func buildPodInfo(pod *corev1.Pod) PodInfo {
 		ReadinessGates: pod.Spec.ReadinessGates,
 		Conditions:     pod.Status.Conditions,
 		PodIP:          pod.Status.PodIP,
+		PodLabels:      pod.Labels,
 
 		ENIInfos: podENIInfos,
 	}

--- a/pkg/k8s/pod_info.go
+++ b/pkg/k8s/pod_info.go
@@ -62,7 +62,6 @@ func (i *PodInfo) GetPodCondition(conditionType corev1.PodConditionType) (corev1
 			return cond, true
 		}
 	}
-
 	return corev1.PodCondition{}, false
 }
 


### PR DESCRIPTION
#1963 

This PR will allow for specification of Target IP from pod label with label specified from `service.beta.kubernetes.io/aws-load-balancer-ip-target-label`

Please advise on any modifications or additions. 