### PR TITLE
Merge tags from alb.ingress.kubernetes.io/tags

### DIFF
--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -741,6 +741,8 @@ The AWS Load Balancer Controller automatically applies following tags to the AWS
 In addition, you can use annotations to specify additional tags
 
 - <a name="tags">`alb.ingress.kubernetes.io/tags`</a> specifies additional tags that will be applied to AWS resources created.
+  In case of target group, the controller will merge the tags from the ingress and the backend service giving precedence 
+  to the values specified on the service when there is conflict.
 
     !!!example
         ```

--- a/pkg/ingress/model_build_tags_test.go
+++ b/pkg/ingress/model_build_tags_test.go
@@ -276,6 +276,7 @@ func Test_defaultModelBuildTask_buildIngressBackendResourceTags(t *testing.T) {
 			want: map[string]string{
 				"tag-c": "value-c1",
 				"tag-d": "value-d1",
+				"tag-e": "value-e",
 			},
 		},
 		{
@@ -401,6 +402,59 @@ func Test_defaultModelBuildTask_buildIngressBackendResourceTags(t *testing.T) {
 				"tag-c": "value-c",
 				"tag-d": "value-d1",
 				"tag-e": "value-e",
+			},
+		},
+		{
+			name: "non-empty annotation tags from Ingress and Service, non-empty IngressClass tags",
+			fields: fields{
+				externalManagedTags: sets.NewString("tag-a", "tag-b"),
+			},
+			args: args{
+				ing: ClassifiedIngress{
+					Ing: &networking.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "awesome-ns",
+							Name:      "awesome-ing",
+							Annotations: map[string]string{
+								"alb.ingress.kubernetes.io/tags": "tag-c=value-c,tag-d=value-d, tag-f=value-f",
+							},
+						},
+					},
+					IngClassConfig: ClassConfiguration{
+						IngClassParams: &elbv2api.IngressClassParams{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "awesome-class",
+							},
+							Spec: elbv2api.IngressClassParamsSpec{
+								Tags: []elbv2api.Tag{
+									{
+										Key:   "tag-d",
+										Value: "value-d1",
+									},
+									{
+										Key:   "tag-e",
+										Value: "value-e",
+									},
+								},
+							},
+						},
+					},
+				},
+				backend: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Name:      "awesome-svc",
+						Annotations: map[string]string{
+							"alb.ingress.kubernetes.io/tags": "tag-c=value-c,tag-d=value-d2",
+						},
+					},
+				},
+			},
+			want: map[string]string{
+				"tag-c": "value-c",
+				"tag-d": "value-d1",
+				"tag-e": "value-e",
+				"tag-f": "value-f",
 			},
 		},
 		{

--- a/test/e2e/ingress/multi_path_backend.go
+++ b/test/e2e/ingress/multi_path_backend.go
@@ -257,7 +257,7 @@ func (s *multiPathBackendStack) buildIngressResource(ns *corev1.Namespace, ingID
 		backendSVC := svcByBackendID[pathCFG.BackendID]
 		exact := networking.PathTypeExact
 		ing.Spec.Rules[0].HTTP.Paths = append(ing.Spec.Rules[0].HTTP.Paths, networking.HTTPIngressPath{
-			Path: pathCFG.Path,
+			Path:     pathCFG.Path,
 			PathType: &exact,
 			Backend: networking.IngressBackend{
 				Service: &networking.IngressServiceBackend{


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->
Fixes https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2411

### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->
This PR will merge the tags specified by `alb.ingress.kubernetes.io/tags` from ingress and service and add them to the corresponding target groups. In case of conflicting values for the tag key, controller gives precedence to the ones specified on the service.

#### Test

- Added unit test
- Created ingress and backend service, verified that the target group has merged tags specified from both ingress and service, and the tags of ingress will not be affected
- Created ingress and beckend service with conflicted tag keys, verified that the target group has the tag values from service for the conflicted tag keys
- Created IngressClass, ingress and backend service, verified that the tags specified via IngressClass still have higher priority than tags specified via annotation on ingress or service

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
