### PR TITLE
Fix annotation code block for load balancer name

### DIFF
--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -53,7 +53,7 @@ Traffic Routing can be controlled with following annotations:
 
     !!!example
         ```
-        service.beta.kubernetes.io/load-balancer-name: custom-name
+        service.beta.kubernetes.io/aws-load-balancer-name: custom-name
         ```
 
 - <a name="lb-type">`service.beta.kubernetes.io/aws-load-balancer-type`</a> specifies the load balancer type. This controller reconciles those service resources with this annotation set to either `nlb-ip` or `external`.


### PR DESCRIPTION
Fix the code block for service.beta.kubernetes.io/aws-load-balancer-name

### Issue

No issue found

### Description

In the doc the code block for service.beta.kubernetes.io/aws-load-balancer-name annotation is not the good one.

It's error prone for people who don't look at the right name of the annotation.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:
