### PR TITLE
Add support for TCP_UDP to NLB TargetGroups and Listeners

### DIFF
--- a/apis/elbv2/v1beta1/targetgroupbinding_types.go
+++ b/apis/elbv2/v1beta1/targetgroupbinding_types.go
@@ -87,6 +87,9 @@ const (
 
 	// NetworkingProtocolUDP is the UDP protocol.
 	NetworkingProtocolUDP NetworkingProtocol = "UDP"
+
+	// NetworkingProtocolTCP_UDP is the TCP_UDP protocol.
+	NetworkingProtocolTCP_UDP NetworkingProtocol = "TCP_UDP"
 )
 
 // NetworkingPort defines the port and protocol for networking rules.

--- a/pkg/service/model_build_listener.go
+++ b/pkg/service/model_build_listener.go
@@ -15,12 +15,35 @@ import (
 
 func (t *defaultModelBuildTask) buildListeners(ctx context.Context, scheme elbv2model.LoadBalancerScheme) error {
 	cfg := t.buildListenerConfig(ctx)
+
+	// group by listener port number
+	portMap := make(map[int32][]corev1.ServicePort)
 	for _, port := range t.service.Spec.Ports {
-		_, err := t.buildListener(ctx, port, cfg, scheme)
-		if err != nil {
-			return err
+		key := port.Port
+		if vals, exists := portMap[key]; exists {
+			portMap[key] = append(vals, port)
+		} else {
+			portMap[key] = []corev1.ServicePort{port}
 		}
 	}
+
+	// execute build listener
+	for _, port := range t.service.Spec.Ports {
+		key := port.Port
+		if vals, exists := portMap[key]; exists {
+			if len(vals) > 1 {
+				port = mergeServicePortsForListener(vals)
+			} else {
+				port = vals[0]
+			}
+			_, err := t.buildListener(ctx, port, cfg, scheme)
+			if err != nil {
+				return err
+			}
+			delete(portMap, key)
+		}
+	}
+
 	return nil
 }
 
@@ -170,4 +193,25 @@ func (t *defaultModelBuildTask) buildListenerConfig(ctx context.Context) listene
 
 func (t *defaultModelBuildTask) buildListenerTags(ctx context.Context) (map[string]string, error) {
 	return t.buildAdditionalResourceTags(ctx)
+}
+
+func mergeServicePortsForListener(ports []corev1.ServicePort) corev1.ServicePort {
+	port0 := ports[0]
+	mergeableProtocols := map[corev1.Protocol]bool{
+		corev1.ProtocolTCP: true,
+		corev1.ProtocolUDP: true,
+	}
+	if _, ok := mergeableProtocols[port0.Protocol]; !ok {
+		return port0
+	}
+	for _, port := range ports[1:] {
+		if _, ok := mergeableProtocols[port.Protocol]; !ok {
+			continue
+		}
+		if port.NodePort == port0.NodePort && port.Protocol != port0.Protocol {
+			port0.Protocol = corev1.Protocol("TCP_UDP")
+			break
+		}
+	}
+	return port0
 }

--- a/pkg/service/model_build_listener_test.go
+++ b/pkg/service/model_build_listener_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
 	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
 )
@@ -87,4 +88,221 @@ func Test_defaultModelBuilderTask_buildListenerALPNPolicy(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_mergeServicePortsForListener(t *testing.T) {
+	tests := []struct {
+		name  string
+		ports []corev1.ServicePort
+		want  corev1.ServicePort
+	}{
+		{
+			name: "one port",
+			ports: []corev1.ServicePort{
+				{
+					Name:       "p1",
+					Port:       80,
+					TargetPort: intstr.FromInt(80),
+					Protocol:   corev1.ProtocolTCP,
+					NodePort:   31223,
+				},
+			},
+			want: corev1.ServicePort{
+				Name:       "p1",
+				Port:       80,
+				TargetPort: intstr.FromInt(80),
+				Protocol:   corev1.ProtocolTCP,
+				NodePort:   31223,
+			},
+		},
+		{
+			name: "two tcp ports, different target and node ports",
+			ports: []corev1.ServicePort{
+				{
+					Name:       "p1",
+					Port:       80,
+					TargetPort: intstr.FromInt(80),
+					Protocol:   corev1.ProtocolTCP,
+					NodePort:   31223,
+				},
+				{
+					Name:       "p2",
+					Port:       80,
+					TargetPort: intstr.FromInt(8888),
+					Protocol:   corev1.ProtocolTCP,
+					NodePort:   31224,
+				},
+			},
+			want: corev1.ServicePort{
+				Name:       "p1",
+				Port:       80,
+				TargetPort: intstr.FromInt(80),
+				Protocol:   corev1.ProtocolTCP,
+				NodePort:   31223,
+			},
+		},
+		{
+			name: "two udp ports, different target and node ports",
+			ports: []corev1.ServicePort{
+				{
+					Name:       "p1",
+					Port:       80,
+					TargetPort: intstr.FromInt(80),
+					Protocol:   corev1.ProtocolUDP,
+					NodePort:   31223,
+				},
+				{
+					Name:       "p2",
+					Port:       80,
+					TargetPort: intstr.FromInt(8888),
+					Protocol:   corev1.ProtocolUDP,
+					NodePort:   31224,
+				},
+			},
+			want: corev1.ServicePort{
+				Name:       "p1",
+				Port:       80,
+				TargetPort: intstr.FromInt(80),
+				Protocol:   corev1.ProtocolUDP,
+				NodePort:   31223,
+			},
+		},
+		{
+			name: "one tcp and one udp, different target and node ports",
+			ports: []corev1.ServicePort{
+				{
+					Name:       "p1",
+					Port:       80,
+					TargetPort: intstr.FromInt(80),
+					Protocol:   corev1.ProtocolTCP,
+					NodePort:   31223,
+				},
+				{
+					Name:       "p2",
+					Port:       80,
+					TargetPort: intstr.FromInt(8888),
+					Protocol:   corev1.ProtocolUDP,
+					NodePort:   31224,
+				},
+			},
+			want: corev1.ServicePort{
+				Name:       "p1",
+				Port:       80,
+				TargetPort: intstr.FromInt(80),
+				Protocol:   corev1.ProtocolTCP,
+				NodePort:   31223,
+			},
+		},
+		{
+			name: "one tcp and one udp, same target and node ports",
+			ports: []corev1.ServicePort{
+				{
+					Name:       "p1",
+					Port:       80,
+					TargetPort: intstr.FromInt(80),
+					Protocol:   corev1.ProtocolTCP,
+					NodePort:   31223,
+				},
+				{
+					Name:       "p2",
+					Port:       80,
+					TargetPort: intstr.FromInt(80),
+					Protocol:   corev1.ProtocolUDP,
+					NodePort:   31223,
+				},
+			},
+			want: corev1.ServicePort{
+				Name:       "p1",
+				Port:       80,
+				TargetPort: intstr.FromInt(80),
+				Protocol:   corev1.Protocol("TCP_UDP"),
+				NodePort:   31223,
+			},
+		},
+		{
+			name: "one udp and one tcp, same target and node ports",
+			ports: []corev1.ServicePort{
+				{
+					Name:       "p1",
+					Port:       80,
+					TargetPort: intstr.FromInt(80),
+					Protocol:   corev1.ProtocolUDP,
+					NodePort:   31223,
+				},
+				{
+					Name:       "p2",
+					Port:       80,
+					TargetPort: intstr.FromInt(80),
+					Protocol:   corev1.ProtocolTCP,
+					NodePort:   31223,
+				},
+			},
+			want: corev1.ServicePort{
+				Name:       "p1",
+				Port:       80,
+				TargetPort: intstr.FromInt(80),
+				Protocol:   corev1.Protocol("TCP_UDP"),
+				NodePort:   31223,
+			},
+		},
+		{
+			name: "one tcp and one udp, same node port, different target port",
+			ports: []corev1.ServicePort{
+				{
+					Name:       "p1",
+					Port:       80,
+					TargetPort: intstr.FromInt(80),
+					Protocol:   corev1.ProtocolTCP,
+					NodePort:   31223,
+				},
+				{
+					Name:       "p2",
+					Port:       80,
+					TargetPort: intstr.FromInt(8888),
+					Protocol:   corev1.ProtocolUDP,
+					NodePort:   31223,
+				},
+			},
+			want: corev1.ServicePort{
+				Name:       "p1",
+				Port:       80,
+				TargetPort: intstr.FromInt(80),
+				Protocol:   corev1.Protocol("TCP_UDP"),
+				NodePort:   31223,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			port := mergeServicePortsForListener(tt.ports)
+			assert.Equal(t, port.Name, tt.want.Name)
+			assert.Equal(t, port.Port, tt.want.Port)
+			assert.Equal(t, port.TargetPort.IntVal, tt.want.TargetPort.IntVal)
+			assert.Equal(t, port.Protocol, tt.want.Protocol)
+			assert.Equal(t, port.NodePort, tt.want.NodePort)
+		})
+	}
+
+	// test that function returns new ServicePort instance
+	p1 := corev1.ServicePort{
+		Name:       "p1",
+		Port:       80,
+		TargetPort: intstr.FromInt(80),
+		Protocol:   corev1.ProtocolTCP,
+		NodePort:   31223,
+	}
+	p2 := corev1.ServicePort{
+		Name:       "p2",
+		Port:       80,
+		TargetPort: intstr.FromInt(80),
+		Protocol:   corev1.ProtocolUDP,
+		NodePort:   31223,
+	}
+	ports := []corev1.ServicePort{p1, p2}
+	mergedPort := mergeServicePortsForListener(ports)
+
+	assert.Equal(t, corev1.ProtocolTCP, p1.Protocol)
+	assert.Equal(t, corev1.Protocol("TCP_UDP"), mergedPort.Protocol)
+	assert.NotEqual(t, &p1, &mergedPort)
 }

--- a/pkg/service/model_build_target_group_test.go
+++ b/pkg/service/model_build_target_group_test.go
@@ -1031,6 +1031,59 @@ func Test_defaultModelBuilderTask_buildTargetGroupBindingNetworking(t *testing.T
 				},
 			},
 		},
+		{
+			name:                "tcpudp-service with no source ranges configuration",
+			svc:                 &corev1.Service{},
+			tgPort:              port80,
+			hcPort:              port808,
+			defaultSourceRanges: []string{"0.0.0.0/0"},
+			subnets: []*ec2.Subnet{
+				{
+					CidrBlock: aws.String("172.16.0.0/19"),
+					SubnetId:  aws.String("az-1"),
+				},
+			},
+			tgProtocol:    corev1.Protocol("TCP_UDP"),
+			ipAddressType: elbv2.TargetGroupIPAddressTypeIPv4,
+			want: &elbv2.TargetGroupBindingNetworking{
+				Ingress: []elbv2.NetworkingIngressRule{
+					{
+						From: []elbv2.NetworkingPeer{
+							{
+								IPBlock: &elbv2api.IPBlock{
+									CIDR: "172.16.0.0/19",
+								},
+							},
+						},
+						Ports: []elbv2api.NetworkingPort{
+							{
+								Protocol: &networkingProtocolTCP,
+								Port:     &port80,
+							},
+							{
+								Protocol: &networkingProtocolUDP,
+								Port:     &port80,
+							},
+						},
+					},
+					{
+						From: []elbv2.NetworkingPeer{
+							{
+								IPBlock: &elbv2api.IPBlock{
+									CIDR: "172.16.0.0/19",
+								},
+							},
+						},
+						Ports: []elbv2api.NetworkingPort{
+							{
+								Protocol: &networkingProtocolTCP,
+								Port:     &port808,
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### Issue

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/1608#issuecomment-937346660

### Description

Previously, aws-load-balancer-controller ignored extra overlapping
ServicePorts defined in the Kubernetes Service spec if the external port
numbers were the same even if the protocols were different (e.g. TCP:53,
UDP:53).
    
This behavior prevented users from exposing services that support TCP
and UDP on the same external load balancer port number.
    
This patch solves the problem by detecting when a user defines multiple
ServicePorts for the same external load balancer port number but using
TCP and UDP protocols separately. In such situations, a TCP_UDP
TargetGroup and Listener are created and SecurityGroup rules are
updated accordingly. If more than two ServicePorts are defined, only the
first two mergeable ServicePorts are used. Otherwise, the first
ServicePort is used.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [x] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:
