### PR TITLE
Helm chart: Add app.kubernetes.io/component label

### DIFF
--- a/helm/aws-load-balancer-controller/Chart.yaml
+++ b/helm/aws-load-balancer-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.2.8
+version: 1.2.9
 appVersion: v2.2.4
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/helm/aws-load-balancer-controller/templates/_helpers.tpl
+++ b/helm/aws-load-balancer-controller/templates/_helpers.tpl
@@ -59,6 +59,7 @@ Selector labels
 {{- define "aws-load-balancer-controller.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "aws-load-balancer-controller.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: controller
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
### Issue

Fixes aws/eks-charts#518

### Description

The [non-helm install][1] and the [documentation][2] add the
`app.kubernetes.io/component: controller` label to the Deployment,
Service, and ServiceAccount.
The helm chart does not, which makes the ServiceAccount non-functional.
This adds the label and fixes it.

[1]: https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/v2.2.1/docs/install/v2_2_1_full.yaml
[2]: https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
