### PR TITLE
Add code for filtering target group & load balancers by VPC ID

### DIFF
--- a/controllers/ingress/group_controller.go
+++ b/controllers/ingress/group_controller.go
@@ -51,7 +51,7 @@ func NewGroupReconciler(cloud aws.Cloud, k8sClient client.Client, eventRecorder 
 	enhancedBackendBuilder := ingress.NewDefaultEnhancedBackendBuilder(k8sClient, annotationParser, authConfigBuilder)
 	referenceIndexer := ingress.NewDefaultReferenceIndexer(enhancedBackendBuilder, authConfigBuilder, logger)
 	trackingProvider := tracking.NewDefaultProvider(ingressTagPrefix, config.ClusterName)
-	elbv2TaggingManager := elbv2deploy.NewDefaultTaggingManager(cloud.ELBV2(), logger)
+	elbv2TaggingManager := elbv2deploy.NewDefaultTaggingManager(cloud.ELBV2(), cloud.VpcID(), logger)
 	modelBuilder := ingress.NewDefaultModelBuilder(k8sClient, eventRecorder,
 		cloud.EC2(), cloud.ACM(),
 		annotationParser, subnetsResolver,

--- a/controllers/service/service_controller.go
+++ b/controllers/service/service_controller.go
@@ -40,7 +40,7 @@ func NewServiceReconciler(cloud aws.Cloud, k8sClient client.Client, eventRecorde
 
 	annotationParser := annotations.NewSuffixAnnotationParser(serviceAnnotationPrefix)
 	trackingProvider := tracking.NewDefaultProvider(serviceTagPrefix, config.ClusterName)
-	elbv2TaggingManager := elbv2.NewDefaultTaggingManager(cloud.ELBV2(), logger)
+	elbv2TaggingManager := elbv2.NewDefaultTaggingManager(cloud.ELBV2(), cloud.VpcID(), logger)
 	modelBuilder := service.NewDefaultModelBuilder(annotationParser, subnetsResolver, vpcResolver, trackingProvider,
 		elbv2TaggingManager, config.ClusterName, config.DefaultTags, config.ExternalManagedTags, config.DefaultSSLPolicy)
 	stackMarshaller := deploy.NewDefaultStackMarshaller()

--- a/pkg/deploy/elbv2/tagging_manager.go
+++ b/pkg/deploy/elbv2/tagging_manager.go
@@ -92,11 +92,11 @@ type TaggingManager interface {
 }
 
 // NewDefaultTaggingManager constructs default TaggingManager.
-func NewDefaultTaggingManager(elbv2Client services.ELBV2, logger logr.Logger) *defaultTaggingManager {
+func NewDefaultTaggingManager(elbv2Client services.ELBV2, vpcID string, logger logr.Logger) *defaultTaggingManager {
 	return &defaultTaggingManager{
-		elbv2Client: elbv2Client,
-		logger:      logger,
-
+		elbv2Client:           elbv2Client,
+		vpcID:                 vpcID,
+		logger:                logger,
 		describeTagsChunkSize: defaultDescribeTagsChunkSize,
 	}
 }
@@ -106,9 +106,9 @@ var _ TaggingManager = &defaultTaggingManager{}
 // default implementation for TaggingManager
 // @TODO: use AWS Resource Groups Tagging API to optimize this implementation once it have PrivateLink support.
 type defaultTaggingManager struct {
-	elbv2Client services.ELBV2
-	logger      logr.Logger
-
+	elbv2Client           services.ELBV2
+	vpcID                 string
+	logger                logr.Logger
 	describeTagsChunkSize int
 }
 
@@ -235,20 +235,23 @@ func (m *defaultTaggingManager) ListLoadBalancers(ctx context.Context, tagFilter
 		return nil, err
 	}
 
-	lbARNs := make([]string, 0, len(lbs))
-	lbByARN := make(map[string]*elbv2sdk.LoadBalancer, len(lbs))
+	lbARNsWithinVPC := make([]string, 0, len(lbs))
+	lbByARNWithinVPC := make(map[string]*elbv2sdk.LoadBalancer, len(lbs))
 	for _, lb := range lbs {
+		if awssdk.StringValue(lb.VpcId) != m.vpcID {
+			continue
+		}
 		lbARN := awssdk.StringValue(lb.LoadBalancerArn)
-		lbARNs = append(lbARNs, lbARN)
-		lbByARN[lbARN] = lb
+		lbARNsWithinVPC = append(lbARNsWithinVPC, lbARN)
+		lbByARNWithinVPC[lbARN] = lb
 	}
-	tagsByARN, err := m.describeResourceTags(ctx, lbARNs)
+	tagsByARN, err := m.describeResourceTags(ctx, lbARNsWithinVPC)
 	if err != nil {
 		return nil, err
 	}
 
 	var matchedLBs []LoadBalancerWithTags
-	for _, arn := range lbARNs {
+	for _, arn := range lbARNsWithinVPC {
 		tags := tagsByARN[arn]
 		matchedAnyTagFilter := false
 		for _, tagFilter := range tagFilters {
@@ -259,7 +262,7 @@ func (m *defaultTaggingManager) ListLoadBalancers(ctx context.Context, tagFilter
 		}
 		if matchedAnyTagFilter {
 			matchedLBs = append(matchedLBs, LoadBalancerWithTags{
-				LoadBalancer: lbByARN[arn],
+				LoadBalancer: lbByARNWithinVPC[arn],
 				Tags:         tags,
 			})
 		}
@@ -274,20 +277,23 @@ func (m *defaultTaggingManager) ListTargetGroups(ctx context.Context, tagFilters
 		return nil, err
 	}
 
-	tgARNs := make([]string, 0, len(tgs))
-	tgByARN := make(map[string]*elbv2sdk.TargetGroup, len(tgs))
+	tgARNsWithinVPC := make([]string, 0, len(tgs))
+	tgByARNWithinVPC := make(map[string]*elbv2sdk.TargetGroup, len(tgs))
 	for _, tg := range tgs {
+		if awssdk.StringValue(tg.VpcId) != m.vpcID {
+			continue
+		}
 		tgARN := awssdk.StringValue(tg.TargetGroupArn)
-		tgARNs = append(tgARNs, tgARN)
-		tgByARN[tgARN] = tg
+		tgARNsWithinVPC = append(tgARNsWithinVPC, tgARN)
+		tgByARNWithinVPC[tgARN] = tg
 	}
-	tagsByARN, err := m.describeResourceTags(ctx, tgARNs)
+	tagsByARN, err := m.describeResourceTags(ctx, tgARNsWithinVPC)
 	if err != nil {
 		return nil, err
 	}
 
 	var matchedTGs []TargetGroupWithTags
-	for _, arn := range tgARNs {
+	for _, arn := range tgARNsWithinVPC {
 		tags := tagsByARN[arn]
 		matchedAnyTagFilter := false
 		for _, tagFilter := range tagFilters {
@@ -298,7 +304,7 @@ func (m *defaultTaggingManager) ListTargetGroups(ctx context.Context, tagFilters
 		}
 		if matchedAnyTagFilter {
 			matchedTGs = append(matchedTGs, TargetGroupWithTags{
-				TargetGroup: tgByARN[arn],
+				TargetGroup: tgByARNWithinVPC[arn],
 				Tags:        tags,
 			})
 		}

--- a/pkg/deploy/elbv2/tagging_manager_test.go
+++ b/pkg/deploy/elbv2/tagging_manager_test.go
@@ -266,7 +266,7 @@ func Test_defaultTaggingManager_ListLoadBalancers(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name: "2/3 loadBalancers matches single tagFilter",
+			name: "2/3 loadBalancers matches single tagFilter; 0 loadBalancers filtered out on VPC ID",
 			fields: fields{
 				describeLoadBalancersAsListCalls: []describeLoadBalancersAsListCall{
 					{
@@ -363,7 +363,7 @@ func Test_defaultTaggingManager_ListLoadBalancers(t *testing.T) {
 			},
 		},
 		{
-			name: "1/3 loadBalancers matches single tagFilter",
+			name: "1/3 loadBalancers matches single tagFilter; 1 loadBalancer filtered out on VPC ID",
 			fields: fields{
 				describeLoadBalancersAsListCalls: []describeLoadBalancersAsListCall{
 					{
@@ -440,7 +440,7 @@ func Test_defaultTaggingManager_ListLoadBalancers(t *testing.T) {
 			},
 		},
 		{
-			name: "1/3 loadBalancers matches single tagFilter",
+			name: "1/3 loadBalancers matches single tagFilter; 2 loadBalancers filtered out on VPC ID",
 			fields: fields{
 				describeLoadBalancersAsListCalls: []describeLoadBalancersAsListCall{
 					{
@@ -504,7 +504,7 @@ func Test_defaultTaggingManager_ListLoadBalancers(t *testing.T) {
 			},
 		},
 		{
-			name: "0/3 loadBalancers matches single tagFilter",
+			name: "0/3 loadBalancers matches single tagFilter; 0 loadBalancers filtered out on VPC ID",
 			fields: fields{
 				describeLoadBalancersAsListCalls: []describeLoadBalancersAsListCall{
 					{
@@ -640,7 +640,7 @@ func Test_defaultTaggingManager_ListTargetGroups(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name: "2/3 targetGroups matches single tagFilter",
+			name: "2/3 targetGroups matches single tagFilter; 0 targetGroups filtered out on VPC ID",
 			fields: fields{
 				describeTargetGroupsAsListCalls: []describeTargetGroupsAsListCall{
 					{
@@ -737,7 +737,7 @@ func Test_defaultTaggingManager_ListTargetGroups(t *testing.T) {
 			},
 		},
 		{
-			name: "1/3 targetGroups matches single tagFilter",
+			name: "1/3 targetGroups matches single tagFilter; 1 targetGroup filtered out on VPC ID",
 			fields: fields{
 				describeTargetGroupsAsListCalls: []describeTargetGroupsAsListCall{
 					{
@@ -814,7 +814,7 @@ func Test_defaultTaggingManager_ListTargetGroups(t *testing.T) {
 			},
 		},
 		{
-			name: "1/3 targetGroups matches single tagFilter",
+			name: "1/3 targetGroups matches single tagFilter; 2 targetGroups filtered out on VPC ID",
 			fields: fields{
 				describeTargetGroupsAsListCalls: []describeTargetGroupsAsListCall{
 					{
@@ -878,7 +878,7 @@ func Test_defaultTaggingManager_ListTargetGroups(t *testing.T) {
 			},
 		},
 		{
-			name: "0/3 targetGroups matches single tagFilter",
+			name: "0/3 targetGroups matches single tagFilter; 0 targetGroups filtered out on VPC ID",
 			fields: fields{
 				describeTargetGroupsAsListCalls: []describeTargetGroupsAsListCall{
 					{

--- a/pkg/deploy/stack_deployer.go
+++ b/pkg/deploy/stack_deployer.go
@@ -29,7 +29,7 @@ func NewDefaultStackDeployer(cloud aws.Cloud, k8sClient client.Client,
 
 	trackingProvider := tracking.NewDefaultProvider(tagPrefix, config.ClusterName)
 	ec2TaggingManager := ec2.NewDefaultTaggingManager(cloud.EC2(), networkingSGManager, cloud.VpcID(), logger)
-	elbv2TaggingManager := elbv2.NewDefaultTaggingManager(cloud.ELBV2(), logger)
+	elbv2TaggingManager := elbv2.NewDefaultTaggingManager(cloud.ELBV2(), cloud.VpcID(), logger)
 
 	return &defaultStackDeployer{
 		cloud:                               cloud,


### PR DESCRIPTION
### Issue

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/1566

### Description

Added Filtering of Target Group and Load Balancer by VPC ID.

### Checklist
- [x] Reproduced issue
- [x] Implemented code
- [x] Added unit tests
- [x]  Carried out manual tests

**Issue Description**: The conditions that led to the error involved dangling TargetGroup that was created for an old (deleted) cluster but was left uncleaned up. In such a scenario, if a user created a new cluster (in a new VPC) and deployed alb resources to the cluster, there is a possibility that the alb controller will reuse to old TargetGroup if the tag values for previous TargetGroup matches. In case of the customer issue, the cluster was deleted but the TargetGroup was not cleaned up by the user. So when the user tried to created a new cluster (in a new VPC with same cluster-name), it found the old TargetGroup and tried re-using it. 

**Solution:** The code fixes this behavior by filtering TargetGroup and Load Balancers by vpc-id. However, customers are responsible for deleting Ingresses before deleting the cluster (so target groups and load balancers can be cleaned up properly).


**Log on Issue Reproduction: (shows status: 404 )**

`{"level":"info","ts":1627076759.10457,"logger":"controllers.ingress","msg":"successfully built model","model":"{\"id\":\"game-2048/ingress-2048\",\"resources\":{\"AWS::EC2::SecurityGroup\":{\"ManagedLBSecurityGroup\":{\"spec\":{\"groupName\":\"k8s-game2048-ingress2-f1f400dac5\",\"description\":\"[k8s] Managed SecurityGroup for LoadBalancer\",\"ingress\":[{\"ipProtocol\":\"tcp\",\"fromPort\":80,\"toPort\":80,\"ipRanges\":[{\"cidrIP\":\"0.0.0.0/0\"}]}]}}},\"AWS::ElasticLoadBalancingV2::Listener\":{\"80\":{\"spec\":{\"loadBalancerARN\":{\"$ref\":\"#/resources/AWS::ElasticLoadBalancingV2::LoadBalancer/LoadBalancer/status/loadBalancerARN\"},\"port\":80,\"protocol\":\"HTTP\",\"defaultActions\":[{\"type\":\"fixed-response\",\"fixedResponseConfig\":{\"contentType\":\"text/plain\",\"statusCode\":\"404\"`

**Manual Tests:**

- I initially built the controller image locally and then pushed it to ECR.
- Next, I deployed the load balancer controller onto the cluster using helm (also attached IAM service account)
- Once the controller pods were in running state, I deployed ingress resouces (using a 2048 game YAML) onto it.
- I checked the logs of the controller pods on deployment using `kubectl logs <pod_name> -n  <ns_name>`
- It showed an error in the log similar to the error reproduced as above and shown below

`{"level":"info","ts":1628208589.8923402,"logger":"controllers.ingress","msg":"successfully built model","model":"{\"id\":\"s-game-2048/s-ingress-2048\",\"resources\":{\"AWS::EC2::SecurityGroup\":{\"ManagedLBSecurityGroup\":{\"spec\":{\"groupName\":\"k8s-sgame204-singress-d845ce2c30\",\"description\":\"[k8s] Managed SecurityGroup for LoadBalancer\",\"ingress\":[{\"ipProtocol\":\"tcp\",\"fromPort\":80,\"toPort\":80,\"ipRanges\":[{\"cidrIP\":\"0.0.0.0/0\"}]}]}}},\"AWS::ElasticLoadBalancingV2::Listener\":{\"80\":{\"spec\":{\"loadBalancerARN\":{\"$ref\":\"#/resources/AWS::ElasticLoadBalancingV2::LoadBalancer/LoadBalancer/status/loadBalancerARN\"},\"port\":80,\"protocol\":\"HTTP\",\"defaultActions\":[{\"type\":\"fixed-response\",\"fixedResponseConfig\":{\"contentType\":\"text/plain\",\"statusCode\":\"404\"}}]}}},`

- Next, I updated the load balancer controller image using `kubectl set image deployment/aws-load-balancer-controller aws-load-balancer-controller=$IMAGE -n <ns_name>` where IMAGE name was exported to be same as the image pushed to ECR.
- After the deployment image was updated, I  checked the new logs of the controller pods on deployment using `kubectl logs <pod_name> -n  <ns_name>`. It did not have any error logs as above.
- Also, I verified that the alb controller pods had the correct image pushed by me to ECR using `kubectl describe <alb_pod_name>  -n <ns_name>`




