### PR TITLE
Use latest image for 2048 example

### DIFF
--- a/docs/examples/2048/2048_full_latest.yaml
+++ b/docs/examples/2048/2048_full_latest.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: app-2048
     spec:
       containers:
-      - image: alexwhen/docker-2048
+      - image: public.ecr.aws/l6m2t8p7/docker-2048:latest
         imagePullPolicy: Always
         name: app-2048
         ports:
@@ -49,6 +49,7 @@ metadata:
     kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/ip-address-type: dualstack
 spec:
   rules:
     - http:


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description
Update 2048 latest example to use recently built docker-2048 image with ipv6 support. Update the ingress manifest to configure dualstack ALB. 
<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
