### PR TITLE
Manage multiple ingress controllers

### DIFF
--- a/pkg/ingress/class_loader_test.go
+++ b/pkg/ingress/class_loader_test.go
@@ -2,6 +2,8 @@ package ingress
 
 import (
 	"context"
+	"testing"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
@@ -18,7 +20,6 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/webhook"
 	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-	"testing"
 )
 
 func Test_defaultClassLoader_Load(t *testing.T) {
@@ -500,7 +501,8 @@ func Test_defaultClassLoader_Load(t *testing.T) {
 			}
 
 			l := &defaultClassLoader{
-				client: k8sClient,
+				client:       k8sClient,
+				ingressClass: "alb",
 			}
 			got, err := l.Load(ctx, tt.args.ing)
 			if tt.wantErr != nil {

--- a/pkg/ingress/reference_indexer.go
+++ b/pkg/ingress/reference_indexer.go
@@ -35,12 +35,14 @@ type ReferenceIndexer interface {
 }
 
 // NewDefaultReferenceIndexer constructs new defaultReferenceIndexer.
-func NewDefaultReferenceIndexer(enhancedBackendBuilder EnhancedBackendBuilder, authConfigBuilder AuthConfigBuilder, logger logr.Logger) *defaultReferenceIndexer {
+func NewDefaultReferenceIndexer(enhancedBackendBuilder EnhancedBackendBuilder, authConfigBuilder AuthConfigBuilder, logger logr.Logger, classLoader ClassLoader) *defaultReferenceIndexer {
 	return &defaultReferenceIndexer{
 		enhancedBackendBuilder: enhancedBackendBuilder,
 		authConfigBuilder:      authConfigBuilder,
 		logger:                 logger,
+		classLoader:            classLoader,
 	}
+
 }
 
 var _ ReferenceIndexer = &defaultReferenceIndexer{}
@@ -50,6 +52,7 @@ type defaultReferenceIndexer struct {
 	enhancedBackendBuilder EnhancedBackendBuilder
 	authConfigBuilder      AuthConfigBuilder
 	logger                 logr.Logger
+	classLoader            ClassLoader
 }
 
 func (i *defaultReferenceIndexer) BuildServiceRefIndexes(ctx context.Context, ing *networking.Ingress) []string {
@@ -103,7 +106,7 @@ func (i *defaultReferenceIndexer) BuildIngressClassRefIndexes(_ context.Context,
 }
 
 func (i *defaultReferenceIndexer) BuildIngressClassParamsRefIndexes(_ context.Context, ingClass *networking.IngressClass) []string {
-	if ingClass.Spec.Controller != ingressClassControllerALB || ingClass.Spec.Parameters == nil {
+	if ingClass.Spec.Controller != i.classLoader.ingressClassController() || ingClass.Spec.Parameters == nil {
 		return nil
 	}
 	if ingClass.Spec.Parameters.APIGroup == nil ||

--- a/pkg/ingress/reference_indexer_test.go
+++ b/pkg/ingress/reference_indexer_test.go
@@ -9,8 +9,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	networking "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -504,12 +506,17 @@ func Test_defaultReferenceIndexer_BuildIngressClassParamsRefIndexes(t *testing.T
 			want: nil,
 		},
 	}
+	k8sSchema := runtime.NewScheme()
+	k8sClient := testclient.NewFakeClientWithScheme(k8sSchema)
+	classLoader := NewDefaultClassLoader(k8sClient)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+
 			i := &defaultReferenceIndexer{
 				enhancedBackendBuilder: tt.fields.enhancedBackendBuilder,
 				authConfigBuilder:      tt.fields.authConfigBuilder,
 				logger:                 tt.fields.logger,
+				classLoader:            classLoader,
 			}
 			got := i.BuildIngressClassParamsRefIndexes(context.Background(), tt.args.ingClass)
 			assert.Equal(t, tt.want, got)


### PR DESCRIPTION
### Issue

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2185

### Description

Ensure that ingress controllers only manage ingress groups
that belong to that controller

This work removes some of the hardcoding of "alb" as a special
ingress name, particularly for ingressClasses that have
spec.controller set.

There is no impact at this stage on the shared node security group rules - this is the bare minimum as I see it to allow two ALB controllers to run without one of them removing the load balancer created by the other.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
