### PR TITLE
Fix typo in service annotations guide

### DIFF
--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -198,7 +198,7 @@ for proxy protocol v2 configuration.
 
 
 ## Access control
-Load balancer access can be controllerd via following annotations:
+Load balancer access can be controlled via following annotations:
 
 - <a name="lb-source-ranges">`service.beta.kubernetes.io/load-balancer-source-ranges`</a> specifies the CIDRs that are allowed to access the NLB.
 


### PR DESCRIPTION
### Issue

N/A

### Description

Fixed a typo: `controllerd` -> `controlled`

### Checklist
- [N/A] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [N/A] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [N/A] Backfilled missing tests for code in same general area :tada:
- [N/A] Refactored something and made the world a better place :star2:
