### PR TITLE
Support for NLBs targeting ALBs

### DIFF
--- a/apis/elbv2/v1beta1/targetgroupbinding_types.go
+++ b/apis/elbv2/v1beta1/targetgroupbinding_types.go
@@ -21,16 +21,18 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-// +kubebuilder:validation:Enum=instance;ip
+// +kubebuilder:validation:Enum=instance;ip;alb
 // TargetType is the targetType of your ELBV2 TargetGroup.
 //
 // * with `instance` TargetType, nodes with nodePort for your service will be registered as targets
 // * with `ip` TargetType, Pods with containerPort for your service will be registered as targets
+// * with `alb` TargetType, an application load balancer will be registered as the target
 type TargetType string
 
 const (
 	TargetTypeInstance TargetType = "instance"
 	TargetTypeIP       TargetType = "ip"
+	TargetTypeALB      TargetType = "alb"
 )
 
 // +kubebuilder:validation:Enum=ipv4;ipv6

--- a/config/crd/bases/elbv2.k8s.aws_targetgroupbindings.yaml
+++ b/config/crd/bases/elbv2.k8s.aws_targetgroupbindings.yaml
@@ -307,6 +307,7 @@ spec:
                 enum:
                 - instance
                 - ip
+                - alb
                 type: string
             required:
             - serviceRef

--- a/controllers/service/eventhandlers/service_events.go
+++ b/controllers/service/eventhandlers/service_events.go
@@ -58,7 +58,7 @@ func (h *enqueueRequestsForServiceEvent) Generic(e event.GenericEvent, queue wor
 }
 
 func (h *enqueueRequestsForServiceEvent) isServiceSupported(service *corev1.Service) bool {
-	lbType := ""
+	var lbType string
 	_ = h.annotationParser.ParseStringAnnotation(annotations.SvcLBSuffixLoadBalancerType, &lbType, service.Annotations)
 	if lbType == svcpkg.LoadBalancerTypeNLBIP {
 		return true
@@ -66,7 +66,8 @@ func (h *enqueueRequestsForServiceEvent) isServiceSupported(service *corev1.Serv
 	var lbTargetType string
 	_ = h.annotationParser.ParseStringAnnotation(annotations.SvcLBSuffixTargetType, &lbTargetType, service.Annotations)
 	if lbType == svcpkg.LoadBalancerTypeExternal && (lbTargetType == svcpkg.LoadBalancerTargetTypeIP ||
-		lbTargetType == svcpkg.LoadBalancerTargetTypeInstance) {
+		lbTargetType == svcpkg.LoadBalancerTargetTypeInstance ||
+		lbTargetType == svcpkg.LoadBalancerTargetTypeALB) {
 		return true
 	}
 	return false

--- a/pkg/deploy/elbv2/target_group_manager_test.go
+++ b/pkg/deploy/elbv2/target_group_manager_test.go
@@ -509,6 +509,43 @@ func Test_buildSDKCreateTargetGroupInput(t *testing.T) {
 				IpAddressType:              awssdk.String("ipv6"),
 			},
 		},
+		{
+			name: "standard case alb target",
+			args: args{
+				tgSpec: elbv2model.TargetGroupSpec{
+					Name:          "my-tg",
+					TargetType:    elbv2model.TargetTypeALB,
+					Port:          8080,
+					Protocol:      elbv2model.ProtocolHTTP,
+					IPAddressType: &ipAddressTypeIPv4,
+					HealthCheckConfig: &elbv2model.TargetGroupHealthCheckConfig{
+						Port:                    &port9090,
+						Protocol:                &protocolHTTP,
+						Path:                    awssdk.String("/healthcheck"),
+						Matcher:                 &elbv2model.HealthCheckMatcher{HTTPCode: awssdk.String("200")},
+						IntervalSeconds:         awssdk.Int64(10),
+						TimeoutSeconds:          awssdk.Int64(5),
+						HealthyThresholdCount:   awssdk.Int64(3),
+						UnhealthyThresholdCount: awssdk.Int64(2),
+					},
+				},
+			},
+			want: &elbv2sdk.CreateTargetGroupInput{
+				HealthCheckEnabled:         awssdk.Bool(true),
+				HealthCheckIntervalSeconds: awssdk.Int64(10),
+				HealthCheckPath:            awssdk.String("/healthcheck"),
+				HealthCheckPort:            awssdk.String("9090"),
+				HealthCheckProtocol:        awssdk.String("HTTP"),
+				HealthCheckTimeoutSeconds:  awssdk.Int64(5),
+				HealthyThresholdCount:      awssdk.Int64(3),
+				Matcher:                    &elbv2sdk.Matcher{HttpCode: awssdk.String("200")},
+				UnhealthyThresholdCount:    awssdk.Int64(2),
+				Name:                       awssdk.String("my-tg"),
+				Port:                       awssdk.Int64(8080),
+				Protocol:                   awssdk.String("HTTP"),
+				TargetType:                 awssdk.String("alb"),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/deploy/elbv2/target_group_synthesizer.go
+++ b/pkg/deploy/elbv2/target_group_synthesizer.go
@@ -40,7 +40,10 @@ type targetGroupSynthesizer struct {
 
 func (s *targetGroupSynthesizer) Synthesize(ctx context.Context) error {
 	var resTGs []*elbv2model.TargetGroup
-	s.stack.ListResources(&resTGs)
+	err := s.stack.ListResources(&resTGs)
+	if err != nil {
+		return err
+	}
 	sdkTGs, err := s.findSDKTargetGroups(ctx)
 	if err != nil {
 		return err

--- a/pkg/model/elbv2/target_group.go
+++ b/pkg/model/elbv2/target_group.go
@@ -9,7 +9,7 @@ import (
 
 var _ core.Resource = &TargetGroup{}
 
-// TargetGroup represents a ELBV2 TargetGroup
+// TargetGroup represents a ELBV2 TargetGroup.
 type TargetGroup struct {
 	core.ResourceMeta `json:"-"`
 
@@ -32,12 +32,12 @@ func NewTargetGroup(stack core.Stack, id string, spec TargetGroupSpec) *TargetGr
 	return tg
 }
 
-// SetStatus sets the TargetGroup's status
+// SetStatus sets the TargetGroup's status.
 func (tg *TargetGroup) SetStatus(status TargetGroupStatus) {
 	tg.Status = &status
 }
 
-// LoadBalancerARN returns The Amazon Resource Name (ARN) of the target group.
+// TargetGroupARN returns The Amazon Resource Name (ARN) of the target group.
 func (tg *TargetGroup) TargetGroupARN() core.StringToken {
 	return core.NewResourceFieldStringToken(tg, "status/targetGroupARN",
 		func(ctx context.Context, res core.Resource, fieldPath string) (s string, err error) {
@@ -55,6 +55,7 @@ type TargetType string
 const (
 	TargetTypeInstance TargetType = "instance"
 	TargetTypeIP       TargetType = "ip"
+	TargetTypeALB      TargetType = "alb"
 )
 
 type TargetGroupIPAddressType string
@@ -64,7 +65,7 @@ const (
 	TargetGroupIPAddressTypeIPv6 TargetGroupIPAddressType = "ipv6"
 )
 
-// Information to use when checking for a successful response from a target.
+// HealthCheckMatcher contains information to use when checking for a successful response from a target.
 type HealthCheckMatcher struct {
 	// The HTTP codes.
 	HTTPCode *string `json:"httpCode,omitempty"`
@@ -73,7 +74,7 @@ type HealthCheckMatcher struct {
 	GRPCCode *string `json:"grpcCode,omitempty"`
 }
 
-// Configuration for TargetGroup's HealthCheck.
+// TargetGroupHealthCheckConfig contains configuration for TargetGroup's HealthCheck.
 type TargetGroupHealthCheckConfig struct {
 	// The port the load balancer uses when performing health checks on targets.
 	// +optional
@@ -108,7 +109,7 @@ type TargetGroupHealthCheckConfig struct {
 	UnhealthyThresholdCount *int64 `json:"unhealthyThresholdCount,omitempty"`
 }
 
-// Specifies a target group attribute.
+// TargetGroupAttribute specifies a target group attribute.
 type TargetGroupAttribute struct {
 	// The name of the attribute.
 	Key string `json:"key"`
@@ -117,7 +118,7 @@ type TargetGroupAttribute struct {
 	Value string `json:"value"`
 }
 
-// TargetGroupSpec defines the observed state of TargetGroup
+// TargetGroupSpec defines the observed state of TargetGroup.
 type TargetGroupSpec struct {
 	// The name of the target group.
 	Name string `json:"name"`
@@ -152,7 +153,7 @@ type TargetGroupSpec struct {
 	Tags map[string]string `json:"tags,omitempty"`
 }
 
-// TargetGroupStatus defines the observed state of TargetGroup
+// TargetGroupStatus defines the observed state of TargetGroup.
 type TargetGroupStatus struct {
 	// The Amazon Resource Name (ARN) of the target group.
 	TargetGroupARN string `json:"targetGroupARN"`

--- a/pkg/service/model_builder.go
+++ b/pkg/service/model_builder.go
@@ -23,6 +23,7 @@ const (
 	LoadBalancerTypeExternal       = "external"
 	LoadBalancerTargetTypeIP       = "ip"
 	LoadBalancerTargetTypeInstance = "instance"
+	LoadBalancerTargetTypeALB      = "alb"
 	lbAttrsDeletionProtection      = "deletion_protection.enabled"
 )
 
@@ -102,6 +103,8 @@ func (b *defaultModelBuilder) Build(ctx context.Context, service *corev1.Service
 		defaultHealthCheckTimeoutForInstanceModeLocal:            6,
 		defaultHealthCheckHealthyThresholdForInstanceModeLocal:   2,
 		defaultHealthCheckUnhealthyThresholdForInstanceModeLocal: 2,
+
+		defaultHealthCheckProtocolForALBTargetType: elbv2model.ProtocolHTTP,
 	}
 
 	if err := task.run(ctx); err != nil {
@@ -154,6 +157,9 @@ type defaultModelBuildTask struct {
 	defaultHealthCheckTimeoutForInstanceModeLocal            int64
 	defaultHealthCheckHealthyThresholdForInstanceModeLocal   int64
 	defaultHealthCheckUnhealthyThresholdForInstanceModeLocal int64
+
+	// Default health check settings for an NLB that targets an ALB
+	defaultHealthCheckProtocolForALBTargetType elbv2model.Protocol
 }
 
 func (t *defaultModelBuildTask) run(ctx context.Context) error {

--- a/pkg/targetgroupbinding/resource_manager.go
+++ b/pkg/targetgroupbinding/resource_manager.go
@@ -89,7 +89,10 @@ func (m *defaultResourceManager) Reconcile(ctx context.Context, tgb *elbv2api.Ta
 	if *tgb.Spec.TargetType == elbv2api.TargetTypeIP {
 		return m.reconcileWithIPTargetType(ctx, tgb)
 	}
-	return m.reconcileWithInstanceTargetType(ctx, tgb)
+	if *tgb.Spec.TargetType == elbv2api.TargetTypeInstance {
+		return m.reconcileWithInstanceTargetType(ctx, tgb)
+	}
+	return m.reconcileWithALBTargetType(ctx, tgb)
 }
 
 func (m *defaultResourceManager) Cleanup(ctx context.Context, tgb *elbv2api.TargetGroupBinding) error {
@@ -199,6 +202,10 @@ func (m *defaultResourceManager) reconcileWithInstanceTargetType(ctx context.Con
 		return err
 	}
 	_ = drainingTargets
+	return nil
+}
+
+func (m *defaultResourceManager) reconcileWithALBTargetType(ctx context.Context, tgb *elbv2api.TargetGroupBinding) error {
 	return nil
 }
 

--- a/scripts/lib/eksctl.sh
+++ b/scripts/lib/eksctl.sh
@@ -129,7 +129,7 @@ eksctl::delete_cluster() {
     return 1
   fi
 
-  echo "ueleted cluster ${cluster_name}"
+  echo "deleted cluster ${cluster_name}"
   return 0
 }
 

--- a/test/e2e/service/nlb_alb_target.go
+++ b/test/e2e/service/nlb_alb_target.go
@@ -1,0 +1,81 @@
+package service
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"net/http"
+	"sigs.k8s.io/aws-load-balancer-controller/test/framework"
+	"sigs.k8s.io/aws-load-balancer-controller/test/framework/utils"
+	"time"
+)
+
+type NLBALBTestStack struct {
+	resourceStack *resourceStack
+}
+
+func (s *NLBALBTestStack) Deploy(ctx context.Context, f *framework.Framework, svc *corev1.Service, dp *appsv1.Deployment) error {
+	s.resourceStack = NewResourceStack(dp, svc, "service-ip-e2e", false)
+	return s.resourceStack.Deploy(ctx, f)
+}
+
+func (s *NLBALBTestStack) UpdateServiceAnnotations(ctx context.Context, f *framework.Framework, svcAnnotations map[string]string) error {
+	return s.resourceStack.UpdateServiceAnnotations(ctx, f, svcAnnotations)
+}
+
+func (s *NLBALBTestStack) ScaleDeployment(ctx context.Context, f *framework.Framework, numReplicas int32) error {
+	return s.resourceStack.ScaleDeployment(ctx, f, numReplicas)
+}
+
+func (s *NLBALBTestStack) Cleanup(ctx context.Context, f *framework.Framework) error {
+	return s.resourceStack.Cleanup(ctx, f)
+}
+
+func (s *NLBALBTestStack) GetLoadBalancerIngressHostName() string {
+	return s.resourceStack.GetLoadBalancerIngressHostname()
+}
+
+func (s *NLBALBTestStack) SendTrafficToLB(ctx context.Context, f *framework.Framework) error {
+	httpClient := http.Client{Timeout: utils.PollIntervalMedium}
+	protocol := "http"
+	if s.listenerTLS() {
+		protocol = "https"
+		httpClient.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		}
+	}
+	// Choose the first port for now, TODO: verify all listeners
+	port := s.resourceStack.svc.Spec.Ports[0].Port
+	noerr := false
+	for i := 0; i < 10; i++ {
+		resp, err := httpClient.Get(fmt.Sprintf("%s://%s:%v/from-tls-client", protocol, s.GetLoadBalancerIngressHostName(), port))
+		if err != nil {
+			time.Sleep(2 * utils.PollIntervalLong)
+			continue
+		}
+		noerr = true
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("Unexpected HTTP status code %v", resp.StatusCode)
+		}
+		if resp.StatusCode == http.StatusOK {
+			break
+		}
+	}
+	if noerr {
+		return nil
+	}
+	return fmt.Errorf("Unsuccessful after 10 retries")
+}
+
+func (s *NLBALBTestStack) listenerTLS() bool {
+	_, ok := s.resourceStack.svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-ssl-cert"]
+	return ok
+}
+
+func (s *NLBALBTestStack) targetGroupTLS() bool {
+	return false
+}

--- a/test/e2e/service/nlb_alb_target_test.go
+++ b/test/e2e/service/nlb_alb_target_test.go
@@ -1,0 +1,187 @@
+package service
+
+import (
+	"context"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/aws-load-balancer-controller/test/framework/utils"
+)
+
+var _ = Describe("k8s nlb service with alb target reconciled by the aws load balancer controller", func() {
+	var (
+		ctx         context.Context
+		deployment  *appsv1.Deployment
+		numReplicas int32
+		name        string
+		dnsName     string
+		lbARN       string
+		labels      map[string]string
+		stack       NLBALBTestStack
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		numReplicas = 3
+		stack = NLBALBTestStack{}
+		name = "nlb-alb-e2e"
+		labels = map[string]string{
+			"app.kubernetes.io/name":     "nlb-alb",
+			"app.kubernetes.io/instance": name,
+		}
+		deployment = &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: &numReplicas,
+				Selector: &metav1.LabelSelector{
+					MatchLabels: labels,
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: labels,
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:            "app",
+								ImagePullPolicy: corev1.PullAlways,
+								Image:           defaultTestImage,
+								Ports: []corev1.ContainerPort{
+									{
+										ContainerPort: appContainerPort,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	})
+
+	AfterEach(func() {
+		err := stack.Cleanup(ctx, tf)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Context("NLB with ALB target configuration", func() {
+		var (
+			svc *corev1.Service
+		)
+		BeforeEach(func() {
+			svc = &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/aws-load-balancer-type":        "external",
+						"service.beta.kubernetes.io/aws-load-balancer-scheme":      "internet-facing",
+						"service.beta.kubernetes.io/aws-load-balancer-target-type": "alb",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Type:     corev1.ServiceTypeLoadBalancer,
+					Selector: labels,
+					Ports: []corev1.ServicePort{
+						{
+							Port:       80,
+							TargetPort: intstr.FromInt(80),
+							Protocol:   corev1.ProtocolTCP,
+						},
+					},
+				},
+			}
+		})
+		It("Should create and verify internet-facing NLB with ALB target", func() {
+			By("deploying stack", func() {
+				err := stack.Deploy(ctx, tf, svc, deployment)
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("checking service status for lb dns name", func() {
+				dnsName = stack.GetLoadBalancerIngressHostName()
+				Expect(dnsName).ToNot(BeEmpty())
+			})
+
+			By("querying AWS loadbalancer from the dns name", func() {
+				var err error
+				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(lbARN).ToNot(BeEmpty())
+			})
+			By("Verify Service with AWS", func() {
+				err := verifyAWSLoadBalancerResources(ctx, tf, lbARN, LoadBalancerExpectation{
+					Type:       "network",
+					Scheme:     "internet-facing",
+					TargetType: "alb",
+					Listeners: map[string]string{
+						"80": "TCP",
+					},
+					TargetGroups: map[string]string{
+						"80": "TCP",
+					},
+					NumTargets: int(numReplicas),
+					TargetGroupHC: &TargetGroupHC{
+						Protocol:           "TCP",
+						Port:               "traffic-port",
+						Interval:           10,
+						Timeout:            10,
+						HealthyThreshold:   3,
+						UnhealthyThreshold: 3,
+					},
+				})
+				Expect(err).ToNot(HaveOccurred())
+			})
+			By("waiting for target group targets to be healthy", func() {
+				err := waitUntilTargetsAreHealthy(ctx, tf, lbARN, int(numReplicas))
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("Send traffic to LB", func() {
+				err := stack.SendTrafficToLB(ctx, tf)
+				Expect(err).ToNot(HaveOccurred())
+			})
+			By("Specifying Healthcheck annotations", func() {
+				err := stack.UpdateServiceAnnotations(ctx, tf, map[string]string{
+					"service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol":            "HTTP",
+					"service.beta.kubernetes.io/aws-load-balancer-healthcheck-port":                "80",
+					"service.beta.kubernetes.io/aws-load-balancer-healthcheck-path":                "/healthz",
+					"service.beta.kubernetes.io/aws-load-balancer-healthcheck-interval":            "30",
+					"service.beta.kubernetes.io/aws-load-balancer-healthcheck-timeout":             "6",
+					"service.beta.kubernetes.io/aws-load-balancer-healthcheck-healthy-threshold":   "2",
+					"service.beta.kubernetes.io/aws-load-balancer-healthcheck-unhealthy-threshold": "2",
+				})
+				Expect(err).ToNot(HaveOccurred())
+
+				Eventually(func() bool {
+					return getTargetGroupHealthCheckProtocol(ctx, tf, lbARN) == "HTTP"
+				}, utils.PollTimeoutShort, utils.PollIntervalMedium).Should(BeTrue())
+
+				err = verifyAWSLoadBalancerResources(ctx, tf, lbARN, LoadBalancerExpectation{
+					Type:       "network",
+					Scheme:     "internet-facing",
+					TargetType: "alb",
+					Listeners: map[string]string{
+						"80": "TCP",
+					},
+					TargetGroups: map[string]string{
+						"80": "TCP",
+					},
+					NumTargets: int(numReplicas),
+					TargetGroupHC: &TargetGroupHC{
+						Protocol:           "HTTP",
+						Port:               "80",
+						Path:               "/healthz",
+						Interval:           30,
+						Timeout:            6,
+						HealthyThreshold:   2,
+						UnhealthyThreshold: 2,
+					},
+				})
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+	})
+})

--- a/webhooks/elbv2/targetgroupbinding_mutator.go
+++ b/webhooks/elbv2/targetgroupbinding_mutator.go
@@ -65,6 +65,8 @@ func (m *targetGroupBindingMutator) defaultingTargetType(ctx context.Context, tg
 		targetType = elbv2api.TargetTypeInstance
 	case elbv2sdk.TargetTypeEnumIp:
 		targetType = elbv2api.TargetTypeIP
+	case elbv2sdk.TargetTypeEnumAlb:
+		targetType = elbv2api.TargetTypeALB
 	default:
 		return errors.Errorf("unsupported TargetType: %v", sdkTargetType)
 	}


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

[Support for NLBs targeting ALBs](https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2297)

### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

The goal of this pull request is to add support for [targeting ALBs from NLBs](https://aws.amazon.com/blogs/networking-and-content-delivery/application-load-balancer-type-target-group-for-network-load-balancer/) by adding the "alb" value to the existing nlb target type annotation. **_It is currently a work in progress._** If possible, it would be great to hear from the maintainers whether this is a feature that you are willing to support in this project. And if so, do you have any thoughts on what the service spec should look like for targeting an ALB? (see below). Thank you in advance!

Example:
```
apiVersion: v1
kind: Service
metadata:
  name: echoserver-nlb
  namespace: echoserver
  annotations:
    service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
    service.beta.kubernetes.io/aws-load-balancer-type: "external"
    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "alb" <-- new alb option
spec:
  # Not sure how everything below should look
  ports:
    - port: 80
      targetPort: 8080
      protocol: TCP
  type: LoadBalancer
  selector:
    (?)app: ???
```

### Checklist
- [x] Added tests that cover your change (if possible) **IN PROGRESS**
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory) **TODO**
- [x] Manually tested **IN PROGRESS**
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:
