### PR TITLE
Enforce one target group per target group binding

### DIFF
--- a/main.go
+++ b/main.go
@@ -144,7 +144,7 @@ func main() {
 		mgr.GetClient(), ctrl.Log.WithName("pod-readiness-gate-injector"))
 	corewebhook.NewPodMutator(podReadinessGateInjector).SetupWithManager(mgr)
 	elbv2webhook.NewTargetGroupBindingMutator(cloud.ELBV2(), ctrl.Log).SetupWithManager(mgr)
-	elbv2webhook.NewTargetGroupBindingValidator(ctrl.Log).SetupWithManager(mgr)
+	elbv2webhook.NewTargetGroupBindingValidator(mgr.GetClient(), ctrl.Log).SetupWithManager(mgr)
 	networkingwebhook.NewIngressValidator(mgr.GetClient(), controllerCFG.IngressConfig, ctrl.Log).SetupWithManager(mgr)
 	//+kubebuilder:scaffold:builder
 

--- a/webhooks/elbv2/targetgroupbinding_validator_test.go
+++ b/webhooks/elbv2/targetgroupbinding_validator_test.go
@@ -6,9 +6,14 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func Test_targetGroupBindingValidator_ValidateCreate(t *testing.T) {
@@ -61,8 +66,13 @@ func Test_targetGroupBindingValidator_ValidateCreate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			k8sSchema := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sSchema)
+			elbv2api.AddToScheme(k8sSchema)
+			k8sClient := testclient.NewFakeClientWithScheme(k8sSchema)
 			v := &targetGroupBindingValidator{
-				logger: &log.NullLogger{},
+				k8sClient: k8sClient,
+				logger:    &log.NullLogger{},
 			}
 			err := v.ValidateCreate(context.Background(), tt.args.obj)
 			if tt.wantErr != nil {
@@ -427,6 +437,223 @@ func Test_targetGroupBindingValidator_checkNodeSelector(t *testing.T) {
 				assert.EqualError(t, err, tt.wantErr.Error())
 			} else {
 				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_targetGroupBindingValidator_checkExistingTargetGroups(t *testing.T) {
+
+	type env struct {
+		existingTGBs []elbv2api.TargetGroupBinding
+	}
+
+	type args struct {
+		tgb *elbv2api.TargetGroupBinding
+	}
+
+	tests := []struct {
+		name    string
+		env     env
+		args    args
+		wantErr error
+	}{
+		{
+			name: "[ok] no existing target groups",
+			env:  env{},
+			args: args{
+				tgb: &elbv2api.TargetGroupBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tgb1",
+						Namespace: "ns1",
+					},
+					Spec: elbv2api.TargetGroupBindingSpec{
+						TargetGroupARN: "tg-1",
+						TargetType:     nil,
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "[ok] no duplicate target groups - one target group binding",
+			env: env{
+				existingTGBs: []elbv2api.TargetGroupBinding{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "tgb1",
+							Namespace: "ns1",
+						},
+						Spec: elbv2api.TargetGroupBindingSpec{
+							TargetGroupARN: "tg-1",
+							TargetType:     nil,
+						},
+					},
+				},
+			},
+			args: args{
+				tgb: &elbv2api.TargetGroupBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tgb2",
+						Namespace: "ns2",
+					},
+					Spec: elbv2api.TargetGroupBindingSpec{
+						TargetGroupARN: "tg-2",
+						TargetType:     nil,
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "[ok] no duplicate target groups - multiple target group bindings",
+			env: env{
+				existingTGBs: []elbv2api.TargetGroupBinding{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "tgb1",
+							Namespace: "ns1",
+						},
+						Spec: elbv2api.TargetGroupBindingSpec{
+							TargetGroupARN: "tg-1",
+							TargetType:     nil,
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "tgb2",
+							Namespace: "ns2",
+						},
+						Spec: elbv2api.TargetGroupBindingSpec{
+							TargetGroupARN: "tg-2",
+							TargetType:     nil,
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "tgb3",
+							Namespace: "ns3",
+						},
+						Spec: elbv2api.TargetGroupBindingSpec{
+							TargetGroupARN: "tg-3",
+							TargetType:     nil,
+						},
+					},
+				},
+			},
+			args: args{
+				tgb: &elbv2api.TargetGroupBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tgb22",
+						Namespace: "ns1",
+					},
+					Spec: elbv2api.TargetGroupBindingSpec{
+						TargetGroupARN: "tg-22",
+						TargetType:     nil,
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "[err] duplicate target groups - one target group binding",
+			env: env{
+				existingTGBs: []elbv2api.TargetGroupBinding{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "tgb1",
+							Namespace: "ns1",
+						},
+						Spec: elbv2api.TargetGroupBindingSpec{
+							TargetGroupARN: "tg-1",
+							TargetType:     nil,
+						},
+					},
+				},
+			},
+			args: args{
+				tgb: &elbv2api.TargetGroupBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tgb2",
+						Namespace: "ns1",
+					},
+					Spec: elbv2api.TargetGroupBindingSpec{
+						TargetGroupARN: "tg-1",
+						TargetType:     nil,
+					},
+				},
+			},
+			wantErr: errors.New("TargetGroup tg-1 is already bound to TargetGroupBinding ns1/tgb1"),
+		},
+		{
+			name: "[err] duplicate target groups - one target group binding",
+			env: env{
+				existingTGBs: []elbv2api.TargetGroupBinding{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "tgb1",
+							Namespace: "ns1",
+						},
+						Spec: elbv2api.TargetGroupBindingSpec{
+							TargetGroupARN: "tg-1",
+							TargetType:     nil,
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "tgb2",
+							Namespace: "ns2",
+						},
+						Spec: elbv2api.TargetGroupBindingSpec{
+							TargetGroupARN: "tg-111",
+							TargetType:     nil,
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "tgb3",
+							Namespace: "ns3",
+						},
+						Spec: elbv2api.TargetGroupBindingSpec{
+							TargetGroupARN: "tg-3",
+							TargetType:     nil,
+						},
+					},
+				},
+			},
+			args: args{
+				tgb: &elbv2api.TargetGroupBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tgb111",
+						Namespace: "ns1",
+					},
+					Spec: elbv2api.TargetGroupBindingSpec{
+						TargetGroupARN: "tg-111",
+						TargetType:     nil,
+					},
+				},
+			},
+			wantErr: errors.New("TargetGroup tg-111 is already bound to TargetGroupBinding ns2/tgb2"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k8sSchema := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sSchema)
+			elbv2api.AddToScheme(k8sSchema)
+			k8sClient := testclient.NewFakeClientWithScheme(k8sSchema)
+			v := &targetGroupBindingValidator{
+				k8sClient: k8sClient,
+				logger:    &log.NullLogger{},
+			}
+			for _, tgb := range tt.env.existingTGBs {
+				assert.NoError(t, k8sClient.Create(context.Background(), tgb.DeepCopy()))
+			}
+			err := v.checkExistingTargetGroups(tt.args.tgb)
+			if tt.wantErr == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.wantErr.Error())
 			}
 		})
 	}


### PR DESCRIPTION
### Issue
#2092 

### Description
Prevent creation of TargetGroupBinding if its already referenced by an existing TargetGroup

TargetGroupBinding has a one-to-one mapping with TargetGroup as per the data model, however, the controller does not enforce this behavior. This can lead to two TargetGroupBinding resources point to the same TargetGroup.

### Checklist
- [X] Added tests that cover your change (if possible)
- [X] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [X] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
