### PR TITLE
chore: clarify how to get internal NLB

### DIFF
--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -63,7 +63,7 @@ Traffic Routing can be controlled with following annotations:
 - <a name="lb-type">`service.beta.kubernetes.io/aws-load-balancer-type`</a> specifies the load balancer type. This controller reconciles those service resources with this annotation set to either `nlb-ip` or `external`.
 
     !!!tip
-        This annotation specifies the controller used to provision LoadBalancers (as specified in [legacy-cloud-provider](#legacy-cloud-provider)). Refer to [lb-scheme](#lb-scheme) to specify whether the LoadBalancer is public-facing or internal.
+        This annotation specifies the controller used to provision LoadBalancers (as specified in [legacy-cloud-provider](#legacy-cloud-provider)). Refer to [lb-scheme](#lb-scheme) to specify whether the LoadBalancer is Internet-facing or internal.
     
     !!!note ""
         - [Deprecated] `nlb-ip` type, controller will provision NLB with IP targets. This value is supported for backwards compatibility.

--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -63,8 +63,8 @@ Traffic Routing can be controlled with following annotations:
 - <a name="lb-type">`service.beta.kubernetes.io/aws-load-balancer-type`</a> specifies the load balancer type. This controller reconciles those service resources with this annotation set to either `nlb-ip` or `external`.
 
     !!!note ""
-        - For `nlb-ip` type, controller will provision NLB with IP targets. This value is supported for backwards compatibility
-        - For `external` type, NLB target type depend on the annotation [nlb-target-type](#nlb-target-type)
+        - For `nlb-ip` type, controller will provision NLB with IP targets. This value is supported for backwards compatibility, but it is deprecated.
+        - For `external` type, NLB target type depend on the annotation [nlb-target-type](#nlb-target-type). If used in combination with [lb-scheme](#lb-scheme) set to internal, it will provision an internal NLB.
 
     !!!warning "limitations"
         - This annotation should not be modified after service creation.
@@ -416,3 +416,9 @@ Load balancer access can be controlled via following annotations:
 The AWS Load Balancer Controller manages Kubernetes Services in a compatible way with the legacy aws cloud provider. The annotation `service.beta.kubernetes.io/aws-load-balancer-type` is used to determine which controller reconciles the service. If the annotation value is `nlb-ip` or `external`, legacy cloud provider ignores the service resource (provided it has the correct patch) so that the AWS Load Balancer controller can take over. For all other values of the annotation, the legacy cloud provider will handle the service. Note that this annotation should be specified during service creation and not edited later.
 
 The legacy cloud provider patch was added in Kubernetes v1.20 and is backported to Kubernetes v1.18.18+, v1.19.10+.
+
+!!!note ""
+    To be able to provision an internal NLB with target type `instance` it can be achieved with the combination of the following annotations:
+        - service.beta.kubernetes.io/aws-load-balancer-type: external
+        - service.beta.kubernetes.io/aws-load-balancer-scheme: internal
+        - service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: instance

--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -419,6 +419,3 @@ Load balancer access can be controlled via following annotations:
 The AWS Load Balancer Controller manages Kubernetes Services in a compatible way with the legacy aws cloud provider. The annotation `service.beta.kubernetes.io/aws-load-balancer-type` is used to determine which controller reconciles the service. If the annotation value is `nlb-ip` or `external`, legacy cloud provider ignores the service resource (provided it has the correct patch) so that the AWS Load Balancer controller can take over. For all other values of the annotation, the legacy cloud provider will handle the service. Note that this annotation should be specified during service creation and not edited later.
 
 The legacy cloud provider patch was added in Kubernetes v1.20 and is backported to Kubernetes v1.18.18+, v1.19.10+.
-
-!!!note ""
-    With the right combination of annotations any Network Load Balancer and Target Group configuration can be provisioned with this controller.

--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -62,9 +62,12 @@ Traffic Routing can be controlled with following annotations:
 
 - <a name="lb-type">`service.beta.kubernetes.io/aws-load-balancer-type`</a> specifies the load balancer type. This controller reconciles those service resources with this annotation set to either `nlb-ip` or `external`.
 
+    !!!tip
+        This annotation specifies the controller used to provision LoadBalancers (as specified in [legacy-cloud-provider](#legacy-cloud-provider)). Refer to [lb-scheme](#lb-scheme) to specify whether the LoadBalancer is public-facing or internal.
+    
     !!!note ""
         - [Deprecated] `nlb-ip` type, controller will provision NLB with IP targets. This value is supported for backwards compatibility.
-        - For `external` type, NLB target type depend on the annotation [nlb-target-type](#nlb-target-type). If used in combination with [lb-scheme](#lb-scheme) set to internal, it will provision an internal NLB.
+        - For `external` type, NLB target type depend on the annotation [nlb-target-type](#nlb-target-type).
 
     !!!warning "limitations"
         - This annotation should not be modified after service creation.
@@ -418,7 +421,4 @@ The AWS Load Balancer Controller manages Kubernetes Services in a compatible way
 The legacy cloud provider patch was added in Kubernetes v1.20 and is backported to Kubernetes v1.18.18+, v1.19.10+.
 
 !!!note ""
-    To be able to provision an internal NLB with target type `instance` it can be achieved with the combination of the following annotations:
-        - service.beta.kubernetes.io/aws-load-balancer-type: external
-        - service.beta.kubernetes.io/aws-load-balancer-scheme: internal
-        - service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: instance
+    With the right combination of annotations any type of Load Balancer and Target Group configuration can be provisioned with this controller.

--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -63,7 +63,7 @@ Traffic Routing can be controlled with following annotations:
 - <a name="lb-type">`service.beta.kubernetes.io/aws-load-balancer-type`</a> specifies the load balancer type. This controller reconciles those service resources with this annotation set to either `nlb-ip` or `external`.
 
     !!!tip
-        This annotation specifies the controller used to provision LoadBalancers (as specified in [legacy-cloud-provider](#legacy-cloud-provider)). Refer to [lb-scheme](#lb-scheme) to specify whether the LoadBalancer is Internet-facing or internal.
+        This annotation specifies the controller used to provision LoadBalancers (as specified in [legacy-cloud-provider](#legacy-cloud-provider)). Refer to [lb-scheme](#lb-scheme) to specify whether the LoadBalancer is internet-facing or internal.
     
     !!!note ""
         - [Deprecated] `nlb-ip` type, controller will provision NLB with IP targets. This value is supported for backwards compatibility.

--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -66,8 +66,8 @@ Traffic Routing can be controlled with following annotations:
         This annotation specifies the controller used to provision LoadBalancers (as specified in [legacy-cloud-provider](#legacy-cloud-provider)). Refer to [lb-scheme](#lb-scheme) to specify whether the LoadBalancer is internet-facing or internal.
     
     !!!note ""
-        - [Deprecated] `nlb-ip` type, controller will provision NLB with IP targets. This value is supported for backwards compatibility.
-        - For `external` type, NLB target type depend on the annotation [nlb-target-type](#nlb-target-type).
+        - [Deprecated] For type `nlb-ip`, the controller will provision an NLB with targets registered by IP address. This value is supported for backwards compatibility.
+        - For type `external`, the NLB target type depends on the [nlb-target-type](#nlb-target-type) annotation.
 
     !!!warning "limitations"
         - This annotation should not be modified after service creation.

--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -63,7 +63,7 @@ Traffic Routing can be controlled with following annotations:
 - <a name="lb-type">`service.beta.kubernetes.io/aws-load-balancer-type`</a> specifies the load balancer type. This controller reconciles those service resources with this annotation set to either `nlb-ip` or `external`.
 
     !!!note ""
-        - For `nlb-ip` type, controller will provision NLB with IP targets. This value is supported for backwards compatibility, but it is deprecated.
+        - [Deprecated] `nlb-ip` type, controller will provision NLB with IP targets. This value is supported for backwards compatibility.
         - For `external` type, NLB target type depend on the annotation [nlb-target-type](#nlb-target-type). If used in combination with [lb-scheme](#lb-scheme) set to internal, it will provision an internal NLB.
 
     !!!warning "limitations"

--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -421,4 +421,4 @@ The AWS Load Balancer Controller manages Kubernetes Services in a compatible way
 The legacy cloud provider patch was added in Kubernetes v1.20 and is backported to Kubernetes v1.18.18+, v1.19.10+.
 
 !!!note ""
-    With the right combination of annotations any type of Load Balancer and Target Group configuration can be provisioned with this controller.
+    With the right combination of annotations any Network Load Balancer and Target Group configuration can be provisioned with this controller.


### PR DESCRIPTION
### Issue
https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2350

### Description
Adding clarifications about the current annotation "service.beta.kubernetes.io/aws-load-balancer-type: external" as it sounds confusing and does not show that an "internal" NLB can be achieved using that type.

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [X] Refactored something and made the world a better place :star2:
