### PR TITLE
add NLB deletion protection annotation

### DIFF
--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -213,7 +213,7 @@ Load balancer access can be controllerd via following annotations:
         ```
         service.beta.kubernetes.io/aws-load-balancer-internal: "true"
         ```
-  
+
 ## Legacy Cloud Provider
 The AWS Load Balancer Controller manages Kubernetes Services in a compatible way with the legacy aws cloud provider. The annotation `service.beta.kubernetes.io/aws-load-balancer-type` is used to determine which controller reconciles the service. If the annotation value is `nlb-ip` or `external`, legacy cloud provider ignores the service resource (provided it has the correct patch) so that the AWS Load Balancer controller can take over. For all other values of the annotation, the legacy cloud provider will handle the service. Note that this annotation should be specified during service creation and not edited later.
 

--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -19,10 +19,10 @@
 | [service.beta.kubernetes.io/aws-load-balancer-scheme](#lb-scheme)                                | string                  | internal                  |                                                        |
 | [service.beta.kubernetes.io/aws-load-balancer-proxy-protocol](#proxy-protocol-v2)                | string                  |                           | Set to `"*"` to enable                                 |
 | [service.beta.kubernetes.io/aws-load-balancer-ip-address-type](#ip-address-type)                 | string                  | ipv4                      | ipv4 \| dualstack                                      |
-| service.beta.kubernetes.io/aws-load-balancer-access-log-enabled                                  | boolean                 | false                     |                                                        |
-| service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-name                           | string                  |                           |                                                        |
-| service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix                         | string                  |                           |                                                        |
-| service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled                   | boolean                 | false                     |                                                        |
+| service.beta.kubernetes.io/aws-load-balancer-access-log-enabled                                  | boolean                 | false                     | deprecated, in favor of [aws-load-balancer-attributes](#load-balancer-attributes)|
+| service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-name                           | string                  |                           | deprecated, in favor of [aws-load-balancer-attributes](#load-balancer-attributes)|
+| service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix                         | string                  |                           | deprecated, in favor of [aws-load-balancer-attributes](#load-balancer-attributes)|
+| service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled                   | boolean                 | false                     | deprecated, in favor of [aws-load-balancer-attributes](#load-balancer-attributes)|
 | service.beta.kubernetes.io/aws-load-balancer-ssl-cert                                            | stringList              |                           |                                                        |
 | service.beta.kubernetes.io/aws-load-balancer-ssl-ports                                           | stringList              |                           |                                                        |
 | service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy                              | string                  | ELBSecurityPolicy-2016-08 |                                                        |
@@ -41,8 +41,7 @@
 | [service.beta.kubernetes.io/aws-load-balancer-subnets](#subnets)                                 | stringList              |                           |                                                        |
 | [service.beta.kubernetes.io/aws-load-balancer-alpn-policy](#alpn-policy)                         | stringList              |                           |                                                        |
 | [service.beta.kubernetes.io/aws-load-balancer-target-node-labels](#target-node-labels)           | stringMap               |                           |                                                        |
-| service.beta.kubernetes.io/aws-load-balancer-deletion-protection-enabled                         | boolean                 | false                     |                                                        |
-
+| [service.beta.kubernetes.io/aws-load-balancer-attributes](#load-balancer-attributes)             | stringMap               |                           |                                                        |
 ## Traffic Routing
 Traffic Routing can be controlled with following annotations:
 
@@ -218,3 +217,25 @@ Load balancer access can be controllerd via following annotations:
 The AWS Load Balancer Controller manages Kubernetes Services in a compatible way with the legacy aws cloud provider. The annotation `service.beta.kubernetes.io/aws-load-balancer-type` is used to determine which controller reconciles the service. If the annotation value is `nlb-ip` or `external`, legacy cloud provider ignores the service resource (provided it has the correct patch) so that the AWS Load Balancer controller can take over. For all other values of the annotation, the legacy cloud provider will handle the service. Note that this annotation should be specified during service creation and not edited later.
 
 The legacy cloud provider patch was added in Kubernetes v1.20 and is backported to Kubernetes v1.18.18+, v1.19.10+.
+
+## Custom attributes
+
+- <a name="load-balancer-attributes">`service.beta.kubernetes.io/aws-load-balancer-attributes`</a> specifies [Load Balancer Attributes](http://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_LoadBalancerAttribute.html) that should be applied to the NLB.
+
+  !!!warning ""
+  Only attributes defined in the annotation will be updated. To unset any AWS defaults(e.g. Disabling access logs after having them enabled once), the values need to be explicitly set to the original values(`access_logs.s3.enabled=false`) and omitting them is not sufficient.
+  Custom attributes set in this annotation's config map will be overriden by annotation-specific attributes. This is to ensure backwards compatibility but using annotation-specific attributes is deprecated and will be removed in the future.
+
+  !!!example
+  - enable access log to s3
+  ```
+  service.beta.kubernetes.io/aws-load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=my-access-log-bucket,access_logs.s3.prefix=my-app
+  ```
+  - enable NLB deletion protection
+  ```
+  service.beta.kubernetes.io/aws-load-balancer-attributes: deletion_protection.enabled=true
+  ```
+  - enable cross zone load balancing
+  ```
+  service.beta.kubernetes.io/aws-load-balancer-attributes: load_balancing.cross_zone.enabled=true
+  ```

--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -41,7 +41,7 @@
 | [service.beta.kubernetes.io/aws-load-balancer-subnets](#subnets)                                 | stringList              |                           |                                                        |
 | [service.beta.kubernetes.io/aws-load-balancer-alpn-policy](#alpn-policy)                         | stringList              |                           |                                                        |
 | [service.beta.kubernetes.io/aws-load-balancer-target-node-labels](#target-node-labels)           | stringMap               |                           |                                                        |
-
+| service.beta.kubernetes.io/aws-load-balancer-deletion-protection-enabled                         | boolean                 | false                     |                                                        |
 
 ## Traffic Routing
 Traffic Routing can be controlled with following annotations:
@@ -213,7 +213,6 @@ Load balancer access can be controllerd via following annotations:
         ```
         service.beta.kubernetes.io/aws-load-balancer-internal: "true"
         ```
-
 ## Legacy Cloud Provider
 The AWS Load Balancer Controller manages Kubernetes Services in a compatible way with the legacy aws cloud provider. The annotation `service.beta.kubernetes.io/aws-load-balancer-type` is used to determine which controller reconciles the service. If the annotation value is `nlb-ip` or `external`, legacy cloud provider ignores the service resource (provided it has the correct patch) so that the AWS Load Balancer controller can take over. For all other values of the annotation, the legacy cloud provider will handle the service. Note that this annotation should be specified during service creation and not edited later.
 

--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -222,20 +222,20 @@ The legacy cloud provider patch was added in Kubernetes v1.20 and is backported 
 
 - <a name="load-balancer-attributes">`service.beta.kubernetes.io/aws-load-balancer-attributes`</a> specifies [Load Balancer Attributes](http://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_LoadBalancerAttribute.html) that should be applied to the NLB.
 
-  !!!warning ""
-  Only attributes defined in the annotation will be updated. To unset any AWS defaults(e.g. Disabling access logs after having them enabled once), the values need to be explicitly set to the original values(`access_logs.s3.enabled=false`) and omitting them is not sufficient.
-  Custom attributes set in this annotation's config map will be overriden by annotation-specific attributes. This is to ensure backwards compatibility but using annotation-specific attributes is deprecated and will be removed in the future.
-
-  !!!example
-  - enable access log to s3
-  ```
-  service.beta.kubernetes.io/aws-load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=my-access-log-bucket,access_logs.s3.prefix=my-app
-  ```
-  - enable NLB deletion protection
-  ```
-  service.beta.kubernetes.io/aws-load-balancer-attributes: deletion_protection.enabled=true
-  ```
-  - enable cross zone load balancing
-  ```
-  service.beta.kubernetes.io/aws-load-balancer-attributes: load_balancing.cross_zone.enabled=true
-  ```
+    !!!warning ""
+        Only attributes defined in the annotation will be updated. To unset any AWS defaults(e.g. Disabling access logs after having them enabled once), the values need to be explicitly set to the original values(`access_logs.s3.enabled=false`) and omitting them is not sufficient.
+        Custom attributes set in this annotation's config map will be overriden by annotation-specific attributes. For backwards compatibility, existing annotations for the individual load balancer attributes get precedence in case of ties.
+  
+    !!!example
+        - enable access log to s3
+        ```
+        service.beta.kubernetes.io/aws-load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=my-access-log-bucket,access_logs.s3.prefix=my-app
+        ```
+        - enable NLB deletion protection
+        ```
+        service.beta.kubernetes.io/aws-load-balancer-attributes: deletion_protection.enabled=true
+        ```
+        - enable cross zone load balancing
+        ```
+        service.beta.kubernetes.io/aws-load-balancer-attributes: load_balancing.cross_zone.enabled=true
+        ```

--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -213,6 +213,7 @@ Load balancer access can be controllerd via following annotations:
         ```
         service.beta.kubernetes.io/aws-load-balancer-internal: "true"
         ```
+  
 ## Legacy Cloud Provider
 The AWS Load Balancer Controller manages Kubernetes Services in a compatible way with the legacy aws cloud provider. The annotation `service.beta.kubernetes.io/aws-load-balancer-type` is used to determine which controller reconciles the service. If the annotation value is `nlb-ip` or `external`, legacy cloud provider ignores the service resource (provided it has the correct patch) so that the AWS Load Balancer controller can take over. For all other values of the annotation, the legacy cloud provider will handle the service. Note that this annotation should be specified during service creation and not edited later.
 

--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -174,6 +174,28 @@ for proxy protocol v2 configuration.
             service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: preserve_client_ip.enabled=true
             ```
 
+
+- <a name="load-balancer-attributes">`service.beta.kubernetes.io/aws-load-balancer-attributes`</a> specifies [Load Balancer Attributes](http://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_LoadBalancerAttribute.html) that should be applied to the NLB.
+
+    !!!warning ""
+        Only attributes defined in the annotation will be updated. To unset any AWS defaults(e.g. Disabling access logs after having them enabled once), the values need to be explicitly set to the original values(`access_logs.s3.enabled=false`) and omitting them is not sufficient.
+        Custom attributes set in this annotation's config map will be overriden by annotation-specific attributes. For backwards compatibility, existing annotations for the individual load balancer attributes get precedence in case of ties.
+
+    !!!example
+        - enable access log to s3
+        ```
+        service.beta.kubernetes.io/aws-load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=my-access-log-bucket,access_logs.s3.prefix=my-app
+        ```
+        - enable NLB deletion protection
+        ```
+        service.beta.kubernetes.io/aws-load-balancer-attributes: deletion_protection.enabled=true
+        ```
+        - enable cross zone load balancing
+        ```
+        service.beta.kubernetes.io/aws-load-balancer-attributes: load_balancing.cross_zone.enabled=true
+        ```
+
+
 ## Access control
 Load balancer access can be controllerd via following annotations:
 
@@ -217,25 +239,3 @@ Load balancer access can be controllerd via following annotations:
 The AWS Load Balancer Controller manages Kubernetes Services in a compatible way with the legacy aws cloud provider. The annotation `service.beta.kubernetes.io/aws-load-balancer-type` is used to determine which controller reconciles the service. If the annotation value is `nlb-ip` or `external`, legacy cloud provider ignores the service resource (provided it has the correct patch) so that the AWS Load Balancer controller can take over. For all other values of the annotation, the legacy cloud provider will handle the service. Note that this annotation should be specified during service creation and not edited later.
 
 The legacy cloud provider patch was added in Kubernetes v1.20 and is backported to Kubernetes v1.18.18+, v1.19.10+.
-
-## Custom attributes
-
-- <a name="load-balancer-attributes">`service.beta.kubernetes.io/aws-load-balancer-attributes`</a> specifies [Load Balancer Attributes](http://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_LoadBalancerAttribute.html) that should be applied to the NLB.
-
-    !!!warning ""
-        Only attributes defined in the annotation will be updated. To unset any AWS defaults(e.g. Disabling access logs after having them enabled once), the values need to be explicitly set to the original values(`access_logs.s3.enabled=false`) and omitting them is not sufficient.
-        Custom attributes set in this annotation's config map will be overriden by annotation-specific attributes. For backwards compatibility, existing annotations for the individual load balancer attributes get precedence in case of ties.
-  
-    !!!example
-        - enable access log to s3
-        ```
-        service.beta.kubernetes.io/aws-load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=my-access-log-bucket,access_logs.s3.prefix=my-app
-        ```
-        - enable NLB deletion protection
-        ```
-        service.beta.kubernetes.io/aws-load-balancer-attributes: deletion_protection.enabled=true
-        ```
-        - enable cross zone load balancing
-        ```
-        service.beta.kubernetes.io/aws-load-balancer-attributes: load_balancing.cross_zone.enabled=true
-        ```

--- a/pkg/annotations/constants.go
+++ b/pkg/annotations/constants.go
@@ -78,4 +78,5 @@ const (
 	SvcLBSuffixSubnets                       = "aws-load-balancer-subnets"
 	SvcLBSuffixALPNPolicy                    = "aws-load-balancer-alpn-policy"
 	SvcLBSuffixTargetNodeLabels              = "aws-load-balancer-target-node-labels"
+	SvcLBSuffixDeletionProtectionEnabled     = "aws-load-balancer-deletion-protection-enabled"
 )

--- a/pkg/annotations/constants.go
+++ b/pkg/annotations/constants.go
@@ -78,5 +78,5 @@ const (
 	SvcLBSuffixSubnets                       = "aws-load-balancer-subnets"
 	SvcLBSuffixALPNPolicy                    = "aws-load-balancer-alpn-policy"
 	SvcLBSuffixTargetNodeLabels              = "aws-load-balancer-target-node-labels"
-	SvcLBSuffixDeletionProtectionEnabled     = "aws-load-balancer-deletion-protection-enabled"
+	SvcLBSuffixLoadBalancerAttributes        = "aws-load-balancer-attributes"
 )

--- a/pkg/service/model_build_load_balancer.go
+++ b/pkg/service/model_build_load_balancer.go
@@ -259,18 +259,11 @@ func makeAttributesSliceFromMap(loadBalancerAttributesMap map[string]string) []e
 }
 
 func (t *defaultModelBuildTask) getLoadBalancerAttributes() (map[string]string, error) {
-	mergedAttributes := make(map[string]string)
-	var rawAttributes map[string]string
-	if _, err := t.annotationParser.ParseStringMapAnnotation(annotations.SvcLBSuffixLoadBalancerAttributes, &rawAttributes, t.service.Annotations); err != nil {
+	var attributes map[string]string
+	if _, err := t.annotationParser.ParseStringMapAnnotation(annotations.SvcLBSuffixLoadBalancerAttributes, &attributes, t.service.Annotations); err != nil {
 		return nil, err
 	}
-	for attrKey, attrValue := range rawAttributes {
-		if existingAttrValue, exists := mergedAttributes[attrKey]; exists && existingAttrValue != attrValue {
-			return nil, errors.Errorf("conflicting loadBalancerAttribute %v: %v | %v", attrKey, existingAttrValue, attrValue)
-		}
-		mergedAttributes[attrKey] = attrValue
-	}
-	return mergedAttributes, nil
+	return attributes, nil
 }
 
 func (t *defaultModelBuildTask) getAnnotationSpecificLbAttributes() (map[string]string, error) {

--- a/pkg/service/model_build_load_balancer.go
+++ b/pkg/service/model_build_load_balancer.go
@@ -24,6 +24,7 @@ const (
 	lbAttrsAccessLogsS3Bucket            = "access_logs.s3.bucket"
 	lbAttrsAccessLogsS3Prefix            = "access_logs.s3.prefix"
 	lbAttrsLoadBalancingCrossZoneEnabled = "load_balancing.cross_zone.enabled"
+	lbAttrsDeletionProtectionEnabled     = "deletion_protection.enabled"
 
 	resourceIDLoadBalancer = "LoadBalancer"
 )
@@ -247,7 +248,10 @@ func (t *defaultModelBuildTask) buildLoadBalancerAttributes(_ context.Context) (
 	if _, err := t.annotationParser.ParseBoolAnnotation(annotations.SvcLBSuffixCrossZoneLoadBalancingEnabled, &crossZoneEnabled, t.service.Annotations); err != nil {
 		return []elbv2model.LoadBalancerAttribute{}, err
 	}
-
+	deletionProtectionEnabled := t.defaultDeletionProtectionEnabled
+	if _, err := t.annotationParser.ParseBoolAnnotation(annotations.SvcLBSuffixDeletionProtectionEnabled, &deletionProtectionEnabled, t.service.Annotations); err != nil {
+		return []elbv2model.LoadBalancerAttribute{}, err
+	}
 	attrs = []elbv2model.LoadBalancerAttribute{
 		{
 			Key:   lbAttrsAccessLogsS3Enabled,
@@ -264,6 +268,10 @@ func (t *defaultModelBuildTask) buildLoadBalancerAttributes(_ context.Context) (
 		{
 			Key:   lbAttrsLoadBalancingCrossZoneEnabled,
 			Value: strconv.FormatBool(crossZoneEnabled),
+		},
+		{
+			Key:   lbAttrsDeletionProtectionEnabled,
+			Value: strconv.FormatBool(deletionProtectionEnabled),
 		},
 	}
 

--- a/pkg/service/model_build_load_balancer_test.go
+++ b/pkg/service/model_build_load_balancer_test.go
@@ -36,24 +36,7 @@ func Test_defaultModelBuilderTask_buildLBAttributes(t *testing.T) {
 				},
 			},
 			wantError: false,
-			wantValue: []elbv2.LoadBalancerAttribute{
-				{
-					Key:   lbAttrsAccessLogsS3Enabled,
-					Value: "false",
-				},
-				{
-					Key:   lbAttrsAccessLogsS3Bucket,
-					Value: "",
-				},
-				{
-					Key:   lbAttrsAccessLogsS3Prefix,
-					Value: "",
-				},
-				{
-					Key:   lbAttrsLoadBalancingCrossZoneEnabled,
-					Value: "false",
-				},
-			},
+			wantValue: []elbv2.LoadBalancerAttribute{},
 		},
 		{
 			testName: "Annotation specified",

--- a/pkg/service/model_build_load_balancer_test.go
+++ b/pkg/service/model_build_load_balancer_test.go
@@ -51,6 +51,10 @@ func Test_defaultModelBuilderTask_buildLBAttributes(t *testing.T) {
 					Key:   lbAttrsLoadBalancingCrossZoneEnabled,
 					Value: "false",
 				},
+				{
+					Key:   lbAttrsDeletionProtectionEnabled,
+					Value: "false",
+				},
 			},
 		},
 		{
@@ -63,6 +67,7 @@ func Test_defaultModelBuilderTask_buildLBAttributes(t *testing.T) {
 						"service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-name":         "nlb-bucket",
 						"service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix":       "bkt-pfx",
 						"service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled": "true",
+						"service.beta.kubernetes.io/aws-load-balancer-deletion-protection-enabled":       "true",
 					},
 				},
 			},
@@ -82,6 +87,10 @@ func Test_defaultModelBuilderTask_buildLBAttributes(t *testing.T) {
 				},
 				{
 					Key:   lbAttrsLoadBalancingCrossZoneEnabled,
+					Value: "true",
+				},
+				{
+					Key:   lbAttrsDeletionProtectionEnabled,
 					Value: "true",
 				},
 			},

--- a/pkg/service/model_builder.go
+++ b/pkg/service/model_builder.go
@@ -138,6 +138,7 @@ type defaultModelBuildTask struct {
 	defaultHealthCheckTimeout            int64
 	defaultHealthCheckHealthyThreshold   int64
 	defaultHealthCheckUnhealthyThreshold int64
+	defaultDeletionProtectionEnabled     bool
 
 	// Default health check settings for NLB instance mode with spec.ExternalTrafficPolicy set to Local
 	defaultHealthCheckProtocolForInstanceModeLocal           elbv2model.Protocol

--- a/pkg/service/model_builder_test.go
+++ b/pkg/service/model_builder_test.go
@@ -149,12 +149,12 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
              ],
              "loadBalancerAttributes":[
                 {
-                   "key":"access_logs.s3.enabled",
-                   "value":"false"
-                },
-                {
                    "key":"access_logs.s3.bucket",
                    "value":""
+                },
+				{
+                   "key":"access_logs.s3.enabled",
+                   "value":"false"
                 },
                 {
                    "key":"access_logs.s3.prefix",
@@ -162,10 +162,6 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                 },
                 {
                    "key":"load_balancing.cross_zone.enabled",
-                   "value":"false"
-                },
-				{
-                   "key":"deletion_protection.enabled",
                    "value":"false"
                 }
              ]
@@ -312,12 +308,12 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
              ],
              "loadBalancerAttributes":[
                 {
-                   "key":"access_logs.s3.enabled",
-                   "value":"false"
-                },
-                {
                    "key":"access_logs.s3.bucket",
                    "value":""
+                },
+                {
+                   "key":"access_logs.s3.enabled",
+                   "value":"false"
                 },
                 {
                    "key":"access_logs.s3.prefix",
@@ -325,10 +321,6 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                 },
                 {
                    "key":"load_balancing.cross_zone.enabled",
-                   "value":"false"
-                },
-				{
-                   "key":"deletion_protection.enabled",
                    "value":"false"
                 }
              ]
@@ -514,12 +506,12 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
              ],
              "loadBalancerAttributes":[
                 {
-                   "key":"access_logs.s3.enabled",
-                   "value":"false"
-                },
-                {
                    "key":"access_logs.s3.bucket",
                    "value":""
+                },
+                {
+                   "key":"access_logs.s3.enabled",
+                   "value":"false"
                 },
                 {
                    "key":"access_logs.s3.prefix",
@@ -527,10 +519,6 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                 },
                 {
                    "key":"load_balancing.cross_zone.enabled",
-                   "value":"false"
-                },
-				{
-                   "key":"deletion_protection.enabled",
                    "value":"false"
                 }
              ]
@@ -847,12 +835,12 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
              ],
              "loadBalancerAttributes":[
                 {
-                   "key":"access_logs.s3.enabled",
-                   "value":"true"
-                },
-                {
                    "key":"access_logs.s3.bucket",
                    "value":"nlb-bucket"
+                },
+                {
+                   "key":"access_logs.s3.enabled",
+                   "value":"true"
                 },
                 {
                    "key":"access_logs.s3.prefix",
@@ -861,10 +849,6 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                 {
                    "key":"load_balancing.cross_zone.enabled",
                    "value":"true"
-                },
-				{
-                   "key":"deletion_protection.enabled",
-                   "value":"false"
                 }
              ]
           }
@@ -1184,12 +1168,12 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
              ],
              "loadBalancerAttributes":[
                 {
-                   "key":"access_logs.s3.enabled",
-                   "value":"false"
-                },
-                {
                    "key":"access_logs.s3.bucket",
                    "value":""
+                },
+                {
+                   "key":"access_logs.s3.enabled",
+                   "value":"false"
                 },
                 {
                    "key":"access_logs.s3.prefix",
@@ -1197,10 +1181,6 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                 },
                 {
                    "key":"load_balancing.cross_zone.enabled",
-                   "value":"false"
-                },
-				{
-                   "key":"deletion_protection.enabled",
                    "value":"false"
                 }
              ]
@@ -1471,12 +1451,12 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
              ],
              "loadBalancerAttributes":[
                 {
-                   "key":"access_logs.s3.enabled",
-                   "value":"false"
-                },
-                {
                    "key":"access_logs.s3.bucket",
                    "value":""
+                },
+                {
+                   "key":"access_logs.s3.enabled",
+                   "value":"false"
                 },
                 {
                    "key":"access_logs.s3.prefix",
@@ -1484,10 +1464,6 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                 },
                 {
                    "key":"load_balancing.cross_zone.enabled",
-                   "value":"false"
-                },
-				{
-                   "key":"deletion_protection.enabled",
                    "value":"false"
                 }
              ]
@@ -1764,12 +1740,12 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
              },
              "loadBalancerAttributes":[
                 {
-                   "key":"access_logs.s3.enabled",
-                   "value":"false"
-                },
-                {
                    "key":"access_logs.s3.bucket",
                    "value":""
+                },
+                {
+                   "key":"access_logs.s3.enabled",
+                   "value":"false"
                 },
                 {
                    "key":"access_logs.s3.prefix",
@@ -1777,10 +1753,6 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                 },
                 {
                    "key":"load_balancing.cross_zone.enabled",
-                   "value":"false"
-                },
-				{
-                   "key":"deletion_protection.enabled",
                    "value":"false"
                 }
              ]
@@ -1976,12 +1948,12 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
           "name": "k8s-default-iptarget-b44ef5a42d",
           "loadBalancerAttributes": [
             {
-              "value": "false",
-              "key": "access_logs.s3.enabled"
-            },
-            {
               "value": "",
               "key": "access_logs.s3.bucket"
+            },
+            {
+              "value": "false",
+              "key": "access_logs.s3.enabled"
             },
             {
               "value": "",
@@ -1990,11 +1962,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
             {
               "value": "false",
               "key": "load_balancing.cross_zone.enabled"
-            },
-			{
-                   "key":"deletion_protection.enabled",
-                   "value":"false"
-			}
+            }
           ],
           "subnetMapping": [
             {

--- a/pkg/service/model_builder_test.go
+++ b/pkg/service/model_builder_test.go
@@ -146,24 +146,6 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                 {
                    "subnetID":"subnet-1"
                 }
-             ],
-             "loadBalancerAttributes":[
-                {
-                   "key":"access_logs.s3.bucket",
-                   "value":""
-                },
-				{
-                   "key":"access_logs.s3.enabled",
-                   "value":"false"
-                },
-                {
-                   "key":"access_logs.s3.prefix",
-                   "value":""
-                },
-                {
-                   "key":"load_balancing.cross_zone.enabled",
-                   "value":"false"
-                }
              ]
           }
        }
@@ -304,24 +286,6 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
              "subnetMapping":[
                 {
                    "subnetID":"subnet-1"
-                }
-             ],
-             "loadBalancerAttributes":[
-                {
-                   "key":"access_logs.s3.bucket",
-                   "value":""
-                },
-                {
-                   "key":"access_logs.s3.enabled",
-                   "value":"false"
-                },
-                {
-                   "key":"access_logs.s3.prefix",
-                   "value":""
-                },
-                {
-                   "key":"load_balancing.cross_zone.enabled",
-                   "value":"false"
                 }
              ]
           }
@@ -502,24 +466,6 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                 },
                 {
                    "subnetID":"subnet-2"
-                }
-             ],
-             "loadBalancerAttributes":[
-                {
-                   "key":"access_logs.s3.bucket",
-                   "value":""
-                },
-                {
-                   "key":"access_logs.s3.enabled",
-                   "value":"false"
-                },
-                {
-                   "key":"access_logs.s3.prefix",
-                   "value":""
-                },
-                {
-                   "key":"load_balancing.cross_zone.enabled",
-                   "value":"false"
                 }
              ]
           }
@@ -1165,24 +1111,6 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                 {
                    "subnetID":"subnet-3"
                 }
-             ],
-             "loadBalancerAttributes":[
-                {
-                   "key":"access_logs.s3.bucket",
-                   "value":""
-                },
-                {
-                   "key":"access_logs.s3.enabled",
-                   "value":"false"
-                },
-                {
-                   "key":"access_logs.s3.prefix",
-                   "value":""
-                },
-                {
-                   "key":"load_balancing.cross_zone.enabled",
-                   "value":"false"
-                }
              ]
           }
        }
@@ -1447,24 +1375,6 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                 },
                 {
                    "subnetID":"subnet-3"
-                }
-             ],
-             "loadBalancerAttributes":[
-                {
-                   "key":"access_logs.s3.bucket",
-                   "value":""
-                },
-                {
-                   "key":"access_logs.s3.enabled",
-                   "value":"false"
-                },
-                {
-                   "key":"access_logs.s3.prefix",
-                   "value":""
-                },
-                {
-                   "key":"load_balancing.cross_zone.enabled",
-                   "value":"false"
                 }
              ]
           }
@@ -1737,25 +1647,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
              "tags": {
                "tag2/purpose": "test.2",
                "resource.tag1": "value1"
-             },
-             "loadBalancerAttributes":[
-                {
-                   "key":"access_logs.s3.bucket",
-                   "value":""
-                },
-                {
-                   "key":"access_logs.s3.enabled",
-                   "value":"false"
-                },
-                {
-                   "key":"access_logs.s3.prefix",
-                   "value":""
-                },
-                {
-                   "key":"load_balancing.cross_zone.enabled",
-                   "value":"false"
-                }
-             ]
+             }
           }
        }
     },
@@ -1946,24 +1838,6 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
         "spec": {
           "ipAddressType": "ipv4",
           "name": "k8s-default-iptarget-b44ef5a42d",
-          "loadBalancerAttributes": [
-            {
-              "value": "",
-              "key": "access_logs.s3.bucket"
-            },
-            {
-              "value": "false",
-              "key": "access_logs.s3.enabled"
-            },
-            {
-              "value": "",
-              "key": "access_logs.s3.prefix"
-            },
-            {
-              "value": "false",
-              "key": "load_balancing.cross_zone.enabled"
-            }
-          ],
           "subnetMapping": [
             {
               "subnetID": "subnet-1"

--- a/pkg/service/model_builder_test.go
+++ b/pkg/service/model_builder_test.go
@@ -163,6 +163,10 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                 {
                    "key":"load_balancing.cross_zone.enabled",
                    "value":"false"
+                },
+				{
+                   "key":"deletion_protection.enabled",
+                   "value":"false"
                 }
              ]
           }
@@ -321,6 +325,10 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                 },
                 {
                    "key":"load_balancing.cross_zone.enabled",
+                   "value":"false"
+                },
+				{
+                   "key":"deletion_protection.enabled",
                    "value":"false"
                 }
              ]
@@ -519,6 +527,10 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                 },
                 {
                    "key":"load_balancing.cross_zone.enabled",
+                   "value":"false"
+                },
+				{
+                   "key":"deletion_protection.enabled",
                    "value":"false"
                 }
              ]
@@ -849,6 +861,10 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                 {
                    "key":"load_balancing.cross_zone.enabled",
                    "value":"true"
+                },
+				{
+                   "key":"deletion_protection.enabled",
+                   "value":"false"
                 }
              ]
           }
@@ -1182,6 +1198,10 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                 {
                    "key":"load_balancing.cross_zone.enabled",
                    "value":"false"
+                },
+				{
+                   "key":"deletion_protection.enabled",
+                   "value":"false"
                 }
              ]
           }
@@ -1464,6 +1484,10 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                 },
                 {
                    "key":"load_balancing.cross_zone.enabled",
+                   "value":"false"
+                },
+				{
+                   "key":"deletion_protection.enabled",
                    "value":"false"
                 }
              ]
@@ -1754,6 +1778,10 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                 {
                    "key":"load_balancing.cross_zone.enabled",
                    "value":"false"
+                },
+				{
+                   "key":"deletion_protection.enabled",
+                   "value":"false"
                 }
              ]
           }
@@ -1962,7 +1990,11 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
             {
               "value": "false",
               "key": "load_balancing.cross_zone.enabled"
-            }
+            },
+			{
+                   "key":"deletion_protection.enabled",
+                   "value":"false"
+			}
           ],
           "subnetMapping": [
             {


### PR DESCRIPTION
fixes: #2051
Config map annotation `service.beta.kubernetes.io/aws-load-balancer-attributes` was added. It allows to specify all attributes annotations, which will be overridden by annotation-specific attributes for now until we delete annotation-specific attributes. Now, attribute-specific annotations have been deprecated in docs