### PR TITLE
remove undesired certificates before adding new ones

### DIFF
--- a/pkg/deploy/elbv2/listener_manager.go
+++ b/pkg/deploy/elbv2/listener_manager.go
@@ -176,30 +176,6 @@ func (m *defaultListenerManager) updateSDKListenerWithExtraCertificates(ctx cont
 		currentExtraCertARNs.Insert(certARNs...)
 	}
 
-	for _, certARN := range desiredExtraCertARNs.Difference(currentExtraCertARNs).List() {
-		req := &elbv2sdk.AddListenerCertificatesInput{
-			ListenerArn: sdkLS.Listener.ListenerArn,
-			Certificates: []*elbv2sdk.Certificate{
-				{
-					CertificateArn: awssdk.String(certARN),
-				},
-			},
-		}
-		m.logger.Info("adding certificate to listener",
-			"stackID", resLS.Stack().StackID(),
-			"resourceID", resLS.ID(),
-			"arn", awssdk.StringValue(sdkLS.Listener.ListenerArn),
-			"certificateARN", certARN)
-		if _, err := m.elbv2Client.AddListenerCertificatesWithContext(ctx, req); err != nil {
-			return err
-		}
-		m.logger.Info("added certificate to listener",
-			"stackID", resLS.Stack().StackID(),
-			"resourceID", resLS.ID(),
-			"arn", awssdk.StringValue(sdkLS.Listener.ListenerArn),
-			"certificateARN", certARN)
-	}
-
 	for _, certARN := range currentExtraCertARNs.Difference(desiredExtraCertARNs).List() {
 		req := &elbv2sdk.RemoveListenerCertificatesInput{
 			ListenerArn: sdkLS.Listener.ListenerArn,
@@ -218,6 +194,30 @@ func (m *defaultListenerManager) updateSDKListenerWithExtraCertificates(ctx cont
 			return err
 		}
 		m.logger.Info("removed certificate from listener",
+			"stackID", resLS.Stack().StackID(),
+			"resourceID", resLS.ID(),
+			"arn", awssdk.StringValue(sdkLS.Listener.ListenerArn),
+			"certificateARN", certARN)
+	}
+
+	for _, certARN := range desiredExtraCertARNs.Difference(currentExtraCertARNs).List() {
+		req := &elbv2sdk.AddListenerCertificatesInput{
+			ListenerArn: sdkLS.Listener.ListenerArn,
+			Certificates: []*elbv2sdk.Certificate{
+				{
+					CertificateArn: awssdk.String(certARN),
+				},
+			},
+		}
+		m.logger.Info("adding certificate to listener",
+			"stackID", resLS.Stack().StackID(),
+			"resourceID", resLS.ID(),
+			"arn", awssdk.StringValue(sdkLS.Listener.ListenerArn),
+			"certificateARN", certARN)
+		if _, err := m.elbv2Client.AddListenerCertificatesWithContext(ctx, req); err != nil {
+			return err
+		}
+		m.logger.Info("added certificate to listener",
 			"stackID", resLS.Stack().StackID(),
 			"resourceID", resLS.ID(),
 			"arn", awssdk.StringValue(sdkLS.Listener.ListenerArn),


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->
https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2449

### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->
Right now the controller adds new certificates before deleting unwanted ones, which may cause the controller being stuck in TooManyCertificates error as shows in the above issue. This PR changes the listener manager to first delete undesired certificates and then to add new ones to avoid this issue.

#### Test

- Created one ingress with 27 certificates, which trigger the TooManyCertificates error immediately. And use `kubectl edit ingress` to bring the number of certificates to under 26, verified that the controller reconciled and created ingressA successfully
- Created ingressA with 26 certificates, which can reconcile successfully. Then created ingressB with 1 more certificate to trigger the TooManyCertificates error. Use `kubectl edit ingress` to delete 1 certificate in ingressA, verified that the controller recovered from the error and created ingressB successfully
- Created ingressA with 26 certificates, which can reconcile successfully. Then created ingressB with 1 more certificate, which trigger the TooManyCertificates error. Deleted ingressA and verified that the controller recovered from the error and created ingressB successfully.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
