### PR TITLE
Adding supports for unweighted target group through feature gate and checking SSL policy availability.

### DIFF
--- a/controllers/ingress/group_controller.go
+++ b/controllers/ingress/group_controller.go
@@ -51,7 +51,7 @@ func NewGroupReconciler(cloud aws.Cloud, k8sClient client.Client, eventRecorder 
 	enhancedBackendBuilder := ingress.NewDefaultEnhancedBackendBuilder(k8sClient, annotationParser, authConfigBuilder)
 	referenceIndexer := ingress.NewDefaultReferenceIndexer(enhancedBackendBuilder, authConfigBuilder, logger)
 	trackingProvider := tracking.NewDefaultProvider(ingressTagPrefix, config.ClusterName)
-	elbv2TaggingManager := elbv2deploy.NewDefaultTaggingManager(cloud.ELBV2(), cloud.VpcID(), config.FeatureGate, logger)
+	elbv2TaggingManager := elbv2deploy.NewDefaultTaggingManager(cloud.ELBV2(), cloud.VpcID(), config.FeatureGates, logger)
 	modelBuilder := ingress.NewDefaultModelBuilder(k8sClient, eventRecorder,
 		cloud.EC2(), cloud.ACM(),
 		annotationParser, subnetsResolver,

--- a/controllers/service/service_controller.go
+++ b/controllers/service/service_controller.go
@@ -40,7 +40,7 @@ func NewServiceReconciler(cloud aws.Cloud, k8sClient client.Client, eventRecorde
 
 	annotationParser := annotations.NewSuffixAnnotationParser(serviceAnnotationPrefix)
 	trackingProvider := tracking.NewDefaultProvider(serviceTagPrefix, config.ClusterName)
-	elbv2TaggingManager := elbv2.NewDefaultTaggingManager(cloud.ELBV2(), cloud.VpcID(), config.FeatureGate, logger)
+	elbv2TaggingManager := elbv2.NewDefaultTaggingManager(cloud.ELBV2(), cloud.VpcID(), config.FeatureGates, logger)
 	modelBuilder := service.NewDefaultModelBuilder(annotationParser, subnetsResolver, vpcResolver, trackingProvider,
 		elbv2TaggingManager, config.ClusterName, config.DefaultTags, config.ExternalManagedTags, config.DefaultSSLPolicy)
 	stackMarshaller := deploy.NewDefaultStackMarshaller()

--- a/docs/deploy/configurations.md
+++ b/docs/deploy/configurations.md
@@ -132,9 +132,9 @@ WAF Regional:^AssociateWebACL|DisassociateWebACL=0.5:1,WAF Regional:^GetWebACLFo
 If running on EC2, the default values are obtained from the instance metadata service.
 
 
-### feature-gates
+### Feature Gates
 This is a controller to enable and disable features. You can use it as flags `--feature-gates=key1=value1,key2=value2`
 |Features-gate Supported Key             | Type                            | Default Value   | Description |
 |---------------------------------------|---------------------------------|-----------------|-------------|
-|EnableListenerRulesTagging             | string                          | true            | Enable or disable tagging load balancer listeners |
+|EnableListenerRulesTagging             | string                          | true            | Enable or disable tagging AWS load balancer listeners and rules |
 |EnableWeightedTargetGroups             | string                          | true            | Enable or disable weighted target groups |

--- a/docs/deploy/configurations.md
+++ b/docs/deploy/configurations.md
@@ -83,7 +83,7 @@ Currently, you can set only 1 namespace to watch in this flag. See [this Kuberne
 |enable-waf                             | boolean                         | true            | Enable WAF addon for ALB |
 |enable-wafv2                           | boolean                         | true            | Enable WAF V2 addon for ALB |
 |external-managed-tags                  | stringList                      |                 | AWS Tag keys that will be managed externally. Specified Tags are ignored during reconciliation |
-|feature-gate                           | string                          | boolean         | A set of key=value pairs to enable or disable features |
+|[feature-gates](#feature-gates)        | stringMap                       |                 | A set of key=value pairs to enable or disable features |
 |ingress-class                          | string                          | alb             | Name of the ingress class this controller satisfies |
 |ingress-max-concurrent-reconciles      | int                             | 3               | Maximum number of concurrently running reconcile loops for ingress |
 |kubeconfig                             | string                          | in-cluster config | Path to the kubeconfig file containing authorization and API server information |
@@ -101,11 +101,6 @@ Currently, you can set only 1 namespace to watch in this flag. See [this Kuberne
 |webhook-cert-dir                       | string                          | /tmp/k8s-webhook-server/serving-certs | The directory that contains the server key and certificate |
 |webhook-cert-file                      | string                          | tls.crt | The server certificate name |
 |webhook-key-file                       | string                          | tls.key | The server key name |
-
-|Feature-gate Supported Key             | Type                            | Default Value   | Description |
-|---------------------------------------|---------------------------------|-----------------|-------------|
-|enable-listener-rules-tagging          | string                          | true            | Enable tagging load balancer listeners |
-|enforce-single-target-group            | string                          | false           | Enforce using only one target group |
 
 
 ### disable-ingress-class-annotation
@@ -135,3 +130,11 @@ WAF Regional:^AssociateWebACL|DisassociateWebACL=0.5:1,WAF Regional:^GetWebACLFo
 
 ### Instance metadata
 If running on EC2, the default values are obtained from the instance metadata service.
+
+
+### feature-gates
+This is a controller to enable and disable features. You can use it as flags `--feature-gates=key1=value1,key2=value2`
+|Features-gate Supported Key             | Type                            | Default Value   | Description |
+|---------------------------------------|---------------------------------|-----------------|-------------|
+|EnableListenerRulesTagging             | string                          | true            | Enable or disable tagging load balancer listeners |
+|EnableWeightedTargetGroups             | string                          | true            | Enable or disable weighted target groups |

--- a/docs/deploy/configurations.md
+++ b/docs/deploy/configurations.md
@@ -83,7 +83,7 @@ Currently, you can set only 1 namespace to watch in this flag. See [this Kuberne
 |enable-waf                             | boolean                         | true            | Enable WAF addon for ALB |
 |enable-wafv2                           | boolean                         | true            | Enable WAF V2 addon for ALB |
 |external-managed-tags                  | stringList                      |                 | AWS Tag keys that will be managed externally. Specified Tags are ignored during reconciliation |
-|feature-gate                         | string                          | true             | A set of key=value pairs to enable or disable features |
+|feature-gate                           | string                          | boolean         | A set of key=value pairs to enable or disable features |
 |ingress-class                          | string                          | alb             | Name of the ingress class this controller satisfies |
 |ingress-max-concurrent-reconciles      | int                             | 3               | Maximum number of concurrently running reconcile loops for ingress |
 |kubeconfig                             | string                          | in-cluster config | Path to the kubeconfig file containing authorization and API server information |
@@ -101,6 +101,12 @@ Currently, you can set only 1 namespace to watch in this flag. See [this Kuberne
 |webhook-cert-dir                       | string                          | /tmp/k8s-webhook-server/serving-certs | The directory that contains the server key and certificate |
 |webhook-cert-file                      | string                          | tls.crt | The server certificate name |
 |webhook-key-file                       | string                          | tls.key | The server key name |
+
+|Feature-gate Supported Key             | Type                            | Default Value   | Description |
+|---------------------------------------|---------------------------------|-----------------|-------------|
+|enable-listener-rules-tagging          | string                          | true            | Enable tagging load balancer listeners |
+|enforce-single-target-group            | string                          | false           | Enforce using only one target group |
+
 
 ### disable-ingress-class-annotation
 `--disable-ingress-class-annotation` controls whether to disable new usage of the `kubernetes.io/ingress.class` annotation.

--- a/docs/deploy/configurations.md
+++ b/docs/deploy/configurations.md
@@ -133,8 +133,9 @@ If running on EC2, the default values are obtained from the instance metadata se
 
 
 ### Feature Gates
-This is a controller to enable and disable features. You can use it as flags `--feature-gates=key1=value1,key2=value2`
-|Features-gate Supported Key             | Type                            | Default Value   | Description |
+They are a set of kye=value pairs that describe AWS load balance controller features. You can use it as flags `--feature-gates=key1=value1,key2=value2`
+
+|Features-gate Supported Key            | Type                            | Default Value   | Description |
 |---------------------------------------|---------------------------------|-----------------|-------------|
-|EnableListenerRulesTagging             | string                          | true            | Enable or disable tagging AWS load balancer listeners and rules |
-|EnableWeightedTargetGroups             | string                          | true            | Enable or disable weighted target groups |
+|ListenerRulesTagging                   | string                          | true            | Enable or disable tagging AWS load balancer listeners and rules |
+|WeightedTargetGroups                   | string                          | true            | Enable or disable weighted target groups |

--- a/main.go
+++ b/main.go
@@ -174,7 +174,7 @@ func loadControllerConfig() (config.ControllerConfig, error) {
 		AWSConfig: aws.CloudConfig{
 			ThrottleConfig: defaultAWSThrottleCFG,
 		},
-		FeatureGate: config.NewFeatureGate(),
+		FeatureGates: config.NewFeatureGates(),
 	}
 
 	fs := pflag.NewFlagSet("", pflag.ExitOnError)

--- a/pkg/config/controller_config.go
+++ b/pkg/config/controller_config.go
@@ -90,7 +90,7 @@ type ControllerConfig struct {
 	// DisableRestrictedSGRules specifies whether to use restricted security group rules
 	DisableRestrictedSGRules bool
 
-	FeatureGate FeatureGate
+	FeatureGates FeatureGates
 }
 
 // BindFlags binds the command line flags to the fields in the config object
@@ -119,7 +119,7 @@ func (cfg *ControllerConfig) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&cfg.DisableRestrictedSGRules, flagDisableRestrictedSGRules, defaultDisableRestrictedSGRules,
 		"Disable the usage of restricted security group rules")
 
-	cfg.FeatureGate.BindFlags(fs)
+	cfg.FeatureGates.BindFlags(fs)
 	cfg.AWSConfig.BindFlags(fs)
 	cfg.RuntimeConfig.BindFlags(fs)
 

--- a/pkg/config/feature_gate.go
+++ b/pkg/config/feature_gate.go
@@ -11,6 +11,7 @@ type Feature string
 
 const (
 	EnableListenerRulesTagging Feature = "enable-listener-rules-tagging"
+	EnforceSingleTargetGroup   Feature = "enforce-single-target-group"
 )
 
 type FeatureGate interface {
@@ -39,6 +40,7 @@ func NewFeatureGate() FeatureGate {
 	return &defaultFeatureGate{
 		featureState: map[Feature]bool{
 			EnableListenerRulesTagging: true,
+			EnforceSingleTargetGroup:   false,
 		},
 	}
 }

--- a/pkg/config/feature_gates.go
+++ b/pkg/config/feature_gates.go
@@ -10,8 +10,8 @@ import (
 type Feature string
 
 const (
-	EnableListenerRulesTagging Feature = "EnableListenerRulesTagging"
-	EnableWeightedTargetGroups Feature = "EnableWeightedTargetGroups"
+	ListenerRulesTagging Feature = "ListenerRulesTagging"
+	WeightedTargetGroups Feature = "WeightedTargetGroups"
 )
 
 type FeatureGates interface {
@@ -39,8 +39,8 @@ type defaultFeatureGates struct {
 func NewFeatureGates() FeatureGates {
 	return &defaultFeatureGates{
 		featureState: map[Feature]bool{
-			EnableListenerRulesTagging: true,
-			EnableWeightedTargetGroups: true,
+			ListenerRulesTagging: true,
+			WeightedTargetGroups: true,
 		},
 	}
 }

--- a/pkg/config/feature_gates.go
+++ b/pkg/config/feature_gates.go
@@ -10,11 +10,11 @@ import (
 type Feature string
 
 const (
-	EnableListenerRulesTagging Feature = "enable-listener-rules-tagging"
-	EnforceSingleTargetGroup   Feature = "enforce-single-target-group"
+	EnableListenerRulesTagging Feature = "EnableListenerRulesTagging"
+	EnableWeightedTargetGroups Feature = "EnableWeightedTargetGroups"
 )
 
-type FeatureGate interface {
+type FeatureGates interface {
 	// Enabled returns whether a feature is enabled
 	Enabled(feature Feature) bool
 
@@ -24,44 +24,44 @@ type FeatureGate interface {
 	// Disable will disable a feature
 	Disable(feature Feature)
 
-	// BindFlags bind featureGate flags
+	// BindFlags bind featureGates flags
 	BindFlags(fs *pflag.FlagSet)
 }
 
-var _ FeatureGate = (*defaultFeatureGate)(nil)
-var _ pflag.Value = (*defaultFeatureGate)(nil)
+var _ FeatureGates = (*defaultFeatureGates)(nil)
+var _ pflag.Value = (*defaultFeatureGates)(nil)
 
-type defaultFeatureGate struct {
+type defaultFeatureGates struct {
 	featureState map[Feature]bool
 }
 
-// NewFeatureGate constructs new featureGate
-func NewFeatureGate() FeatureGate {
-	return &defaultFeatureGate{
+// NewFeatureGates constructs new featureGates
+func NewFeatureGates() FeatureGates {
+	return &defaultFeatureGates{
 		featureState: map[Feature]bool{
 			EnableListenerRulesTagging: true,
-			EnforceSingleTargetGroup:   false,
+			EnableWeightedTargetGroups: true,
 		},
 	}
 }
 
-func (f *defaultFeatureGate) BindFlags(fs *pflag.FlagSet) {
-	fs.Var(f, "feature-gate", "A set of key=bool pairs enable/disable features")
+func (f *defaultFeatureGates) BindFlags(fs *pflag.FlagSet) {
+	fs.Var(f, "feature-gates", "A set of key=bool pairs enable/disable features")
 }
 
-func (f *defaultFeatureGate) Enabled(feature Feature) bool {
+func (f *defaultFeatureGates) Enabled(feature Feature) bool {
 	return f.featureState[feature]
 }
 
-func (f *defaultFeatureGate) Enable(feature Feature) {
+func (f *defaultFeatureGates) Enable(feature Feature) {
 	f.featureState[feature] = true
 }
 
-func (f *defaultFeatureGate) Disable(feature Feature) {
+func (f *defaultFeatureGates) Disable(feature Feature) {
 	f.featureState[feature] = false
 }
 
-func (f *defaultFeatureGate) String() string {
+func (f *defaultFeatureGates) String() string {
 	var featureSettings []string
 	for feature, enabled := range f.featureState {
 		featureSettings = append(featureSettings, fmt.Sprintf("%v=%v", feature, enabled))
@@ -70,7 +70,7 @@ func (f *defaultFeatureGate) String() string {
 }
 
 // SplitMapStringBool parse comma-separated string of key1=value1,key2=value2. value is either true or false
-func (f *defaultFeatureGate) SplitMapStringBool(str string) (map[string]bool, error) {
+func (f *defaultFeatureGates) SplitMapStringBool(str string) (map[string]bool, error) {
 	result := make(map[string]bool)
 	for _, s := range strings.Split(str, ",") {
 		if len(s) == 0 {
@@ -90,10 +90,10 @@ func (f *defaultFeatureGate) SplitMapStringBool(str string) (map[string]bool, er
 	return result, nil
 }
 
-func (f *defaultFeatureGate) Set(value string) error {
+func (f *defaultFeatureGates) Set(value string) error {
 	settings, err := f.SplitMapStringBool(value)
 	if err != nil {
-		return fmt.Errorf("failed to parse feature-gate settings due to %v", err)
+		return fmt.Errorf("failed to parse feature-gates settings due to %v", err)
 	}
 	for k, v := range settings {
 		_, ok := f.featureState[Feature(k)]
@@ -105,6 +105,6 @@ func (f *defaultFeatureGate) Set(value string) error {
 	return nil
 }
 
-func (f *defaultFeatureGate) Type() string {
+func (f *defaultFeatureGates) Type() string {
 	return "mapStringBool"
 }

--- a/pkg/deploy/elbv2/listener_manager.go
+++ b/pkg/deploy/elbv2/listener_manager.go
@@ -62,7 +62,7 @@ func (m *defaultListenerManager) Create(ctx context.Context, resLS *elbv2model.L
 		return elbv2model.ListenerStatus{}, err
 	}
 	var lsTags map[string]string
-	if m.featureGates.Enabled(config.EnableListenerRulesTagging) {
+	if m.featureGates.Enabled(config.ListenerRulesTagging) {
 		lsTags = m.trackingProvider.ResourceTags(resLS.Stack(), resLS, resLS.Spec.Tags)
 	}
 	req.Tags = convertTagsToSDKTags(lsTags)
@@ -92,7 +92,7 @@ func (m *defaultListenerManager) Create(ctx context.Context, resLS *elbv2model.L
 }
 
 func (m *defaultListenerManager) Update(ctx context.Context, resLS *elbv2model.Listener, sdkLS ListenerWithTags) (elbv2model.ListenerStatus, error) {
-	if m.featureGates.Enabled(config.EnableListenerRulesTagging) {
+	if m.featureGates.Enabled(config.ListenerRulesTagging) {
 		if err := m.updateSDKListenerWithTags(ctx, resLS, sdkLS); err != nil {
 			return elbv2model.ListenerStatus{}, err
 		}

--- a/pkg/deploy/elbv2/listener_manager.go
+++ b/pkg/deploy/elbv2/listener_manager.go
@@ -28,13 +28,13 @@ type ListenerManager interface {
 }
 
 func NewDefaultListenerManager(elbv2Client services.ELBV2, trackingProvider tracking.Provider,
-	taggingManager TaggingManager, externalManagedTags []string, featureGate config.FeatureGate, logger logr.Logger) *defaultListenerManager {
+	taggingManager TaggingManager, externalManagedTags []string, featureGates config.FeatureGates, logger logr.Logger) *defaultListenerManager {
 	return &defaultListenerManager{
 		elbv2Client:                 elbv2Client,
 		trackingProvider:            trackingProvider,
 		taggingManager:              taggingManager,
 		externalManagedTags:         externalManagedTags,
-		featureGate:                 featureGate,
+		featureGates:                featureGates,
 		logger:                      logger,
 		waitLSExistencePollInterval: defaultWaitLSExistencePollInterval,
 		waitLSExistenceTimeout:      defaultWaitLSExistenceTimeout,
@@ -49,7 +49,7 @@ type defaultListenerManager struct {
 	trackingProvider    tracking.Provider
 	taggingManager      TaggingManager
 	externalManagedTags []string
-	featureGate         config.FeatureGate
+	featureGates        config.FeatureGates
 	logger              logr.Logger
 
 	waitLSExistencePollInterval time.Duration
@@ -57,12 +57,12 @@ type defaultListenerManager struct {
 }
 
 func (m *defaultListenerManager) Create(ctx context.Context, resLS *elbv2model.Listener) (elbv2model.ListenerStatus, error) {
-	req, err := buildSDKCreateListenerInput(resLS.Spec, m.featureGate)
+	req, err := buildSDKCreateListenerInput(resLS.Spec, m.featureGates)
 	if err != nil {
 		return elbv2model.ListenerStatus{}, err
 	}
 	var lsTags map[string]string
-	if m.featureGate.Enabled(config.EnableListenerRulesTagging) {
+	if m.featureGates.Enabled(config.EnableListenerRulesTagging) {
 		lsTags = m.trackingProvider.ResourceTags(resLS.Stack(), resLS, resLS.Spec.Tags)
 	}
 	req.Tags = convertTagsToSDKTags(lsTags)
@@ -92,7 +92,7 @@ func (m *defaultListenerManager) Create(ctx context.Context, resLS *elbv2model.L
 }
 
 func (m *defaultListenerManager) Update(ctx context.Context, resLS *elbv2model.Listener, sdkLS ListenerWithTags) (elbv2model.ListenerStatus, error) {
-	if m.featureGate.Enabled(config.EnableListenerRulesTagging) {
+	if m.featureGates.Enabled(config.EnableListenerRulesTagging) {
 		if err := m.updateSDKListenerWithTags(ctx, resLS, sdkLS); err != nil {
 			return elbv2model.ListenerStatus{}, err
 		}
@@ -128,7 +128,7 @@ func (m *defaultListenerManager) updateSDKListenerWithTags(ctx context.Context, 
 }
 
 func (m *defaultListenerManager) updateSDKListenerWithSettings(ctx context.Context, resLS *elbv2model.Listener, sdkLS ListenerWithTags) error {
-	desiredDefaultActions, err := buildSDKActions(resLS.Spec.DefaultActions, m.featureGate)
+	desiredDefaultActions, err := buildSDKActions(resLS.Spec.DefaultActions, m.featureGates)
 	if err != nil {
 		return err
 	}
@@ -158,10 +158,9 @@ func (m *defaultListenerManager) updateSDKListenerWithExtraCertificates(ctx cont
 	sdkLS ListenerWithTags, isNewSDKListener bool) error {
 	// if TLS is not supported, we shouldn't update
 	if sdkLS.Listener.SslPolicy == nil {
-		m.logger.Info("SDK Listner doesn't have SSL Policy set, we skip updating extra certs.")
+		m.logger.V(1).Info("SDK Listner doesn't have SSL Policy set, we skip updating extra certs for non-TLS listener.")
 		return nil
 	}
-
 
 	desiredExtraCertARNs := sets.NewString()
 	_, desiredExtraCerts := buildSDKCertificates(resLS.Spec.Certificates)
@@ -269,7 +268,7 @@ func isSDKListenerSettingsDrifted(lsSpec elbv2model.ListenerSpec, sdkLS Listener
 	return false
 }
 
-func buildSDKCreateListenerInput(lsSpec elbv2model.ListenerSpec, featureGate config.FeatureGate) (*elbv2sdk.CreateListenerInput, error) {
+func buildSDKCreateListenerInput(lsSpec elbv2model.ListenerSpec, featureGates config.FeatureGates) (*elbv2sdk.CreateListenerInput, error) {
 	ctx := context.Background()
 	lbARN, err := lsSpec.LoadBalancerARN.Resolve(ctx)
 	if err != nil {
@@ -279,7 +278,7 @@ func buildSDKCreateListenerInput(lsSpec elbv2model.ListenerSpec, featureGate con
 	sdkObj.LoadBalancerArn = awssdk.String(lbARN)
 	sdkObj.Port = awssdk.Int64(lsSpec.Port)
 	sdkObj.Protocol = awssdk.String(string(lsSpec.Protocol))
-	defaultActions, err := buildSDKActions(lsSpec.DefaultActions, featureGate)
+	defaultActions, err := buildSDKActions(lsSpec.DefaultActions, featureGates)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/deploy/elbv2/listener_rule_manager.go
+++ b/pkg/deploy/elbv2/listener_rule_manager.go
@@ -27,13 +27,13 @@ type ListenerRuleManager interface {
 
 // NewDefaultListenerRuleManager constructs new defaultListenerRuleManager.
 func NewDefaultListenerRuleManager(elbv2Client services.ELBV2, trackingProvider tracking.Provider,
-	taggingManager TaggingManager, externalManagedTags []string, featureGate config.FeatureGate, logger logr.Logger) *defaultListenerRuleManager {
+	taggingManager TaggingManager, externalManagedTags []string, featureGates config.FeatureGates, logger logr.Logger) *defaultListenerRuleManager {
 	return &defaultListenerRuleManager{
 		elbv2Client:                 elbv2Client,
 		trackingProvider:            trackingProvider,
 		taggingManager:              taggingManager,
 		externalManagedTags:         externalManagedTags,
-		featureGate:                 featureGate,
+		featureGates:                featureGates,
 		logger:                      logger,
 		waitLSExistencePollInterval: defaultWaitLSExistencePollInterval,
 		waitLSExistenceTimeout:      defaultWaitLSExistenceTimeout,
@@ -46,7 +46,7 @@ type defaultListenerRuleManager struct {
 	trackingProvider    tracking.Provider
 	taggingManager      TaggingManager
 	externalManagedTags []string
-	featureGate         config.FeatureGate
+	featureGates        config.FeatureGates
 	logger              logr.Logger
 
 	waitLSExistencePollInterval time.Duration
@@ -54,12 +54,12 @@ type defaultListenerRuleManager struct {
 }
 
 func (m *defaultListenerRuleManager) Create(ctx context.Context, resLR *elbv2model.ListenerRule) (elbv2model.ListenerRuleStatus, error) {
-	req, err := buildSDKCreateListenerRuleInput(resLR.Spec, m.featureGate)
+	req, err := buildSDKCreateListenerRuleInput(resLR.Spec, m.featureGates)
 	if err != nil {
 		return elbv2model.ListenerRuleStatus{}, err
 	}
 	var ruleTags map[string]string
-	if m.featureGate.Enabled(config.EnableListenerRulesTagging) {
+	if m.featureGates.Enabled(config.EnableListenerRulesTagging) {
 		ruleTags = m.trackingProvider.ResourceTags(resLR.Stack(), resLR, resLR.Spec.Tags)
 	}
 	req.Tags = convertTagsToSDKTags(ruleTags)
@@ -90,7 +90,7 @@ func (m *defaultListenerRuleManager) Create(ctx context.Context, resLR *elbv2mod
 }
 
 func (m *defaultListenerRuleManager) Update(ctx context.Context, resLR *elbv2model.ListenerRule, sdkLR ListenerRuleWithTags) (elbv2model.ListenerRuleStatus, error) {
-	if m.featureGate.Enabled(config.EnableListenerRulesTagging) {
+	if m.featureGates.Enabled(config.EnableListenerRulesTagging) {
 		if err := m.updateSDKListenerRuleWithTags(ctx, resLR, sdkLR); err != nil {
 			return elbv2model.ListenerRuleStatus{}, err
 		}
@@ -116,7 +116,7 @@ func (m *defaultListenerRuleManager) Delete(ctx context.Context, sdkLR ListenerR
 }
 
 func (m *defaultListenerRuleManager) updateSDKListenerRuleWithSettings(ctx context.Context, resLR *elbv2model.ListenerRule, sdkLR ListenerRuleWithTags) error {
-	desiredActions, err := buildSDKActions(resLR.Spec.Actions, m.featureGate)
+	desiredActions, err := buildSDKActions(resLR.Spec.Actions, m.featureGates)
 	if err != nil {
 		return err
 	}
@@ -161,7 +161,7 @@ func isSDKListenerRuleSettingsDrifted(lrSpec elbv2model.ListenerRuleSpec, sdkLR 
 	return false
 }
 
-func buildSDKCreateListenerRuleInput(lrSpec elbv2model.ListenerRuleSpec, featureGate config.FeatureGate) (*elbv2sdk.CreateRuleInput, error) {
+func buildSDKCreateListenerRuleInput(lrSpec elbv2model.ListenerRuleSpec, featureGates config.FeatureGates) (*elbv2sdk.CreateRuleInput, error) {
 	ctx := context.Background()
 	lsARN, err := lrSpec.ListenerARN.Resolve(ctx)
 	if err != nil {
@@ -170,7 +170,7 @@ func buildSDKCreateListenerRuleInput(lrSpec elbv2model.ListenerRuleSpec, feature
 	sdkObj := &elbv2sdk.CreateRuleInput{}
 	sdkObj.ListenerArn = awssdk.String(lsARN)
 	sdkObj.Priority = awssdk.Int64(lrSpec.Priority)
-	actions, err := buildSDKActions(lrSpec.Actions, featureGate)
+	actions, err := buildSDKActions(lrSpec.Actions, featureGates)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/deploy/elbv2/listener_rule_manager.go
+++ b/pkg/deploy/elbv2/listener_rule_manager.go
@@ -59,7 +59,7 @@ func (m *defaultListenerRuleManager) Create(ctx context.Context, resLR *elbv2mod
 		return elbv2model.ListenerRuleStatus{}, err
 	}
 	var ruleTags map[string]string
-	if m.featureGates.Enabled(config.EnableListenerRulesTagging) {
+	if m.featureGates.Enabled(config.ListenerRulesTagging) {
 		ruleTags = m.trackingProvider.ResourceTags(resLR.Stack(), resLR, resLR.Spec.Tags)
 	}
 	req.Tags = convertTagsToSDKTags(ruleTags)
@@ -90,7 +90,7 @@ func (m *defaultListenerRuleManager) Create(ctx context.Context, resLR *elbv2mod
 }
 
 func (m *defaultListenerRuleManager) Update(ctx context.Context, resLR *elbv2model.ListenerRule, sdkLR ListenerRuleWithTags) (elbv2model.ListenerRuleStatus, error) {
-	if m.featureGates.Enabled(config.EnableListenerRulesTagging) {
+	if m.featureGates.Enabled(config.ListenerRulesTagging) {
 		if err := m.updateSDKListenerRuleWithTags(ctx, resLR, sdkLR); err != nil {
 			return elbv2model.ListenerRuleStatus{}, err
 		}

--- a/pkg/deploy/elbv2/listener_rule_manager.go
+++ b/pkg/deploy/elbv2/listener_rule_manager.go
@@ -54,7 +54,7 @@ type defaultListenerRuleManager struct {
 }
 
 func (m *defaultListenerRuleManager) Create(ctx context.Context, resLR *elbv2model.ListenerRule) (elbv2model.ListenerRuleStatus, error) {
-	req, err := buildSDKCreateListenerRuleInput(resLR.Spec)
+	req, err := buildSDKCreateListenerRuleInput(resLR.Spec, m.featureGate)
 	if err != nil {
 		return elbv2model.ListenerRuleStatus{}, err
 	}
@@ -116,7 +116,7 @@ func (m *defaultListenerRuleManager) Delete(ctx context.Context, sdkLR ListenerR
 }
 
 func (m *defaultListenerRuleManager) updateSDKListenerRuleWithSettings(ctx context.Context, resLR *elbv2model.ListenerRule, sdkLR ListenerRuleWithTags) error {
-	desiredActions, err := buildSDKActions(resLR.Spec.Actions)
+	desiredActions, err := buildSDKActions(resLR.Spec.Actions, m.featureGate)
 	if err != nil {
 		return err
 	}
@@ -161,7 +161,7 @@ func isSDKListenerRuleSettingsDrifted(lrSpec elbv2model.ListenerRuleSpec, sdkLR 
 	return false
 }
 
-func buildSDKCreateListenerRuleInput(lrSpec elbv2model.ListenerRuleSpec) (*elbv2sdk.CreateRuleInput, error) {
+func buildSDKCreateListenerRuleInput(lrSpec elbv2model.ListenerRuleSpec, featureGate config.FeatureGate) (*elbv2sdk.CreateRuleInput, error) {
 	ctx := context.Background()
 	lsARN, err := lrSpec.ListenerARN.Resolve(ctx)
 	if err != nil {
@@ -170,7 +170,7 @@ func buildSDKCreateListenerRuleInput(lrSpec elbv2model.ListenerRuleSpec) (*elbv2
 	sdkObj := &elbv2sdk.CreateRuleInput{}
 	sdkObj.ListenerArn = awssdk.String(lsARN)
 	sdkObj.Priority = awssdk.Int64(lrSpec.Priority)
-	actions, err := buildSDKActions(lrSpec.Actions)
+	actions, err := buildSDKActions(lrSpec.Actions, featureGate)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/deploy/elbv2/listener_utils.go
+++ b/pkg/deploy/elbv2/listener_utils.go
@@ -52,7 +52,7 @@ func buildSDKAction(modelAction elbv2model.Action, featureGates config.FeatureGa
 		if err != nil {
 			return nil, err
 		}
-		if !featureGates.Enabled(config.EnableWeightedTargetGroups) {
+		if !featureGates.Enabled(config.WeightedTargetGroups) {
 			if len(forwardConfig.TargetGroups) == 1 {
 				sdkObj.TargetGroupArn = forwardConfig.TargetGroups[0].TargetGroupArn
 			} else {

--- a/pkg/deploy/elbv2/listener_utils.go
+++ b/pkg/deploy/elbv2/listener_utils.go
@@ -6,8 +6,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	elbv2sdk "github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/pkg/errors"
-	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/config"
+	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
 	"time"
 )
 
@@ -16,12 +16,12 @@ const (
 	defaultWaitLSExistenceTimeout      = 20 * time.Second
 )
 
-func buildSDKActions(modelActions []elbv2model.Action, featureGate config.FeatureGate) ([]*elbv2sdk.Action, error) {
+func buildSDKActions(modelActions []elbv2model.Action, featureGates config.FeatureGates) ([]*elbv2sdk.Action, error) {
 	var sdkActions []*elbv2sdk.Action
 	if len(modelActions) != 0 {
 		sdkActions = make([]*elbv2sdk.Action, 0, len(modelActions))
 		for index, modelAction := range modelActions {
-			sdkAction, err := buildSDKAction(modelAction, featureGate)
+			sdkAction, err := buildSDKAction(modelAction, featureGates)
 			sdkAction.Order = awssdk.Int64(int64(index) + 1)
 			if err != nil {
 				return nil, err
@@ -32,7 +32,7 @@ func buildSDKActions(modelActions []elbv2model.Action, featureGate config.Featur
 	return sdkActions, nil
 }
 
-func buildSDKAction(modelAction elbv2model.Action, featureGate config.FeatureGate) (*elbv2sdk.Action, error) {
+func buildSDKAction(modelAction elbv2model.Action, featureGates config.FeatureGates) (*elbv2sdk.Action, error) {
 	sdkObj := &elbv2sdk.Action{}
 	sdkObj.Type = awssdk.String(string(modelAction.Type))
 	if modelAction.AuthenticateCognitoConfig != nil {
@@ -52,11 +52,11 @@ func buildSDKAction(modelAction elbv2model.Action, featureGate config.FeatureGat
 		if err != nil {
 			return nil, err
 		}
-		if featureGate.Enabled(config.EnforceSingleTargetGroup) {
+		if !featureGates.Enabled(config.EnableWeightedTargetGroups) {
 			if len(forwardConfig.TargetGroups) == 1 {
 				sdkObj.TargetGroupArn = forwardConfig.TargetGroups[0].TargetGroupArn
 			} else {
-				return nil, errors.New("The controller is configured to specify single Target Group but has more than one.")
+				return nil, errors.New("Weighted target groups feature is disabled.")
 			}
 		} else {
 			sdkObj.ForwardConfig = forwardConfig
@@ -69,12 +69,12 @@ func buildSDKAuthenticateCognitoActionConfig(modelCfg elbv2model.AuthenticateCog
 	return &elbv2sdk.AuthenticateCognitoActionConfig{
 		AuthenticationRequestExtraParams: awssdk.StringMap(modelCfg.AuthenticationRequestExtraParams),
 		OnUnauthenticatedRequest:         (*string)(modelCfg.OnUnauthenticatedRequest),
-		Scope:             modelCfg.Scope,
-		SessionCookieName: modelCfg.SessionCookieName,
-		SessionTimeout:    modelCfg.SessionTimeout,
-		UserPoolArn:       awssdk.String(modelCfg.UserPoolARN),
-		UserPoolClientId:  awssdk.String(modelCfg.UserPoolClientID),
-		UserPoolDomain:    awssdk.String(modelCfg.UserPoolDomain),
+		Scope:                            modelCfg.Scope,
+		SessionCookieName:                modelCfg.SessionCookieName,
+		SessionTimeout:                   modelCfg.SessionTimeout,
+		UserPoolArn:                      awssdk.String(modelCfg.UserPoolARN),
+		UserPoolClientId:                 awssdk.String(modelCfg.UserPoolClientID),
+		UserPoolDomain:                   awssdk.String(modelCfg.UserPoolDomain),
 	}
 }
 
@@ -82,15 +82,15 @@ func buildSDKAuthenticateOidcActionConfig(modelCfg elbv2model.AuthenticateOIDCAc
 	return &elbv2sdk.AuthenticateOidcActionConfig{
 		AuthenticationRequestExtraParams: awssdk.StringMap(modelCfg.AuthenticationRequestExtraParams),
 		OnUnauthenticatedRequest:         (*string)(modelCfg.OnUnauthenticatedRequest),
-		Scope:                 modelCfg.Scope,
-		SessionCookieName:     modelCfg.SessionCookieName,
-		SessionTimeout:        modelCfg.SessionTimeout,
-		ClientId:              awssdk.String(modelCfg.ClientID),
-		ClientSecret:          awssdk.String(modelCfg.ClientSecret),
-		Issuer:                awssdk.String(modelCfg.Issuer),
-		AuthorizationEndpoint: awssdk.String(modelCfg.AuthorizationEndpoint),
-		TokenEndpoint:         awssdk.String(modelCfg.TokenEndpoint),
-		UserInfoEndpoint:      awssdk.String(modelCfg.UserInfoEndpoint),
+		Scope:                            modelCfg.Scope,
+		SessionCookieName:                modelCfg.SessionCookieName,
+		SessionTimeout:                   modelCfg.SessionTimeout,
+		ClientId:                         awssdk.String(modelCfg.ClientID),
+		ClientSecret:                     awssdk.String(modelCfg.ClientSecret),
+		Issuer:                           awssdk.String(modelCfg.Issuer),
+		AuthorizationEndpoint:            awssdk.String(modelCfg.AuthorizationEndpoint),
+		TokenEndpoint:                    awssdk.String(modelCfg.TokenEndpoint),
+		UserInfoEndpoint:                 awssdk.String(modelCfg.UserInfoEndpoint),
 	}
 }
 

--- a/pkg/deploy/elbv2/tagging_manager.go
+++ b/pkg/deploy/elbv2/tagging_manager.go
@@ -187,7 +187,7 @@ func (m *defaultTaggingManager) ListListeners(ctx context.Context, lbARN string)
 		lsByARN[lsARN] = listener
 	}
 	var tagsByARN map[string]map[string]string
-	if m.featureGates.Enabled(config.EnableListenerRulesTagging) {
+	if m.featureGates.Enabled(config.ListenerRulesTagging) {
 		tagsByARN, err = m.describeResourceTags(ctx, lsARNs)
 		if err != nil {
 			return nil, err
@@ -220,7 +220,7 @@ func (m *defaultTaggingManager) ListListenerRules(ctx context.Context, lsARN str
 		lrByARN[lrARN] = rule
 	}
 	var tagsByARN map[string]map[string]string
-	if m.featureGates.Enabled(config.EnableListenerRulesTagging) {
+	if m.featureGates.Enabled(config.ListenerRulesTagging) {
 		tagsByARN, err = m.describeResourceTags(ctx, lrARNs)
 		if err != nil {
 			return nil, err

--- a/pkg/deploy/elbv2/tagging_manager.go
+++ b/pkg/deploy/elbv2/tagging_manager.go
@@ -93,11 +93,11 @@ type TaggingManager interface {
 }
 
 // NewDefaultTaggingManager constructs default TaggingManager.
-func NewDefaultTaggingManager(elbv2Client services.ELBV2, vpcID string, featureGate config.FeatureGate, logger logr.Logger) *defaultTaggingManager {
+func NewDefaultTaggingManager(elbv2Client services.ELBV2, vpcID string, featureGates config.FeatureGates, logger logr.Logger) *defaultTaggingManager {
 	return &defaultTaggingManager{
 		elbv2Client:           elbv2Client,
 		vpcID:                 vpcID,
-		featureGate:           featureGate,
+		featureGates:          featureGates,
 		logger:                logger,
 		describeTagsChunkSize: defaultDescribeTagsChunkSize,
 	}
@@ -110,7 +110,7 @@ var _ TaggingManager = &defaultTaggingManager{}
 type defaultTaggingManager struct {
 	elbv2Client           services.ELBV2
 	vpcID                 string
-	featureGate           config.FeatureGate
+	featureGates          config.FeatureGates
 	logger                logr.Logger
 	describeTagsChunkSize int
 }
@@ -187,7 +187,7 @@ func (m *defaultTaggingManager) ListListeners(ctx context.Context, lbARN string)
 		lsByARN[lsARN] = listener
 	}
 	var tagsByARN map[string]map[string]string
-	if m.featureGate.Enabled(config.EnableListenerRulesTagging) {
+	if m.featureGates.Enabled(config.EnableListenerRulesTagging) {
 		tagsByARN, err = m.describeResourceTags(ctx, lsARNs)
 		if err != nil {
 			return nil, err
@@ -220,7 +220,7 @@ func (m *defaultTaggingManager) ListListenerRules(ctx context.Context, lsARN str
 		lrByARN[lrARN] = rule
 	}
 	var tagsByARN map[string]map[string]string
-	if m.featureGate.Enabled(config.EnableListenerRulesTagging) {
+	if m.featureGates.Enabled(config.EnableListenerRulesTagging) {
 		tagsByARN, err = m.describeResourceTags(ctx, lrARNs)
 		if err != nil {
 			return nil, err

--- a/pkg/deploy/stack_deployer.go
+++ b/pkg/deploy/stack_deployer.go
@@ -29,7 +29,7 @@ func NewDefaultStackDeployer(cloud aws.Cloud, k8sClient client.Client,
 
 	trackingProvider := tracking.NewDefaultProvider(tagPrefix, config.ClusterName)
 	ec2TaggingManager := ec2.NewDefaultTaggingManager(cloud.EC2(), networkingSGManager, cloud.VpcID(), logger)
-	elbv2TaggingManager := elbv2.NewDefaultTaggingManager(cloud.ELBV2(), cloud.VpcID(), config.FeatureGate, logger)
+	elbv2TaggingManager := elbv2.NewDefaultTaggingManager(cloud.ELBV2(), cloud.VpcID(), config.FeatureGates, logger)
 
 	return &defaultStackDeployer{
 		cloud:                               cloud,
@@ -40,8 +40,8 @@ func NewDefaultStackDeployer(cloud aws.Cloud, k8sClient client.Client,
 		ec2SGManager:                        ec2.NewDefaultSecurityGroupManager(cloud.EC2(), trackingProvider, ec2TaggingManager, networkingSGReconciler, cloud.VpcID(), config.ExternalManagedTags, logger),
 		elbv2TaggingManager:                 elbv2TaggingManager,
 		elbv2LBManager:                      elbv2.NewDefaultLoadBalancerManager(cloud.ELBV2(), trackingProvider, elbv2TaggingManager, config.ExternalManagedTags, logger),
-		elbv2LSManager:                      elbv2.NewDefaultListenerManager(cloud.ELBV2(), trackingProvider, elbv2TaggingManager, config.ExternalManagedTags, config.FeatureGate, logger),
-		elbv2LRManager:                      elbv2.NewDefaultListenerRuleManager(cloud.ELBV2(), trackingProvider, elbv2TaggingManager, config.ExternalManagedTags, config.FeatureGate, logger),
+		elbv2LSManager:                      elbv2.NewDefaultListenerManager(cloud.ELBV2(), trackingProvider, elbv2TaggingManager, config.ExternalManagedTags, config.FeatureGates, logger),
+		elbv2LRManager:                      elbv2.NewDefaultListenerRuleManager(cloud.ELBV2(), trackingProvider, elbv2TaggingManager, config.ExternalManagedTags, config.FeatureGates, logger),
 		elbv2TGManager:                      elbv2.NewDefaultTargetGroupManager(cloud.ELBV2(), trackingProvider, elbv2TaggingManager, cloud.VpcID(), config.ExternalManagedTags, logger),
 		elbv2TGBManager:                     elbv2.NewDefaultTargetGroupBindingManager(k8sClient, trackingProvider, logger),
 		wafv2WebACLAssociationManager:       wafv2.NewDefaultWebACLAssociationManager(cloud.WAFv2(), logger),


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description
In air gapped AWS regions, we need disable some features due to parity. We are using feature gate to manager this feature parity and also make them easily reversible. 
<!--
Please explain the changes you made here.

1. We added one feature in feature gate to enable an old API working with single target group.
2. We added a if condition check on SslPolicy in case that the feature is not supported in some regions.


Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
