### PR TITLE
Fix listener utils error handling

### DIFF
--- a/pkg/deploy/elbv2/listener_utils.go
+++ b/pkg/deploy/elbv2/listener_utils.go
@@ -56,7 +56,7 @@ func buildSDKAction(modelAction elbv2model.Action, featureGates config.FeatureGa
 			if len(forwardConfig.TargetGroups) == 1 {
 				sdkObj.TargetGroupArn = forwardConfig.TargetGroups[0].TargetGroupArn
 			} else {
-				return nil, errors.New("Weighted target groups feature is disabled.")
+				return nil, errors.New("weighted target groups feature is disabled")
 			}
 		} else {
 			sdkObj.ForwardConfig = forwardConfig

--- a/pkg/deploy/elbv2/listener_utils.go
+++ b/pkg/deploy/elbv2/listener_utils.go
@@ -22,10 +22,10 @@ func buildSDKActions(modelActions []elbv2model.Action, featureGates config.Featu
 		sdkActions = make([]*elbv2sdk.Action, 0, len(modelActions))
 		for index, modelAction := range modelActions {
 			sdkAction, err := buildSDKAction(modelAction, featureGates)
-			sdkAction.Order = awssdk.Int64(int64(index) + 1)
 			if err != nil {
 				return nil, err
 			}
+			sdkAction.Order = awssdk.Int64(int64(index) + 1)
 			sdkActions = append(sdkActions, sdkAction)
 		}
 	}


### PR DESCRIPTION
### Issue
Controller crashes when WeightedTargetGroups is disabled, and ingress has multiple target groups configured.
 
<!-- Please link the GitHub issues related to this PR, if available -->

### Description
The listener utils buildSDKActions function did not handle the error from the buildSDKAction function before referencing the returned sdkAction. In case WeightedTargetGroups is disabled and ingress configuration has multiple target group, the `buildSDKAction` returned error as expected, however, further processing did not stop on error. This PR fixes the util to handle the error immediately.
<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
