### PR TITLE
Add support for AWS SDK override

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ IMG ?= amazon/aws-alb-ingress-controller:v2.2.1
 
 CRD_OPTIONS ?= "crd:crdVersions=v1"
 
+# Whether to override AWS SDK models. set to 'y' when we need to build against custom AWS SDK models.
+AWS_SDK_MODEL_OVERRIDE ?= "n"
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -57,8 +60,16 @@ helm-lint:
 	${MAKEFILE_PATH}/test/helm/helm-lint.sh
 
 # Generate code
-generate: controller-gen
+generate: aws-sdk-model-override controller-gen
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+
+aws-sdk-model-override:
+	@if [ "$(AWS_SDK_MODEL_OVERRIDE)" = "y" ] ; then \
+		./scripts/aws_sdk_model_override/setup.sh ; \
+	else \
+		./scripts/aws_sdk_model_override/cleanup.sh ; \
+	fi
+
 
 # Push the docker image
 docker-push:

--- a/scripts/aws_sdk_model_override/cleanup.sh
+++ b/scripts/aws_sdk_model_override/cleanup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+SDK_VENDOR_PATH="./scripts/aws_sdk_model_override/aws-sdk-go"
+rm -rf "${SDK_VENDOR_PATH}"
+go mod edit -dropreplace github.com/aws/aws-sdk-go

--- a/scripts/aws_sdk_model_override/setup.sh
+++ b/scripts/aws_sdk_model_override/setup.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+SDK_VENDOR_PATH="./scripts/aws_sdk_model_override/aws-sdk-go"
+SDK_MODEL_OVERRIDE_DST_PATH="${SDK_VENDOR_PATH}/models"
+SDK_MODEL_OVERRIDE_SRC_PATH="./scripts/aws_sdk_model_override/models"
+
+# Clone the SDK to the vendor path (removing an old one if necessary)
+rm -rf "${SDK_VENDOR_PATH}"
+git clone --depth 1 https://github.com/aws/aws-sdk-go.git "${SDK_VENDOR_PATH}"
+
+# Override the SDK models
+cp -r "${SDK_MODEL_OVERRIDE_SRC_PATH}/" "${SDK_MODEL_OVERRIDE_DST_PATH}/"
+
+# Generate the SDK
+pushd "${SDK_VENDOR_PATH}"
+make generate
+popd
+
+# Use the vendored version of aws-sdk-go
+go mod edit -replace github.com/aws/aws-sdk-go="${SDK_VENDOR_PATH}"


### PR DESCRIPTION
### Description
Add support for AWS SDK override, this allow us to include features in preview mode

How to setup SDK override:
1. put the sdk model files under `./scripts/aws_sdk_model_override/models/`. e.g. `./scripts/aws_sdk_model_override/models/apis/ec2/2016-11-15/api-2.json`

How to compile:
* Compile with SDK override: `AWS_SDK_MODEL_OVERRIDE=y make controller`
* Compile without SDK override: `AWS_SDK_MODEL_OVERRIDE=n make controller`

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
