### PR TITLE
Clarify cluster tag requirement in docs

### DIFF
--- a/docs/deploy/subnet_discovery.md
+++ b/docs/deploy/subnet_discovery.md
@@ -31,4 +31,4 @@ In version v2.1.1 and older, both the public and private subnets must be tagged 
 
  `${cluster-name}` is the name of the kubernetes cluster
  
- The cluster tag is not required in v2.1.2 and newer releases. 
+ The cluster tag is not required in v2.1.2 and newer releases, unless a cluster tag for another cluster is present.


### PR DESCRIPTION
### Description

Clarify cluster tag requirement in docs.

[checkSubnetIsNotTaggedForOtherClusters](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/76bd7e3fc59a3dffa28397db2991edfd1a5889c7/pkg/networking/subnet_resolver.go#L343-L346
) explictly checks if there is another cluster tag and refuses to use it if it is not also tagged for the current cluster.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
