### PR TITLE
fix: Update apiVersion for Ingress

### DIFF
--- a/docs/examples/2048/2048_full.yaml
+++ b/docs/examples/2048/2048_full.yaml
@@ -40,7 +40,7 @@ spec:
   selector:
     app.kubernetes.io/name: app-2048
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   namespace: game-2048


### PR DESCRIPTION
networking.k8s.io/v1beta1 is also deprecated.