### PR TITLE
Improve contributing documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,12 +6,16 @@ _As contributors and maintainers of this project, and in the interest of fosteri
 
 ## Getting Started
 
-[Controller developement documentation](/docs/controller-devel.md) has instructions on how to build the project.
+### Building the project
+[Controller developement documentation](/docs/controller-devel.md) has instructions on how to build the project and project specific expectations.
+
+
+### Contributing
 We also have more documentation on how to get started contributing here:
 
 - [Contributor License Agreement](https://git.k8s.io/community/CLA.md) Kubernetes projects require that you sign a Contributor License Agreement (CLA) before we can accept your pull requests
-- [Kubernetes Contributor Guide](http://git.k8s.io/community/contributors/guide) - Main contributor documentation, or you can just jump directly to the [contributing section](http://git.k8s.io/community/contributors/guide#contributing)
-- [Contributor Cheat Sheet](https://git.k8s.io/community/contributors/guide/contributor-cheatsheet.md) - Common resources for existing developers
+- [Kubernetes Contributor Guide](https://git.k8s.io/community/contributors/guide) - Main contributor documentation, or you can just jump directly to the [contributing section](http://git.k8s.io/community/contributors/guide#contributing)
+- [Contributor Cheat Sheet](https://git.k8s.io/community/contributors/guide/contributor-cheatsheet) - Common resources for existing developers
 
 ## Mentorship
 


### PR DESCRIPTION
### Issue

Contributing.md document had a broken link to  the "cheat sheet". 

### Description

CONTRIBUTING.md document had a broken link to  the "cheat sheet".  Reformatted `Getting Started` section a little to make it slightly easier to read.

Since the cheat-sheet markdown document looks like it has various translations, I've updated the link to point to the directory which by default will display the English cheat-sheet markdown document but will also display the various language translations as well.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [] Refactored something and made the world a better place :star2:
