### PR TITLE
add helm timeout & use eks-charts helm chart

### DIFF
--- a/test/framework/controller/constants.go
+++ b/test/framework/controller/constants.go
@@ -1,7 +1,10 @@
 package controller
 
+import "time"
+
 const (
-	EKSHelmChartsRepo                    = "https://kishorj.github.io/eks-charts"
-	AWSLoadBalancerControllerHelmChart   = "aws-load-balancer-controller"
-	AWSLoadBalancerControllerHelmRelease = "aws-load-balancer-controller"
+	EKSHelmChartsRepo                            = "https://aws.github.io/eks-charts"
+	AWSLoadBalancerControllerHelmChart           = "aws-load-balancer-controller"
+	AWSLoadBalancerControllerHelmRelease         = "aws-load-balancer-controller"
+	AWSLoadBalancerControllerInstallationTimeout = 2 * time.Minute
 )

--- a/test/framework/controller/installation_manager.go
+++ b/test/framework/controller/installation_manager.go
@@ -22,7 +22,9 @@ func NewDefaultInstallationManager(helmReleaseManager helm.ReleaseManager, clust
 		region:             region,
 		vpcID:              vpcID,
 
-		logger: logger,
+		namespace:        "kube-system",
+		controllerSAName: "aws-load-balancer-controller",
+		logger:           logger,
 	}
 }
 
@@ -35,12 +37,16 @@ type defaultInstallationManager struct {
 	region             string
 	vpcID              string
 
-	logger logr.Logger
+	namespace        string
+	controllerSAName string
+	logger           logr.Logger
 }
 
 func (m *defaultInstallationManager) ResetController() error {
 	vals := m.computeDefaultHelmVals()
-	_, err := m.helmReleaseManager.InstallOrUpgradeRelease(EKSHelmChartsRepo, AWSLoadBalancerControllerHelmChart, "kube-system", AWSLoadBalancerControllerHelmRelease, vals)
+	_, err := m.helmReleaseManager.InstallOrUpgradeRelease(EKSHelmChartsRepo, AWSLoadBalancerControllerHelmChart,
+		m.namespace, AWSLoadBalancerControllerHelmRelease, vals,
+		helm.WithTimeout(AWSLoadBalancerControllerInstallationTimeout))
 	return err
 }
 
@@ -57,7 +63,9 @@ func (m *defaultInstallationManager) UpgradeController(controllerImage string) e
 	vals["podLabels"] = map[string]string{
 		"revision": string(uuid.NewUUID()),
 	}
-	_, err = m.helmReleaseManager.InstallOrUpgradeRelease(EKSHelmChartsRepo, AWSLoadBalancerControllerHelmChart, "kube-system", AWSLoadBalancerControllerHelmRelease, vals)
+	_, err = m.helmReleaseManager.InstallOrUpgradeRelease(EKSHelmChartsRepo, AWSLoadBalancerControllerHelmChart,
+		m.namespace, AWSLoadBalancerControllerHelmRelease, vals,
+		helm.WithTimeout(AWSLoadBalancerControllerInstallationTimeout))
 	return err
 }
 
@@ -68,7 +76,7 @@ func (m *defaultInstallationManager) computeDefaultHelmVals() map[string]interfa
 	vals["vpcId"] = m.vpcID
 	vals["serviceAccount"] = map[string]interface{}{
 		"create": false,
-		"name":   "aws-load-balancer-controller",
+		"name":   m.controllerSAName,
 	}
 	return vals
 }


### PR DESCRIPTION
This PR
1. adds ability to specify timeouts for helm operations.
2. set controller helm operations to timeout at 2 minute
3. use eks-charts helm chart to install controller