### PR TITLE
use minimal base docker image (cherry-pick PR-2196 into release-2.2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:experimental
 
-FROM --platform=${BUILDPLATFORM} golang:1.15.0 AS base
+FROM --platform=${TARGETPLATFORM} golang:1.16 AS base
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
@@ -21,17 +21,11 @@ RUN --mount=type=bind,target=. \
     GOOS=${TARGETOS} GOARCH=${TARGETARCH} GO111MODULE=on \
     CGO_CPPFLAGS="-D_FORTIFY_SOURCE=2" \
     CGO_LDFLAGS="-Wl,-z,relro,-z,now" \
-    go build -ldflags="-s -w -X ${VERSION_PKG}.GitVersion=${GIT_VERSION} -X ${VERSION_PKG}.GitCommit=${GIT_COMMIT} -X ${VERSION_PKG}.BuildDate=${BUILD_DATE}" -buildmode=pie -mod=readonly -a -o /out/controller main.go
+    go build -buildmode=pie -tags 'osusergo,netgo,static_build' -ldflags="-s -w -linkmode=external -extldflags '-static-pie' -X ${VERSION_PKG}.GitVersion=${GIT_VERSION} -X ${VERSION_PKG}.GitCommit=${GIT_COMMIT} -X ${VERSION_PKG}.BuildDate=${BUILD_DATE}" -mod=readonly -a -o /out/controller main.go
 
-FROM amazonlinux:2 as bin-unix
-
-RUN yum update -y && \
-    yum clean all && \
-    rm -rf /var/cache/yum
-
+FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:2021-08-22-1629654770 as bin-unix
 
 COPY --from=build /out/controller /controller
-USER 1002
 ENTRYPOINT ["/controller"]
 
 FROM bin-unix AS bin-linux

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/aws-load-balancer-controller
 
-go 1.13
+go 1.16
 
 require (
 	github.com/aws/aws-sdk-go v1.40.10


### PR DESCRIPTION
### Issue
N/A 
### Description
use minimal base docker image (cherry-pick PR-2196 into release-2.2)

Note:
in addition to changes in PR-2196, we also upgraded the golang to be 1.16, as golang1.15's base image contains bugs prevent static-pie build in arm64.


<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
