### PR TITLE
Update spec for new apiVersion

### DIFF
--- a/docs/examples/2048/2048_full.yaml
+++ b/docs/examples/2048/2048_full.yaml
@@ -53,7 +53,7 @@ spec:
   rules:
     - http:
         paths:
-        - path: /*
+        - path: /
           pathType: Prefix
           backend:
              service:

--- a/docs/examples/2048/2048_full.yaml
+++ b/docs/examples/2048/2048_full.yaml
@@ -53,7 +53,11 @@ spec:
   rules:
     - http:
         paths:
-          - path: /*
-            backend:
-              serviceName: service-2048
-              servicePort: 80
+        - path: /*
+          pathType: Prefix
+          backend:
+             service:
+               name:  service-2048
+               port:
+                 number: 80
+


### PR DESCRIPTION
This change updates the spec to support `apiVersion: networking.k8s.io/v1` for Kubernetes version 1.19+