### PR TITLE
[Doc] Update migrate_v1_v2 document

### DIFF
--- a/docs/deploy/upgrade/migrate_v1_v2.md
+++ b/docs/deploy/upgrade/migrate_v1_v2.md
@@ -65,7 +65,7 @@ foo@bar:~$ kubectl describe deployment  -n kube-system  alb-ingress-controller |
         Existing Ingress resources do not need to be deleted.
 
 3. Install new AWSLoadBalancerController
-    1. Install AWSLoadBalancerController(v2.0.1) by following the [installation instructions](../installation.md)
+    1. Install AWSLoadBalancerController(v2.4.1) by following the [installation instructions](../installation.md)
     2. Grant [additional IAM policy](../../install/iam_policy_v1_to_v2_additional.json) needed for migration to the controller.
 
 4. Verify all Ingresses works as expected.


### PR DESCRIPTION
### Issue

Update the migration document. Currently, the new version link is using version "2.4.1". However, the document still mention "2.0.1".  Update this to avoid misunderstanding.

### Description

Change the document description: 

Upgrade steps --> Install new AWSLoadBalancerController --> Install AWSLoadBalancerController(v2.0.1) by following the [installation instructions](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/deploy/installation/)

to 

Upgrade steps --> Install new AWSLoadBalancerController --> Install AWSLoadBalancerController(v2.4.1) by following the [installation instructions](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/deploy/installation/)

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
