### PR TITLE
Make e2e LB name test work with clusters that have . in the name

### DIFF
--- a/test/e2e/ingress/vanilla_ingress_test.go
+++ b/test/e2e/ingress/vanilla_ingress_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	awssdk "github.com/aws/aws-sdk-go/aws"
@@ -237,7 +238,8 @@ var _ = Describe("vanilla ingress tests", func() {
 					},
 				},
 			}
-			lbName := fmt.Sprintf("%.16s-%.15s", tf.Options.ClusterName, sandboxNS.Name)
+			safeClusterName := strings.ReplaceAll(tf.Options.ClusterName, ".", "-")
+			lbName := fmt.Sprintf("%.16s-%.15s", safeClusterName, sandboxNS.Name)
 			ing := ingBuilder.
 				AddHTTPRoute("", networking.HTTPIngressPath{Path: "/path", PathType: &exact, Backend: ingBackend}).
 				WithAnnotations(map[string]string{


### PR DESCRIPTION
### Description

ELB names cannot have `.` in the name, but cluster names can. So when the `load-balancer-name` annotation e2e test directly copies cluster name into the ELB name, the test fails.

This PR replaces `.` with `-` to make tests pass.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
