### PR TITLE
Update ssl_redirect.md

### DIFF
--- a/docs/guide/tasks/ssl_redirect.md
+++ b/docs/guide/tasks/ssl_redirect.md
@@ -15,6 +15,7 @@ metadata:
     alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-west-2:xxxx:certificate/xxxxxx
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
     alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
+    alb.ingress.kubernetes.io/ssl-redirect: '443'
 spec:
   rules:
     - http:


### PR DESCRIPTION
Syntax to implement ssl redirection changed apparently with v2.2. Current documentation seems to refer to v2.1 syntax for redirect.
Example should include the documented annotation: alb.ingress.kubernetes.io/ssl-redirect: '443'