### PR TITLE
update example for latest api version

### DIFF
--- a/docs/examples/2048/2048_full_latest.yaml
+++ b/docs/examples/2048/2048_full_latest.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: game-2048
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: game-2048
+  name: deployment-2048
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: app-2048
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: app-2048
+    spec:
+      containers:
+      - image: alexwhen/docker-2048
+        imagePullPolicy: Always
+        name: app-2048
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: game-2048
+  name: service-2048
+spec:
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+  type: NodePort
+  selector:
+    app.kubernetes.io/name: app-2048
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: game-2048
+  name: ingress-2048
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+spec:
+  rules:
+    - http:
+        paths:
+        - path: /
+          pathType: Prefix
+          backend:
+            service:
+              name: service-2048
+              port:
+                number: 80

--- a/docs/guide/ingress/spec.md
+++ b/docs/guide/ingress/spec.md
@@ -1,7 +1,7 @@
 # Ingress specification
 This document covers how ingress resources work in relation to The AWS Load Balancer Controller.
 
-An example ingress, from [example](../../examples/2048/2048_full.yaml) is as follows.
+An example ingress for Kubernetes Version 1.18 and below, from [example](../../examples/2048/2048_full.yaml) is as follows.
 
 ```yaml
 apiVersion: extensions/v1beta1
@@ -22,6 +22,32 @@ spec:
             backend:
               serviceName: "service-2048"
               servicePort: 80
+```
+
+An example ingress for Kubernetes Version 1.19 and above, from [example](../../examples/2048/2048_full_latest.yaml) is as follows.
+
+```yaml
+apiVersion: extensions/v1
+kind: Ingress
+metadata:
+  name: "2048-ingress"
+  namespace: "2048-game"
+  annotations:
+    kubernetes.io/ingress.class: alb
+  labels:
+    app: 2048-nginx-ingress
+spec:
+  rules:
+    - host: 2048.example.com
+      http:
+        paths:
+        - path: /
+          pathType: Prefix
+          backend:
+            service:
+              name: service-2048
+              port:
+                number: 80
 ```
 
 The host field specifies the eventual Route 53-managed domain that will route to this service.


### PR DESCRIPTION
This PR is to add support for the new spec in the Ingress Resource for Kubernetes version 1.19+.  

Details on this PR can be found in #2067 and #2066