### PR TITLE
Fix documentation edit link to correct repo

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,7 @@
 site_name: AWS Load Balancer Controller
 repo_name: kubernetes-sigs/aws-load-balancer-controller
 repo_url: https://github.com/kubernetes-sigs/aws-load-balancer-controller
+edit_uri: edit/main/docs/
 strict: true
 
 nav:


### PR DESCRIPTION
Huge thanks to @kishorj in #2266 for the help!

### Issue

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2266

### Description

This generates a [proper link](https://github.com/kubernetes-sigs/aws-load-balancer-controller/edit/main/docs/deploy/installation.md) when running `make docs-preview`.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
