### PR TITLE
support IPv6 Pods during AZ detection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	golang.org/x/time v0.0.0-20210611083556-38a9dc6acbc6
 	gomodules.xyz/jsonpatch/v2 v2.2.0
 	helm.sh/helm/v3 v3.6.1
+	inet.af/netaddr v0.0.0-20211027220019-c74959edd3b6 // indirect
 	k8s.io/api v0.21.2
 	k8s.io/apimachinery v0.21.2
 	k8s.io/cli-runtime v0.21.2

--- a/go.sum
+++ b/go.sum
@@ -200,6 +200,7 @@ github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1/go.mod h1:cyGadeNE
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/dvyukov/go-fuzz v0.0.0-20210103155950-6a8e9d1f2415/go.mod h1:11Gm+ccJnvAhCNLlf5+cS9KjtbaD5I5zaZpFMsTHWTw=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
@@ -850,6 +851,10 @@ go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.13.0/go.mod h1:zwrFLgMcdUuIBviXEYEH1YKNaOBnKXsx2IPda5bBwHM=
 go.uber.org/zap v1.17.0 h1:MTjgFu6ZLKvY6Pvaqk97GlxNBuMpV4Hy/3P6tRGlI2U=
 go.uber.org/zap v1.17.0/go.mod h1:MXVU+bhUf/A7Xi2HNOnopQOrmycQ5Ih87HtOu4q5SSo=
+go4.org/intern v0.0.0-20211027215823-ae77deb06f29 h1:UXLjNohABv4S58tHmeuIZDO6e3mHpW2Dx33gaNt03LE=
+go4.org/intern v0.0.0-20211027215823-ae77deb06f29/go.mod h1:cS2ma+47FKrLPdXFpr7CuxiTW3eyJbWew4qx0qtQWDA=
+go4.org/unsafe/assume-no-moving-gc v0.0.0-20211027215541-db492cf91b37 h1:Tx9kY6yUkLge/pFG7IEMwDZy6CS2ajFc9TvQdPCW0uA=
+go4.org/unsafe/assume-no-moving-gc v0.0.0-20211027215541-db492cf91b37/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -1162,6 +1167,8 @@ honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+inet.af/netaddr v0.0.0-20211027220019-c74959edd3b6 h1:acCzuUSQ79tGsM/O50VRFySfMm19IoMKL+sZztZkCxw=
+inet.af/netaddr v0.0.0-20211027220019-c74959edd3b6/go.mod h1:y3MGhcFMlh0KZPMuXXow8mpjxxAk3yoDNsp4cQz54i8=
 k8s.io/api v0.21.0/go.mod h1:+YbrhBBGgsxbF6o6Kj4KJPJnBmAKuXDeS3E18bgHNVU=
 k8s.io/api v0.21.2 h1:vz7DqmRsXTCSa6pNxXwQ1IYeAZgdIsua+DZU+o+SX3Y=
 k8s.io/api v0.21.2/go.mod h1:Lv6UGJZ1rlMI1qusN8ruAp9PUBFyBwpEHAdG24vIsiU=

--- a/pkg/networking/utils.go
+++ b/pkg/networking/utils.go
@@ -1,0 +1,28 @@
+package networking
+
+import "inet.af/netaddr"
+
+// TODO: replace netaddr package with built-in netip package once golang 1.18 released: https://pkg.go.dev/net/netip@master#Prefix
+
+// ParseCIDRs will parse CIDRs in string format into parsed IPPrefix
+func ParseCIDRs(cidrs []string) ([]netaddr.IPPrefix, error) {
+	var ipPrefixes []netaddr.IPPrefix
+	for _, cidr := range cidrs {
+		ipPrefix, err := netaddr.ParseIPPrefix(cidr)
+		if err != nil {
+			return nil, err
+		}
+		ipPrefixes = append(ipPrefixes, ipPrefix)
+	}
+	return ipPrefixes, nil
+}
+
+// IsIPWithinCIDRs checks whether specific IP is in IPv4 CIDR or IPv6 CIDRs.
+func IsIPWithinCIDRs(ip netaddr.IP, cidrs []netaddr.IPPrefix) bool {
+	for _, cidr := range cidrs {
+		if cidr.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/networking/utils_test.go
+++ b/pkg/networking/utils_test.go
@@ -1,0 +1,139 @@
+package networking
+
+import (
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"inet.af/netaddr"
+	"testing"
+)
+
+func TestParseCIDRs(t *testing.T) {
+	type args struct {
+		cidrs []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []netaddr.IPPrefix
+		wantErr error
+	}{
+		{
+			name: "has one valid CIDR",
+			args: args{
+				cidrs: []string{"192.168.5.100/16"},
+			},
+			want: []netaddr.IPPrefix{
+				netaddr.MustParseIPPrefix("192.168.5.100/16"),
+			},
+		},
+		{
+			name: "has multiple valid CIDRs",
+			args: args{
+				cidrs: []string{"192.168.5.100/16", "10.100.0.0/16"},
+			},
+			want: []netaddr.IPPrefix{
+				netaddr.MustParseIPPrefix("192.168.5.100/16"),
+				netaddr.MustParseIPPrefix("10.100.0.0/16"),
+			},
+		},
+		{
+			name: "has one invalid CIDR",
+			args: args{
+				cidrs: []string{"192.168.5.100/16", "10.100.0.0"},
+			},
+			wantErr: errors.New("netaddr.ParseIPPrefix(\"10.100.0.0\"): no '/'"),
+		},
+		{
+			name: "empty CIDRs",
+			args: args{
+				cidrs: []string{},
+			},
+			want: nil,
+		},
+		{
+			name: "nil CIDRs",
+			args: args{
+				cidrs: nil,
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseCIDRs(tt.args.cidrs)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestIsIPWithinCIDRs(t *testing.T) {
+	type args struct {
+		ip    netaddr.IP
+		cidrs []netaddr.IPPrefix
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "ipv4 address within CIDRs",
+			args: args{
+				ip: netaddr.MustParseIP("192.168.1.42"),
+				cidrs: []netaddr.IPPrefix{
+					netaddr.MustParseIPPrefix("10.100.0.0/16"),
+					netaddr.MustParseIPPrefix("192.168.0.0/16"),
+					netaddr.MustParseIPPrefix("2600:1f14:f8c:2700::/56"),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "ipv4 address not within CIDRs",
+			args: args{
+				ip: netaddr.MustParseIP("172.16.1.42"),
+				cidrs: []netaddr.IPPrefix{
+					netaddr.MustParseIPPrefix("10.100.0.0/16"),
+					netaddr.MustParseIPPrefix("192.168.0.0/16"),
+					netaddr.MustParseIPPrefix("2600:1f14:f8c:2700::/56"),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "ipv6 address within CIDRs",
+			args: args{
+				ip: netaddr.MustParseIP("2600:1f14:f8c:2701:a740::"),
+				cidrs: []netaddr.IPPrefix{
+					netaddr.MustParseIPPrefix("10.100.0.0/16"),
+					netaddr.MustParseIPPrefix("2700:1f14:f8c:2700::/56"),
+					netaddr.MustParseIPPrefix("2600:1f14:f8c:2700::/56"),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "ipv6 address not within CIDRs",
+			args: args{
+				ip: netaddr.MustParseIP("2800:1f14:f8c:2701:a740::"),
+				cidrs: []netaddr.IPPrefix{
+					netaddr.MustParseIPPrefix("10.100.0.0/16"),
+					netaddr.MustParseIPPrefix("2700:1f14:f8c:2700::/56"),
+					netaddr.MustParseIPPrefix("2600:1f14:f8c:2700::/56"),
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsIPWithinCIDRs(tt.args.ip, tt.args.cidrs)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/networking/vpc_info_provider.go
+++ b/pkg/networking/vpc_info_provider.go
@@ -14,9 +14,56 @@ import (
 
 const defaultVPCInfoCacheTTL = 10 * time.Minute
 
+type VPCInfo ec2sdk.Vpc
+
+// AssociatedIPv4CIDRs computes associated IPv4CIDRs for VPC.
+func (vpc *VPCInfo) AssociatedIPv4CIDRs() []string {
+	var ipv4CIDRs []string
+	for _, cidr := range vpc.CidrBlockAssociationSet {
+		if awssdk.StringValue(cidr.CidrBlockState.State) != ec2sdk.VpcCidrBlockStateCodeAssociated {
+			continue
+		}
+		ipv4CIDRs = append(ipv4CIDRs, awssdk.StringValue(cidr.CidrBlock))
+	}
+	return ipv4CIDRs
+}
+
+// AssociatedIPv6CIDRs computes associated IPv6CIDRs for VPC.
+func (vpc *VPCInfo) AssociatedIPv6CIDRs() []string {
+	var ipv6CIDRs []string
+	for _, cidr := range vpc.Ipv6CidrBlockAssociationSet {
+		if awssdk.StringValue(cidr.Ipv6CidrBlockState.State) != ec2sdk.VpcCidrBlockStateCodeAssociated {
+			continue
+		}
+		ipv6CIDRs = append(ipv6CIDRs, awssdk.StringValue(cidr.Ipv6CidrBlock))
+	}
+	return ipv6CIDRs
+}
+
+type FetchVPCInfoOptions struct {
+	// whether to ignore cache and reload VPC Info from AWS directly.
+	ReloadIgnoringCache bool
+}
+
+// ApplyOptions applies FetchVPCInfoOption options
+func (opts *FetchVPCInfoOptions) ApplyOptions(options ...FetchVPCInfoOption) {
+	for _, option := range options {
+		option(opts)
+	}
+}
+
+type FetchVPCInfoOption func(opts *FetchVPCInfoOptions)
+
+// FetchVPCInfoWithoutCache is an option that sets the ReloadIgnoringCache to true.
+func FetchVPCInfoWithoutCache() FetchVPCInfoOption {
+	return func(opts *FetchVPCInfoOptions) {
+		opts.ReloadIgnoringCache = true
+	}
+}
+
 // VPCInfoProvider is responsible for providing VPC info.
 type VPCInfoProvider interface {
-	FetchVPCInfo(ctx context.Context, vpcID string) (*ec2sdk.Vpc, error)
+	FetchVPCInfo(ctx context.Context, vpcID string, opts ...FetchVPCInfoOption) (VPCInfo, error)
 }
 
 // NewDefaultVPCInfoProvider constructs new defaultVPCInfoProvider.
@@ -42,48 +89,55 @@ type defaultVPCInfoProvider struct {
 	logger logr.Logger
 }
 
-func (p *defaultVPCInfoProvider) FetchVPCInfo(ctx context.Context, vpcID string) (*ec2sdk.Vpc, error) {
-	if vpcInfo := p.fetchVPCInfoFromCache(); vpcInfo != nil {
-		return vpcInfo, nil
+// FetchVPCInfo fetches VPC info for vpcID.
+func (p *defaultVPCInfoProvider) FetchVPCInfo(ctx context.Context, vpcID string, opts ...FetchVPCInfoOption) (VPCInfo, error) {
+	fetchOpts := FetchVPCInfoOptions{
+		ReloadIgnoringCache: false,
+	}
+	fetchOpts.ApplyOptions(opts...)
+
+	if !fetchOpts.ReloadIgnoringCache {
+		if vpcInfo, exists := p.fetchVPCInfoFromCache(vpcID); exists {
+			return vpcInfo, nil
+		}
 	}
 
-	// Fetch VPC info from the AWS API and cache response before returning.
 	vpcInfo, err := p.fetchVPCInfoFromAWS(ctx, vpcID)
 	if err != nil {
-		return nil, err
+		return VPCInfo{}, err
 	}
-	p.saveVPCInfoToCache(vpcInfo)
-
+	p.saveVPCInfoToCache(vpcID, vpcInfo)
 	return vpcInfo, nil
 }
 
-func (p *defaultVPCInfoProvider) fetchVPCInfoFromCache() *ec2sdk.Vpc {
+// fetchVPCInfoFromCache fetches VPC info for vpcID from cache.
+func (p *defaultVPCInfoProvider) fetchVPCInfoFromCache(vpcID string) (VPCInfo, bool) {
 	p.vpcInfoCacheMutex.RLock()
 	defer p.vpcInfoCacheMutex.RUnlock()
 
-	if rawCacheItem, exists := p.vpcInfoCache.Get("vpcInfo"); exists {
-		return rawCacheItem.(*ec2sdk.Vpc)
+	if rawCacheItem, exists := p.vpcInfoCache.Get(vpcID); exists {
+		return rawCacheItem.(VPCInfo), true
 	}
-
-	return nil
+	return VPCInfo{}, false
 }
 
-func (p *defaultVPCInfoProvider) saveVPCInfoToCache(vpcInfo *ec2sdk.Vpc) {
+// saveVPCInfoToCache saves VPC info for vpcID into cache.
+func (p *defaultVPCInfoProvider) saveVPCInfoToCache(vpcID string, vpcInfo VPCInfo) {
 	p.vpcInfoCacheMutex.Lock()
 	defer p.vpcInfoCacheMutex.Unlock()
 
-	p.vpcInfoCache.Set("vpcInfo", vpcInfo, p.vpcInfoCacheTTL)
+	p.vpcInfoCache.Set(vpcID, vpcInfo, p.vpcInfoCacheTTL)
 }
 
 // fetchVPCInfoFromAWS will fetch VPC info from the AWS API.
-func (p *defaultVPCInfoProvider) fetchVPCInfoFromAWS(ctx context.Context, vpcID string) (*ec2sdk.Vpc, error) {
+func (p *defaultVPCInfoProvider) fetchVPCInfoFromAWS(ctx context.Context, vpcID string) (VPCInfo, error) {
 	req := &ec2sdk.DescribeVpcsInput{
 		VpcIds: []*string{awssdk.String(vpcID)},
 	}
 	resp, err := p.ec2Client.DescribeVpcsWithContext(ctx, req)
 	if err != nil {
-		return nil, err
+		return VPCInfo{}, err
 	}
 
-	return resp.Vpcs[0], nil
+	return VPCInfo(*resp.Vpcs[0]), nil
 }

--- a/pkg/networking/vpc_info_provider_mocks.go
+++ b/pkg/networking/vpc_info_provider_mocks.go
@@ -6,45 +6,50 @@ package networking
 
 import (
 	context "context"
-	ec2 "github.com/aws/aws-sdk-go/service/ec2"
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockVPCInfoProvider is a mock of VPCInfoProvider interface
+// MockVPCInfoProvider is a mock of VPCInfoProvider interface.
 type MockVPCInfoProvider struct {
 	ctrl     *gomock.Controller
 	recorder *MockVPCInfoProviderMockRecorder
 }
 
-// MockVPCInfoProviderMockRecorder is the mock recorder for MockVPCInfoProvider
+// MockVPCInfoProviderMockRecorder is the mock recorder for MockVPCInfoProvider.
 type MockVPCInfoProviderMockRecorder struct {
 	mock *MockVPCInfoProvider
 }
 
-// NewMockVPCInfoProvider creates a new mock instance
+// NewMockVPCInfoProvider creates a new mock instance.
 func NewMockVPCInfoProvider(ctrl *gomock.Controller) *MockVPCInfoProvider {
 	mock := &MockVPCInfoProvider{ctrl: ctrl}
 	mock.recorder = &MockVPCInfoProviderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockVPCInfoProvider) EXPECT() *MockVPCInfoProviderMockRecorder {
 	return m.recorder
 }
 
-// FetchVPCInfo mocks base method
-func (m *MockVPCInfoProvider) FetchVPCInfo(arg0 context.Context, arg1 string) (*ec2.Vpc, error) {
+// FetchVPCInfo mocks base method.
+func (m *MockVPCInfoProvider) FetchVPCInfo(arg0 context.Context, arg1 string, arg2 ...FetchVPCInfoOption) (VPCInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FetchVPCInfo", arg0, arg1)
-	ret0, _ := ret[0].(*ec2.Vpc)
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "FetchVPCInfo", varargs...)
+	ret0, _ := ret[0].(VPCInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// FetchVPCInfo indicates an expected call of FetchVPCInfo
-func (mr *MockVPCInfoProviderMockRecorder) FetchVPCInfo(arg0, arg1 interface{}) *gomock.Call {
+// FetchVPCInfo indicates an expected call of FetchVPCInfo.
+func (mr *MockVPCInfoProviderMockRecorder) FetchVPCInfo(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchVPCInfo", reflect.TypeOf((*MockVPCInfoProvider)(nil).FetchVPCInfo), arg0, arg1)
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchVPCInfo", reflect.TypeOf((*MockVPCInfoProvider)(nil).FetchVPCInfo), varargs...)
 }

--- a/pkg/networking/vpc_info_provider_test.go
+++ b/pkg/networking/vpc_info_provider_test.go
@@ -4,79 +4,526 @@ import (
 	"context"
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	ec2sdk "github.com/aws/aws-sdk-go/service/ec2"
-	gomock "github.com/golang/mock/gomock"
-	"reflect"
+	"github.com/golang/mock/gomock"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/services"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"testing"
 )
 
 func Test_defaultVPCInfoProvider_FetchVPCInfo(t *testing.T) {
-	type describeVpcCall struct {
-		input  *ec2sdk.DescribeVpcsInput
-		output *ec2sdk.DescribeVpcsOutput
-		err    error
+	type describeVpcsCall struct {
+		req  *ec2sdk.DescribeVpcsInput
+		resp *ec2sdk.DescribeVpcsOutput
+		err  error
+	}
+	type fields struct {
+		describeVpcsCalls []describeVpcsCall
+	}
+	type fetchVPCInfoCall struct {
+		vpcID   string
+		opts    []FetchVPCInfoOption
+		want    VPCInfo
+		wantErr error
+	}
+	tests := []struct {
+		name              string
+		fields            fields
+		fetchVPCInfoCalls []fetchVPCInfoCall
+	}{
+		{
+			name: "fetch single VPC twice with cache",
+			fields: fields{
+				describeVpcsCalls: []describeVpcsCall{
+					{
+						req: &ec2sdk.DescribeVpcsInput{
+							VpcIds: awssdk.StringSlice([]string{"vpc-2f09a348"}),
+						},
+						resp: &ec2sdk.DescribeVpcsOutput{
+							Vpcs: []*ec2sdk.Vpc{
+								{
+									VpcId: awssdk.String("vpc-2f09a348"),
+									CidrBlockAssociationSet: []*ec2sdk.VpcCidrBlockAssociation{
+										{
+											CidrBlock: awssdk.String("192.168.0.0/16"),
+											CidrBlockState: &ec2sdk.VpcCidrBlockState{
+												State: awssdk.String(ec2sdk.VpcCidrBlockStateCodeAssociated),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			fetchVPCInfoCalls: []fetchVPCInfoCall{
+				{
+					vpcID: "vpc-2f09a348",
+					want: VPCInfo{
+						VpcId: awssdk.String("vpc-2f09a348"),
+						CidrBlockAssociationSet: []*ec2sdk.VpcCidrBlockAssociation{
+							{
+								CidrBlock: awssdk.String("192.168.0.0/16"),
+								CidrBlockState: &ec2sdk.VpcCidrBlockState{
+									State: awssdk.String(ec2sdk.VpcCidrBlockStateCodeAssociated),
+								},
+							},
+						},
+					},
+				},
+				{
+					vpcID: "vpc-2f09a348",
+					want: VPCInfo{
+						VpcId: awssdk.String("vpc-2f09a348"),
+						CidrBlockAssociationSet: []*ec2sdk.VpcCidrBlockAssociation{
+							{
+								CidrBlock: awssdk.String("192.168.0.0/16"),
+								CidrBlockState: &ec2sdk.VpcCidrBlockState{
+									State: awssdk.String(ec2sdk.VpcCidrBlockStateCodeAssociated),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "fetch single VPC twice without cache",
+			fields: fields{
+				describeVpcsCalls: []describeVpcsCall{
+					{
+						req: &ec2sdk.DescribeVpcsInput{
+							VpcIds: awssdk.StringSlice([]string{"vpc-2f09a348"}),
+						},
+						resp: &ec2sdk.DescribeVpcsOutput{
+							Vpcs: []*ec2sdk.Vpc{
+								{
+									VpcId: awssdk.String("vpc-2f09a348"),
+									CidrBlockAssociationSet: []*ec2sdk.VpcCidrBlockAssociation{
+										{
+											CidrBlock: awssdk.String("192.168.0.0/16"),
+											CidrBlockState: &ec2sdk.VpcCidrBlockState{
+												State: awssdk.String(ec2sdk.VpcCidrBlockStateCodeAssociated),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						req: &ec2sdk.DescribeVpcsInput{
+							VpcIds: awssdk.StringSlice([]string{"vpc-2f09a348"}),
+						},
+						resp: &ec2sdk.DescribeVpcsOutput{
+							Vpcs: []*ec2sdk.Vpc{
+								{
+									VpcId: awssdk.String("vpc-2f09a348"),
+									CidrBlockAssociationSet: []*ec2sdk.VpcCidrBlockAssociation{
+										{
+											CidrBlock: awssdk.String("192.168.0.0/16"),
+											CidrBlockState: &ec2sdk.VpcCidrBlockState{
+												State: awssdk.String(ec2sdk.VpcCidrBlockStateCodeAssociated),
+											},
+										},
+										{
+											CidrBlock: awssdk.String("10.100.0.0/16"),
+											CidrBlockState: &ec2sdk.VpcCidrBlockState{
+												State: awssdk.String(ec2sdk.VpcCidrBlockStateCodeAssociated),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			fetchVPCInfoCalls: []fetchVPCInfoCall{
+				{
+					vpcID: "vpc-2f09a348",
+					opts:  []FetchVPCInfoOption{FetchVPCInfoWithoutCache()},
+					want: VPCInfo{
+						VpcId: awssdk.String("vpc-2f09a348"),
+						CidrBlockAssociationSet: []*ec2sdk.VpcCidrBlockAssociation{
+							{
+								CidrBlock: awssdk.String("192.168.0.0/16"),
+								CidrBlockState: &ec2sdk.VpcCidrBlockState{
+									State: awssdk.String(ec2sdk.VpcCidrBlockStateCodeAssociated),
+								},
+							},
+						},
+					},
+				},
+				{
+					vpcID: "vpc-2f09a348",
+					opts:  []FetchVPCInfoOption{FetchVPCInfoWithoutCache()},
+					want: VPCInfo{
+						VpcId: awssdk.String("vpc-2f09a348"),
+						CidrBlockAssociationSet: []*ec2sdk.VpcCidrBlockAssociation{
+							{
+								CidrBlock: awssdk.String("192.168.0.0/16"),
+								CidrBlockState: &ec2sdk.VpcCidrBlockState{
+									State: awssdk.String(ec2sdk.VpcCidrBlockStateCodeAssociated),
+								},
+							},
+							{
+								CidrBlock: awssdk.String("10.100.0.0/16"),
+								CidrBlockState: &ec2sdk.VpcCidrBlockState{
+									State: awssdk.String(ec2sdk.VpcCidrBlockStateCodeAssociated),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "fetch multiple VPC twice with cache",
+			fields: fields{
+				describeVpcsCalls: []describeVpcsCall{
+					{
+						req: &ec2sdk.DescribeVpcsInput{
+							VpcIds: awssdk.StringSlice([]string{"vpc-2f09a348"}),
+						},
+						resp: &ec2sdk.DescribeVpcsOutput{
+							Vpcs: []*ec2sdk.Vpc{
+								{
+									VpcId: awssdk.String("vpc-2f09a348"),
+									CidrBlockAssociationSet: []*ec2sdk.VpcCidrBlockAssociation{
+										{
+											CidrBlock: awssdk.String("192.168.0.0/16"),
+											CidrBlockState: &ec2sdk.VpcCidrBlockState{
+												State: awssdk.String(ec2sdk.VpcCidrBlockStateCodeAssociated),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						req: &ec2sdk.DescribeVpcsInput{
+							VpcIds: awssdk.StringSlice([]string{"vpc-2f09a842"}),
+						},
+						resp: &ec2sdk.DescribeVpcsOutput{
+							Vpcs: []*ec2sdk.Vpc{
+								{
+									VpcId: awssdk.String("vpc-2f09a842"),
+									CidrBlockAssociationSet: []*ec2sdk.VpcCidrBlockAssociation{
+										{
+											CidrBlock: awssdk.String("10.100.0.0/16"),
+											CidrBlockState: &ec2sdk.VpcCidrBlockState{
+												State: awssdk.String(ec2sdk.VpcCidrBlockStateCodeAssociated),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			fetchVPCInfoCalls: []fetchVPCInfoCall{
+				{
+					vpcID: "vpc-2f09a348",
+					want: VPCInfo{
+						VpcId: awssdk.String("vpc-2f09a348"),
+						CidrBlockAssociationSet: []*ec2sdk.VpcCidrBlockAssociation{
+							{
+								CidrBlock: awssdk.String("192.168.0.0/16"),
+								CidrBlockState: &ec2sdk.VpcCidrBlockState{
+									State: awssdk.String(ec2sdk.VpcCidrBlockStateCodeAssociated),
+								},
+							},
+						},
+					},
+				},
+				{
+					vpcID: "vpc-2f09a842",
+					want: VPCInfo{
+						VpcId: awssdk.String("vpc-2f09a842"),
+						CidrBlockAssociationSet: []*ec2sdk.VpcCidrBlockAssociation{
+							{
+								CidrBlock: awssdk.String("10.100.0.0/16"),
+								CidrBlockState: &ec2sdk.VpcCidrBlockState{
+									State: awssdk.String(ec2sdk.VpcCidrBlockStateCodeAssociated),
+								},
+							},
+						},
+					},
+				},
+				{
+					vpcID: "vpc-2f09a348",
+					want: VPCInfo{
+						VpcId: awssdk.String("vpc-2f09a348"),
+						CidrBlockAssociationSet: []*ec2sdk.VpcCidrBlockAssociation{
+							{
+								CidrBlock: awssdk.String("192.168.0.0/16"),
+								CidrBlockState: &ec2sdk.VpcCidrBlockState{
+									State: awssdk.String(ec2sdk.VpcCidrBlockStateCodeAssociated),
+								},
+							},
+						},
+					},
+				},
+				{
+					vpcID: "vpc-2f09a842",
+					want: VPCInfo{
+						VpcId: awssdk.String("vpc-2f09a842"),
+						CidrBlockAssociationSet: []*ec2sdk.VpcCidrBlockAssociation{
+							{
+								CidrBlock: awssdk.String("10.100.0.0/16"),
+								CidrBlockState: &ec2sdk.VpcCidrBlockState{
+									State: awssdk.String(ec2sdk.VpcCidrBlockStateCodeAssociated),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			ec2Client := services.NewMockEC2(ctrl)
+			for _, call := range tt.fields.describeVpcsCalls {
+				ec2Client.EXPECT().DescribeVpcsWithContext(gomock.Any(), call.req).Return(call.resp, call.err)
+			}
+
+			p := NewDefaultVPCInfoProvider(ec2Client, &log.NullLogger{})
+			for _, call := range tt.fetchVPCInfoCalls {
+				got, err := p.FetchVPCInfo(context.Background(), call.vpcID, call.opts...)
+				if call.wantErr != nil {
+					assert.EqualError(t, err, call.wantErr.Error())
+				} else {
+					assert.NoError(t, err)
+					assert.Equal(t, call.want, got)
+				}
+			}
+		})
+	}
+}
+
+func Test_defaultVPCInfoProvider_fetchVPCInfoFromAWS(t *testing.T) {
+	type describeVpcsCall struct {
+		req  *ec2sdk.DescribeVpcsInput
+		resp *ec2sdk.DescribeVpcsOutput
+		err  error
+	}
 	type fields struct {
-		describeVpcCalls []describeVpcCall
+		describeVpcsCalls []describeVpcsCall
+	}
+	type args struct {
+		vpcID string
 	}
 	tests := []struct {
 		name    string
 		fields  fields
-		want    *ec2sdk.Vpc
-		wantErr bool
+		args    args
+		want    VPCInfo
+		wantErr error
 	}{
 		{
-			name: "from AWS",
+			name: "describeVpcs succeeded",
 			fields: fields{
-				describeVpcCalls: []describeVpcCall{
+				describeVpcsCalls: []describeVpcsCall{
 					{
-						input: &ec2sdk.DescribeVpcsInput{
-							VpcIds: []*string{awssdk.String("vpc-2f09a348")},
+						req: &ec2sdk.DescribeVpcsInput{
+							VpcIds: awssdk.StringSlice([]string{"vpc-2f09a348"}),
 						},
-						output: &ec2sdk.DescribeVpcsOutput{
-							Vpcs: []*ec2sdk.Vpc{{VpcId: awssdk.String("vpc-2f09a348")}},
+						resp: &ec2sdk.DescribeVpcsOutput{
+							Vpcs: []*ec2sdk.Vpc{
+								{
+									VpcId: awssdk.String("vpc-2f09a348"),
+									CidrBlockAssociationSet: []*ec2sdk.VpcCidrBlockAssociation{
+										{
+											CidrBlock: awssdk.String("192.168.0.0/16"),
+											CidrBlockState: &ec2sdk.VpcCidrBlockState{
+												State: awssdk.String(ec2sdk.VpcCidrBlockStateCodeAssociated),
+											},
+										},
+									},
+								},
+							},
 						},
-						err: nil,
 					},
 				},
 			},
-			want: &ec2sdk.Vpc{
-				VpcId: awssdk.String("vpc-2f09a348"),
+			args: args{
+				vpcID: "vpc-2f09a348",
 			},
-			wantErr: false,
+			want: VPCInfo{
+				VpcId: awssdk.String("vpc-2f09a348"),
+				CidrBlockAssociationSet: []*ec2sdk.VpcCidrBlockAssociation{
+					{
+						CidrBlock: awssdk.String("192.168.0.0/16"),
+						CidrBlockState: &ec2sdk.VpcCidrBlockState{
+							State: awssdk.String(ec2sdk.VpcCidrBlockStateCodeAssociated),
+						},
+					},
+				},
+			},
 		},
 		{
-			name:   "from cache",
-			fields: fields{},
-			want: &ec2sdk.Vpc{
-				VpcId: awssdk.String("vpc-2f09a348"),
+			name: "describeVpcs failed",
+			fields: fields{
+				describeVpcsCalls: []describeVpcsCall{
+					{
+						req: &ec2sdk.DescribeVpcsInput{
+							VpcIds: awssdk.StringSlice([]string{"vpc-2f09a348"}),
+						},
+						err: errors.New("some error happened"),
+					},
+				},
 			},
-			wantErr: false,
+			args: args{
+				vpcID: "vpc-2f09a348",
+			},
+			wantErr: errors.New("some error happened"),
 		},
 	}
-
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	ec2Client := services.NewMockEC2(ctrl)
-	p := NewDefaultVPCInfoProvider(ec2Client, &log.NullLogger{})
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			for _, call := range tt.fields.describeVpcCalls {
-				ec2Client.EXPECT().DescribeVpcsWithContext(gomock.Any(), call.input).Return(call.output, call.err)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			ec2Client := services.NewMockEC2(ctrl)
+			for _, call := range tt.fields.describeVpcsCalls {
+				ec2Client.EXPECT().DescribeVpcsWithContext(gomock.Any(), call.req).Return(call.resp, call.err)
 			}
 
-			got, err := p.FetchVPCInfo(context.Background(), "vpc-2f09a348")
-			if (err != nil) != tt.wantErr {
-				t.Errorf("defaultVPCInfoProvider.FetchVPCInfo() error = %v, wantErr %v", err, tt.wantErr)
-				return
+			p := &defaultVPCInfoProvider{
+				ec2Client: ec2Client,
+				logger:    &log.NullLogger{},
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("defaultVPCInfoProvider.FetchVPCInfo() = %v, want %v", got, tt.want)
+			got, err := p.fetchVPCInfoFromAWS(context.Background(), tt.args.vpcID)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
 			}
+		})
+	}
+}
+
+func TestVPCInfo_AssociatedIPv4CIDRs(t *testing.T) {
+	tests := []struct {
+		name string
+		vpc  VPCInfo
+		want []string
+	}{
+		{
+			name: "single associated CIDR",
+			vpc: VPCInfo{
+				VpcId: awssdk.String("vpc-2f09a348"),
+				CidrBlockAssociationSet: []*ec2sdk.VpcCidrBlockAssociation{
+					{
+						CidrBlock: awssdk.String("192.168.0.0/16"),
+						CidrBlockState: &ec2sdk.VpcCidrBlockState{
+							State: awssdk.String(ec2sdk.VpcCidrBlockStateCodeAssociated),
+						},
+					},
+				},
+			},
+			want: []string{"192.168.0.0/16"},
+		},
+		{
+			name: "multiple CIDRs",
+			vpc: VPCInfo{
+				VpcId: awssdk.String("vpc-2f09a348"),
+				CidrBlockAssociationSet: []*ec2sdk.VpcCidrBlockAssociation{
+					{
+						CidrBlock: awssdk.String("192.168.0.0/16"),
+						CidrBlockState: &ec2sdk.VpcCidrBlockState{
+							State: awssdk.String(ec2sdk.VpcCidrBlockStateCodeAssociated),
+						},
+					},
+					{
+						CidrBlock: awssdk.String("10.100.0.0/16"),
+						CidrBlockState: &ec2sdk.VpcCidrBlockState{
+							State: awssdk.String(ec2sdk.VpcCidrBlockStateCodeDisassociated),
+						},
+					},
+					{
+						CidrBlock: awssdk.String("172.16.0.0/16"),
+						CidrBlockState: &ec2sdk.VpcCidrBlockState{
+							State: awssdk.String(ec2sdk.VpcCidrBlockStateCodeAssociated),
+						},
+					},
+				},
+			},
+			want: []string{"192.168.0.0/16", "172.16.0.0/16"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.vpc.AssociatedIPv4CIDRs()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestVPCInfo_AssociatedIPv6CIDRs(t *testing.T) {
+	tests := []struct {
+		name string
+		vpc  VPCInfo
+		want []string
+	}{
+		{
+			name: "single associated CIDR",
+			vpc: VPCInfo{
+				VpcId: awssdk.String("vpc-2f09a348"),
+				Ipv6CidrBlockAssociationSet: []*ec2sdk.VpcIpv6CidrBlockAssociation{
+					{
+						Ipv6CidrBlock: awssdk.String("2600:1f14:f8c:2700::/56"),
+						Ipv6CidrBlockState: &ec2sdk.VpcCidrBlockState{
+							State: awssdk.String(ec2sdk.VpcCidrBlockStateCodeAssociated),
+						},
+					},
+				},
+			},
+			want: []string{"2600:1f14:f8c:2700::/56"},
+		},
+		{
+			name: "multiple CIDRs",
+			vpc: VPCInfo{
+				VpcId: awssdk.String("vpc-2f09a348"),
+				Ipv6CidrBlockAssociationSet: []*ec2sdk.VpcIpv6CidrBlockAssociation{
+					{
+						Ipv6CidrBlock: awssdk.String("2600:1f14:f8c:2700::/56"),
+						Ipv6CidrBlockState: &ec2sdk.VpcCidrBlockState{
+							State: awssdk.String(ec2sdk.VpcCidrBlockStateCodeAssociated),
+						},
+					},
+					{
+						Ipv6CidrBlock: awssdk.String("2700:1f14:f8c:2700::/56"),
+						Ipv6CidrBlockState: &ec2sdk.VpcCidrBlockState{
+							State: awssdk.String(ec2sdk.VpcCidrBlockStateCodeDisassociated),
+						},
+					},
+					{
+						Ipv6CidrBlock: awssdk.String("2800:1f14:f8c:2700::/56"),
+						Ipv6CidrBlockState: &ec2sdk.VpcCidrBlockState{
+							State: awssdk.String(ec2sdk.VpcCidrBlockStateCodeAssociated),
+						},
+					},
+				},
+			},
+			want: []string{"2600:1f14:f8c:2700::/56", "2800:1f14:f8c:2700::/56"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.vpc.AssociatedIPv6CIDRs()
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/targetgroupbinding/resource_manager.go
+++ b/pkg/targetgroupbinding/resource_manager.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net"
+	"inet.af/netaddr"
 	"time"
 
 	"k8s.io/client-go/tools/record"
 
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	ec2sdk "github.com/aws/aws-sdk-go/service/ec2"
 	elbv2sdk "github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -138,11 +137,15 @@ func (m *defaultResourceManager) reconcileWithIPTargetType(ctx context.Context, 
 	if err := m.networkingManager.ReconcileForPodEndpoints(ctx, tgb, endpoints); err != nil {
 		return err
 	}
-	if err := m.deregisterTargets(ctx, tgARN, unmatchedTargets); err != nil {
-		return err
+	if len(unmatchedTargets) > 0 {
+		if err := m.deregisterTargets(ctx, tgARN, unmatchedTargets); err != nil {
+			return err
+		}
 	}
-	if err := m.registerPodEndpoints(ctx, tgARN, unmatchedEndpoints); err != nil {
-		return err
+	if len(unmatchedEndpoints) > 0 {
+		if err := m.registerPodEndpoints(ctx, tgARN, unmatchedEndpoints); err != nil {
+			return err
+		}
 	}
 
 	anyPodNeedFurtherProbe, err := m.updateTargetHealthPodCondition(ctx, targetHealthCondType, matchedEndpointAndTargets, unmatchedEndpoints)
@@ -192,11 +195,15 @@ func (m *defaultResourceManager) reconcileWithInstanceTargetType(ctx context.Con
 	if err := m.networkingManager.ReconcileForNodePortEndpoints(ctx, tgb, endpoints); err != nil {
 		return err
 	}
-	if err := m.deregisterTargets(ctx, tgARN, unmatchedTargets); err != nil {
-		return err
+	if len(unmatchedTargets) > 0 {
+		if err := m.deregisterTargets(ctx, tgARN, unmatchedTargets); err != nil {
+			return err
+		}
 	}
-	if err := m.registerNodePortEndpoints(ctx, tgARN, unmatchedEndpoints); err != nil {
-		return err
+	if len(unmatchedEndpoints) > 0 {
+		if err := m.registerNodePortEndpoints(ctx, tgARN, unmatchedEndpoints); err != nil {
+			return err
+		}
 	}
 	_ = drainingTargets
 	return nil
@@ -326,7 +333,14 @@ func (m *defaultResourceManager) deregisterTargets(ctx context.Context, tgARN st
 }
 
 func (m *defaultResourceManager) registerPodEndpoints(ctx context.Context, tgARN string, endpoints []backend.PodEndpoint) error {
-	vpc, err := m.vpcInfoProvider.FetchVPCInfo(ctx, m.vpcID)
+	vpcInfo, err := m.vpcInfoProvider.FetchVPCInfo(ctx, m.vpcID)
+	if err != nil {
+		return err
+	}
+	var vpcRawCIDRs []string
+	vpcRawCIDRs = append(vpcRawCIDRs, vpcInfo.AssociatedIPv4CIDRs()...)
+	vpcRawCIDRs = append(vpcRawCIDRs, vpcInfo.AssociatedIPv6CIDRs()...)
+	vpcCIDRs, err := networking.ParseCIDRs(vpcRawCIDRs)
 	if err != nil {
 		return err
 	}
@@ -337,7 +351,11 @@ func (m *defaultResourceManager) registerPodEndpoints(ctx context.Context, tgARN
 			Id:   awssdk.String(endpoint.IP),
 			Port: awssdk.Int64(endpoint.Port),
 		}
-		if !isELBV2TargetInELBVPC(endpoint.IP, vpc) {
+		podIP, err := netaddr.ParseIP(endpoint.IP)
+		if err != nil {
+			return err
+		}
+		if !networking.IsIPWithinCIDRs(podIP, vpcCIDRs) {
 			target.AvailabilityZone = awssdk.String("all")
 		}
 		sdkTargets = append(sdkTargets, target)
@@ -487,30 +505,4 @@ func isELBV2TargetGroupNotFoundError(err error) bool {
 		return awsErr.Code() == "TargetGroupNotFound"
 	}
 	return false
-}
-
-func isELBV2TargetInELBVPC(podIP string, vpc *ec2sdk.Vpc) bool {
-	// Check if the pod IP is found in a VPC CIDR block.
-	for _, v := range vpc.CidrBlockAssociationSet {
-		if isIPinCIDR(podIP, awssdk.StringValue(v.CidrBlock)) {
-			return true
-		}
-	}
-
-	// Cannot find pod IP in a VPC CIDR block.
-	return false
-}
-
-func isIPinCIDR(ipAddr, cidrBlock string) bool {
-	_, cidr, err := net.ParseCIDR(cidrBlock)
-	if err != nil {
-		return false
-	}
-
-	ip := net.ParseIP(ipAddr)
-	if ip == nil {
-		return false
-	}
-
-	return cidr.Contains(ip)
 }

--- a/pkg/targetgroupbinding/resource_manager_test.go
+++ b/pkg/targetgroupbinding/resource_manager_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	awssdk "github.com/aws/aws-sdk-go/aws"
-	ec2sdk "github.com/aws/aws-sdk-go/service/ec2"
 	elbv2sdk "github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -498,109 +497,6 @@ func Test_buildPodConditionPatch(t *testing.T) {
 				gotPatch, _ := got.Data(nil)
 				assert.Equal(t, tt.wantPatch, gotPatch)
 				assert.Equal(t, types.StrategicMergePatchType, got.Type())
-			}
-		})
-	}
-}
-
-func Test_isELBV2TargetInELBVPC(t *testing.T) {
-	v := &ec2sdk.Vpc{
-		CidrBlock: awssdk.String("192.168.1.0/24"),
-		CidrBlockAssociationSet: []*ec2sdk.VpcCidrBlockAssociation{
-			{
-				CidrBlock: awssdk.String("192.168.1.0/24"),
-			},
-			{
-				CidrBlock: awssdk.String("10.10.10.0/24"),
-			},
-			{
-				CidrBlock: awssdk.String("10.10.20.0/24"),
-			},
-		},
-	}
-
-	type args struct {
-		podIP string
-		vpc   *ec2sdk.Vpc
-	}
-	tests := []struct {
-		name string
-		args args
-		want bool
-	}{
-		{
-			name: "pod IP is in VPC CIDR",
-			args: args{
-				podIP: "192.168.1.1",
-				vpc:   v,
-			},
-			want: true,
-		},
-		{
-			name: "pod IP is in first secondary VPC CIDR",
-			args: args{
-				podIP: "10.10.10.1",
-				vpc:   v,
-			},
-			want: true,
-		},
-		{
-			name: "pod IP is in second secondary first VPC CIDR",
-			args: args{
-				podIP: "10.10.20.1",
-				vpc:   v,
-			},
-			want: true,
-		},
-		{
-			name: "pod IP is not in VPC",
-			args: args{
-				podIP: "10.0.0.1",
-				vpc:   v,
-			},
-			want: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := isELBV2TargetInELBVPC(tt.args.podIP, tt.args.vpc); got != tt.want {
-				t.Errorf("isELBV2TargetInELBVPC() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func Test_isIPinCIDR(t *testing.T) {
-	type args struct {
-		ipAddr    string
-		cidrBlock string
-	}
-	tests := []struct {
-		name string
-		args args
-		want bool
-	}{
-		{
-			name: "yes",
-			args: args{
-				ipAddr:    "10.10.10.10",
-				cidrBlock: "10.0.0.0/8",
-			},
-			want: true,
-		},
-		{
-			name: "no",
-			args: args{
-				ipAddr:    "10.10.10.10",
-				cidrBlock: "10.0.0.0/24",
-			},
-			want: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := isIPinCIDR(tt.args.ipAddr, tt.args.cidrBlock); got != tt.want {
-				t.Errorf("isIPinCIDR() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
### Description
Follow up PR for #1862
* Support IPv6 Pods when detecting AZ.
* Support to disable cache when fetchVPCInfo. which can be used to replace VPCInfoResolver once [PR-2332](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2332) merged
* Support multiples VPCs

Additional notes:
* used inet.af/netaddr to deal with IP, which will be a built-in lib with go 1.18. (It provides better behavior/performance when deal with IP addresses)
* tested below cases:
   *  ipv4 + cluster's VPC
  *   ipv6 + cluster's VPC
  *   ipv4 + peered VPC
  *   ipv6 + peered VPC
<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [x] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:
