### PR TITLE
Update anchor link of Nodeport from #nodeport to #type-nodeport

### DIFF
--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -170,7 +170,7 @@ Traffic Routing can be controlled with following annotations:
 
 - <a name="target-type">`alb.ingress.kubernetes.io/target-type`</a> specifies how to route traffic to pods. You can choose between `instance` and `ip`:
 
-    - `instance` mode will route traffic to all ec2 instances within cluster on [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport) opened for your service.
+    - `instance` mode will route traffic to all ec2 instances within cluster on [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport) opened for your service.
 
         !!!note ""
             service must be of type "NodePort" or "LoadBalancer" to use `instance` mode

--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -76,7 +76,7 @@ Traffic Routing can be controlled with following annotations:
 
 - <a name="nlb-target-type">`service.beta.kubernetes.io/aws-load-balancer-nlb-target-type`</a> specifies the target type to configure for NLB. You can choose between
 `instance` and `ip`.
-    - `instance` mode will route traffic to all EC2 instances within cluster on the [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport) opened for your service.
+    - `instance` mode will route traffic to all EC2 instances within cluster on the [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport) opened for your service.
 
         !!!note ""
             service must be of type `NodePort` or `LoadBalancer` for `instance` targets


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description
This PR updates the anchor links of `Nodeport` from https://kubernetes.io/docs/concepts/services-networking/service/#nodeport to https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport. 

In https://github.com/kubernetes/website/pull/30388#issuecomment-963772337, we can see that no. of files redirecting to [#type-nodeport](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport) is 230, whereas for [#nodeport](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport) it is only 31. Making changes to 230 files is though possible, but would take much toil. Hence, I found updating the latter to be an easy fix and practically feasible.

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
