### PR TITLE
WIP: Add --service-default-target-type flag

### DIFF
--- a/controllers/service/eventhandlers/service_events.go
+++ b/controllers/service/eventhandlers/service_events.go
@@ -60,7 +60,7 @@ func (h *enqueueRequestsForServiceEvent) Generic(e event.GenericEvent, queue wor
 }
 
 func (h *enqueueRequestsForServiceEvent) isServiceSupported(service *corev1.Service) bool {
-	if h.handleByDefault {
+	if h.handleByDefault && service.Spec.Type == corev1.ServiceTypeLoadBalancer {
 		return true
 	}
 	lbType := ""

--- a/controllers/service/eventhandlers/service_events.go
+++ b/controllers/service/eventhandlers/service_events.go
@@ -15,11 +15,12 @@ import (
 )
 
 // NewEnqueueRequestForServiceEvent constructs new enqueueRequestsForServiceEvent.
-func NewEnqueueRequestForServiceEvent(eventRecorder record.EventRecorder, annotationParser annotations.Parser, logger logr.Logger) *enqueueRequestsForServiceEvent {
+func NewEnqueueRequestForServiceEvent(eventRecorder record.EventRecorder, annotationParser annotations.Parser, logger logr.Logger, handleByDefault bool) *enqueueRequestsForServiceEvent {
 	return &enqueueRequestsForServiceEvent{
 		eventRecorder:    eventRecorder,
 		annotationParser: annotationParser,
 		logger:           logger,
+		handleByDefault:  handleByDefault,
 	}
 }
 
@@ -29,6 +30,7 @@ type enqueueRequestsForServiceEvent struct {
 	eventRecorder    record.EventRecorder
 	annotationParser annotations.Parser
 	logger           logr.Logger
+	handleByDefault  bool
 }
 
 func (h *enqueueRequestsForServiceEvent) Create(e event.CreateEvent, queue workqueue.RateLimitingInterface) {
@@ -58,6 +60,9 @@ func (h *enqueueRequestsForServiceEvent) Generic(e event.GenericEvent, queue wor
 }
 
 func (h *enqueueRequestsForServiceEvent) isServiceSupported(service *corev1.Service) bool {
+	if h.handleByDefault {
+		return true
+	}
 	lbType := ""
 	_ = h.annotationParser.ParseStringAnnotation(annotations.SvcLBSuffixLoadBalancerType, &lbType, service.Annotations)
 	if lbType == svcpkg.LoadBalancerTypeNLBIP {

--- a/docs/deploy/configurations.md
+++ b/docs/deploy/configurations.md
@@ -91,6 +91,7 @@ Currently, you can set only 1 namespace to watch in this flag. See [this Kuberne
 |leader-election-namespace              | string                          |                 | Name of the leader election ID to use for this controller |
 |log-level                              | string                          | info            | Set the controller log level - info, debug |
 |metrics-bind-addr                      | string                          | :8080           | The address the metric endpoint binds to |
+|service-default-target-type            | string                          |                 | Default target type for Services - ip, instance |
 |service-max-concurrent-reconciles      | int                             | 3               | Maximum number of concurrently running reconcile loops for service |
 |sync-period                            | duration                        | 1h0m0s          | Period at which the controller forces the repopulation of its local object stores|
 |targetgroupbinding-max-concurrent-reconciles | int                       | 3               | Maximum number of concurrently running reconcile loops for targetGroupBinding |

--- a/pkg/service/model_build_target_group.go
+++ b/pkg/service/model_build_target_group.go
@@ -347,6 +347,9 @@ func (t *defaultModelBuildTask) buildTargetType(_ context.Context) (elbv2model.T
 		}
 		return elbv2model.TargetTypeInstance, nil
 	}
+	if t.defaultTargetType != "" {
+		return t.defaultTargetType, nil
+	}
 	return "", errors.Errorf("unsupported target type \"%v\" for load balancer type \"%v\"", lbTargetType, lbType)
 }
 

--- a/pkg/service/model_build_target_group_test.go
+++ b/pkg/service/model_build_target_group_test.go
@@ -1142,10 +1142,11 @@ func Test_defaultModelBuilder_buildPreserveClientIPFlag(t *testing.T) {
 func Test_defaultModelBuilder_buildTargetType(t *testing.T) {
 
 	tests := []struct {
-		testName string
-		svc      *corev1.Service
-		want     elbv2.TargetType
-		wantErr  error
+		testName          string
+		svc               *corev1.Service
+		defaultTargetType string
+		want              elbv2.TargetType
+		wantErr           error
 	}{
 		{
 			testName: "empty annotation",
@@ -1225,13 +1226,26 @@ func Test_defaultModelBuilder_buildTargetType(t *testing.T) {
 			},
 			wantErr: errors.New("unsupported service type \"ClusterIP\" for load balancer target type \"instance\""),
 		},
+		{
+			testName:          "default instance",
+			svc:               &corev1.Service{},
+			defaultTargetType: "instance",
+			want:              elbv2.TargetTypeInstance,
+		},
+		{
+			testName:          "default ip",
+			svc:               &corev1.Service{},
+			defaultTargetType: "ip",
+			want:              elbv2.TargetTypeIP,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
 			parser := annotations.NewSuffixAnnotationParser("service.beta.kubernetes.io")
 			builder := &defaultModelBuildTask{
-				annotationParser: parser,
-				service:          tt.svc,
+				annotationParser:  parser,
+				service:           tt.svc,
+				defaultTargetType: elbv2.TargetType(tt.defaultTargetType),
 			}
 			got, err := builder.buildTargetType(context.Background())
 			if tt.wantErr != nil {

--- a/pkg/service/model_builder_test.go
+++ b/pkg/service/model_builder_test.go
@@ -2,9 +2,10 @@ package service
 
 import (
 	"context"
-	"github.com/pkg/errors"
 	"testing"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -2407,7 +2408,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 				vpcInfoProvider.EXPECT().FetchVPCInfo(gomock.Any(), gomock.Any(), gomock.Any()).Return(call.wantVPCInfo, call.err).AnyTimes()
 			}
 			builder := NewDefaultModelBuilder(annotationParser, subnetsResolver, vpcInfoProvider, "vpc-xxx", trackingProvider, elbv2TaggingManager,
-				"my-cluster", nil, nil, "ELBSecurityPolicy-2016-08")
+				"my-cluster", nil, nil, "ELBSecurityPolicy-2016-08", "")
 			ctx := context.Background()
 			stack, _, err := builder.Build(ctx, tt.svc)
 			if tt.wantError {


### PR DESCRIPTION
### Issue

### Description

Adds a `--service-default-target-type` flag to specify the target type for `Service` objects that don't have a `service.beta.kubernetes.io/aws-load-balancer-nlb-target-type` annotation.

This is useful when kube-controller-manager's service controller is disabled. It is particularly useful for IPv6-only clusters with nodes in IPv6-only subnets, since KCM's service controller defaults to CLBs and CLBs don't support IPv6 backends.

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
