### PR TITLE
modify .Capabilities.APIVersions.Has for pdb

### DIFF
--- a/helm/aws-load-balancer-controller/Chart.yaml
+++ b/helm/aws-load-balancer-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.2.10
+version: 1.2.11
 appVersion: v2.2.4
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/helm/aws-load-balancer-controller/templates/pdb.yaml
+++ b/helm/aws-load-balancer-controller/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.podDisruptionBudget (gt (int .Values.replicaCount) 1) }}
-{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
 apiVersion: policy/v1
 {{- else }}
 apiVersion: policy/v1beta1


### PR DESCRIPTION
Signed-off-by: cw-sakamoto <sakamoto@chatwork.com>

### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

If `.Capabilities.APIVersions.Has` do not specify even resource, we will get the following error in 1.20.

```
error: unable to recognize "STDIN": no matches for kind "PodDisruptionBudget" in version "policy/v1"
```


### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
