### PR TITLE
webhook server use TLS 1.2 as minimum version

### DIFF
--- a/main.go
+++ b/main.go
@@ -91,7 +91,7 @@ func main() {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
 	}
-	config.ConfigureWebhookServerCert(controllerCFG.RuntimeConfig, mgr)
+	config.ConfigureWebhookServer(controllerCFG.RuntimeConfig, mgr)
 	clientSet, err := kubernetes.NewForConfig(mgr.GetConfig())
 	if err != nil {
 		setupLog.Error(err, "unable to obtain clientSet")

--- a/pkg/config/runtime_config.go
+++ b/pkg/config/runtime_config.go
@@ -124,8 +124,9 @@ func BuildRuntimeOptions(rtCfg RuntimeConfig, scheme *runtime.Scheme) ctrl.Optio
 	}
 }
 
-// ConfigureWebhookServerCert set up the server cert for the webhook server.
-func ConfigureWebhookServerCert(rtCfg RuntimeConfig, mgr ctrl.Manager) {
+// ConfigureWebhookServer set up the server cert for the webhook server.
+func ConfigureWebhookServer(rtCfg RuntimeConfig, mgr ctrl.Manager) {
 	mgr.GetWebhookServer().CertName = rtCfg.WebhookCertName
 	mgr.GetWebhookServer().KeyName = rtCfg.WebhookKeyName
+	mgr.GetWebhookServer().TLSMinVersion = "1.2"
 }


### PR DESCRIPTION
### Issue
Fixes #2368
<!-- Please link the GitHub issues related to this PR, if available -->

### Description
Use TLS 1.2 as the min version for the webhook server.
<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Tests
Verified the webhook server refuses to negotiate TLS protocols older than 1.2.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
