### PR TITLE
Fix default image repository in Helm chart

### DIFF
--- a/helm/aws-load-balancer-controller/Chart.yaml
+++ b/helm/aws-load-balancer-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
 version: 1.2.7
-appVersion: v2.2.4
+appVersion: v2.2.5
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/helm/aws-load-balancer-controller/values.yaml
+++ b/helm/aws-load-balancer-controller/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 2
 
 image:
-  repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-load-balancer-controller
+  repository: amazon/aws-alb-ingress-controller
   tag: v2.2.4
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
### Description

I was getting errors trying to pull the image specified on the helm chart, the docs from the site is using a different image repository
```
Failed to pull image "602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-load-balancer-controller:v2.2.4": rpc error: code = Unknown desc = Error response from daemon: Get https://602401143452.dkr.ecr.us-west-2.amazonaws.com/v2/amazon/aws-load-balancer-controller/manifests/v2.2.4: no basic auth credentials
```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
