### PR TITLE
Minimalist IAM permissions for TargetGroupBinding [documentation]

### DIFF
--- a/docs/deploy/installation.md
+++ b/docs/deploy/installation.md
@@ -22,7 +22,7 @@
 If you are using the IMDSv2 you must set the hop limit to 2 or higher in order to allow the AWS Load Balancer Controller to perform the metadata introspection. Otherwise you have to manually specify the AWS region and the VPC via the controller flags `--aws-region` and `--aws-vpc-id`.
 
 
-!!!tip 
+!!!tip
     You can set the IMDSv2 hop limit as follows:
     ```
     aws ec2 modify-instance-metadata-options --http-put-response-hop-limit 2 --region <region> --instance-id <instance-id>
@@ -31,7 +31,7 @@ If you are using the IMDSv2 you must set the hop limit to 2 or higher in order t
 ## IAM Permissions
 
 #### Setup IAM role for service accounts
-The controller runs on the worker nodes, so it needs access to the AWS ALB/NLB resources via IAM permissions. 
+The controller runs on the worker nodes, so it needs access to the AWS ALB/NLB resources via IAM permissions.
 The IAM permissions can either be setup via IAM roles for ServiceAccount or can be attached directly to the worker node IAM roles.
 
 !!!warning "Permissions with the least privileges"
@@ -102,14 +102,38 @@ If not setting up IAM for ServiceAccount, apply the IAM policies from the follow
 ```
 curl -o iam-policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.3.0/docs/install/iam_policy.json
 ```
+
+##### IAM permission subsets for those who use *TargetGroupBinding* only and don't plan to use the AWS Load Balancer Controller to manage security group rules:
+
+```
+{
+    "Statement": [
+        {
+            "Action": [
+                "ec2:DescribeSecurityGroups",
+                "ec2:DescribeInstances",
+                "elasticloadbalancing:DescribeTargetGroups",
+                "elasticloadbalancing:DescribeTargetHealth",
+                "elasticloadbalancing:ModifyTargetGroup",
+                "elasticloadbalancing:ModifyTargetGroupAttributes",
+                "elasticloadbalancing:RegisterTargets",
+                "elasticloadbalancing:DeregisterTargets"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        }
+    ],
+    "Version": "2012-10-17"
+}
+```
 ## Add Controller to Cluster
 
 !!!note "Use Fargate"
     If you want to run the controller on Fargate, use Helm chart since it does not depend on the cert-manager.
 
-=== "Via Helm" 
+=== "Via Helm"
 
-    ### Detailed Instructions 
+    ### Detailed Instructions
     Follow the instructions in [aws-load-balancer-controller](https://github.com/aws/eks-charts/tree/master/stable/aws-load-balancer-controller) helm chart.
 
     ### Summary
@@ -138,17 +162,17 @@ curl -o iam-policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-lo
     helm install aws-load-balancer-controller eks/aws-load-balancer-controller -n kube-system --set clusterName=<cluster-name>
     ```
 
-    
+
 
 === "Via YAML manifests"
     ### Install cert-manager
-    
+
     ```
     kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.5.3/cert-manager.yaml
     ```
-    
+
     ### Apply YAML
-    1. Download spec for load balancer controller. 
+    1. Download spec for load balancer controller.
     ```
     wget https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases/download/v2.3.0/v2_3_0_full.yaml
     ```
@@ -156,11 +180,11 @@ curl -o iam-policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-lo
     ```
     apiVersion: apps/v1
     kind: Deployment
-    . . . 
+    . . .
     name: aws-load-balancer-controller
     namespace: kube-system
     spec:
-        . . . 
+        . . .
         template:
             spec:
                 containers:
@@ -172,9 +196,9 @@ curl -o iam-policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-lo
     apiVersion: v1
     kind: ServiceAccount
     ```
-    1. Apply the yaml file 
+    1. Apply the yaml file
     ```
     kubectl apply -f v2_3_0_full.yaml
     ```
-    
-    
+
+

--- a/docs/deploy/installation.md
+++ b/docs/deploy/installation.md
@@ -103,7 +103,7 @@ If not setting up IAM for ServiceAccount, apply the IAM policies from the follow
 curl -o iam-policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.3.0/docs/install/iam_policy.json
 ```
 
-##### IAM permission subsets for those who use *TargetGroupBinding* only and don't plan to use the AWS Load Balancer Controller to manage security group rules:
+##### IAM permission subset for those who use *TargetGroupBinding* only and don't plan to use the AWS Load Balancer Controller to manage security group rules:
 
 ```
 {


### PR DESCRIPTION
Small update on the documentation for those who want to use aws-load-balancer-controller only to add and remove targets into the target group and manage everything else elsewhere (like terraform or cloud formation)