### PR TITLE
Limit HealthCheckNodePort to service type LoadBalancer

### DIFF
--- a/pkg/service/model_build_target_group.go
+++ b/pkg/service/model_build_target_group.go
@@ -82,7 +82,8 @@ func (t *defaultModelBuildTask) buildTargetGroupSpec(ctx context.Context, tgProt
 }
 
 func (t *defaultModelBuildTask) buildTargetGroupHealthCheckConfig(ctx context.Context, targetType elbv2model.TargetType) (*elbv2model.TargetGroupHealthCheckConfig, error) {
-	if targetType == elbv2model.TargetTypeInstance && t.service.Spec.ExternalTrafficPolicy == corev1.ServiceExternalTrafficPolicyTypeLocal {
+	if targetType == elbv2model.TargetTypeInstance && t.service.Spec.ExternalTrafficPolicy == corev1.ServiceExternalTrafficPolicyTypeLocal &&
+		t.service.Spec.Type == corev1.ServiceTypeLoadBalancer {
 		return t.buildTargetGroupHealthCheckConfigForInstanceModeLocal(ctx)
 	}
 	return t.buildTargetGroupHealthCheckConfigDefault(ctx)

--- a/pkg/service/model_build_target_group_test.go
+++ b/pkg/service/model_build_target_group_test.go
@@ -292,6 +292,7 @@ func Test_defaultModelBuilderTask_buildTargetHealthCheck(t *testing.T) {
 			testName: "traffic policy local, target type Instance, default healthcheck",
 			svc: &corev1.Service{
 				Spec: corev1.ServiceSpec{
+					Type:                  corev1.ServiceTypeLoadBalancer,
 					ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
 					HealthCheckNodePort:   31223,
 				},


### PR DESCRIPTION
The service `HealthCheckNodePort` is significant only when`ExternalTrafficPolicy` is set to `Local` and `Type` set to `LoadBaalncer`. Use the `HealthCheckNodePort` for target target group health check only in the above mentioned case. In all other case, the default health check port is `traffic-port`.