### PR TITLE
Fix the regression of IP mode support for fargate pods

### DIFF
--- a/pkg/k8s/node_utils_test.go
+++ b/pkg/k8s/node_utils_test.go
@@ -212,7 +212,7 @@ func TestExtractNodeInstanceID(t *testing.T) {
 			wantErr: errors.New("providerID is not specified for node: my-node-name"),
 		},
 		{
-			name: "node with providerID",
+			name: "node by EC2 instance",
 			args: args{
 				node: &corev1.Node{
 					ObjectMeta: metav1.ObjectMeta{
@@ -224,6 +224,20 @@ func TestExtractNodeInstanceID(t *testing.T) {
 				},
 			},
 			want: "i-abcdefg0",
+		},
+		{
+			name: "node by EKS Fargate",
+			args: args{
+				node: &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "fargate-ip-192-168-138-30.us-west-2.compute.internal",
+					},
+					Spec: corev1.NodeSpec{
+						ProviderID: "aws:///us-west-2b/368270442a-793d42d32c704bb793ca88a6a14ddd6e/fargate-ip-192-168-138-30.us-west-2.compute.internal",
+					},
+				},
+			},
+			wantErr: errors.New("providerID aws:///us-west-2b/368270442a-793d42d32c704bb793ca88a6a14ddd6e/fargate-ip-192-168-138-30.us-west-2.compute.internal is invalid for EC2 instances, node: fargate-ip-192-168-138-30.us-west-2.compute.internal"),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/targetgroupbinding/resource_manager.go
+++ b/pkg/targetgroupbinding/resource_manager.go
@@ -43,7 +43,7 @@ func NewDefaultResourceManager(k8sClient client.Client, elbv2Client services.ELB
 	endpointResolver := backend.NewDefaultEndpointResolver(k8sClient, podInfoRepo, logger)
 
 	nodeInfoProvider := networking.NewDefaultNodeInfoProvider(ec2Client, logger)
-	podENIResolver := networking.NewDefaultPodENIInfoResolver(k8sClient, ec2Client, nodeInfoProvider, logger)
+	podENIResolver := networking.NewDefaultPodENIInfoResolver(k8sClient, ec2Client, nodeInfoProvider, vpcID, logger)
 	nodeENIResolver := networking.NewDefaultNodeENIInfoResolver(nodeInfoProvider, logger)
 
 	networkingManager := NewDefaultNetworkingManager(k8sClient, podENIResolver, nodeENIResolver, sgManager, sgReconciler, vpcID, clusterName, logger)


### PR DESCRIPTION
### Issue

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2156

### Description

Fix the regression of IP mode support for Fargate pods introduced by https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2137.
These Fargate pod's ENI have to be resolved via VPC IPAddress.

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
