### PR TITLE
Node termination handler taints

### DIFF
--- a/pkg/k8s/node_utils.go
+++ b/pkg/k8s/node_utils.go
@@ -30,7 +30,7 @@ func IsNodeSuitableAsTrafficProxy(node *corev1.Node) bool {
 		if taint.Key == toBeDeletedByCATaint {
 			return false
 		}
-		if strings.HasPrefix(taint.Value, awsNodeTerminationHandlerTaintPrefix) {
+		if strings.HasPrefix(taint.Key, awsNodeTerminationHandlerTaintPrefix) {
 			return false
 		}
 	}

--- a/pkg/k8s/node_utils.go
+++ b/pkg/k8s/node_utils.go
@@ -8,8 +8,8 @@ import (
 )
 
 const (
-	toBeDeletedByCATaint = "ToBeDeletedByClusterAutoscaler"
-  awsNodeTerminationHandlerTaintPrefix = "aws-node-termination-handler/"
+	toBeDeletedByCATaint                 = "ToBeDeletedByClusterAutoscaler"
+	awsNodeTerminationHandlerTaintPrefix = "aws-node-termination-handler/"
 )
 
 var awsInstanceIDRegex = regexp.MustCompile("^i-[^/]*$")
@@ -30,9 +30,9 @@ func IsNodeSuitableAsTrafficProxy(node *corev1.Node) bool {
 		if taint.Key == toBeDeletedByCATaint {
 			return false
 		}
-    if strings.HasPrefix(taint.Value, awsNodeTerminationHandlerTaintPrefix) {
-      return false
-    }
+		if strings.HasPrefix(taint.Value, awsNodeTerminationHandlerTaintPrefix) {
+			return false
+		}
 	}
 
 	return IsNodeReady(node)


### PR DESCRIPTION
### Issue

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2498

### Description

Checks for taints added by aws-node-termination-handler in a similar fashion to how cluster autoscaler taints are checked.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
