### PR TITLE
added correct alb annotation

### DIFF
--- a/docs/examples/2048/2048_full.yaml
+++ b/docs/examples/2048/2048_full.yaml
@@ -48,8 +48,8 @@ metadata:
   annotations:
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip
+    kubernetes.io/ingress.class: alb
 spec:
-  ingressClassName: alb
   rules:
     - http:
         paths:


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description



<!--
When running kubectl apply with the current 2048_game.yaml example this error is produced:

Error from server (invalid ingress class: IngressClass.networking.k8s.io "alb" not found): error when creating "https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/main/docs/examples/2048/2048_full.yaml": admission webhook "vingress.elbv2.k8s.aws" denied the request: invalid ingress class: IngressClass.networking.k8s.io "alb" not found

Upon replacing with what I am pushing, the ingress gets created without errors and am able to navigate to the address produced externally.

-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [X] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
