### PR TITLE
allow invalid ingressClass for update events without ingressClass change.

### DIFF
--- a/webhooks/networking/ingress_validator.go
+++ b/webhooks/networking/ingress_validator.go
@@ -2,6 +2,7 @@ package networking
 
 import (
 	"context"
+	awssdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	networking "k8s.io/api/networking/v1beta1"
@@ -54,7 +55,7 @@ func (v *ingressValidator) ValidateCreate(ctx context.Context, obj runtime.Objec
 	if err := v.checkGroupNameAnnotationUsage(ing, nil); err != nil {
 		return err
 	}
-	if err := v.checkIngressClassUsage(ctx, ing); err != nil {
+	if err := v.checkIngressClassUsage(ctx, ing, nil); err != nil {
 		return err
 	}
 	return nil
@@ -69,7 +70,7 @@ func (v *ingressValidator) ValidateUpdate(ctx context.Context, obj runtime.Objec
 	if err := v.checkGroupNameAnnotationUsage(ing, oldIng); err != nil {
 		return err
 	}
-	if err := v.checkIngressClassUsage(ctx, ing); err != nil {
+	if err := v.checkIngressClassUsage(ctx, ing, oldIng); err != nil {
 		return err
 	}
 	return nil
@@ -125,20 +126,38 @@ func (v *ingressValidator) checkGroupNameAnnotationUsage(ing *networking.Ingress
 			usedInOldIng = true
 		}
 	}
-	if !usedInOldIng && usedInNewIng {
-		return errors.Errorf("new usage of `%s/%s` annotation is forbidden", annotations.AnnotationPrefixIngress, annotations.IngressSuffixGroupName)
-	}
-	if usedInOldIng && usedInNewIng && (oldGroupName != newGroupName) {
-		return errors.Errorf("new value of `%s/%s` annotation is forbidden", annotations.AnnotationPrefixIngress, annotations.IngressSuffixGroupName)
+
+	if usedInNewIng {
+		if !usedInOldIng || (newGroupName != oldGroupName) {
+			return errors.Errorf("new usage of `%s/%s` annotation is forbidden", annotations.AnnotationPrefixIngress, annotations.IngressSuffixGroupName)
+		}
 	}
 	return nil
 }
 
-func (v *ingressValidator) checkIngressClassUsage(ctx context.Context, ing *networking.Ingress) error {
+// checkIngressClassUsage checks the usage of "ingressClassName" field.
+// if ingressClassName is mutated, it must refer to a existing & valid IngressClass.
+func (v *ingressValidator) checkIngressClassUsage(ctx context.Context, ing *networking.Ingress, oldIng *networking.Ingress) error {
+	usedInNewIng := false
+	usedInOldIng := false
+	newIngressClassName := ""
+	oldIngressClassName := ""
+
 	if ing.Spec.IngressClassName != nil {
-		_, err := v.classLoader.Load(ctx, ing)
-		if err != nil {
-			return err
+		usedInNewIng = true
+		newIngressClassName = awssdk.StringValue(ing.Spec.IngressClassName)
+	}
+	if oldIng != nil && oldIng.Spec.IngressClassName != nil {
+		usedInOldIng = true
+		oldIngressClassName = awssdk.StringValue(oldIng.Spec.IngressClassName)
+	}
+
+	if usedInNewIng {
+		if !usedInOldIng || (newIngressClassName != oldIngressClassName) {
+			_, err := v.classLoader.Load(ctx, ing)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
This PR will allow invalid ingressClass for update events without ingressClass change.

When Ingress is updated without ingressClass change, it should be allowed even if it refers to an invalid ingressClass. (e.g. non-existent IngressClass or IngressClassParams namespaceSelector mismatch).
This is useful for cases like remove finalizers.