### PR TITLE
Reject custom load balancer name longer than 32 characters

### DIFF
--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -157,8 +157,7 @@ Traffic Listening can be controlled with following annotations:
 ## Traffic Routing
 Traffic Routing can be controlled with following annotations:
 
-- <a name="load-balancer-name">`alb.ingress.kubernetes.io/load-balancer-name`</a> specifies the custom name to use for the load balancer. Name longer than 32 characters will be trimmed.
-
+- <a name="load-balancer-name">`alb.ingress.kubernetes.io/load-balancer-name`</a> specifies the custom name to use for the load balancer. Name longer than 32 characters will be treated as an error.
     !!!note "Merge Behavior"
         `name` is exclusive across all Ingresses in an IngressGroup.
 

--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -45,7 +45,7 @@
 ## Traffic Routing
 Traffic Routing can be controlled with following annotations:
 
-- <a name="load-balancer-name">`service.beta.kubernetes.io/aws-load-balancer-name`</a> specifies the custom name to use for the load balancer. Name longer than 32 characters will be trimmed.
+- <a name="load-balancer-name">`service.beta.kubernetes.io/aws-load-balancer-name`</a> specifies the custom name to use for the load balancer. Name longer than 32 characters will be treated as an error.
 
     !!!note "limitations"
         - If you modify this annotation after service creation, there is no effect.

--- a/pkg/ingress/model_build_load_balancer.go
+++ b/pkg/ingress/model_build_load_balancer.go
@@ -100,7 +100,7 @@ func (t *defaultModelBuildTask) buildLoadBalancerName(_ context.Context, scheme 
 		name, _ := explicitNames.PopAny()
 		// The name of the loadbalancer can only have up to 32 characters
 		if len(name) > 32 {
-			name = name[:32]
+			return "", errors.New("load balancer name cannot be longer than 32 characters")
 		}
 		return name, nil
 	}

--- a/pkg/ingress/model_build_load_balancer_test.go
+++ b/pkg/ingress/model_build_load_balancer_test.go
@@ -579,7 +579,7 @@ func Test_defaultModelBuildTask_buildLoadBalancerName(t *testing.T) {
 				},
 				scheme: elbv2.LoadBalancerSchemeInternetFacing,
 			},
-			want: "bazbazfoofoobazbazfoofoobazbazfo",
+			wantErr: errors.New("load balancer name cannot be longer than 32 characters"),
 		},
 		{
 			name: "name annotation on single ingress only",

--- a/pkg/service/model_build_load_balancer.go
+++ b/pkg/service/model_build_load_balancer.go
@@ -57,7 +57,10 @@ func (t *defaultModelBuildTask) buildLoadBalancerSpec(ctx context.Context, schem
 	if err != nil {
 		return elbv2model.LoadBalancerSpec{}, err
 	}
-	name := t.buildLoadBalancerName(ctx, scheme)
+	name, err := t.buildLoadBalancerName(ctx, scheme)
+	if err != nil {
+		return elbv2model.LoadBalancerSpec{}, err
+	}
 	spec := elbv2model.LoadBalancerSpec{
 		Name:                   name,
 		Type:                   elbv2model.LoadBalancerTypeNetwork,
@@ -354,14 +357,14 @@ func (t *defaultModelBuildTask) getAnnotationSpecificLbAttributes() (map[string]
 
 var invalidLoadBalancerNamePattern = regexp.MustCompile("[[:^alnum:]]")
 
-func (t *defaultModelBuildTask) buildLoadBalancerName(_ context.Context, scheme elbv2model.LoadBalancerScheme) string {
+func (t *defaultModelBuildTask) buildLoadBalancerName(_ context.Context, scheme elbv2model.LoadBalancerScheme) (string, error) {
 	var name string
 	if exists := t.annotationParser.ParseStringAnnotation(annotations.SvcLBSuffixLoadBalancerName, &name, t.service.Annotations); exists {
 		// The name of the loadbalancer can only have up to 32 characters
 		if len(name) > 32 {
-			name = name[:32]
+			return "", errors.New("load balancer name cannot be longer than 32 characters")
 		}
-		return name
+		return name, nil
 	}
 	uuidHash := sha256.New()
 	_, _ = uuidHash.Write([]byte(t.clusterName))
@@ -371,5 +374,5 @@ func (t *defaultModelBuildTask) buildLoadBalancerName(_ context.Context, scheme 
 
 	sanitizedNamespace := invalidLoadBalancerNamePattern.ReplaceAllString(t.service.Namespace, "")
 	sanitizedName := invalidLoadBalancerNamePattern.ReplaceAllString(t.service.Name, "")
-	return fmt.Sprintf("k8s-%.8s-%.8s-%.10s", sanitizedNamespace, sanitizedName, uuid)
+	return fmt.Sprintf("k8s-%.8s-%.8s-%.10s", sanitizedNamespace, sanitizedName, uuid), nil
 }


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description
AWS only allows loadbalancer names with a length up to 32 characters. For custom name specified via annotation, this change validates the length not greater than 32 characters, and reports error in case the validation fails. This is to ensure the end user get the error notification instead of controller silently trimming the input.
<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
