### PR TITLE
Updated test helper script for e2e  tests

### DIFF
--- a/test/e2e/run-e2e-test.sh
+++ b/test/e2e/run-e2e-test.sh
@@ -71,7 +71,7 @@ echo "Install TargetGroupBinding CRDs"
 kubectl apply -k "github.com/aws/eks-charts/stable/aws-load-balancer-controller//crds?ref=master"
 
 echo "Install aws-load-balancer-controller"
-helm upgrade -i aws-load-balancer-controller eks/aws-load-balancer-controller -n kube-system --set clusterName=$CLUSTER_NAME --set serviceAccount.create=false --set serviceAccount.name=aws-load-balancer-controller
+helm upgrade -i aws-load-balancer-controller eks/aws-load-balancer-controller -n kube-system --set clusterName=$CLUSTER_NAME --set serviceAccount.create=false --set serviceAccount.name=aws-load-balancer-controller --set region=$REGION --set vpcId=$VPC_ID
 
 #Start the test
 echo "Starting the ginkgo test suite" 


### PR DESCRIPTION
### Issue
NA
<!-- Please link the GitHub issues related to this PR, if available -->

### Description
Without this change, load balancer controller pods would crash with following error
```
{"level":"info","ts":1644967493.3334715,"msg":"version","GitVersion":"v2.3.1","GitCommit":"1d492cb8648b2053086761140d9db9236f867237","BuildDate":"2021-12-08T18:13:11+0000"}
{"level":"error","ts":1644967496.4600484,"logger":"setup","msg":"unable to initialize AWS cloud","error":"failed to introspect vpcID from EC2Metadata, specify --aws-vpc-id instead if EC2Metadata is unavailable: EC2MetadataError: failed to make EC2Metadata request\n\n\tstatus code: 401, request id: "}
```

Renamed file
added region and vpc_id arguments for installing the controller

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
