### PR TITLE
helm: Remove unnecessary admissionregistration.k8s.io/v1beta1

### DIFF
--- a/helm/aws-load-balancer-controller/templates/webhook.yaml
+++ b/helm/aws-load-balancer-controller/templates/webhook.yaml
@@ -1,10 +1,6 @@
 {{ $tls := fromYaml ( include "aws-load-balancer-controller.webhook-certs" . ) }}
 ---
-{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" }}
 apiVersion: admissionregistration.k8s.io/v1
-{{- else }}
-apiVersion: admissionregistration.k8s.io/v1beta1
-{{- end }}
 kind: MutatingWebhookConfiguration
 metadata:
 {{- if $.Values.enableCertManager }}
@@ -76,11 +72,7 @@ webhooks:
     - targetgroupbindings
   sideEffects: None
 ---
-{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" }}
 apiVersion: admissionregistration.k8s.io/v1
-{{- else }}
-apiVersion: admissionregistration.k8s.io/v1beta1
-{{- end }}
 kind: ValidatingWebhookConfiguration
 metadata:
 {{- if $.Values.enableCertManager }}


### PR DESCRIPTION
### Issue

### Description

Now that the minimum supported Kubernetes version supports `admissionregistration.k8s.io/v1` there is no reason for the Helm templates to support older API versions.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
