### PR TITLE
Add clusterName as debug info for troubleshooting

### DIFF
--- a/pkg/targetgroupbinding/networking_manager.go
+++ b/pkg/targetgroupbinding/networking_manager.go
@@ -525,8 +525,10 @@ func (m *defaultNetworkingManager) resolveEndpointSGForENI(ctx context.Context, 
 		}
 	}
 	if len(sgIDsWithClusterTag) != 1 {
-		return "", errors.Errorf("expect exactly one securityGroup tagged with %v for eni %v, got: %v",
-			clusterResourceTagKey, eniInfo.NetworkInterfaceID, sgIDsWithClusterTag.List())
+		// user may provide incorrect `--cluster-name` at bootstrap or modify the tag key unexpectedly, it is hard to find out if no clusterName included in error message.
+		// having `clusterName` included in error message might be helpful for shorten the troubleshooting time spent.
+		return "", errors.Errorf("expect exactly one securityGroup tagged with %v for eni %v, got: %v (clusterName: %v)",
+			clusterResourceTagKey, eniInfo.NetworkInterfaceID, sgIDsWithClusterTag.List(), m.clusterName)
 	}
 	sgID, _ := sgIDsWithClusterTag.PopAny()
 	return sgID, nil

--- a/scripts/ci_e2e_test.sh
+++ b/scripts/ci_e2e_test.sh
@@ -29,7 +29,7 @@ CONTROLLER_IAM_POLICY_NAME="lb-controller-e2e-${PULL_NUMBER}-$BUILD_ID"
 CONTROLLER_IAM_POLICY_ARN="" # will be fulfilled during setup_controller_iam_sa
 
 # Cluster settings
-EKSCTL_VERSION="v0.77.0"
+EKSCTL_VERSION="v0.100.0"
 CLUSTER_NAME="lb-controller-e2e-${PULL_NUMBER}-$BUILD_ID"
 CLUSTER_VERSION=${CLUSTER_VERSION:-"1.19"}
 CLUSTER_INSTANCE_TYPE="m5.xlarge"

--- a/scripts/lib/eksctl.sh
+++ b/scripts/lib/eksctl.sh
@@ -16,7 +16,7 @@ EKSCTL_TEMPLATE_IAM_SA="$(dirname "${BASH_SOURCE[0]}")/eksctl_tmpl_iam_sa.yaml"
 # Arguments:
 #   version         the version of eksctl
 #
-# sample: eksctl::init 0.34.0
+# sample: eksctl::init 0.100.0
 #######################################
 eksctl::init() {
   declare -r version="$1"
@@ -76,7 +76,7 @@ eksctl::init() {
 #   node_count          EKS cluster's node count
 #   cluster_kubeconfig  filename of cluster's kubeconfig
 #
-# sample: eksctl::create_cluster awesome-cluster us-west-2 1.18 m5.xlarge 4 awesome-cluster.kubeconfig
+# sample: eksctl::create_cluster awesome-cluster us-west-2 1.19 m5.xlarge 4 awesome-cluster.kubeconfig
 #######################################
 eksctl::create_cluster() {
   declare -r cluster_name="$1" region="$2" k8s_version="$3" instance_type="$4" node_count="$5" cluster_kubeconfig="$6"


### PR DESCRIPTION
### Issue

No issue, it's an minor improvement.

### Description

User may provide incorrect `--cluster-name` or modify the tag key unexpectedly, it is hard to find out if no clusterName included in error message. Having `clusterName` included in error message might be helpful for shorten the troubleshooting time spent.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
