### PR TITLE
Add code for acquiring region from env; Refactor code to reduce EC2 c…

### DIFF
--- a/pkg/aws/cloud.go
+++ b/pkg/aws/cloud.go
@@ -43,10 +43,9 @@ type Cloud interface {
 
 // NewCloud constructs new Cloud implementation.
 func NewCloud(cfg CloudConfig, metricsRegisterer prometheus.Registerer) (Cloud, error) {
-	metadata := (services.EC2Metadata)(nil)
+	metadataSess := session.Must(session.NewSession(aws.NewConfig()))
+	metadata := services.NewEC2Metadata(metadataSess)
 	if len(cfg.VpcID) == 0 {
-		metadataSess := session.Must(session.NewSession(aws.NewConfig()))
-		metadata = services.NewEC2Metadata(metadataSess)
 		vpcId, err := metadata.VpcID()
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to introspect vpcID from EC2Metadata, specify --aws-vpc-id instead if EC2Metadata is unavailable")
@@ -61,10 +60,6 @@ func NewCloud(cfg CloudConfig, metricsRegisterer prometheus.Registerer) (Cloud, 
 		}
 
 		if region == ""{
-			if metadata  == nil {
-				metadataSess := session.Must(session.NewSession(aws.NewConfig()))
-				metadata = services.NewEC2Metadata(metadataSess)
-			}
 			err := (error)(nil)
 			region, err = metadata.Region()
 			if err != nil {

--- a/pkg/aws/cloud.go
+++ b/pkg/aws/cloud.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"os"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/metrics"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/services"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/throttle"
@@ -42,22 +43,23 @@ type Cloud interface {
 
 // NewCloud constructs new Cloud implementation.
 func NewCloud(cfg CloudConfig, metricsRegisterer prometheus.Registerer) (Cloud, error) {
-	metadataSess := session.Must(session.NewSession(aws.NewConfig()))
-	metadata := services.NewEC2Metadata(metadataSess)
-	if len(cfg.Region) == 0 {
-		region, err := metadata.Region()
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to introspect region from EC2Metadata, specify --aws-region instead if EC2Metadata is unavailable")
-		}
-		cfg.Region = region
-	}
 
 	if len(cfg.VpcID) == 0 {
+		metadataSess := session.Must(session.NewSession(aws.NewConfig()))
+		metadata := services.NewEC2Metadata(metadataSess)
 		vpcId, err := metadata.VpcID()
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to introspect vpcID from EC2Metadata, specify --aws-vpc-id instead if EC2Metadata is unavailable")
 		}
 		cfg.VpcID = vpcId
+	}
+
+	if len(cfg.Region) == 0 {
+		region := os.Getenv("AWS_DEFAULT_REGION")
+		if region == "" {
+			region = os.Getenv("AWS_REGION")
+		}
+		cfg.Region = region
 	}
 
 	awsCFG := aws.NewConfig().WithRegion(cfg.Region).WithSTSRegionalEndpoint(endpoints.RegionalSTSEndpoint).WithMaxRetries(cfg.MaxRetries)


### PR DESCRIPTION
### Issue

[#2139](https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2139)

### Description
When deploying the  ALB controller to EC2 nodes, we end up getting Region and Vpc Id from EC2  metadata service (IMDS). In case of Fargate however, we need to specify --set region=region-code and --set vpcId=vpc-xxxxxxxx flags during the deployment. The controller code currently makes an IMDS call irrespective of the scenario  without checking the cloud configuration set through flags. The code has two main changes listed below:

1. The code is refactored to only make an IMDS call if required, thus reducing the number of EC2 calls per instance. It makes sure to check flags set in cloud configurations or environment variables before making the call.

2. The region value is acquired from the environment variable "AWS_DEFAULT_REGION" or "AWS_REGION" if it is not obtained through the configuration flags. 


### Research
My initial attempt involved trying to eliminate IMDS calls completely and also retrieve cluster name through node data instead of in the deployment parameters. Currently for non Fargate case, both Vpc Id and Region are acquired from  configuration flags and if not specified in flags, it is got through  EC2 metadata. For Fargate case, Vpc Id and Region are acquired only from the configuration flags. Cluster name is retrieved from the parameters specified during deployment of the controller for both cases. I was able to eliminate the need for IMDS call for region by retrieving it through the environment variables set by  IAM roles for service accounts tooling. However, I wasn't able to find a solution to eliminate the need for IMDS call for Vpc Id in case it is not specified in the flags. Also, I wasn't able to find a way to eliminate the need for specifying cluster name in the deployment parameters. 

In case of Vpc Id, it can be found as a field in the Instance struct, whereas Cluster Name can be found as a field in the Node struct. The following line of code in main.go 

`podInfoRepo := k8s.NewDefaultPodInfoRepo(clientSet.CoreV1().RESTClient(), rtOpts.Namespace, ctrl.Log)`

returns podInfoRepo which in turn can be used to get podInfo using Get() and ListKeys() handlers. The podInfo retrieved can be used to get NodeName which is present as a field in the struct. The NodeName fetched can be used to retrieve the node using the k8s client. The cluster name then can be got straight forward from the node struct retrieved. As far as fetching the Vpc Id is concerned, it too can be retrieved using the FetchNodeInstances() function which in turn consequently retrieves instances that have Vpc Id present in the struct. 

However, for a lot of the above functions, a context need to be passed which is initialized as follows 

`ctx := ctrl.SetupSignalHandler()`

and is only done once ingGroupReconciler, svcReconciler and tgbReconciler are initialized using Vpc Id, cluster name and region bringing us back to our original problem. This seems to me like a case of chicken and egg problem. 

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:
