### PR TITLE
EndpointSlice support for IP target groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ site
 
 # editor and IDE paraphernalia
 .idea
+.vscode
 *.swp
 *.swo
 *~

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -78,6 +78,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - elbv2.k8s.aws
   resources:
   - ingressclassparams

--- a/controllers/elbv2/eventhandlers/endpointslices.go
+++ b/controllers/elbv2/eventhandlers/endpointslices.go
@@ -1,0 +1,92 @@
+package eventhandlers
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	discv1 "k8s.io/api/discovery/v1beta1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/targetgroupbinding"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// NewEnqueueRequestsForEndpointSlicesEvent constructs new enqueueRequestsForEndpointSlicesEvent.
+func NewEnqueueRequestsForEndpointSlicesEvent(k8sClient client.Client, logger logr.Logger) handler.EventHandler {
+	return &enqueueRequestsForEndpointSlicesEvent{
+		k8sClient: k8sClient,
+		logger:    logger,
+	}
+}
+
+var _ handler.EventHandler = (*enqueueRequestsForEndpointSlicesEvent)(nil)
+
+type enqueueRequestsForEndpointSlicesEvent struct {
+	k8sClient client.Client
+	logger    logr.Logger
+}
+
+// Create is called in response to an create event - e.g. EndpointSlice Creation.
+func (h *enqueueRequestsForEndpointSlicesEvent) Create(e event.CreateEvent, queue workqueue.RateLimitingInterface) {
+	epNew := e.Object.(*discv1.EndpointSlice)
+	h.logger.Info("Create event for EndpointSlices", "name", epNew.Name)
+	h.enqueueImpactedTargetGroupBindings(queue, epNew)
+}
+
+// Update is called in response to an update event -  e.g. EndpointSlice Updated.
+func (h *enqueueRequestsForEndpointSlicesEvent) Update(e event.UpdateEvent, queue workqueue.RateLimitingInterface) {
+	epOld := e.ObjectOld.(*discv1.EndpointSlice)
+	epNew := e.ObjectNew.(*discv1.EndpointSlice)
+	h.logger.Info("Update event for EndpointSlices", "name", epNew.Name)
+	if !equality.Semantic.DeepEqual(epOld.Ports, epNew.Ports) || !equality.Semantic.DeepEqual(epOld.Endpoints, epNew.Endpoints) {
+		h.logger.Info("Enqueue EndpointSlice", "name", epNew.Name)
+		h.enqueueImpactedTargetGroupBindings(queue, epNew)
+	}
+}
+
+// Delete is called in response to a delete event - e.g. EndpointSlice Deleted.
+func (h *enqueueRequestsForEndpointSlicesEvent) Delete(e event.DeleteEvent, queue workqueue.RateLimitingInterface) {
+	epOld := e.Object.(*discv1.EndpointSlice)
+	h.logger.Info("Deletion event for EndpointSlices", "name", epOld.Name)
+	h.enqueueImpactedTargetGroupBindings(queue, epOld)
+}
+
+// Generic is called in response to an event of an unknown type or a synthetic event triggered as a cron or
+// external trigger request - e.g. reconcile AutoScaling, or a WebHook.
+func (h *enqueueRequestsForEndpointSlicesEvent) Generic(event.GenericEvent, workqueue.RateLimitingInterface) {
+}
+
+func (h *enqueueRequestsForEndpointSlicesEvent) enqueueImpactedTargetGroupBindings(queue workqueue.RateLimitingInterface, epslice *discv1.EndpointSlice) {
+	tgbList := &elbv2api.TargetGroupBindingList{}
+	svcName := epslice.Labels["kubernetes.io/service-name"]
+	if err := h.k8sClient.List(context.Background(), tgbList,
+		client.InNamespace(epslice.Namespace),
+		client.MatchingFields{targetgroupbinding.IndexKeyServiceRefName: svcName}); err != nil {
+		h.logger.Error(err, "failed to fetch targetGroupBindings")
+		return
+	}
+
+	epsliceKey := k8s.NamespacedName(epslice)
+	for _, tgb := range tgbList.Items {
+		if tgb.Spec.TargetType == nil || (*tgb.Spec.TargetType) != elbv2api.TargetTypeIP {
+			continue
+		}
+
+		h.logger.V(1).Info("enqueue targetGroupBinding for endpointslices event",
+			"endpointslices", epsliceKey,
+			"targetGroupBinding", k8s.NamespacedName(&tgb),
+		)
+		queue.Add(reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: tgb.Namespace,
+				Name:      tgb.Name,
+			},
+		})
+	}
+}

--- a/controllers/elbv2/eventhandlers/endpointslices_test.go
+++ b/controllers/elbv2/eventhandlers/endpointslices_test.go
@@ -1,0 +1,183 @@
+package eventhandlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	discv1 "k8s.io/api/discovery/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
+	mock_client "sigs.k8s.io/aws-load-balancer-controller/mocks/controller-runtime/client"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/testutils"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllertest"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func Test_enqueueRequestsForEndpointSlicesEvent_enqueueImpactedTargetGroupBindings(t *testing.T) {
+	instanceTargetType := elbv2api.TargetTypeInstance
+	ipTargetType := elbv2api.TargetTypeIP
+
+	type tgbListCall struct {
+		opts []client.ListOption
+		tgbs []*elbv2api.TargetGroupBinding
+		err  error
+	}
+	type fields struct {
+		tgbListCalls []tgbListCall
+	}
+	type args struct {
+		epslice *discv1.EndpointSlice
+	}
+	tests := []struct {
+		name         string
+		fields       fields
+		args         args
+		wantRequests []ctrl.Request
+	}{
+		{
+			name: "service event should enqueue impacted ip TargetType TGBs",
+			fields: fields{
+				tgbListCalls: []tgbListCall{
+					{
+						opts: []client.ListOption{
+							client.InNamespace("awesome-ns"),
+							client.MatchingFields{"spec.serviceRef.name": "awesome-svc"},
+						},
+						tgbs: []*elbv2api.TargetGroupBinding{
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "awesome-ns",
+									Name:      "tgb-1",
+								},
+								Spec: elbv2api.TargetGroupBindingSpec{
+									TargetType: &ipTargetType,
+								},
+							},
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "awesome-ns",
+									Name:      "tgb-2",
+								},
+								Spec: elbv2api.TargetGroupBindingSpec{
+									TargetType: &instanceTargetType,
+								},
+							},
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "awesome-ns",
+									Name:      "tgb-3",
+								},
+								Spec: elbv2api.TargetGroupBindingSpec{
+									TargetType: &ipTargetType,
+								},
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				epslice: &discv1.EndpointSlice{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Name:      "awesome-svc",
+						Labels:    map[string]string{"kubernetes.io/service-name": "awesome-svc"},
+					},
+				},
+			},
+			wantRequests: []ctrl.Request{
+				{
+					NamespacedName: types.NamespacedName{Namespace: "awesome-ns", Name: "tgb-1"},
+				},
+				{
+					NamespacedName: types.NamespacedName{Namespace: "awesome-ns", Name: "tgb-3"},
+				},
+			},
+		},
+		{
+			name: "service event should enqueue impacted ip TargetType TGBs - ignore nil TargetType",
+			fields: fields{
+				tgbListCalls: []tgbListCall{
+					{
+						opts: []client.ListOption{
+							client.InNamespace("awesome-ns"),
+							client.MatchingFields{"spec.serviceRef.name": "awesome-svc"},
+						},
+						tgbs: []*elbv2api.TargetGroupBinding{
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "awesome-ns",
+									Name:      "tgb-1",
+								},
+								Spec: elbv2api.TargetGroupBindingSpec{
+									TargetType: &ipTargetType,
+								},
+							},
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "awesome-ns",
+									Name:      "tgb-2",
+								},
+								Spec: elbv2api.TargetGroupBindingSpec{
+									TargetType: nil,
+								},
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				epslice: &discv1.EndpointSlice{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Name:      "awesome-svc",
+						Labels:    map[string]string{"kubernetes.io/service-name": "awesome-svc"},
+					},
+				},
+			},
+			wantRequests: []ctrl.Request{
+				{
+					NamespacedName: types.NamespacedName{Namespace: "awesome-ns", Name: "tgb-1"},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			k8sClient := mock_client.NewMockClient(ctrl)
+			for _, call := range tt.fields.tgbListCalls {
+				var extraMatchers []interface{}
+				for _, opt := range call.opts {
+					extraMatchers = append(extraMatchers, testutils.NewListOptionEquals(opt))
+				}
+				k8sClient.EXPECT().List(gomock.Any(), gomock.Any(), extraMatchers...).DoAndReturn(
+					func(ctx context.Context, tgbList *elbv2api.TargetGroupBindingList, opts ...client.ListOption) error {
+						for _, tgb := range call.tgbs {
+							tgbList.Items = append(tgbList.Items, *(tgb.DeepCopy()))
+						}
+						return call.err
+					},
+				)
+			}
+
+			h := &enqueueRequestsForEndpointSlicesEvent{
+				k8sClient: k8sClient,
+				logger:    &log.NullLogger{},
+			}
+			queue := controllertest.Queue{Interface: workqueue.New()}
+			h.enqueueImpactedTargetGroupBindings(queue, tt.args.epslice)
+			gotRequests := testutils.ExtractCTRLRequestsFromQueue(queue)
+			assert.True(t, cmp.Equal(tt.wantRequests, gotRequests),
+				"diff", cmp.Diff(tt.wantRequests, gotRequests))
+		})
+	}
+}

--- a/controllers/elbv2/targetgroupbinding_controller.go
+++ b/controllers/elbv2/targetgroupbinding_controller.go
@@ -61,7 +61,7 @@ func NewTargetGroupBindingReconciler(k8sClient client.Client, eventRecorder reco
 
 		maxConcurrentReconciles:    config.TargetGroupBindingMaxConcurrentReconciles,
 		maxExponentialBackoffDelay: config.TargetGroupBindingMaxExponentialBackoffDelay,
-		useEndpointSlices:          config.UseEndpointSlices,
+		enableEndpointSlices:       config.EnableEndpointSlices,
 	}
 }
 
@@ -75,7 +75,7 @@ type targetGroupBindingReconciler struct {
 
 	maxConcurrentReconciles    int
 	maxExponentialBackoffDelay time.Duration
-	useEndpointSlices          bool
+	enableEndpointSlices       bool
 }
 
 // +kubebuilder:rbac:groups=elbv2.k8s.aws,resources=targetgroupbindings,verbs=get;list;watch;update;patch;create;delete
@@ -87,15 +87,16 @@ type targetGroupBindingReconciler struct {
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups="discovery.k8s.io",resources=endpointslices,verbs=get;list;watch
 
 func (r *targetGroupBindingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.logger.Info("Reconcile request", "name", req.Name)
+	r.logger.V(1).Info("Reconcile request", "name", req.Name)
 	return runtime.HandleReconcileError(r.reconcile(ctx, req), r.logger)
 }
 
 func (r *targetGroupBindingReconciler) reconcile(ctx context.Context, req ctrl.Request) error {
 	tgb := &elbv2api.TargetGroupBinding{}
-	r.logger.Info("reconcile request Get", "name", req.Name, "tgb name", tgb.ObjectMeta.Name)
+	r.logger.V(1).Info("reconcile request Get", "name", req.Name, "tgb name", tgb.ObjectMeta.Name)
 	if err := r.k8sClient.Get(ctx, req.NamespacedName, tgb); err != nil {
 		return client.IgnoreNotFound(err)
 	}
@@ -107,16 +108,15 @@ func (r *targetGroupBindingReconciler) reconcile(ctx context.Context, req ctrl.R
 }
 
 func (r *targetGroupBindingReconciler) reconcileTargetGroupBinding(ctx context.Context, tgb *elbv2api.TargetGroupBinding) error {
-	r.logger.Info("reconcileTargetGroupBinding AddFinalizers", "name", tgb.ObjectMeta.Name)
 	if err := r.finalizerManager.AddFinalizers(ctx, tgb, targetGroupBindingFinalizer); err != nil {
 		r.eventRecorder.Event(tgb, corev1.EventTypeWarning, k8s.TargetGroupBindingEventReasonFailedAddFinalizer, fmt.Sprintf("Failed add finalizer due to %v", err))
 		return err
 	}
-	r.logger.Info("reconcileTargetGroupBinding Reconcile", "name", tgb.ObjectMeta.Name)
+
 	if err := r.tgbResourceManager.Reconcile(ctx, tgb); err != nil {
 		return err
 	}
-	r.logger.Info("reconcileTargetGroupBinding updateTargetGroupBindingStatus", "name", tgb.ObjectMeta.Name)
+
 	if err := r.updateTargetGroupBindingStatus(ctx, tgb); err != nil {
 		r.eventRecorder.Event(tgb, corev1.EventTypeWarning, k8s.TargetGroupBindingEventReasonFailedUpdateStatus, fmt.Sprintf("Failed update status due to %v", err))
 		return err
@@ -163,7 +163,7 @@ func (r *targetGroupBindingReconciler) SetupWithManager(ctx context.Context, mgr
 		r.logger.WithName("eventHandlers").WithName("node"))
 
 	// Use the config flag to decide whether to use and watch an Endpoints event handler or an EndpointSlices event handler
-	if r.useEndpointSlices {
+	if r.enableEndpointSlices {
 		epSliceEventsHandler := eventhandlers.NewEnqueueRequestsForEndpointSlicesEvent(r.k8sClient,
 			r.logger.WithName("eventHandlers").WithName("endpointslices"))
 		return ctrl.NewControllerManagedBy(mgr).

--- a/controllers/elbv2/targetgroupbinding_controller.go
+++ b/controllers/elbv2/targetgroupbinding_controller.go
@@ -96,7 +96,6 @@ func (r *targetGroupBindingReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 func (r *targetGroupBindingReconciler) reconcile(ctx context.Context, req ctrl.Request) error {
 	tgb := &elbv2api.TargetGroupBinding{}
-	r.logger.V(1).Info("reconcile request Get", "name", req.Name, "tgb name", tgb.ObjectMeta.Name)
 	if err := r.k8sClient.Get(ctx, req.NamespacedName, tgb); err != nil {
 		return client.IgnoreNotFound(err)
 	}

--- a/docs/deploy/configurations.md
+++ b/docs/deploy/configurations.md
@@ -93,7 +93,7 @@ Currently, you can set only 1 namespace to watch in this flag. See [this Kuberne
 |sync-period                            | duration                        | 1h0m0s          | Period at which the controller forces the repopulation of its local object stores|
 |targetgroupbinding-max-concurrent-reconciles | int                       | 3               | Maximum number of concurrently running reconcile loops for targetGroupBinding |
 |targetgroupbinding-max-exponential-backoff-delay | duration              | 16m40s          | Maximum duration of exponential backoff for targetGroupBinding reconcile failures |
-|use-endpoint-slices                    | boolean                         | false           | Use EndpointSlices instead of Endpoints for pod endpoint and TargetGroupBinding resolution. |
+|enable-endpoint-slices                 | boolean                         | false           | Use EndpointSlices instead of Endpoints for pod endpoint and TargetGroupBinding resolution for load balancers with IP targets. |
 |watch-namespace                        | string                          |                 | Namespace the controller watches for updates to Kubernetes objects, If empty, all namespaces are watched. |
 |webhook-bind-port                      | int                             | 9443            | The TCP port the Webhook server binds to |
 |webhook-cert-dir                       | string                          | /tmp/k8s-webhook-server/serving-certs | The directory that contains the server key and certificate |

--- a/docs/deploy/configurations.md
+++ b/docs/deploy/configurations.md
@@ -93,6 +93,7 @@ Currently, you can set only 1 namespace to watch in this flag. See [this Kuberne
 |sync-period                            | duration                        | 1h0m0s          | Period at which the controller forces the repopulation of its local object stores|
 |targetgroupbinding-max-concurrent-reconciles | int                       | 3               | Maximum number of concurrently running reconcile loops for targetGroupBinding |
 |targetgroupbinding-max-exponential-backoff-delay | duration              | 16m40s          | Maximum duration of exponential backoff for targetGroupBinding reconcile failures |
+|use-endpoint-slices                    | boolean                         | false           | Use EndpointSlices instead of Endpoints for pod endpoint and TargetGroupBinding resolution. |
 |watch-namespace                        | string                          |                 | Namespace the controller watches for updates to Kubernetes objects, If empty, all namespaces are watched. |
 |webhook-bind-port                      | int                             | 9443            | The TCP port the Webhook server binds to |
 |webhook-cert-dir                       | string                          | /tmp/k8s-webhook-server/serving-certs | The directory that contains the server key and certificate |

--- a/main.go
+++ b/main.go
@@ -106,7 +106,7 @@ func main() {
 	subnetResolver := networking.NewDefaultSubnetsResolver(azInfoProvider, cloud.EC2(), cloud.VpcID(), controllerCFG.ClusterName, ctrl.Log.WithName("subnets-resolver"))
 	vpcResolver := networking.NewDefaultVPCResolver(cloud.EC2(), cloud.VpcID(), ctrl.Log.WithName("vpc-resolver"))
 	tgbResManager := targetgroupbinding.NewDefaultResourceManager(mgr.GetClient(), cloud.ELBV2(), cloud.EC2(),
-		podInfoRepo, sgManager, sgReconciler, cloud.VpcID(), controllerCFG.ClusterName, mgr.GetEventRecorderFor("targetGroupBinding"), ctrl.Log, controllerCFG.UseEndpointSlices)
+		podInfoRepo, sgManager, sgReconciler, cloud.VpcID(), controllerCFG.ClusterName, mgr.GetEventRecorderFor("targetGroupBinding"), ctrl.Log, controllerCFG.EnableEndpointSlices)
 	backendSGProvider := networking.NewBackendSGProvider(controllerCFG.ClusterName, controllerCFG.BackendSecurityGroup,
 		cloud.VpcID(), cloud.EC2(), mgr.GetClient(), ctrl.Log.WithName("backend-sg-provider"))
 	ingGroupReconciler := ingress.NewGroupReconciler(cloud, mgr.GetClient(), mgr.GetEventRecorderFor("ingress"),

--- a/main.go
+++ b/main.go
@@ -17,6 +17,8 @@ limitations under the License.
 package main
 
 import (
+	"os"
+
 	"github.com/go-logr/logr"
 	"github.com/spf13/pflag"
 	zapraw "go.uber.org/zap"
@@ -24,7 +26,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-	"os"
 	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
 	elbv2controller "sigs.k8s.io/aws-load-balancer-controller/controllers/elbv2"
 	"sigs.k8s.io/aws-load-balancer-controller/controllers/ingress"
@@ -105,7 +106,7 @@ func main() {
 	subnetResolver := networking.NewDefaultSubnetsResolver(azInfoProvider, cloud.EC2(), cloud.VpcID(), controllerCFG.ClusterName, ctrl.Log.WithName("subnets-resolver"))
 	vpcResolver := networking.NewDefaultVPCResolver(cloud.EC2(), cloud.VpcID(), ctrl.Log.WithName("vpc-resolver"))
 	tgbResManager := targetgroupbinding.NewDefaultResourceManager(mgr.GetClient(), cloud.ELBV2(), cloud.EC2(),
-		podInfoRepo, sgManager, sgReconciler, cloud.VpcID(), controllerCFG.ClusterName, mgr.GetEventRecorderFor("targetGroupBinding"), ctrl.Log)
+		podInfoRepo, sgManager, sgReconciler, cloud.VpcID(), controllerCFG.ClusterName, mgr.GetEventRecorderFor("targetGroupBinding"), ctrl.Log, controllerCFG.UseEndpointSlices)
 	backendSGProvider := networking.NewBackendSGProvider(controllerCFG.ClusterName, controllerCFG.BackendSecurityGroup,
 		cloud.VpcID(), cloud.EC2(), mgr.GetClient(), ctrl.Log.WithName("backend-sg-provider"))
 	ingGroupReconciler := ingress.NewGroupReconciler(cloud, mgr.GetClient(), mgr.GetEventRecorderFor("ingress"),

--- a/pkg/aws/cloud.go
+++ b/pkg/aws/cloud.go
@@ -59,7 +59,7 @@ func NewCloud(cfg CloudConfig, metricsRegisterer prometheus.Registerer) (Cloud, 
 			region = os.Getenv("AWS_REGION")
 		}
 
-		if region == ""{
+		if region == "" {
 			err := (error)(nil)
 			region, err = metadata.Region()
 			if err != nil {

--- a/pkg/backend/endpoint_resolver.go
+++ b/pkg/backend/endpoint_resolver.go
@@ -16,6 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const svcNameLabel = "kubernetes.io/service-name"
+
 var ErrNotFound = errors.New("backend not found")
 
 // TODO: for pod endpoints, we currently rely on endpoints events, we might change to use pod events directly in the future.
@@ -139,7 +141,6 @@ func (r *defaultEndpointResolver) ResolvePodEndpointsFromSlices(ctx context.Cont
 		return nil, false, err
 	}
 
-	const svcNameLabel = "kubernetes.io/service-name"
 	epSlicesList := &discv1.EndpointSliceList{}
 	if err := r.k8sClient.List(ctx, epSlicesList,
 		client.InNamespace(svcKey.Namespace),

--- a/pkg/backend/endpoint_resolver_test.go
+++ b/pkg/backend/endpoint_resolver_test.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"testing"
+
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	discv1 "k8s.io/api/discovery/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -20,7 +23,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"testing"
 )
 
 func Test_defaultEndpointResolver_ResolvePodEndpoints(t *testing.T) {
@@ -1095,6 +1097,937 @@ func Test_defaultEndpointResolver_ResolveNodePortEndpoints(t *testing.T) {
 				}
 				assert.True(t, cmp.Equal(tt.want, got, opt),
 					"diff: %v", cmp.Diff(tt.want, got, opt))
+			}
+		})
+	}
+}
+
+func Test_defaultEndpointResolver_ResolvePodEndpointsFromSlices(t *testing.T) {
+	testNS := "test-ns"
+	pod1 := k8s.PodInfo{
+		Key:            types.NamespacedName{Namespace: testNS, Name: "pod-1"},
+		UID:            "pod-uuid-1",
+		ReadinessGates: nil,
+		Conditions: []corev1.PodCondition{
+			{
+				Type:   corev1.PodReady,
+				Status: corev1.ConditionTrue,
+			},
+			{
+				Type:   corev1.ContainersReady,
+				Status: corev1.ConditionTrue,
+			},
+		},
+		PodIP: "192.168.1.1",
+	}
+	pod2 := k8s.PodInfo{
+		Key:            types.NamespacedName{Namespace: testNS, Name: "pod-2"},
+		UID:            "pod-uuid-2",
+		ReadinessGates: nil,
+		Conditions: []corev1.PodCondition{
+			{
+				Type:   corev1.PodReady,
+				Status: corev1.ConditionTrue,
+			},
+			{
+				Type:   corev1.ContainersReady,
+				Status: corev1.ConditionTrue,
+			},
+		},
+		PodIP: "192.168.1.2",
+	}
+	pod3 := k8s.PodInfo{
+		Key: types.NamespacedName{Namespace: testNS, Name: "pod-3"},
+		UID: "pod-uuid-3",
+		Conditions: []corev1.PodCondition{
+			{
+				Type:   corev1.PodReady,
+				Status: corev1.ConditionFalse,
+			},
+			{
+				Type:   corev1.ContainersReady,
+				Status: corev1.ConditionTrue,
+			},
+		},
+		PodIP: "192.168.1.3",
+	}
+	pod4 := k8s.PodInfo{
+		Key: types.NamespacedName{Namespace: testNS, Name: "pod-4"},
+		UID: "pod-uuid-4",
+		ReadinessGates: []corev1.PodReadinessGate{
+			{
+				ConditionType: "custom-condition",
+			},
+		},
+		Conditions: []corev1.PodCondition{
+			{
+				Type:   corev1.PodReady,
+				Status: corev1.ConditionFalse,
+			},
+			{
+				Type:   corev1.ContainersReady,
+				Status: corev1.ConditionTrue,
+			},
+		},
+		PodIP: "192.168.1.4",
+	}
+	pod5 := k8s.PodInfo{
+		Key: types.NamespacedName{Namespace: testNS, Name: "pod-5"},
+		UID: "pod-uuid-5",
+		ReadinessGates: []corev1.PodReadinessGate{
+			{
+				ConditionType: "custom-condition",
+			},
+		},
+		Conditions: []corev1.PodCondition{
+			{
+				Type:   corev1.PodReady,
+				Status: corev1.ConditionFalse,
+			},
+			{
+				Type:   corev1.ContainersReady,
+				Status: corev1.ConditionFalse,
+			},
+		},
+		PodIP: "192.168.1.5",
+	}
+	svc1 := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNS,
+			Name:      "svc-1",
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{
+				{
+					Name: "http",
+					Port: 80,
+				},
+				{
+					Name: "https",
+					Port: 443,
+				},
+			},
+		},
+	}
+	svc1WithoutHTTPPort := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNS,
+			Name:      "svc-1",
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{
+				{
+					Name: "https",
+					Port: 443,
+				},
+			},
+		},
+	}
+	port1AName := "http"
+	port1ANumber := int32(8080)
+	epSlice1AConditions := []bool{true, true, false, false}
+	epSlice1A := &discv1.EndpointSlice{
+		AddressType: discv1.AddressTypeIPv4,
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNS,
+			Name:      "svc-1-1A",
+			Labels:    map[string]string{"kubernetes.io/service-name": "svc-1"},
+		},
+		Ports: []discv1.EndpointPort{
+			{
+				Name: &port1AName,
+				Port: &port1ANumber,
+			},
+		},
+		Endpoints: []discv1.Endpoint{
+			{
+				Addresses: []string{
+					pod1.PodIP,
+				},
+				Conditions: discv1.EndpointConditions{
+					Ready: &epSlice1AConditions[0],
+				},
+				TargetRef: &corev1.ObjectReference{
+					Kind:      "Pod",
+					Namespace: pod1.Key.Namespace,
+					Name:      pod1.Key.Name,
+				},
+			},
+			{
+				Addresses: []string{
+					pod2.PodIP,
+				},
+				Conditions: discv1.EndpointConditions{
+					Ready: &epSlice1AConditions[1],
+				},
+				TargetRef: &corev1.ObjectReference{
+					Kind:      "Pod",
+					Namespace: pod2.Key.Namespace,
+					Name:      pod2.Key.Name,
+				},
+			},
+			{
+				Addresses: []string{
+					pod3.PodIP,
+				},
+				Conditions: discv1.EndpointConditions{
+					Ready: &epSlice1AConditions[2],
+				},
+				TargetRef: &corev1.ObjectReference{
+					Kind:      "Pod",
+					Namespace: pod3.Key.Namespace,
+					Name:      pod3.Key.Name,
+				},
+			},
+			{
+				Addresses: []string{
+					pod4.PodIP,
+				},
+				Conditions: discv1.EndpointConditions{
+					Ready: &epSlice1AConditions[3],
+				},
+				TargetRef: &corev1.ObjectReference{
+					Kind:      "Pod",
+					Namespace: pod4.Key.Namespace,
+					Name:      pod4.Key.Name,
+				},
+			},
+		},
+	}
+	port1BName := "http"
+	port1BNumber := int32(8080)
+	epSlice1BConditions := []bool{true, true, false, false}
+	epSlice1B := &discv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNS,
+			Name:      "svc-1-1B",
+			Labels:    map[string]string{"kubernetes.io/service-name": "svc-1"},
+		},
+		Ports: []discv1.EndpointPort{
+			{
+				Name: &port1BName,
+				Port: &port1BNumber,
+			},
+		},
+		Endpoints: []discv1.Endpoint{
+			{
+				Addresses: []string{
+					pod1.PodIP,
+				},
+				Conditions: discv1.EndpointConditions{
+					Ready: &epSlice1BConditions[0],
+				},
+				TargetRef: &corev1.ObjectReference{
+					Kind:      "Pod",
+					Namespace: pod1.Key.Namespace,
+					Name:      pod1.Key.Name,
+				},
+			},
+			{
+				Addresses: []string{
+					pod2.PodIP,
+				},
+				Conditions: discv1.EndpointConditions{
+					Ready: &epSlice1BConditions[1],
+				},
+				TargetRef: &corev1.ObjectReference{
+					Kind:      "Pod",
+					Namespace: pod2.Key.Namespace,
+					Name:      pod2.Key.Name,
+				},
+			},
+			{
+				Addresses: []string{
+					pod3.PodIP,
+				},
+				Conditions: discv1.EndpointConditions{
+					Ready: &epSlice1BConditions[2],
+				},
+				TargetRef: &corev1.ObjectReference{
+					Kind:      "Pod",
+					Namespace: pod3.Key.Namespace,
+					Name:      pod3.Key.Name,
+				},
+			},
+			{
+				Addresses: []string{
+					pod4.PodIP,
+				},
+				Conditions: discv1.EndpointConditions{
+					Ready: &epSlice1BConditions[3],
+				},
+				TargetRef: &corev1.ObjectReference{
+					Kind:      "Pod",
+					Namespace: pod4.Key.Namespace,
+					Name:      pod4.Key.Name,
+				},
+			},
+		},
+	}
+	port1CNames := []string{"http", "https"}
+	port1CNumbers := []int32{8080, 8080}
+	epSlice1CConditions := []bool{true, true, false, false}
+	epSlice1C := &discv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNS,
+			Name:      "svc-1-1C",
+			Labels:    map[string]string{"kubernetes.io/service-name": "svc-1"},
+		},
+		Ports: []discv1.EndpointPort{
+			{
+				Name: &port1CNames[0],
+				Port: &port1CNumbers[0],
+			},
+			{
+				Name: &port1CNames[1],
+				Port: &port1CNumbers[1],
+			},
+		},
+		Endpoints: []discv1.Endpoint{
+			{
+				Addresses: []string{
+					pod1.PodIP,
+				},
+				Conditions: discv1.EndpointConditions{
+					Ready: &epSlice1CConditions[0],
+				},
+				TargetRef: &corev1.ObjectReference{
+					Kind:      "Pod",
+					Namespace: pod1.Key.Namespace,
+					Name:      pod1.Key.Name,
+				},
+			},
+			{
+				Addresses: []string{
+					pod2.PodIP,
+				},
+				Conditions: discv1.EndpointConditions{
+					Ready: &epSlice1CConditions[1],
+				},
+				TargetRef: &corev1.ObjectReference{
+					Kind:      "Pod",
+					Namespace: pod2.Key.Namespace,
+					Name:      pod2.Key.Name,
+				},
+			},
+			{
+				Addresses: []string{
+					pod3.PodIP,
+				},
+				Conditions: discv1.EndpointConditions{
+					Ready: &epSlice1CConditions[2],
+				},
+				TargetRef: &corev1.ObjectReference{
+					Kind:      "Pod",
+					Namespace: pod3.Key.Namespace,
+					Name:      pod3.Key.Name,
+				},
+			},
+			{
+				Addresses: []string{
+					pod4.PodIP,
+				},
+				Conditions: discv1.EndpointConditions{
+					Ready: &epSlice1CConditions[3],
+				},
+				TargetRef: &corev1.ObjectReference{
+					Kind:      "Pod",
+					Namespace: pod4.Key.Namespace,
+					Name:      pod4.Key.Name,
+				},
+			},
+		},
+	}
+	port1DName := "http"
+	port1DNumber := int32(8080)
+	epSlice1DConditions := []bool{true, true, false, false, false}
+	epSlice1D := &discv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNS,
+			Name:      "svc-1-1D",
+			Labels:    map[string]string{"kubernetes.io/service-name": "svc-1"},
+		},
+		Ports: []discv1.EndpointPort{
+			{
+				Name: &port1DName,
+				Port: &port1DNumber,
+			},
+		},
+		Endpoints: []discv1.Endpoint{
+			{
+				Addresses: []string{
+					pod1.PodIP,
+				},
+				Conditions: discv1.EndpointConditions{
+					Ready: &epSlice1DConditions[0],
+				},
+				TargetRef: &corev1.ObjectReference{
+					Kind:      "Pod",
+					Namespace: pod1.Key.Namespace,
+					Name:      pod1.Key.Name,
+				},
+			},
+			{
+				Addresses: []string{
+					pod2.PodIP,
+				},
+				Conditions: discv1.EndpointConditions{
+					Ready: &epSlice1DConditions[1],
+				},
+				TargetRef: &corev1.ObjectReference{
+					Kind:      "Pod",
+					Namespace: pod2.Key.Namespace,
+					Name:      pod2.Key.Name,
+				},
+			},
+			{
+				Addresses: []string{
+					pod3.PodIP,
+				},
+				Conditions: discv1.EndpointConditions{
+					Ready: &epSlice1DConditions[2],
+				},
+				TargetRef: &corev1.ObjectReference{
+					Kind:      "Pod",
+					Namespace: pod3.Key.Namespace,
+					Name:      pod3.Key.Name,
+				},
+			},
+			{
+				Addresses: []string{
+					pod4.PodIP,
+				},
+				Conditions: discv1.EndpointConditions{
+					Ready: &epSlice1DConditions[3],
+				},
+				TargetRef: &corev1.ObjectReference{
+					Kind:      "Pod",
+					Namespace: pod4.Key.Namespace,
+					Name:      pod4.Key.Name,
+				},
+			},
+			{
+				Addresses: []string{
+					pod5.PodIP,
+				},
+				Conditions: discv1.EndpointConditions{
+					Ready: &epSlice1DConditions[4],
+				},
+				TargetRef: &corev1.ObjectReference{
+					Kind:      "Pod",
+					Namespace: pod5.Key.Namespace,
+					Name:      pod5.Key.Name,
+				},
+			},
+		},
+	}
+	port1EName := "http"
+	port1ENumber := int32(8080)
+	epSlice1EConditions := []bool{true, true, false, false}
+	epSlice1E := &discv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNS,
+			Name:      "svc-1-1E",
+			Labels:    map[string]string{"kubernetes.io/service-name": "svc-1"},
+		},
+		Ports: []discv1.EndpointPort{
+			{
+				Name: &port1EName,
+				Port: &port1ENumber,
+			},
+		},
+		Endpoints: []discv1.Endpoint{
+			{
+				Addresses: []string{
+					pod1.PodIP,
+				},
+				Conditions: discv1.EndpointConditions{
+					Ready: &epSlice1EConditions[0],
+				},
+				TargetRef: &corev1.ObjectReference{
+					Kind:      "Pod",
+					Namespace: pod1.Key.Namespace,
+					Name:      pod1.Key.Name,
+				},
+			},
+			{
+				Addresses: []string{
+					pod2.PodIP,
+				},
+				Conditions: discv1.EndpointConditions{
+					Ready: &epSlice1EConditions[1],
+				},
+				TargetRef: &corev1.ObjectReference{
+					Kind:      "Pod",
+					Namespace: pod2.Key.Namespace,
+					Name:      pod2.Key.Name,
+				},
+			},
+			{
+				Addresses: []string{
+					pod3.PodIP,
+				},
+				Conditions: discv1.EndpointConditions{
+					Ready: &epSlice1EConditions[2],
+				},
+				TargetRef: &corev1.ObjectReference{
+					Kind:      "Pod",
+					Namespace: pod3.Key.Namespace,
+					Name:      pod3.Key.Name,
+				},
+			},
+			{
+				Addresses: []string{
+					pod4.PodIP,
+				},
+				Conditions: discv1.EndpointConditions{
+					Ready: &epSlice1EConditions[3],
+				},
+				TargetRef: &corev1.ObjectReference{
+					Kind:      "Pod",
+					Namespace: pod4.Key.Namespace,
+					Name:      pod4.Key.Name,
+				},
+			},
+		},
+	}
+
+	type podInfoRepoGetCall struct {
+		key    types.NamespacedName
+		pod    k8s.PodInfo
+		exists bool
+		err    error
+	}
+	type env struct {
+		services    []*corev1.Service
+		epSliceList []*discv1.EndpointSlice
+	}
+	type fields struct {
+		podInfoRepoGetCalls []podInfoRepoGetCall
+	}
+	type args struct {
+		svcKey types.NamespacedName
+		port   intstr.IntOrString
+		opts   []EndpointResolveOption
+	}
+	tests := []struct {
+		name                                string
+		env                                 env
+		fields                              fields
+		args                                args
+		want                                []PodEndpoint
+		wantContainsPotentialReadyEndpoints bool
+		wantErr                             error
+	}{
+		{
+			name: "only ready pods will be included by default",
+			env: env{
+				services:    []*corev1.Service{svc1},
+				epSliceList: []*discv1.EndpointSlice{epSlice1A},
+			},
+			fields: fields{
+				podInfoRepoGetCalls: []podInfoRepoGetCall{
+					{
+						key:    pod1.Key,
+						pod:    pod1,
+						exists: true,
+					},
+					{
+						key:    pod2.Key,
+						pod:    pod2,
+						exists: true,
+					},
+				},
+			},
+			args: args{
+				svcKey: k8s.NamespacedName(svc1),
+				port:   intstr.FromString("http"),
+				opts:   nil,
+			},
+			want: []PodEndpoint{
+				{
+					IP:   "192.168.1.1",
+					Port: 8080,
+					Pod:  pod1,
+				},
+				{
+					IP:   "192.168.1.2",
+					Port: 8080,
+					Pod:  pod2,
+				},
+			},
+			wantContainsPotentialReadyEndpoints: false,
+		},
+		{
+			name: "unready only be included if it have readinessGate and containerReady",
+			env: env{
+				services:    []*corev1.Service{svc1},
+				epSliceList: []*discv1.EndpointSlice{epSlice1A},
+			},
+			fields: fields{
+				podInfoRepoGetCalls: []podInfoRepoGetCall{
+					{
+						key:    pod1.Key,
+						pod:    pod1,
+						exists: true,
+					},
+					{
+						key:    pod2.Key,
+						pod:    pod2,
+						exists: true,
+					},
+					{
+						key:    pod3.Key,
+						pod:    pod3,
+						exists: true,
+					},
+					{
+						key:    pod4.Key,
+						pod:    pod4,
+						exists: true,
+					},
+				},
+			},
+			args: args{
+				svcKey: k8s.NamespacedName(svc1),
+				port:   intstr.FromString("http"),
+				opts:   []EndpointResolveOption{WithPodReadinessGate("custom-condition")},
+			},
+			want: []PodEndpoint{
+				{
+					IP:   "192.168.1.1",
+					Port: 8080,
+					Pod:  pod1,
+				},
+				{
+					IP:   "192.168.1.2",
+					Port: 8080,
+					Pod:  pod2,
+				},
+				{
+					IP:   "192.168.1.4",
+					Port: 8080,
+					Pod:  pod4,
+				},
+			},
+			wantContainsPotentialReadyEndpoints: false,
+		},
+		{
+			name: "IP addresses that appear in multiple slices shouldn't appear in duplicate endpoints",
+			env: env{
+				services:    []*corev1.Service{svc1},
+				epSliceList: []*discv1.EndpointSlice{epSlice1B, epSlice1E},
+			},
+			fields: fields{
+				podInfoRepoGetCalls: []podInfoRepoGetCall{
+					{
+						key:    pod1.Key,
+						pod:    pod1,
+						exists: true,
+					},
+					{
+						key:    pod2.Key,
+						pod:    pod2,
+						exists: true,
+					},
+					{
+						key:    pod3.Key,
+						pod:    pod3,
+						exists: true,
+					},
+					{
+						key:    pod4.Key,
+						pod:    pod4,
+						exists: true,
+					},
+				},
+			},
+			args: args{
+				svcKey: k8s.NamespacedName(svc1),
+				port:   intstr.FromString("http"),
+				opts:   []EndpointResolveOption{WithPodReadinessGate("custom-condition")},
+			},
+			want: []PodEndpoint{
+				{
+					IP:   "192.168.1.1",
+					Port: 8080,
+					Pod:  pod1,
+				},
+				{
+					IP:   "192.168.1.2",
+					Port: 8080,
+					Pod:  pod2,
+				},
+				{
+					IP:   "192.168.1.4",
+					Port: 8080,
+					Pod:  pod4,
+				},
+			},
+			wantContainsPotentialReadyEndpoints: false,
+		},
+		{
+			name: "endpointslices with multiple ports should work as expected",
+			env: env{
+				services:    []*corev1.Service{svc1},
+				epSliceList: []*discv1.EndpointSlice{epSlice1C},
+			},
+			fields: fields{
+				podInfoRepoGetCalls: []podInfoRepoGetCall{
+					{
+						key:    pod1.Key,
+						pod:    pod1,
+						exists: true,
+					},
+					{
+						key:    pod2.Key,
+						pod:    pod2,
+						exists: true,
+					},
+					{
+						key:    pod3.Key,
+						pod:    pod3,
+						exists: true,
+					},
+					{
+						key:    pod4.Key,
+						pod:    pod4,
+						exists: true,
+					},
+				},
+			},
+			args: args{
+				svcKey: k8s.NamespacedName(svc1),
+				port:   intstr.FromString("http"),
+				opts:   []EndpointResolveOption{WithPodReadinessGate("custom-condition")},
+			},
+			want: []PodEndpoint{
+				{
+					IP:   "192.168.1.1",
+					Port: 8080,
+					Pod:  pod1,
+				},
+				{
+					IP:   "192.168.1.2",
+					Port: 8080,
+					Pod:  pod2,
+				},
+				{
+					IP:   "192.168.1.4",
+					Port: 8080,
+					Pod:  pod4,
+				},
+			},
+			wantContainsPotentialReadyEndpoints: false,
+		},
+		{
+			name: "unready but not found pod will be ignored, but signal potentialReadyEndpoints",
+			env: env{
+				services:    []*corev1.Service{svc1},
+				epSliceList: []*discv1.EndpointSlice{epSlice1A},
+			},
+			fields: fields{
+				podInfoRepoGetCalls: []podInfoRepoGetCall{
+					{
+						key:    pod1.Key,
+						pod:    pod1,
+						exists: true,
+					},
+					{
+						key:    pod2.Key,
+						pod:    pod2,
+						exists: true,
+					},
+					{
+						key:    pod3.Key,
+						exists: false,
+					},
+					{
+						key:    pod4.Key,
+						pod:    pod4,
+						exists: true,
+					},
+				},
+			},
+			args: args{
+				svcKey: k8s.NamespacedName(svc1),
+				port:   intstr.FromString("http"),
+				opts:   []EndpointResolveOption{WithPodReadinessGate("custom-condition")},
+			},
+			want: []PodEndpoint{
+				{
+					IP:   "192.168.1.1",
+					Port: 8080,
+					Pod:  pod1,
+				},
+				{
+					IP:   "192.168.1.2",
+					Port: 8080,
+					Pod:  pod2,
+				},
+				{
+					IP:   "192.168.1.4",
+					Port: 8080,
+					Pod:  pod4,
+				},
+			},
+			wantContainsPotentialReadyEndpoints: true,
+		},
+		{
+			name: "unready only be included if it have readinessGate and containerReady - not containerReady will signal containsPotentialReadyEndpoints",
+			env: env{
+				services:    []*corev1.Service{svc1},
+				epSliceList: []*discv1.EndpointSlice{epSlice1D},
+			},
+			fields: fields{
+				podInfoRepoGetCalls: []podInfoRepoGetCall{
+					{
+						key:    pod1.Key,
+						pod:    pod1,
+						exists: true,
+					},
+					{
+						key:    pod2.Key,
+						pod:    pod2,
+						exists: true,
+					},
+					{
+						key:    pod3.Key,
+						pod:    pod3,
+						exists: true,
+					},
+					{
+						key:    pod4.Key,
+						pod:    pod4,
+						exists: true,
+					},
+					{
+						key:    pod5.Key,
+						pod:    pod5,
+						exists: true,
+					},
+				},
+			},
+			args: args{
+				svcKey: k8s.NamespacedName(svc1),
+				port:   intstr.FromString("http"),
+				opts:   []EndpointResolveOption{WithPodReadinessGate("custom-condition")},
+			},
+			want: []PodEndpoint{
+				{
+					IP:   "192.168.1.1",
+					Port: 8080,
+					Pod:  pod1,
+				},
+				{
+					IP:   "192.168.1.2",
+					Port: 8080,
+					Pod:  pod2,
+				},
+				{
+					IP:   "192.168.1.4",
+					Port: 8080,
+					Pod:  pod4,
+				},
+			},
+			wantContainsPotentialReadyEndpoints: true,
+		},
+		{
+			name: "service not found",
+			env: env{
+				services:    []*corev1.Service{},
+				epSliceList: []*discv1.EndpointSlice{},
+			},
+			fields: fields{
+				podInfoRepoGetCalls: []podInfoRepoGetCall{},
+			},
+			args: args{
+				svcKey: k8s.NamespacedName(svc1),
+				port:   intstr.FromString("http"),
+				opts:   nil,
+			},
+			want:                                []PodEndpoint{},
+			wantContainsPotentialReadyEndpoints: false,
+			wantErr:                             fmt.Errorf("%w: %v", ErrNotFound, "services \"svc-1\" not found"),
+		},
+		{
+			name: "service port not found",
+			env: env{
+				services:    []*corev1.Service{svc1WithoutHTTPPort},
+				epSliceList: []*discv1.EndpointSlice{},
+			},
+			fields: fields{
+				podInfoRepoGetCalls: []podInfoRepoGetCall{},
+			},
+			args: args{
+				svcKey: k8s.NamespacedName(svc1),
+				port:   intstr.FromString("http"),
+				opts:   nil,
+			},
+			wantErr: fmt.Errorf("%w: %v", ErrNotFound, "unable to find port http on service test-ns/svc-1"),
+		},
+		{
+			name: "endpointslices not found",
+			env: env{
+				services:    []*corev1.Service{svc1},
+				epSliceList: []*discv1.EndpointSlice{},
+			},
+			fields: fields{
+				podInfoRepoGetCalls: []podInfoRepoGetCall{},
+			},
+			args: args{
+				svcKey: k8s.NamespacedName(svc1),
+				port:   intstr.FromString("http"),
+				opts:   nil,
+			},
+			wantErr: fmt.Errorf("%w: %v", ErrNotFound, "endpointslices for \"svc-1\" not found"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			podInfoRepo := k8s.NewMockPodInfoRepo(ctrl)
+			for _, call := range tt.fields.podInfoRepoGetCalls {
+				// None of the tests use more than 2 EndpointSlices (potentially referencing the same pods/pod addresses),
+				// so there should not be more than 2 calls to findPodByReference for each pod
+				podInfoRepo.EXPECT().Get(gomock.Any(), call.key).Return(call.pod, call.exists, call.err).MaxTimes(2)
+			}
+
+			k8sSchema := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sSchema)
+			k8sClient := testclient.NewFakeClientWithScheme(k8sSchema)
+
+			ctx := context.Background()
+			for _, svc := range tt.env.services {
+				assert.NoError(t, k8sClient.Create(ctx, svc.DeepCopy()))
+			}
+			for _, epSlice := range tt.env.epSliceList {
+				assert.NoError(t, k8sClient.Create(ctx, epSlice.DeepCopy()))
+			}
+
+			r := &defaultEndpointResolver{
+				k8sClient:   k8sClient,
+				podInfoRepo: podInfoRepo,
+				logger:      &log.NullLogger{},
+			}
+			got, gotContainsPotentialReadyEndpoints, err := r.ResolvePodEndpointsFromSlices(ctx, tt.args.svcKey, tt.args.port, tt.args.opts...)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				opt := cmp.Options{
+					equality.IgnoreFakeClientPopulatedFields(),
+					cmpopts.SortSlices(func(lhs PodEndpoint, rhs PodEndpoint) bool {
+						return lhs.IP < rhs.IP
+					}),
+				}
+				assert.True(t, cmp.Equal(tt.want, got, opt),
+					"diff: %v", cmp.Diff(tt.want, got, opt))
+				assert.Equal(t, tt.wantContainsPotentialReadyEndpoints, gotContainsPotentialReadyEndpoints)
 			}
 		})
 	}

--- a/pkg/config/controller_config.go
+++ b/pkg/config/controller_config.go
@@ -20,15 +20,15 @@ const (
 	flagTargetGroupBindingMaxConcurrentReconciles    = "targetgroupbinding-max-concurrent-reconciles"
 	flagTargetGroupBindingMaxExponentialBackoffDelay = "targetgroupbinding-max-exponential-backoff-delay"
 	flagDefaultSSLPolicy                             = "default-ssl-policy"
-	flagUseEndpointSlices                            = "use-endpoint-slices"
 	flagEnableBackendSG                              = "enable-backend-security-group"
 	flagBackendSecurityGroup                         = "backend-security-group"
+	flagEnableEndpointSlices                         = "enable-endpoint-slices"
 	defaultLogLevel                                  = "info"
 	defaultMaxConcurrentReconciles                   = 3
 	defaultMaxExponentialBackoffDelay                = time.Second * 1000
 	defaultSSLPolicy                                 = "ELBSecurityPolicy-2016-08"
-	defaultUseEndpointSlices                         = false
 	defaultEnableBackendSG                           = true
+	defaultEnableEndpointSlices                      = false
 )
 
 var (
@@ -68,8 +68,8 @@ type ControllerConfig struct {
 	// the SSL Policy annotation.
 	DefaultSSLPolicy string
 
-	// Whether to use EndpointSlices resources(true) or Endpoints resources(false) in endpoint and TGB resolution.
-	UseEndpointSlices bool
+	// Whether to use endpointslices resources(true) or Endpoints resources(false) in endpoint and TGB resolution.
+	EnableEndpointSlices bool
 
 	// Max concurrent reconcile loops for Service objects
 	ServiceMaxConcurrentReconciles int
@@ -107,8 +107,7 @@ func (cfg *ControllerConfig) BindFlags(fs *pflag.FlagSet) {
 		"Enable sharing of security groups for backend traffic")
 	fs.StringVar(&cfg.BackendSecurityGroup, flagBackendSecurityGroup, "",
 		"Backend security group id to use for the ingress rules on the worker node SG")
-
-	fs.BoolVar(&cfg.UseEndpointSlices, flagUseEndpointSlices, defaultUseEndpointSlices,
+	fs.BoolVar(&cfg.EnableEndpointSlices, flagEnableEndpointSlices, defaultEnableEndpointSlices,
 		"Use EndpointSlices(true) or Endpoints(false) resources in endpoint and TGB resolution")
 	cfg.AWSConfig.BindFlags(fs)
 	cfg.RuntimeConfig.BindFlags(fs)

--- a/pkg/config/controller_config.go
+++ b/pkg/config/controller_config.go
@@ -68,7 +68,7 @@ type ControllerConfig struct {
 	// the SSL Policy annotation.
 	DefaultSSLPolicy string
 
-	//  Enable EndpointSlices for IP targets instead of Endpoints
+	// Enable EndpointSlices for IP targets instead of Endpoints
 	EnableEndpointSlices bool
 
 	// Max concurrent reconcile loops for Service objects
@@ -108,7 +108,7 @@ func (cfg *ControllerConfig) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&cfg.BackendSecurityGroup, flagBackendSecurityGroup, "",
 		"Backend security group id to use for the ingress rules on the worker node SG")
 	fs.BoolVar(&cfg.EnableEndpointSlices, flagEnableEndpointSlices, defaultEnableEndpointSlices,
-		"Use EndpointSlices(true) or Endpoints(false) resources in endpoint and TGB resolution")
+		"Enable EndpointSlices for IP targets instead of Endpoints")
 	cfg.AWSConfig.BindFlags(fs)
 	cfg.RuntimeConfig.BindFlags(fs)
 

--- a/pkg/config/controller_config.go
+++ b/pkg/config/controller_config.go
@@ -68,7 +68,7 @@ type ControllerConfig struct {
 	// the SSL Policy annotation.
 	DefaultSSLPolicy string
 
-	// Whether to use endpointslices resources(true) or Endpoints resources(false) in endpoint and TGB resolution.
+	//  Enable EndpointSlices for IP targets instead of Endpoints
 	EnableEndpointSlices bool
 
 	// Max concurrent reconcile loops for Service objects

--- a/pkg/config/controller_config.go
+++ b/pkg/config/controller_config.go
@@ -20,12 +20,14 @@ const (
 	flagTargetGroupBindingMaxConcurrentReconciles    = "targetgroupbinding-max-concurrent-reconciles"
 	flagTargetGroupBindingMaxExponentialBackoffDelay = "targetgroupbinding-max-exponential-backoff-delay"
 	flagDefaultSSLPolicy                             = "default-ssl-policy"
+	flagUseEndpointSlices                            = "use-endpoint-slices"
 	flagEnableBackendSG                              = "enable-backend-security-group"
 	flagBackendSecurityGroup                         = "backend-security-group"
 	defaultLogLevel                                  = "info"
 	defaultMaxConcurrentReconciles                   = 3
 	defaultMaxExponentialBackoffDelay                = time.Second * 1000
 	defaultSSLPolicy                                 = "ELBSecurityPolicy-2016-08"
+	defaultUseEndpointSlices                         = false
 	defaultEnableBackendSG                           = true
 )
 
@@ -66,6 +68,9 @@ type ControllerConfig struct {
 	// the SSL Policy annotation.
 	DefaultSSLPolicy string
 
+	// Whether to use EndpointSlices resources(true) or Endpoints resources(false) in endpoint and TGB resolution.
+	UseEndpointSlices bool
+
 	// Max concurrent reconcile loops for Service objects
 	ServiceMaxConcurrentReconciles int
 	// Max concurrent reconcile loops for TargetGroupBinding objects
@@ -103,6 +108,8 @@ func (cfg *ControllerConfig) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&cfg.BackendSecurityGroup, flagBackendSecurityGroup, "",
 		"Backend security group id to use for the ingress rules on the worker node SG")
 
+	fs.BoolVar(&cfg.UseEndpointSlices, flagUseEndpointSlices, defaultUseEndpointSlices,
+		"Use EndpointSlices(true) or Endpoints(false) resources in endpoint and TGB resolution")
 	cfg.AWSConfig.BindFlags(fs)
 	cfg.RuntimeConfig.BindFlags(fs)
 

--- a/pkg/targetgroupbinding/resource_manager.go
+++ b/pkg/targetgroupbinding/resource_manager.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"k8s.io/client-go/tools/record"
 	"time"
+
+	"k8s.io/client-go/tools/record"
 
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -38,7 +39,7 @@ type ResourceManager interface {
 // NewDefaultResourceManager constructs new defaultResourceManager.
 func NewDefaultResourceManager(k8sClient client.Client, elbv2Client services.ELBV2, ec2Client services.EC2,
 	podInfoRepo k8s.PodInfoRepo, sgManager networking.SecurityGroupManager, sgReconciler networking.SecurityGroupReconciler,
-	vpcID string, clusterName string, eventRecorder record.EventRecorder, logger logr.Logger) *defaultResourceManager {
+	vpcID string, clusterName string, eventRecorder record.EventRecorder, logger logr.Logger, useEPSlices bool) *defaultResourceManager {
 	targetsManager := NewCachedTargetsManager(elbv2Client, logger)
 	endpointResolver := backend.NewDefaultEndpointResolver(k8sClient, podInfoRepo, logger)
 
@@ -56,6 +57,7 @@ func NewDefaultResourceManager(k8sClient client.Client, elbv2Client services.ELB
 		logger:            logger,
 
 		targetHealthRequeueDuration: defaultTargetHealthRequeueDuration,
+		useEndpointSlices:           useEPSlices,
 	}
 }
 
@@ -71,6 +73,7 @@ type defaultResourceManager struct {
 	logger            logr.Logger
 
 	targetHealthRequeueDuration time.Duration
+	useEndpointSlices           bool
 }
 
 func (m *defaultResourceManager) Reconcile(ctx context.Context, tgb *elbv2api.TargetGroupBinding) error {
@@ -100,7 +103,16 @@ func (m *defaultResourceManager) reconcileWithIPTargetType(ctx context.Context, 
 	resolveOpts := []backend.EndpointResolveOption{
 		backend.WithPodReadinessGate(targetHealthCondType),
 	}
-	endpoints, containsPotentialReadyEndpoints, err := m.endpointResolver.ResolvePodEndpoints(ctx, svcKey, tgb.Spec.ServiceRef.Port, resolveOpts...)
+	var endpoints []backend.PodEndpoint
+	var containsPotentialReadyEndpoints bool
+	var err error
+
+	// Decide whether to use Endpoints or EndpointSlices based on config flag
+	if m.useEndpointSlices {
+		endpoints, containsPotentialReadyEndpoints, err = m.endpointResolver.ResolvePodEndpointsFromSlices(ctx, svcKey, tgb.Spec.ServiceRef.Port, resolveOpts...)
+	} else {
+		endpoints, containsPotentialReadyEndpoints, err = m.endpointResolver.ResolvePodEndpoints(ctx, svcKey, tgb.Spec.ServiceRef.Port, resolveOpts...)
+	}
 	if err != nil {
 		if errors.Is(err, backend.ErrNotFound) {
 			m.eventRecorder.Event(tgb, corev1.EventTypeWarning, k8s.TargetGroupBindingEventReasonBackendNotFound, err.Error())

--- a/pkg/targetgroupbinding/resource_manager.go
+++ b/pkg/targetgroupbinding/resource_manager.go
@@ -39,7 +39,7 @@ type ResourceManager interface {
 // NewDefaultResourceManager constructs new defaultResourceManager.
 func NewDefaultResourceManager(k8sClient client.Client, elbv2Client services.ELBV2, ec2Client services.EC2,
 	podInfoRepo k8s.PodInfoRepo, sgManager networking.SecurityGroupManager, sgReconciler networking.SecurityGroupReconciler,
-	vpcID string, clusterName string, eventRecorder record.EventRecorder, logger logr.Logger, useEPSlices bool) *defaultResourceManager {
+	vpcID string, clusterName string, eventRecorder record.EventRecorder, logger logr.Logger, useEndpointSlices bool) *defaultResourceManager {
 	targetsManager := NewCachedTargetsManager(elbv2Client, logger)
 	endpointResolver := backend.NewDefaultEndpointResolver(k8sClient, podInfoRepo, logger)
 
@@ -57,7 +57,7 @@ func NewDefaultResourceManager(k8sClient client.Client, elbv2Client services.ELB
 		logger:            logger,
 
 		targetHealthRequeueDuration: defaultTargetHealthRequeueDuration,
-		useEndpointSlices:           useEPSlices,
+		enableEndpointSlices:        useEndpointSlices,
 	}
 }
 
@@ -73,7 +73,7 @@ type defaultResourceManager struct {
 	logger            logr.Logger
 
 	targetHealthRequeueDuration time.Duration
-	useEndpointSlices           bool
+	enableEndpointSlices        bool
 }
 
 func (m *defaultResourceManager) Reconcile(ctx context.Context, tgb *elbv2api.TargetGroupBinding) error {
@@ -108,7 +108,7 @@ func (m *defaultResourceManager) reconcileWithIPTargetType(ctx context.Context, 
 	var err error
 
 	// Decide whether to use Endpoints or EndpointSlices based on config flag
-	if m.useEndpointSlices {
+	if m.enableEndpointSlices {
 		endpoints, containsPotentialReadyEndpoints, err = m.endpointResolver.ResolvePodEndpointsFromSlices(ctx, svcKey, tgb.Spec.ServiceRef.Port, resolveOpts...)
 	} else {
 		endpoints, containsPotentialReadyEndpoints, err = m.endpointResolver.ResolvePodEndpoints(ctx, svcKey, tgb.Spec.ServiceRef.Port, resolveOpts...)


### PR DESCRIPTION
### Description

Added support for [EndpointSlices](https://kubernetes.io/blog/2020/09/02/scaling-kubernetes-networking-with-endpointslices/) for TargetGroupBindings/pod endpoint resolution for IP targets!

Components added:
- new event handler for EndpointSlices, unit tests
- method for pod endpoint resolution from EndpointSlices, unit tests
- command line flag for enabling the use of EndpointSlices. Based on this flag:
    - conditional use of Endpoints vs. EndpointSlices event handlers in TGB controller
    - conditional use of Endpoints vs. EndpointSlices pod endpoint resolution methods in TGB resource manager
- update `aws-load-balancer-controller-role` to be able to access EndpointSlices

### Checklist
- [X] Added tests that cover your change (if possible)
- [X] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [X] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
