### PR TITLE
New error generation/message when ServiceType is "ClusterIP" and LoadBalancerTargetType is "instance"

### DIFF
--- a/pkg/service/model_build_target_group.go
+++ b/pkg/service/model_build_target_group.go
@@ -327,6 +327,7 @@ func (t *defaultModelBuildTask) buildTargetGroupHealthCheckUnhealthyThresholdCou
 }
 
 func (t *defaultModelBuildTask) buildTargetType(_ context.Context) (elbv2model.TargetType, error) {
+	svcType := t.service.Spec.Type
 	var lbType string
 	_ = t.annotationParser.ParseStringAnnotation(annotations.SvcLBSuffixLoadBalancerType, &lbType, t.service.Annotations)
 	var lbTargetType string
@@ -335,6 +336,9 @@ func (t *defaultModelBuildTask) buildTargetType(_ context.Context) (elbv2model.T
 		return elbv2model.TargetTypeIP, nil
 	}
 	if lbType == LoadBalancerTypeExternal && lbTargetType == LoadBalancerTargetTypeInstance {
+		if svcType == corev1.ServiceTypeClusterIP {
+			return "", errors.Errorf("unsupported service type \"%v\" for load balancer target type \"%v\"", svcType, lbTargetType)
+		}
 		return elbv2model.TargetTypeInstance, nil
 	}
 	return "", errors.Errorf("unsupported target type \"%v\" for load balancer type \"%v\"", lbTargetType, lbType)

--- a/pkg/service/model_build_target_group_test.go
+++ b/pkg/service/model_build_target_group_test.go
@@ -3,6 +3,10 @@ package service
 import (
 	"context"
 	"errors"
+	"sort"
+	"strconv"
+	"testing"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/stretchr/testify/assert"
@@ -12,9 +16,6 @@ import (
 	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
-	"sort"
-	"strconv"
-	"testing"
 )
 
 func Test_defaultModelBuilderTask_targetGroupAttrs(t *testing.T) {
@@ -1043,6 +1044,21 @@ func Test_defaultModelBuilder_buildTargetType(t *testing.T) {
 				},
 			},
 			wantErr: errors.New("unsupported target type \"unknown\" for load balancer type \"external\""),
+		},
+		{
+			testName: "external, ClusterIP with target type instance",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/aws-load-balancer-type":            "external",
+						"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "instance",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeClusterIP,
+				},
+			},
+			wantErr: errors.New("unsupported service type \"ClusterIP\" for load balancer target type \"instance\""),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
### Description

Added more specific erroring for this situation so that the error is no longer simply "InvalidParameter"

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
