### PR TITLE
filter redundant health check SG rules

### DIFF
--- a/pkg/service/model_build_target_group_test.go
+++ b/pkg/service/model_build_target_group_test.go
@@ -624,26 +624,6 @@ func Test_defaultModelBuilderTask_buildTargetGroupBindingNetworking(t *testing.T
 							},
 						},
 					},
-					{
-						From: []elbv2.NetworkingPeer{
-							{
-								IPBlock: &elbv2api.IPBlock{
-									CIDR: "172.16.0.0/19",
-								},
-							},
-							{
-								IPBlock: &elbv2api.IPBlock{
-									CIDR: "1.2.3.4/19",
-								},
-							},
-						},
-						Ports: []elbv2api.NetworkingPort{
-							{
-								Protocol: &networkingProtocolTCP,
-								Port:     &port80,
-							},
-						},
-					},
 				},
 			},
 		},
@@ -824,6 +804,57 @@ func Test_defaultModelBuilderTask_buildTargetGroupBindingNetworking(t *testing.T
 							{
 								IPBlock: &elbv2api.IPBlock{
 									CIDR: "1.2.3.4/19",
+								},
+							},
+						},
+						Ports: []elbv2api.NetworkingPort{
+							{
+								Protocol: &networkingProtocolTCP,
+								Port:     &port80,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "tcp-service with preserve Client IP, hc is traffic port, source range specified and contains 0/0",
+			svc: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					LoadBalancerSourceRanges: []string{"10.0.0.0/16", "1.2.3.4/24", "0.0.0.0/0"},
+				},
+			},
+			tgPort: port80,
+			hcPort: port80,
+			subnets: []*ec2.Subnet{
+				{
+					CidrBlock: aws.String("172.16.0.0/19"),
+					SubnetId:  aws.String("sn-1"),
+				},
+				{
+					CidrBlock: aws.String("1.2.3.4/19"),
+					SubnetId:  aws.String("sn-2"),
+				},
+			},
+			tgProtocol:       corev1.ProtocolTCP,
+			preserveClientIP: true,
+			want: &elbv2.TargetGroupBindingNetworking{
+				Ingress: []elbv2.NetworkingIngressRule{
+					{
+						From: []elbv2.NetworkingPeer{
+							{
+								IPBlock: &elbv2api.IPBlock{
+									CIDR: "10.0.0.0/16",
+								},
+							},
+							{
+								IPBlock: &elbv2api.IPBlock{
+									CIDR: "1.2.3.4/24",
+								},
+							},
+							{
+								IPBlock: &elbv2api.IPBlock{
+									CIDR: "0.0.0.0/0",
 								},
 							},
 						},

--- a/pkg/service/model_builder_test.go
+++ b/pkg/service/model_builder_test.go
@@ -1265,31 +1265,6 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                                   "port":31223
                                }
                             ]
-                         },
-                         {
-                            "from":[
-                               {
-                                  "ipBlock":{
-                                     "cidr":"192.168.0.0/19"
-                                  }
-                               },
-                               {
-                                  "ipBlock":{
-                                     "cidr":"192.168.32.0/19"
-                                  }
-                               },
-                               {
-                                  "ipBlock":{
-                                     "cidr":"192.168.64.0/19"
-                                  }
-                               }
-                            ],
-                            "ports":[
-                               {
-                                  "protocol":"TCP",
-                                  "port":31223
-                               }
-                            ]
                          }
                       ]
                    }
@@ -1321,31 +1296,6 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                                {
                                   "ipBlock":{
                                      "cidr":"192.168.0.0/16"
-                                  }
-                               }
-                            ],
-                            "ports":[
-                               {
-                                  "protocol":"TCP",
-                                  "port":32323
-                               }
-                            ]
-                         },
-                         {
-                            "from":[
-                               {
-                                  "ipBlock":{
-                                     "cidr":"192.168.0.0/19"
-                                  }
-                               },
-                               {
-                                  "ipBlock":{
-                                     "cidr":"192.168.32.0/19"
-                                  }
-                               },
-                               {
-                                  "ipBlock":{
-                                     "cidr":"192.168.64.0/19"
                                   }
                                }
                             ],
@@ -1965,21 +1915,6 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                       {
                         "ipBlock": {
                           "cidr": "100.64.0.0/16"
-                        }
-                      }
-                    ],
-                    "ports": [
-                      {
-                        "protocol": "TCP",
-                        "port": 80
-                      }
-                    ]
-                  },
-                  {
-                    "from": [
-                      {
-                        "ipBlock": {
-                          "cidr": "192.168.0.0/19"
                         }
                       }
                     ],


### PR DESCRIPTION
Filter out redundant health check security group rules when the following conditions are met
- health check and traffic ports are the same
- preserve client IP is enabled
- custom source ranges is not configured on the service resource, or 0.0.0.0/0 is allowed

In case of preserve client IP disabled, separate set of health check rules do not get added if traffic and health check ports are the same.