### PR TITLE
Fix for failing Ingress tests

### DIFF
--- a/test/e2e/ingress/vanilla_ingress_test.go
+++ b/test/e2e/ingress/vanilla_ingress_test.go
@@ -102,7 +102,9 @@ var _ = Describe("vanilla ingress tests", func() {
 				WithIngressClassName(ingClass.Name).
 				WithAnnotations(annotation).Build(sandboxNS.Name, "ing")
 			resStack := fixture.NewK8SResourceStack(tf, dp, svc, ingClass, ing)
-			resStack.Setup(ctx)
+			err := resStack.Setup(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
 			defer resStack.TearDown(ctx)
 
 			lbARN, lbDNS := ExpectOneLBProvisionedForIngress(ctx, tf, ing)
@@ -138,7 +140,9 @@ var _ = Describe("vanilla ingress tests", func() {
 				AddHTTPRoute("", networking.HTTPIngressPath{Path: "/path", PathType: &exact, Backend: ingBackend}).
 				WithAnnotations(annotation).Build(sandboxNS.Name, "ing")
 			resStack := fixture.NewK8SResourceStack(tf, dp, svc, ing)
-			resStack.Setup(ctx)
+			err := resStack.Setup(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
 			defer resStack.TearDown(ctx)
 
 			lbARN, lbDNS := ExpectOneLBProvisionedForIngress(ctx, tf, ing)
@@ -183,7 +187,9 @@ var _ = Describe("vanilla ingress tests", func() {
 				WithIngressClassName(ingClass.Name).
 				WithAnnotations(annotation).Build(sandboxNS.Name, "ing")
 			resStack := fixture.NewK8SResourceStack(tf, dp, svc, ingClass, ing)
-			resStack.Setup(ctx)
+			err := resStack.Setup(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
 			defer resStack.TearDown(ctx)
 
 			ExpectNoLBProvisionedForIngress(ctx, tf, ing)
@@ -212,7 +218,9 @@ var _ = Describe("vanilla ingress tests", func() {
 				AddHTTPRoute("", networking.HTTPIngressPath{Path: "/path", PathType: &exact, Backend: ingBackend}).
 				WithAnnotations(annotation).Build(sandboxNS.Name, "ing")
 			resStack := fixture.NewK8SResourceStack(tf, dp, svc, ing)
-			resStack.Setup(ctx)
+			err := resStack.Setup(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
 			defer resStack.TearDown(ctx)
 
 			ExpectNoLBProvisionedForIngress(ctx, tf, ing)
@@ -240,7 +248,9 @@ var _ = Describe("vanilla ingress tests", func() {
 				AddHTTPRoute("", networking.HTTPIngressPath{Path: "/path", PathType: &exact, Backend: ingBackend}).
 				WithAnnotations(annotation).Build(sandboxNS.Name, "ing")
 			resStack := fixture.NewK8SResourceStack(tf, dp, svc, ing)
-			resStack.Setup(ctx)
+			err := resStack.Setup(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
 			defer resStack.TearDown(ctx)
 
 			ExpectNoLBProvisionedForIngress(ctx, tf, ing)
@@ -275,7 +285,9 @@ var _ = Describe("vanilla ingress tests", func() {
 				AddHTTPRoute("", networking.HTTPIngressPath{Path: "/path", PathType: &exact, Backend: ingBackend}).
 				WithAnnotations(annotation).Build(sandboxNS.Name, "ing")
 			resStack := fixture.NewK8SResourceStack(tf, dp, svc, ing)
-			resStack.Setup(ctx)
+			err := resStack.Setup(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
 			defer resStack.TearDown(ctx)
 
 			lbARN, lbDNS := ExpectOneLBProvisionedForIngress(ctx, tf, ing)
@@ -318,7 +330,9 @@ var _ = Describe("vanilla ingress tests", func() {
 				AddHTTPRoute("", networking.HTTPIngressPath{Path: "/path", PathType: &exact, Backend: ingBackend}).
 				WithAnnotations(annotation).Build(sandboxNS.Name, "ing")
 			resStack := fixture.NewK8SResourceStack(tf, dp, svc, ing)
-			resStack.Setup(ctx)
+			err := resStack.Setup(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
 			defer resStack.TearDown(ctx)
 
 			lbARN, lbDNS := ExpectOneLBProvisionedForIngress(ctx, tf, ing)
@@ -389,7 +403,9 @@ var _ = Describe("vanilla ingress tests", func() {
 				AddHTTPRoute("", networking.HTTPIngressPath{Path: "/forward-multiple-tg", PathType: &exact, Backend: ingForwardMultipleTGBackend}).
 				WithAnnotations(annotation).Build(sandboxNS.Name, "ing")
 			resStack := fixture.NewK8SResourceStack(tf, dp1, svc1, dp2, svc2, ing)
-			resStack.Setup(ctx)
+			err := resStack.Setup(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
 			defer resStack.TearDown(ctx)
 
 			lbARN, lbDNS := ExpectOneLBProvisionedForIngress(ctx, tf, ing)
@@ -503,7 +519,9 @@ var _ = Describe("vanilla ingress tests", func() {
 				AddHTTPRoute("www.example.com", networking.HTTPIngressPath{Path: "/path7", PathType: &exact, Backend: ingRulePath7Backend}).
 				WithAnnotations(annotation).Build(sandboxNS.Name, "ing")
 			resStack := fixture.NewK8SResourceStack(tf, ing)
-			resStack.Setup(ctx)
+			err := resStack.Setup(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
 			defer resStack.TearDown(ctx)
 
 			lbARN, lbDNS := ExpectOneLBProvisionedForIngress(ctx, tf, ing)


### PR DESCRIPTION
Add controller deployment ready logic to e2e script
Add error handling

### Issue
NA
<!-- Please link the GitHub issues related to this PR, if available -->

### Description
Ingress tests would fail as they would get triggered before aws-load-balancer controller was ready.

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->
So added a logic to check for controller ready, thanks @kishorj 
Add ginkgo check for error handling in Ingress test

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
