### PR TITLE
Add support to disable cluster tag check during subnet auto-discovery

### DIFF
--- a/controllers/ingress/group_controller.go
+++ b/controllers/ingress/group_controller.go
@@ -55,7 +55,7 @@ func NewGroupReconciler(cloud aws.Cloud, k8sClient client.Client, eventRecorder 
 	modelBuilder := ingress.NewDefaultModelBuilder(k8sClient, eventRecorder,
 		cloud.EC2(), cloud.ACM(),
 		annotationParser, subnetsResolver,
-		authConfigBuilder, enhancedBackendBuilder, trackingProvider, elbv2TaggingManager,
+		authConfigBuilder, enhancedBackendBuilder, trackingProvider, elbv2TaggingManager, controllerConfig.FeatureGates,
 		cloud.VpcID(), controllerConfig.ClusterName, controllerConfig.DefaultTags, controllerConfig.ExternalManagedTags,
 		controllerConfig.DefaultSSLPolicy, backendSGProvider, controllerConfig.EnableBackendSecurityGroup, controllerConfig.DisableRestrictedSGRules, controllerConfig.FeatureGates.Enabled(config.EnableIPTargetType), logger)
 	stackMarshaller := deploy.NewDefaultStackMarshaller()

--- a/controllers/service/service_controller.go
+++ b/controllers/service/service_controller.go
@@ -43,7 +43,7 @@ func NewServiceReconciler(cloud aws.Cloud, k8sClient client.Client, eventRecorde
 	elbv2TaggingManager := elbv2.NewDefaultTaggingManager(cloud.ELBV2(), cloud.VpcID(), controllerConfig.FeatureGates, logger)
 	serviceUtils := service.NewServiceUtils(annotationParser, serviceFinalizer, controllerConfig.ServiceConfig.LoadBalancerClass, controllerConfig.FeatureGates)
 	modelBuilder := service.NewDefaultModelBuilder(annotationParser, subnetsResolver, vpcInfoProvider, cloud.VpcID(), trackingProvider,
-		elbv2TaggingManager, controllerConfig.ClusterName, controllerConfig.DefaultTags, controllerConfig.ExternalManagedTags, controllerConfig.DefaultSSLPolicy, controllerConfig.FeatureGates.Enabled(config.EnableIPTargetType), serviceUtils)
+		elbv2TaggingManager, controllerConfig.FeatureGates, controllerConfig.ClusterName, controllerConfig.DefaultTags, controllerConfig.ExternalManagedTags, controllerConfig.DefaultSSLPolicy, controllerConfig.FeatureGates.Enabled(config.EnableIPTargetType), serviceUtils)
 	stackMarshaller := deploy.NewDefaultStackMarshaller()
 	stackDeployer := deploy.NewDefaultStackDeployer(cloud, k8sClient, networkingSGManager, networkingSGReconciler, controllerConfig, serviceTagPrefix, logger)
 	return &serviceReconciler{

--- a/docs/deploy/configurations.md
+++ b/docs/deploy/configurations.md
@@ -147,3 +147,4 @@ They are a set of kye=value pairs that describe AWS load balance controller feat
 | EndpointsFailOpen                     | string                          | false          | Enable or disable allowing endpoints with `ready:unknown` state in the target groups. |
 | EnableServiceController               | string                          | true           | Toggles support for `Service` type resources. |
 | EnableIPTargetType                    | string                          | true           | Used to toggle support for target-type `ip` across `Ingress` and `Service` type resources. |
+| SubnetsClusterTagCheck                | string                          | true           | Enable or disable the check for `kubernetes.io/cluster/${cluster-name}` during subnet auto-discovery |

--- a/docs/deploy/subnet_discovery.md
+++ b/docs/deploy/subnet_discovery.md
@@ -31,4 +31,6 @@ In version v2.1.1 and older, both the public and private subnets must be tagged 
 
  `${cluster-name}` is the name of the kubernetes cluster
  
- The cluster tag is not required in v2.1.2 and newer releases, unless a cluster tag for another cluster is present.
+The cluster tag is not required in versions from v2.1.2 to v2.4.1, unless a cluster tag for another cluster is present.
+
+Starting from v2.4.2 release, you can disable the cluster tag check completely by specifying the feature gate `SubnetsClusterTagCheck=false`

--- a/pkg/config/feature_gates.go
+++ b/pkg/config/feature_gates.go
@@ -16,6 +16,7 @@ const (
 	EndpointsFailOpen           Feature = "EndpointsFailOpen"
 	EnableServiceController     Feature = "EnableServiceController"
 	EnableIPTargetType          Feature = "EnableIPTargetType"
+	SubnetsClusterTagCheck      Feature = "SubnetsClusterTagCheck"
 )
 
 type FeatureGates interface {
@@ -49,6 +50,7 @@ func NewFeatureGates() FeatureGates {
 			EndpointsFailOpen:           false,
 			EnableServiceController:     true,
 			EnableIPTargetType:          true,
+			SubnetsClusterTagCheck:      true,
 		},
 	}
 }

--- a/pkg/ingress/model_build_load_balancer.go
+++ b/pkg/ingress/model_build_load_balancer.go
@@ -6,10 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"regexp"
-	"sigs.k8s.io/aws-load-balancer-controller/pkg/config"
 	"strings"
-
-	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/tracking"
 
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	ec2sdk "github.com/aws/aws-sdk-go/service/ec2"
@@ -18,6 +15,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/algorithm"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/config"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/tracking"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/equality"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/core"

--- a/pkg/ingress/model_build_load_balancer.go
+++ b/pkg/ingress/model_build_load_balancer.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"regexp"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/config"
 	"strings"
 
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/tracking"
@@ -225,6 +226,7 @@ func (t *defaultModelBuildTask) buildLoadBalancerSubnetMappings(ctx context.Cont
 			networking.WithSubnetsResolveLBType(elbv2model.LoadBalancerTypeApplication),
 			networking.WithSubnetsResolveLBScheme(scheme),
 			networking.WithSubnetsResolveAvailableIPAddressCount(minimalAvailableIPAddressCount),
+			networking.WithSubnetsClusterTagCheck(t.featureGates.Enabled(config.SubnetsClusterTagCheck)),
 		)
 		if err != nil {
 			return nil, errors.Wrap(err, "couldn't auto-discover subnets")

--- a/pkg/ingress/model_builder.go
+++ b/pkg/ingress/model_builder.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/services"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/config"
 	elbv2deploy "sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/elbv2"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/tracking"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
@@ -38,7 +39,7 @@ func NewDefaultModelBuilder(k8sClient client.Client, eventRecorder record.EventR
 	ec2Client services.EC2, acmClient services.ACM,
 	annotationParser annotations.Parser, subnetsResolver networkingpkg.SubnetsResolver,
 	authConfigBuilder AuthConfigBuilder, enhancedBackendBuilder EnhancedBackendBuilder,
-	trackingProvider tracking.Provider, elbv2TaggingManager elbv2deploy.TaggingManager,
+	trackingProvider tracking.Provider, elbv2TaggingManager elbv2deploy.TaggingManager, featureGates config.FeatureGates,
 	vpcID string, clusterName string, defaultTags map[string]string, externalManagedTags []string, defaultSSLPolicy string,
 	backendSGProvider networkingpkg.BackendSGProvider, enableBackendSG bool, disableRestrictedSGRules bool, enableIPTargetType bool, logger logr.Logger) *defaultModelBuilder {
 	certDiscovery := NewACMCertDiscovery(acmClient, logger)
@@ -58,6 +59,7 @@ func NewDefaultModelBuilder(k8sClient client.Client, eventRecorder record.EventR
 		ruleOptimizer:            ruleOptimizer,
 		trackingProvider:         trackingProvider,
 		elbv2TaggingManager:      elbv2TaggingManager,
+		featureGates:             featureGates,
 		defaultTags:              defaultTags,
 		externalManagedTags:      sets.NewString(externalManagedTags...),
 		defaultSSLPolicy:         defaultSSLPolicy,
@@ -88,6 +90,7 @@ type defaultModelBuilder struct {
 	ruleOptimizer            RuleOptimizer
 	trackingProvider         tracking.Provider
 	elbv2TaggingManager      elbv2deploy.TaggingManager
+	featureGates             config.FeatureGates
 	defaultTags              map[string]string
 	externalManagedTags      sets.String
 	defaultSSLPolicy         string
@@ -115,6 +118,7 @@ func (b *defaultModelBuilder) Build(ctx context.Context, ingGroup Group) (core.S
 		ruleOptimizer:            b.ruleOptimizer,
 		trackingProvider:         b.trackingProvider,
 		elbv2TaggingManager:      b.elbv2TaggingManager,
+		featureGates:             b.featureGates,
 		backendSGProvider:        b.backendSGProvider,
 		logger:                   b.logger,
 		enableBackendSG:          b.enableBackendSG,
@@ -167,6 +171,7 @@ type defaultModelBuildTask struct {
 	ruleOptimizer          RuleOptimizer
 	trackingProvider       tracking.Provider
 	elbv2TaggingManager    elbv2deploy.TaggingManager
+	featureGates           config.FeatureGates
 	logger                 logr.Logger
 
 	ingGroup                 Group

--- a/pkg/ingress/model_builder_test.go
+++ b/pkg/ingress/model_builder_test.go
@@ -2,7 +2,6 @@ package ingress
 
 import (
 	"context"
-	"sigs.k8s.io/aws-load-balancer-controller/pkg/config"
 	"testing"
 	"time"
 
@@ -21,6 +20,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/services"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/config"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/elbv2"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/tracking"

--- a/pkg/ingress/model_builder_test.go
+++ b/pkg/ingress/model_builder_test.go
@@ -2,6 +2,7 @@ package ingress
 
 import (
 	"context"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/config"
 	"testing"
 	"time"
 
@@ -3949,6 +3950,7 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 				trackingProvider:       trackingProvider,
 				elbv2TaggingManager:    elbv2TaggingManager,
 				enableBackendSG:        tt.fields.enableBackendSG,
+				featureGates:           config.NewFeatureGates(),
 				logger:                 &log.NullLogger{},
 
 				defaultSSLPolicy: "ELBSecurityPolicy-2016-08",

--- a/pkg/networking/subnet_resolver.go
+++ b/pkg/networking/subnet_resolver.go
@@ -97,8 +97,8 @@ func WithSubnetsClusterTagCheck(SubnetsClusterTagCheck bool) SubnetsResolveOptio
 type SubnetsResolver interface {
 	// ResolveViaDiscovery resolve subnets by auto discover matching subnets.
 	// Discovery candidate includes all subnets within the clusterVPC. Additionally,
-	//   * for internet-facing Load Balancer, "kubernetes.io/role/elb" tag must presents.
-	//   * for internal Load Balancer, "kubernetes.io/role/internal-elb" tag must presents.
+	//   * for internet-facing Load Balancer, "kubernetes.io/role/elb" tag must be present.
+	//   * for internal Load Balancer, "kubernetes.io/role/internal-elb" tag must be present.
 	//   * if SubnetClusterTagCheck is enabled, subnets within the clusterVPC must contain no cluster tag at all
 	//     or contain the "kubernetes.io/cluster/<cluster_name>" tag for the current cluster
 	// If multiple subnets are found for specific AZ, one subnet is chosen based on the lexical order of subnetID.

--- a/pkg/networking/subnet_resolver.go
+++ b/pkg/networking/subnet_resolver.go
@@ -65,28 +65,28 @@ func defaultSubnetsResolveOptions() SubnetsResolveOptions {
 
 type SubnetsResolveOption func(opts *SubnetsResolveOptions)
 
-// WithSubnetsResolveLBType generates a option that configures LBType.
+// WithSubnetsResolveLBType generates an option that configures LBType.
 func WithSubnetsResolveLBType(lbType elbv2model.LoadBalancerType) SubnetsResolveOption {
 	return func(opts *SubnetsResolveOptions) {
 		opts.LBType = lbType
 	}
 }
 
-// WithSubnetsResolveLBScheme generates a option that configures LBScheme.
+// WithSubnetsResolveLBScheme generates an option that configures LBScheme.
 func WithSubnetsResolveLBScheme(lbScheme elbv2model.LoadBalancerScheme) SubnetsResolveOption {
 	return func(opts *SubnetsResolveOptions) {
 		opts.LBScheme = lbScheme
 	}
 }
 
-// WithSubnetsResolveAvailableIPAddressCount generates a option that configures AvailableIPAddressCount.
+// WithSubnetsResolveAvailableIPAddressCount generates an option that configures AvailableIPAddressCount.
 func WithSubnetsResolveAvailableIPAddressCount(AvailableIPAddressCount int64) SubnetsResolveOption {
 	return func(opts *SubnetsResolveOptions) {
 		opts.AvailableIPAddressCount = AvailableIPAddressCount
 	}
 }
 
-// WithSubnetsResolveAvailableIPAddressCount generates a option that configures AvailableIPAddressCount.
+// WithSubnetsClusterTagCheck generates an option that configures SubnetsClusterTagCheck.
 func WithSubnetsClusterTagCheck(SubnetsClusterTagCheck bool) SubnetsResolveOption {
 	return func(opts *SubnetsResolveOptions) {
 		opts.SubnetsClusterTagCheck = SubnetsClusterTagCheck
@@ -96,10 +96,12 @@ func WithSubnetsClusterTagCheck(SubnetsClusterTagCheck bool) SubnetsResolveOptio
 // SubnetsResolver is responsible for resolve EC2 Subnets for Load Balancers.
 type SubnetsResolver interface {
 	// ResolveViaDiscovery resolve subnets by auto discover matching subnets.
-	//   * if SubnetClusterTagCheck is enabled, the discovered subnets within clusterVPC must contain the "kubernetes.io/cluster/<cluster-name>" tag
+	// Discovery candidate includes all subnets within the clusterVPC. Additionally,
 	//   * for internet-facing Load Balancer, "kubernetes.io/role/elb" tag must presents.
 	//   * for internal Load Balancer, "kubernetes.io/role/internal-elb" tag must presents.
-	// 	 * if multiple subnets are found for specific AZ, one subnet is chosen based on the lexical order of subnetID.
+	//   * if SubnetClusterTagCheck is enabled, subnets within the clusterVPC must contain no cluster tag at all
+	//     or contain the "kubernetes.io/cluster/<cluster_name>" tag for the current cluster
+	// If multiple subnets are found for specific AZ, one subnet is chosen based on the lexical order of subnetID.
 	ResolveViaDiscovery(ctx context.Context, opts ...SubnetsResolveOption) ([]*ec2sdk.Subnet, error)
 
 	// ResolveViaNameOrIDSlice resolve subnets using subnet name or ID.
@@ -351,6 +353,7 @@ func (r *defaultSubnetsResolver) checkSubnetHasClusterTag(subnet *ec2sdk.Subnet)
 // checkSubnetIsNotTaggedForOtherClusters checks whether the subnet is tagged for the current cluster
 // or it doesn't contain the cluster tag at all. If the subnet contains a tag for other clusters, then
 // this check returns false so that the subnet does not used for the load balancer.
+// it returns true if the subnetsClusterTagCheck is disabled
 func (r *defaultSubnetsResolver) checkSubnetIsNotTaggedForOtherClusters(subnet *ec2sdk.Subnet, subnetsClusterTagCheck bool) bool {
 	if !subnetsClusterTagCheck {
 		return true

--- a/pkg/networking/subnet_resolver_test.go
+++ b/pkg/networking/subnet_resolver_test.go
@@ -616,7 +616,7 @@ func Test_defaultSubnetsResolver_ResolveViaDiscovery(t *testing.T) {
 			wantErr: errors.New("some error"),
 		},
 		{
-			name: "subnet with cluster tag gets precedence, with SubnetsClusterTagCheck enabled",
+			name: "subnet with cluster tag gets precedence",
 			fields: fields{
 				vpcID:       "vpc-1",
 				clusterName: "kube-cluster",
@@ -672,7 +672,6 @@ func Test_defaultSubnetsResolver_ResolveViaDiscovery(t *testing.T) {
 				opts: []SubnetsResolveOption{
 					WithSubnetsResolveLBType(elbv2model.LoadBalancerTypeNetwork),
 					WithSubnetsResolveLBScheme(elbv2model.LoadBalancerSchemeInternetFacing),
-					WithSubnetsClusterTagCheck(defaultSubnetsClusterTagCheck),
 				},
 			},
 			want: []*ec2sdk.Subnet{
@@ -691,76 +690,7 @@ func Test_defaultSubnetsResolver_ResolveViaDiscovery(t *testing.T) {
 			},
 		},
 		{
-			name: "subnet with cluster tag does not get precedence, with SubnetsClusterTagCheck disabled",
-			fields: fields{
-				vpcID:       "vpc-1",
-				clusterName: "kube-cluster",
-				describeSubnetsAsListCalls: []describeSubnetsAsListCall{
-					{
-						input: &ec2sdk.DescribeSubnetsInput{
-							Filters: []*ec2sdk.Filter{
-								{
-									Name:   awssdk.String("tag:kubernetes.io/role/elb"),
-									Values: awssdk.StringSlice([]string{"", "1"}),
-								},
-								{
-									Name:   awssdk.String("vpc-id"),
-									Values: awssdk.StringSlice([]string{"vpc-1"}),
-								},
-							},
-						},
-						output: []*ec2sdk.Subnet{
-							{
-								SubnetId:           awssdk.String("subnet-1"),
-								AvailabilityZone:   awssdk.String("us-west-2b"),
-								AvailabilityZoneId: awssdk.String("usw2-az2"),
-								VpcId:              awssdk.String("vpc-1"),
-							},
-							{
-								SubnetId:           awssdk.String("subnet-2"),
-								AvailabilityZone:   awssdk.String("us-west-2b"),
-								AvailabilityZoneId: awssdk.String("usw2-az2"),
-								VpcId:              awssdk.String("vpc-1"),
-								Tags: []*ec2sdk.Tag{
-									{
-										Key:   awssdk.String("kubernetes.io/cluster/kube-cluster"),
-										Value: awssdk.String("owned"),
-									},
-								},
-							},
-						},
-					},
-				},
-				fetchAZInfosCalls: []fetchAZInfosCall{
-					{
-						availabilityZoneIDs: []string{"usw2-az2"},
-						azInfoByAZID: map[string]ec2sdk.AvailabilityZone{
-							"usw2-az2": {
-								ZoneId:   awssdk.String("usw2-az2"),
-								ZoneType: awssdk.String("availability-zone"),
-							},
-						},
-					},
-				},
-			},
-			args: args{
-				opts: []SubnetsResolveOption{
-					WithSubnetsResolveLBType(elbv2model.LoadBalancerTypeNetwork),
-					WithSubnetsResolveLBScheme(elbv2model.LoadBalancerSchemeInternetFacing),
-					WithSubnetsClusterTagCheck(false),
-				},
-			},
-			want: []*ec2sdk.Subnet{
-				{
-					SubnetId:           awssdk.String("subnet-1"),
-					AvailabilityZone:   awssdk.String("us-west-2b"),
-					AvailabilityZoneId: awssdk.String("usw2-az2"),
-					VpcId:              awssdk.String("vpc-1"),
-				},
-			},
-		},
-		{
-			name: "subnets tagged for some other clusters get ignored",
+			name: "subnets tagged for some other clusters get ignored, with SubnetsClusterTagCheck enabled",
 			fields: fields{
 				vpcID:       "vpc-1",
 				clusterName: "kube-cluster",
@@ -861,6 +791,7 @@ func Test_defaultSubnetsResolver_ResolveViaDiscovery(t *testing.T) {
 				opts: []SubnetsResolveOption{
 					WithSubnetsResolveLBType(elbv2model.LoadBalancerTypeNetwork),
 					WithSubnetsResolveLBScheme(elbv2model.LoadBalancerSchemeInternetFacing),
+					WithSubnetsClusterTagCheck(defaultSubnetsClusterTagCheck),
 				},
 			},
 			want: []*ec2sdk.Subnet{
@@ -881,6 +812,120 @@ func Test_defaultSubnetsResolver_ResolveViaDiscovery(t *testing.T) {
 					AvailabilityZone:   awssdk.String("us-west-2c"),
 					AvailabilityZoneId: awssdk.String("usw2-az3"),
 					VpcId:              awssdk.String("vpc-1"),
+				},
+			},
+		},
+		{
+			name: "subnets tagged for some other clusters doesn't get ignored, with SubnetsClusterTagCheck disabled",
+			fields: fields{
+				vpcID:       "vpc-1",
+				clusterName: "kube-cluster",
+				describeSubnetsAsListCalls: []describeSubnetsAsListCall{
+					{
+						input: &ec2sdk.DescribeSubnetsInput{
+							Filters: []*ec2sdk.Filter{
+								{
+									Name:   awssdk.String("tag:kubernetes.io/role/elb"),
+									Values: awssdk.StringSlice([]string{"", "1"}),
+								},
+								{
+									Name:   awssdk.String("vpc-id"),
+									Values: awssdk.StringSlice([]string{"vpc-1"}),
+								},
+							},
+						},
+						output: []*ec2sdk.Subnet{
+							{
+								SubnetId:           awssdk.String("subnet-3"),
+								AvailabilityZone:   awssdk.String("us-west-2c"),
+								AvailabilityZoneId: awssdk.String("usw2-az3"),
+								VpcId:              awssdk.String("vpc-1"),
+								Tags: []*ec2sdk.Tag{
+									{
+										Key:   awssdk.String("kubernetes.io/cluster/some-other-cluster"),
+										Value: awssdk.String("owned"),
+									},
+								},
+							},
+							{
+								SubnetId:           awssdk.String("subnet-1"),
+								AvailabilityZone:   awssdk.String("us-west-2a"),
+								AvailabilityZoneId: awssdk.String("usw2-az1"),
+								VpcId:              awssdk.String("vpc-1"),
+								Tags: []*ec2sdk.Tag{
+									{
+										Key:   awssdk.String("kubernetes.io/cluster/some-other-cluster"),
+										Value: awssdk.String("owned"),
+									},
+								},
+							},
+							{
+								SubnetId:           awssdk.String("subnet-2"),
+								AvailabilityZone:   awssdk.String("us-west-2c"),
+								AvailabilityZoneId: awssdk.String("usw2-az3"),
+								VpcId:              awssdk.String("vpc-1"),
+								Tags: []*ec2sdk.Tag{
+									{
+										Key:   awssdk.String("kubernetes.io/cluster/kube-cluster"),
+										Value: awssdk.String("owned"),
+									},
+								},
+							},
+						},
+					},
+				},
+				fetchAZInfosCalls: []fetchAZInfosCall{
+					{
+						availabilityZoneIDs: []string{"usw2-az1"},
+						azInfoByAZID: map[string]ec2sdk.AvailabilityZone{
+							"usw2-az1": {
+								ZoneId:   awssdk.String("usw2-az1"),
+								ZoneType: awssdk.String("availability-zone"),
+							},
+						},
+					},
+					{
+						availabilityZoneIDs: []string{"usw2-az3"},
+						azInfoByAZID: map[string]ec2sdk.AvailabilityZone{
+							"usw2-az3": {
+								ZoneId:   awssdk.String("usw2-az3"),
+								ZoneType: awssdk.String("availability-zone"),
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				opts: []SubnetsResolveOption{
+					WithSubnetsResolveLBType(elbv2model.LoadBalancerTypeNetwork),
+					WithSubnetsResolveLBScheme(elbv2model.LoadBalancerSchemeInternetFacing),
+					WithSubnetsClusterTagCheck(false),
+				},
+			},
+			want: []*ec2sdk.Subnet{
+				{
+					SubnetId:           awssdk.String("subnet-1"),
+					AvailabilityZone:   awssdk.String("us-west-2a"),
+					AvailabilityZoneId: awssdk.String("usw2-az1"),
+					VpcId:              awssdk.String("vpc-1"),
+					Tags: []*ec2sdk.Tag{
+						{
+							Key:   awssdk.String("kubernetes.io/cluster/some-other-cluster"),
+							Value: awssdk.String("owned"),
+						},
+					},
+				},
+				{
+					SubnetId:           awssdk.String("subnet-2"),
+					AvailabilityZone:   awssdk.String("us-west-2c"),
+					AvailabilityZoneId: awssdk.String("usw2-az3"),
+					VpcId:              awssdk.String("vpc-1"),
+					Tags: []*ec2sdk.Tag{
+						{
+							Key:   awssdk.String("kubernetes.io/cluster/kube-cluster"),
+							Value: awssdk.String("owned"),
+						},
+					},
 				},
 			},
 		},

--- a/pkg/networking/subnet_resolver_test.go
+++ b/pkg/networking/subnet_resolver_test.go
@@ -37,6 +37,7 @@ func Test_defaultSubnetsResolver_ResolveViaDiscovery(t *testing.T) {
 	}
 	const (
 		minimalAvailableIPAddressCount = int64(8)
+		defaultSubnetsClusterTagCheck  = true
 	)
 	tests := []struct {
 		name    string
@@ -615,7 +616,7 @@ func Test_defaultSubnetsResolver_ResolveViaDiscovery(t *testing.T) {
 			wantErr: errors.New("some error"),
 		},
 		{
-			name: "subnet with cluster tag gets precedence",
+			name: "subnet with cluster tag gets precedence, with SubnetsClusterTagCheck enabled",
 			fields: fields{
 				vpcID:       "vpc-1",
 				clusterName: "kube-cluster",
@@ -671,6 +672,7 @@ func Test_defaultSubnetsResolver_ResolveViaDiscovery(t *testing.T) {
 				opts: []SubnetsResolveOption{
 					WithSubnetsResolveLBType(elbv2model.LoadBalancerTypeNetwork),
 					WithSubnetsResolveLBScheme(elbv2model.LoadBalancerSchemeInternetFacing),
+					WithSubnetsClusterTagCheck(defaultSubnetsClusterTagCheck),
 				},
 			},
 			want: []*ec2sdk.Subnet{
@@ -685,6 +687,75 @@ func Test_defaultSubnetsResolver_ResolveViaDiscovery(t *testing.T) {
 							Value: awssdk.String("owned"),
 						},
 					},
+				},
+			},
+		},
+		{
+			name: "subnet with cluster tag does not get precedence, with SubnetsClusterTagCheck disabled",
+			fields: fields{
+				vpcID:       "vpc-1",
+				clusterName: "kube-cluster",
+				describeSubnetsAsListCalls: []describeSubnetsAsListCall{
+					{
+						input: &ec2sdk.DescribeSubnetsInput{
+							Filters: []*ec2sdk.Filter{
+								{
+									Name:   awssdk.String("tag:kubernetes.io/role/elb"),
+									Values: awssdk.StringSlice([]string{"", "1"}),
+								},
+								{
+									Name:   awssdk.String("vpc-id"),
+									Values: awssdk.StringSlice([]string{"vpc-1"}),
+								},
+							},
+						},
+						output: []*ec2sdk.Subnet{
+							{
+								SubnetId:           awssdk.String("subnet-1"),
+								AvailabilityZone:   awssdk.String("us-west-2b"),
+								AvailabilityZoneId: awssdk.String("usw2-az2"),
+								VpcId:              awssdk.String("vpc-1"),
+							},
+							{
+								SubnetId:           awssdk.String("subnet-2"),
+								AvailabilityZone:   awssdk.String("us-west-2b"),
+								AvailabilityZoneId: awssdk.String("usw2-az2"),
+								VpcId:              awssdk.String("vpc-1"),
+								Tags: []*ec2sdk.Tag{
+									{
+										Key:   awssdk.String("kubernetes.io/cluster/kube-cluster"),
+										Value: awssdk.String("owned"),
+									},
+								},
+							},
+						},
+					},
+				},
+				fetchAZInfosCalls: []fetchAZInfosCall{
+					{
+						availabilityZoneIDs: []string{"usw2-az2"},
+						azInfoByAZID: map[string]ec2sdk.AvailabilityZone{
+							"usw2-az2": {
+								ZoneId:   awssdk.String("usw2-az2"),
+								ZoneType: awssdk.String("availability-zone"),
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				opts: []SubnetsResolveOption{
+					WithSubnetsResolveLBType(elbv2model.LoadBalancerTypeNetwork),
+					WithSubnetsResolveLBScheme(elbv2model.LoadBalancerSchemeInternetFacing),
+					WithSubnetsClusterTagCheck(false),
+				},
+			},
+			want: []*ec2sdk.Subnet{
+				{
+					SubnetId:           awssdk.String("subnet-1"),
+					AvailabilityZone:   awssdk.String("us-west-2b"),
+					AvailabilityZoneId: awssdk.String("usw2-az2"),
+					VpcId:              awssdk.String("vpc-1"),
 				},
 			},
 		},

--- a/pkg/service/model_build_load_balancer.go
+++ b/pkg/service/model_build_load_balancer.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/config"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/tracking"
 	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/networking"
@@ -282,11 +283,13 @@ func (t *defaultModelBuildTask) buildLoadBalancerSubnets(ctx context.Context, sc
 			networking.WithSubnetsResolveLBType(elbv2model.LoadBalancerTypeNetwork),
 			networking.WithSubnetsResolveLBScheme(scheme),
 			networking.WithSubnetsResolveAvailableIPAddressCount(minimalAvailableIPAddressCount),
+			networking.WithSubnetsClusterTagCheck(t.featureGates.Enabled(config.SubnetsClusterTagCheck)),
 		)
 	}
 	return t.subnetsResolver.ResolveViaDiscovery(ctx,
 		networking.WithSubnetsResolveLBType(elbv2model.LoadBalancerTypeNetwork),
 		networking.WithSubnetsResolveLBScheme(scheme),
+		networking.WithSubnetsClusterTagCheck(t.featureGates.Enabled(config.SubnetsClusterTagCheck)),
 	)
 }
 

--- a/pkg/service/model_build_load_balancer_test.go
+++ b/pkg/service/model_build_load_balancer_test.go
@@ -17,6 +17,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/config"
 	elbv2deploy "sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/elbv2"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/tracking"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
@@ -760,6 +761,7 @@ func Test_defaultModelBuilderTask_buildLoadBalancerSubnets(t *testing.T) {
 
 			clusterName := "cluster-name"
 			trackingProvider := tracking.NewDefaultProvider("ingress.k8s.aws", clusterName)
+			featureGates := config.NewFeatureGates()
 
 			builder := &defaultModelBuildTask{
 				clusterName:         clusterName,
@@ -769,6 +771,7 @@ func Test_defaultModelBuilderTask_buildLoadBalancerSubnets(t *testing.T) {
 				subnetsResolver:     subnetsResolver,
 				trackingProvider:    trackingProvider,
 				elbv2TaggingManager: elbv2TaggingManager,
+				featureGates:        featureGates,
 			}
 			got, err := builder.buildLoadBalancerSubnets(context.Background(), tt.scheme)
 			if tt.wantErr != nil {

--- a/pkg/service/model_builder.go
+++ b/pkg/service/model_builder.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/config"
 	elbv2deploy "sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/elbv2"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/tracking"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
@@ -35,7 +36,7 @@ type ModelBuilder interface {
 // NewDefaultModelBuilder construct a new defaultModelBuilder
 func NewDefaultModelBuilder(annotationParser annotations.Parser, subnetsResolver networking.SubnetsResolver,
 	vpcInfoProvider networking.VPCInfoProvider, vpcID string, trackingProvider tracking.Provider,
-	elbv2TaggingManager elbv2deploy.TaggingManager, clusterName string, defaultTags map[string]string,
+	elbv2TaggingManager elbv2deploy.TaggingManager, featureGates config.FeatureGates, clusterName string, defaultTags map[string]string,
 	externalManagedTags []string, defaultSSLPolicy string, enableIPTargetType bool, serviceUtils ServiceUtils) *defaultModelBuilder {
 	return &defaultModelBuilder{
 		annotationParser:    annotationParser,
@@ -43,6 +44,7 @@ func NewDefaultModelBuilder(annotationParser annotations.Parser, subnetsResolver
 		vpcInfoProvider:     vpcInfoProvider,
 		trackingProvider:    trackingProvider,
 		elbv2TaggingManager: elbv2TaggingManager,
+		featureGates:        featureGates,
 		serviceUtils:        serviceUtils,
 		clusterName:         clusterName,
 		vpcID:               vpcID,
@@ -61,6 +63,7 @@ type defaultModelBuilder struct {
 	vpcInfoProvider     networking.VPCInfoProvider
 	trackingProvider    tracking.Provider
 	elbv2TaggingManager elbv2deploy.TaggingManager
+	featureGates        config.FeatureGates
 	serviceUtils        ServiceUtils
 
 	clusterName         string
@@ -81,6 +84,7 @@ func (b *defaultModelBuilder) Build(ctx context.Context, service *corev1.Service
 		vpcInfoProvider:     b.vpcInfoProvider,
 		trackingProvider:    b.trackingProvider,
 		elbv2TaggingManager: b.elbv2TaggingManager,
+		featureGates:        b.featureGates,
 		serviceUtils:        b.serviceUtils,
 		enableIPTargetType:  b.enableIPTargetType,
 
@@ -131,6 +135,7 @@ type defaultModelBuildTask struct {
 	vpcInfoProvider     networking.VPCInfoProvider
 	trackingProvider    tracking.Provider
 	elbv2TaggingManager elbv2deploy.TaggingManager
+	featureGates        config.FeatureGates
 	serviceUtils        ServiceUtils
 	enableIPTargetType  bool
 

--- a/pkg/service/model_builder_test.go
+++ b/pkg/service/model_builder_test.go
@@ -2770,7 +2770,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 			} else {
 				enableIPTargetType = *tt.enableIPTargetType
 			}
-			builder := NewDefaultModelBuilder(annotationParser, subnetsResolver, vpcInfoProvider, "vpc-xxx", trackingProvider, elbv2TaggingManager,
+			builder := NewDefaultModelBuilder(annotationParser, subnetsResolver, vpcInfoProvider, "vpc-xxx", trackingProvider, elbv2TaggingManager, featureGates,
 				"my-cluster", nil, nil, "ELBSecurityPolicy-2016-08", enableIPTargetType, serviceUtils)
 			ctx := context.Background()
 			stack, _, err := builder.Build(ctx, tt.svc)


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->
Add a feature gate `SubnetsClusterTagCheck` to enable/disable the check for cluster tag `kubernetes.io/cluster/${cluster-name}` during subnet auto-discovery, with default value to `true`. When set to `false`, the subnets do not have to be tagged for current cluster.
This flag is to solve the user case that for EKS 1.19 and later versions, EKS stops adding the cluster tag `kubernetes.io/cluster/{cluster-name}` to subnets. For customer reusing the subnets for new 1.19 and later versions, the subnets will not be tagged for new clusters, so the subnets gets ignored during auto-discovery. In this case they can disable the cluster tag check so they do not need to tag the subnets for current cluster manually. 

#### Tests

- Add unit tests to cover the change
- With `SubnetsClusterTagCheck=true`, created ALB and NLB with 2 subnets in the same AZ (1 tagged for current cluster, 1 tagged for other cluster), verified that the subnet tagged for current cluster got precedence.
- With `SubnetsClusterTagCheck=false`, created ALB and NLB with 2 subnets (both tagged for other clusters), verified the subnet got discovered by the order of subnet_id.
- With `SubnetsClusterTagCheck=false`, created ALB and NLB with 2 subnets (both contained no cluster tag at all), verified the subnet got discovered by the order of subnet_id.
- With `SubnetsClusterTagCheck=false`, created ALB and NLB with 2 subnets (1 tagged for current cluster, 1 tagged for other cluster), verified the subnet tagged for current cluster still got precedence.

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
