### PR TITLE
Set maximum length for custom load-balancer-name

### DIFF
--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -157,7 +157,7 @@ Traffic Listening can be controlled with following annotations:
 ## Traffic Routing
 Traffic Routing can be controlled with following annotations:
 
-- <a name="load-balancer-name">`alb.ingress.kubernetes.io/load-balancer-name`</a> specifies the custom name to use for the load balancer.
+- <a name="load-balancer-name">`alb.ingress.kubernetes.io/load-balancer-name`</a> specifies the custom name to use for the load balancer. Name longer than 32 characters will be trimmed.
 
     !!!note "Merge Behavior"
         `name` is exclusive across all Ingresses in an IngressGroup.

--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -45,7 +45,7 @@
 ## Traffic Routing
 Traffic Routing can be controlled with following annotations:
 
-- <a name="load-balancer-name">`service.beta.kubernetes.io/aws-load-balancer-name`</a> specifies the custom name to use for the load balancer.
+- <a name="load-balancer-name">`service.beta.kubernetes.io/aws-load-balancer-name`</a> specifies the custom name to use for the load balancer. Name longer than 32 characters will be trimmed.
 
     !!!note "limitations"
         - If you modify this annotation after service creation, there is no effect.

--- a/pkg/ingress/model_build_load_balancer.go
+++ b/pkg/ingress/model_build_load_balancer.go
@@ -6,8 +6,9 @@ import (
 	"encoding/hex"
 	"fmt"
 	"regexp"
-	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/tracking"
 	"strings"
+
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/tracking"
 
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	ec2sdk "github.com/aws/aws-sdk-go/service/ec2"
@@ -97,6 +98,10 @@ func (t *defaultModelBuildTask) buildLoadBalancerName(_ context.Context, scheme 
 	}
 	if len(explicitNames) == 1 {
 		name, _ := explicitNames.PopAny()
+		// The name of the loadbalancer can only have up to 32 characters
+		if len(name) > 32 {
+			name = name[:32]
+		}
 		return name, nil
 	}
 	if len(explicitNames) > 1 {

--- a/pkg/ingress/model_build_load_balancer_test.go
+++ b/pkg/ingress/model_build_load_balancer_test.go
@@ -3,6 +3,8 @@ package ingress
 import (
 	"context"
 	"errors"
+	"testing"
+
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/assert"
 	networking "k8s.io/api/networking/v1beta1"
@@ -10,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
-	"testing"
 )
 
 func Test_defaultModelBuildTask_buildLoadBalancerCOIPv4Pool(t *testing.T) {
@@ -556,6 +557,29 @@ func Test_defaultModelBuildTask_buildLoadBalancerName(t *testing.T) {
 				scheme: elbv2.LoadBalancerSchemeInternetFacing,
 			},
 			want: "foo",
+		},
+		{
+			name: "trim name annotation",
+			fields: fields{
+				ingGroup: Group{
+					ID: GroupID{Namespace: "awesome-ns", Name: "ing-1"},
+					Members: []ClassifiedIngress{
+						{
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "awesome-ns",
+									Name:      "ing-1",
+									Annotations: map[string]string{
+										"alb.ingress.kubernetes.io/load-balancer-name": "bazbazfoofoobazbazfoofoobazbazfoo",
+									},
+								},
+							},
+						},
+					},
+				},
+				scheme: elbv2.LoadBalancerSchemeInternetFacing,
+			},
+			want: "bazbazfoofoobazbazfoofoobazbazfo",
 		},
 		{
 			name: "name annotation on single ingress only",

--- a/pkg/service/model_build_load_balancer.go
+++ b/pkg/service/model_build_load_balancer.go
@@ -7,10 +7,11 @@ import (
 	"fmt"
 	"net"
 	"regexp"
-	"sigs.k8s.io/aws-load-balancer-controller/pkg/algorithm"
-	elbv2deploy "sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/elbv2"
 	"sort"
 	"strconv"
+
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/algorithm"
+	elbv2deploy "sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/elbv2"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -356,6 +357,10 @@ var invalidLoadBalancerNamePattern = regexp.MustCompile("[[:^alnum:]]")
 func (t *defaultModelBuildTask) buildLoadBalancerName(_ context.Context, scheme elbv2model.LoadBalancerScheme) string {
 	var name string
 	if exists := t.annotationParser.ParseStringAnnotation(annotations.SvcLBSuffixLoadBalancerName, &name, t.service.Annotations); exists {
+		// The name of the loadbalancer can only have up to 32 characters
+		if len(name) > 32 {
+			name = name[:32]
+		}
 		return name
 	}
 	uuidHash := sha256.New()

--- a/pkg/service/model_build_load_balancer_test.go
+++ b/pkg/service/model_build_load_balancer_test.go
@@ -3,11 +3,12 @@ package service
 import (
 	"context"
 	"errors"
+	"testing"
+
 	elbv2sdk "github.com/aws/aws-sdk-go/service/elbv2"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/core"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/networking"
-	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -937,6 +938,19 @@ func Test_defaultModelBuildTask_buildLoadBalancerName(t *testing.T) {
 				},
 			},
 			want: "baz",
+		},
+		{
+			name: "trim name annotation",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Name:      "bar",
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/aws-load-balancer-name": "bazbazfoofoobazbazfoofoobazbazfoo",
+					},
+				},
+			},
+			want: "bazbazfoofoobazbazfoofoobazbazfo",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

AWS only allows loadbalancer names with a length up to 32 characters, this change trims the length of the provided value when a custom load balancer name is provided.

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
