### PR TITLE
Create target group not explicity specify ipAddressType ipv4

### DIFF
--- a/pkg/deploy/elbv2/target_group_manager.go
+++ b/pkg/deploy/elbv2/target_group_manager.go
@@ -192,7 +192,7 @@ func buildSDKCreateTargetGroupInput(tgSpec elbv2model.TargetGroupSpec) *elbv2sdk
 	sdkObj.TargetType = awssdk.String(string(tgSpec.TargetType))
 	sdkObj.Port = awssdk.Int64(tgSpec.Port)
 	sdkObj.Protocol = awssdk.String(string(tgSpec.Protocol))
-	if tgSpec.IPAddressType != nil {
+	if tgSpec.IPAddressType != nil && *tgSpec.IPAddressType != elbv2model.TargetGroupIPAddressTypeIPv4 {
 		sdkObj.IpAddressType = (*string)(tgSpec.IPAddressType)
 	}
 	if tgSpec.ProtocolVersion != nil {

--- a/pkg/deploy/elbv2/target_group_manager_test.go
+++ b/pkg/deploy/elbv2/target_group_manager_test.go
@@ -386,6 +386,8 @@ func Test_buildSDKCreateTargetGroupInput(t *testing.T) {
 	port9090 := intstr.FromInt(9090)
 	protocolHTTP := elbv2model.ProtocolHTTP
 	protocolVersionHTTP2 := elbv2model.ProtocolVersionHTTP2
+	ipAddressTypeIPv4 := elbv2model.TargetGroupIPAddressTypeIPv4
+	ipAddressTypeIPv6 := elbv2model.TargetGroupIPAddressTypeIPv6
 	type args struct {
 		tgSpec elbv2model.TargetGroupSpec
 	}
@@ -398,10 +400,11 @@ func Test_buildSDKCreateTargetGroupInput(t *testing.T) {
 			name: "standard case",
 			args: args{
 				tgSpec: elbv2model.TargetGroupSpec{
-					Name:       "my-tg",
-					TargetType: elbv2model.TargetTypeIP,
-					Port:       8080,
-					Protocol:   elbv2model.ProtocolHTTP,
+					Name:          "my-tg",
+					TargetType:    elbv2model.TargetTypeIP,
+					Port:          8080,
+					Protocol:      elbv2model.ProtocolHTTP,
+					IPAddressType: &ipAddressTypeIPv4,
 					HealthCheckConfig: &elbv2model.TargetGroupHealthCheckConfig{
 						Port:                    &port9090,
 						Protocol:                &protocolHTTP,
@@ -466,6 +469,44 @@ func Test_buildSDKCreateTargetGroupInput(t *testing.T) {
 				Protocol:                   awssdk.String("HTTP"),
 				ProtocolVersion:            awssdk.String("HTTP2"),
 				TargetType:                 awssdk.String("ip"),
+			},
+		},
+		{
+			name: "standard case ipv6 address",
+			args: args{
+				tgSpec: elbv2model.TargetGroupSpec{
+					Name:          "my-tg",
+					TargetType:    elbv2model.TargetTypeIP,
+					Port:          8080,
+					Protocol:      elbv2model.ProtocolHTTP,
+					IPAddressType: &ipAddressTypeIPv6,
+					HealthCheckConfig: &elbv2model.TargetGroupHealthCheckConfig{
+						Port:                    &port9090,
+						Protocol:                &protocolHTTP,
+						Path:                    awssdk.String("/healthcheck"),
+						Matcher:                 &elbv2model.HealthCheckMatcher{HTTPCode: awssdk.String("200")},
+						IntervalSeconds:         awssdk.Int64(10),
+						TimeoutSeconds:          awssdk.Int64(5),
+						HealthyThresholdCount:   awssdk.Int64(3),
+						UnhealthyThresholdCount: awssdk.Int64(2),
+					},
+				},
+			},
+			want: &elbv2sdk.CreateTargetGroupInput{
+				HealthCheckEnabled:         awssdk.Bool(true),
+				HealthCheckIntervalSeconds: awssdk.Int64(10),
+				HealthCheckPath:            awssdk.String("/healthcheck"),
+				HealthCheckPort:            awssdk.String("9090"),
+				HealthCheckProtocol:        awssdk.String("HTTP"),
+				HealthCheckTimeoutSeconds:  awssdk.Int64(5),
+				HealthyThresholdCount:      awssdk.Int64(3),
+				Matcher:                    &elbv2sdk.Matcher{HttpCode: awssdk.String("200")},
+				UnhealthyThresholdCount:    awssdk.Int64(2),
+				Name:                       awssdk.String("my-tg"),
+				Port:                       awssdk.Int64(8080),
+				Protocol:                   awssdk.String("HTTP"),
+				TargetType:                 awssdk.String("ip"),
+				IpAddressType:              awssdk.String("ipv6"),
 			},
 		},
 	}


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description
The IPAddressType filed in aws SDK CreateTargetGroupInput is optional, valid values are ipv4 and ipv6. If not specified it defaults to ipv4. This is a new field introduced in recent AWS SDK. Due to the default value, this change will make the controller not explicity set the ipAddressType to ipv4.

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
