### PR TITLE
Update internal nlb service access control docs

### DIFF
--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -208,6 +208,7 @@ Load balancer access can be controlled via following annotations:
     !!!note "Default"
         - `0.0.0.0/0` will be used if the IPAddressType is "ipv4"
         - `0.0.0.0/0` and `::/0` will be used if the IPAddressType is "dualstack"
+        - The VPC CIDR will be used if `service.beta.kubernetes.io/aws-load-balancer-scheme` is `internal`
 
     !!!warning ""
         This annotation will be ignored in case preserve client IP is not enabled.


### PR DESCRIPTION
Ref. #2303 
Updates docs to explain that VPC CIDR is used for `load-balancer-source-ranges` by default when NLB is internal

/sig docs
/kind documentation
/assign @kishorj 