### PR TITLE
Upgrade webhook server minimum version to TLS1.3

### DIFF
--- a/pkg/config/runtime_config.go
+++ b/pkg/config/runtime_config.go
@@ -128,5 +128,5 @@ func BuildRuntimeOptions(rtCfg RuntimeConfig, scheme *runtime.Scheme) ctrl.Optio
 func ConfigureWebhookServer(rtCfg RuntimeConfig, mgr ctrl.Manager) {
 	mgr.GetWebhookServer().CertName = rtCfg.WebhookCertName
 	mgr.GetWebhookServer().KeyName = rtCfg.WebhookKeyName
-	mgr.GetWebhookServer().TLSMinVersion = "1.2"
+	mgr.GetWebhookServer().TLSMinVersion = "1.3"
 }


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->
https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2531

### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->
Use TLS1.3 as the webhook server minimum version.

#### Tests
Manually tested on eks cluster with k8s 1.19, verified that TLS1.3 is supported.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
