### PR TITLE
resolve VPC CIDRs for UDP protocol

### DIFF
--- a/pkg/service/model_build_target_group.go
+++ b/pkg/service/model_build_target_group.go
@@ -369,7 +369,7 @@ func (t *defaultModelBuildTask) buildTargetGroupBindingSpec(ctx context.Context,
 		targetPort = intstr.FromInt(int(port.NodePort))
 	}
 	defaultSourceRanges := []string{"0.0.0.0/0"}
-	if preserveClientIP && scheme == elbv2model.LoadBalancerSchemeInternal {
+	if (port.Protocol == corev1.ProtocolUDP || preserveClientIP) && scheme == elbv2model.LoadBalancerSchemeInternal {
 		defaultSourceRanges, err = t.vpcResolver.ResolveCIDRs(ctx)
 		if err != nil {
 			return elbv2model.TargetGroupBindingResourceSpec{}, err


### PR DESCRIPTION
Restrict SG rules for UDP protocol in case of an internal load balancer

Tests:
- Created UDP service with default internal scheme, verified the SG rules were restricted to the VPC CIDR ranges
- Created UDP service with internet-facing scheme, verified SG rules were as per the loadBalancerSourceRanges configuration
- Verified TCP health check rules were added for UDP service