### PR TITLE
Fix Dockerfile go dependency caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ COPY go.sum go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN --mount=type=bind,target=. \
-    --mount=type=cache,target=/root/.cache/go-build \
     GOPROXY=direct go mod download
 
 FROM base AS build


### PR DESCRIPTION
### Issue

N/A

### Description

The current Dockerfile uses a bind mount when downloading the go dependencies.
This causes the entire project folder to be added to the Docker context when
only the `go.mod` and `go.sum` files are needed.  This ends up breaking the
caching of the dependencies as any change to any file in the project will cause
the docker context to change.  Removing this bind mount allows the dependencies
to be correctly cached.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
