### PR TITLE
NLB Instance mode guide referenced the wrong annotation

### DIFF
--- a/docs/guide/service/nlb.md
+++ b/docs/guide/service/nlb.md
@@ -58,7 +58,7 @@ NLB IP mode is determined based on the `service.beta.kubernetes.io/aws-load-bala
     the controller will provision NLB in IP mode. With this, the `service.beta.kubernetes.io/aws-load-balancer-nlb-target-type` annotation gets ignored.
 
 ### Instance mode
-Similar to the IP mode, the instance mode is based on the annotation `service.beta.kubernetes.io/aws-load-balancer-type` value `instance`. Here is a sample manifest snippet:
+Similar to the IP mode, the instance mode is based on the annotation `service.beta.kubernetes.io/aws-load-balancer-nlb-target-type` value `instance`. Here is a sample manifest snippet:
 
 ```yaml
     metadata:


### PR DESCRIPTION
### Issue

None, noticed while reading the documentation.

### Description

> Similar to the IP mode, the instance mode is based on the annotation `service.beta.kubernetes.io/aws-load-balancer-type` value `instance`.

The annotation that takes an `instance` value is `service.beta.kubernetes.io/aws-load-balancer-nlb-target-type`, and this also matches the text we're being "similar to":

> NLB IP mode is determined based on the `service.beta.kubernetes.io/aws-load-balancer-nlb-target-type` annotation.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
