### PR TITLE
call subnet auto discovery when lb scheme changes

### DIFF
--- a/pkg/ingress/model_build_load_balancer.go
+++ b/pkg/ingress/model_build_load_balancer.go
@@ -220,7 +220,7 @@ func (t *defaultModelBuildTask) buildLoadBalancerSubnetMappings(ctx context.Cont
 		return nil, err
 	}
 
-	if len(sdkLBs) == 0 {
+	if len(sdkLBs) == 0 || (string(scheme) != awssdk.StringValue(sdkLBs[0].LoadBalancer.Scheme)) {
 		chosenSubnets, err := t.subnetsResolver.ResolveViaDiscovery(ctx,
 			networking.WithSubnetsResolveLBType(elbv2model.LoadBalancerTypeApplication),
 			networking.WithSubnetsResolveLBScheme(scheme),

--- a/pkg/ingress/model_builder_test.go
+++ b/pkg/ingress/model_builder_test.go
@@ -2453,6 +2453,7 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 											SubnetId: awssdk.String("subnet-f"),
 										},
 									},
+									Scheme: awssdk.String("internal"),
 								},
 								Tags: map[string]string{
 									"elbv2.k8s.aws/cluster": "cluster-name",
@@ -2470,6 +2471,7 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 											SubnetId: awssdk.String("subnet-f"),
 										},
 									},
+									Scheme: awssdk.String("internal"),
 								},
 								Tags: map[string]string{
 									"keyA": "valueA2",
@@ -2487,6 +2489,7 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 											SubnetId: awssdk.String("subnet-f"),
 										},
 									},
+									Scheme: awssdk.String("internal"),
 								},
 								Tags: map[string]string{
 									"keyA": "valueA3",

--- a/pkg/service/model_build_load_balancer.go
+++ b/pkg/service/model_build_load_balancer.go
@@ -271,14 +271,13 @@ func (t *defaultModelBuildTask) buildLoadBalancerSubnets(ctx context.Context, sc
 			networking.WithSubnetsResolveLBScheme(scheme),
 		)
 	}
+
 	// for internet-facing Load Balancers, the subnets mush have at least 8 available IP addresses;
-	// for internal Load Balancers, this is only required if private ip address is not assigned;
-	// if the scheme would change, we will call subnet auto discovery
+	// for internal Load Balancers, this is only required if private ip address is not assigned
 	var privateIpv4Addresses []string
 	ipv4Configured := t.annotationParser.ParseStringSliceAnnotation(annotations.SvcLBSuffixPrivateIpv4Addresses, &privateIpv4Addresses, t.service.Annotations)
 	if (scheme == elbv2model.LoadBalancerSchemeInternetFacing) ||
-		((scheme == elbv2model.LoadBalancerSchemeInternal) && !ipv4Configured) ||
-		(existingLB != nil && string(scheme) != aws.StringValue(existingLB.LoadBalancer.Scheme)) {
+		((scheme == elbv2model.LoadBalancerSchemeInternal) && !ipv4Configured) {
 		return t.subnetsResolver.ResolveViaDiscovery(ctx,
 			networking.WithSubnetsResolveLBType(elbv2model.LoadBalancerTypeNetwork),
 			networking.WithSubnetsResolveLBScheme(scheme),


### PR DESCRIPTION
### Description

Follow up with the [PR 2125](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2125) and [PR 2129](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2129).

Call subnet auto discovery when the LB scheme would change.

#### Tests:
1. Created internal NLB, changed the scheme to internet-facing, verified the controller selected public subnet for new NLB;
2. Created internet-facing NLB, changed the scheme to internal, verified the controller selected internal subnet for new NLB;
3. Created internal ALB, changed the scheme to internet-facing, verified the controller selected public subnets for new ALB;
4. Created internet-facing ALB, changed the scheme to internal, verified the controller selected internal subnets for new ALB;

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
