### PR TITLE
remove ip-address-type dualstack annotation from 2048 example

### DIFF
--- a/docs/examples/2048/2048_full_latest.yaml
+++ b/docs/examples/2048/2048_full_latest.yaml
@@ -49,7 +49,6 @@ metadata:
     kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip
-    alb.ingress.kubernetes.io/ip-address-type: dualstack
 spec:
   rules:
     - http:


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->
The `alb.ingress.kubernetes.io/ip-address-type: dualstack` annotation in the example manifest requires subnets with IPv6 CIDR configuration. Remove the annotation for the example to work on an ipv4 setup.

### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
