### PR TITLE
make COIP drift check logs drifts instead of error out

### DIFF
--- a/pkg/deploy/elbv2/load_balancer_manager.go
+++ b/pkg/deploy/elbv2/load_balancer_manager.go
@@ -6,7 +6,6 @@ import (
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	elbv2sdk "github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/services"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/tracking"
@@ -214,7 +213,9 @@ func (m *defaultLoadBalancerManager) updateSDKLoadBalancerWithSecurityGroups(ctx
 
 func (m *defaultLoadBalancerManager) checkSDKLoadBalancerWithCOIPv4Pool(_ context.Context, resLB *elbv2model.LoadBalancer, sdkLB LoadBalancerWithTags) error {
 	if awssdk.StringValue(resLB.Spec.CustomerOwnedIPv4Pool) != awssdk.StringValue(sdkLB.LoadBalancer.CustomerOwnedIpv4Pool) {
-		return errors.New("loadBalancer has drifted CustomerOwnedIPv4Pool setting")
+		m.logger.Info("loadBalancer has drifted CustomerOwnedIPv4Pool setting",
+			"desired", awssdk.StringValue(resLB.Spec.CustomerOwnedIPv4Pool),
+			"current", awssdk.StringValue(sdkLB.LoadBalancer.CustomerOwnedIpv4Pool))
 	}
 	return nil
 }

--- a/pkg/deploy/elbv2/load_balancer_manager_test.go
+++ b/pkg/deploy/elbv2/load_balancer_manager_test.go
@@ -2,12 +2,12 @@ package elbv2
 
 import (
 	"context"
-	"errors"
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	elbv2sdk "github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/stretchr/testify/assert"
 	coremodel "sigs.k8s.io/aws-load-balancer-controller/pkg/model/core"
 	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"testing"
 )
 
@@ -363,7 +363,7 @@ func Test_defaultLoadBalancerManager_checkSDKLoadBalancerWithCOIPv4Pool(t *testi
 					},
 				},
 			},
-			wantErr: errors.New("loadBalancer has drifted CustomerOwnedIPv4Pool setting"),
+			wantErr: nil,
 		},
 		{
 			name: "only resLB have CustomerOwnedIPv4Pool setting",
@@ -379,7 +379,7 @@ func Test_defaultLoadBalancerManager_checkSDKLoadBalancerWithCOIPv4Pool(t *testi
 					},
 				},
 			},
-			wantErr: errors.New("loadBalancer has drifted CustomerOwnedIPv4Pool setting"),
+			wantErr: nil,
 		},
 		{
 			name: "only sdkLB have CustomerOwnedIPv4Pool setting",
@@ -395,12 +395,14 @@ func Test_defaultLoadBalancerManager_checkSDKLoadBalancerWithCOIPv4Pool(t *testi
 					},
 				},
 			},
-			wantErr: errors.New("loadBalancer has drifted CustomerOwnedIPv4Pool setting"),
+			wantErr: nil,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m := &defaultLoadBalancerManager{}
+			m := &defaultLoadBalancerManager{
+				logger: &log.NullLogger{},
+			}
 			err := m.checkSDKLoadBalancerWithCOIPv4Pool(context.Background(), tt.args.resLB, tt.args.sdkLB)
 			if tt.wantErr != nil {
 				assert.EqualError(t, err, tt.wantErr.Error())


### PR DESCRIPTION
### Description
ALB's COIP settings is immutable. We originally error out the model deploy if we detected the annotation's COIP value no longer matches the COIP setting on existing ALB.
However, on a new type of ALB platform(similar to outpost), the DescribeLoadBalancer always returns a empty COIP pool instead of correct COIP value, and ALB don't plan to change the API behavior in near term.

This PR make COIP drift check logs drifts instead of error out

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
