### PR TITLE
Whitespace changes for mkdocs rendering

### DIFF
--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -152,10 +152,10 @@ on the load balancer.
         - You must specify the same number of private IPv4 addresses as load balancer subnets [annotation](#subnets)
         - You must specify the IPv4 addresses from the load balancer subnet IPv4 ranges
 
-  !!!example
-      ```
-      service.beta.kubernetes.io/aws-load-balancer-private-ipv4-addresses: 192.168.10.15, 192.168.32.16
-      ```
+    !!!example
+        ```
+        service.beta.kubernetes.io/aws-load-balancer-private-ipv4-addresses: 192.168.10.15, 192.168.32.16
+        ```
 
 ## Traffic Listening
 Traffic Listening can be controlled with following annotations:
@@ -274,7 +274,7 @@ Health check on target groups can be configured with following annotations:
 
 - <a name="healthcheck-port">`service.beta.kubernetes.io/aws-load-balancer-healthcheck-port`</a> specifies the TCP port to use for target group health check.
 
-    !!!note""
+    !!!note ""
         - if you do not specify the health check port, controller uses `traffic-port` as default value
 
     !!!example
@@ -296,14 +296,12 @@ Health check on target groups can be configured with following annotations:
 
 - <a name="healthcheck-healthy-threshold">`service.beta.kubernetes.io/aws-load-balancer-healthcheck-healthy-threshold`</a> specifies the consecutive health check successes required before a target is considered healthy.
 
-
     !!!example
         ```
         service.beta.kubernetes.io/aws-load-balancer-healthcheck-healthy-threshold: "3"
         ```
 
 - <a name="healthcheck-unhealthy-threshold">`service.beta.kubernetes.io/aws-load-balancer-healthcheck-unhealthy-threshold`</a> specifies the consecutive health check failures before a target gets marked unhealthy.
-
 
     !!!example
         ```


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description
Whitespace changes for the service annotations live docs.
<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Tests
Ran `make docs-preview` and verified the modified notes/examples sections rendering worked as expected.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
