### PR TITLE
add information on load balancer lifecycle

### DIFF
--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -12,6 +12,7 @@ You can add annotations to kubernetes Ingress and Service objects to customize t
     - Annotations that configures LoadBalancer / Listener behaviors have different merge behavior when IngressGroup feature is been used. `MergeBehavior` column below indicates how such annotation will be merged.
         - Exclusive: such annotation should only be specified on a single Ingress within IngressGroup or specified with same value across all Ingresses within IngressGroup.
         - Merge: such annotation can be specified on all Ingresses within IngressGroup, and will be merged together.
+    - The controller may not update the configuration of an *existing* load balancer if an annotation is added/updated. New load balancers will be have an appropriate configuration. 
 
 ## Annotations
 |Name                       | Type |Default|Location|MergeBehavior|

--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -7,6 +7,7 @@
         - stringList: `"s1,s2,s3"`
         - stringMap: `"k1=v1,k2=v2"`
         - json: `"{ \"key\": \"value\" }"`
+    - The controller may not update the configuration of an *existing* load balancer if an annotation is added/updated. New load balancers will be have an appropriate configuration. 
 
 ## Annotations
 !!!warning

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -43,3 +43,21 @@ Ingress traffic starts at the ALB and reaches the Kubernetes nodes through each 
 #### IP mode
 Ingress traffic starts at the ALB and reaches the Kubernetes pods directly. CNIs must support directly accessible POD ip via [secondary IP addresses on ENI](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html).
 
+## Lifecycle of AWS Load Balancers
+
+!!! warning 
+    The controller, generally, does not update load balancers after creation. 
+
+
+The controller updates the targets of load balancers in response to cluster workload changes. However, the controller may not update the configuration of load balancers in response to annotations added to cluster resources after the load balancer is created. 
+    
+For example, if you add the annotation `aws-load-balancer-ssl-cert` to a service after the load balancer is created, the controller will *not* update the configuration of the AWS load balancer. However, if you delete the AWS load balancer, the controller will *recreate* the load balancer with the desired configuration.
+
+Recommendations: 
+1. Assume AWS load balancers may need to be replaced.
+1. Do not manually update the configuration of load balancers provisioned by the controller. This will cause the in-cluster resource definitions and the AWS configuration to get out of sync. 
+1. If durability of a specific load balancer resource is important, consider using IAM permissions to block the controller from creating or deleting new load balancers. Use the controller only to update the targets of self-managed load balancers.
+1. Use the [ExternalDNS Controller](https://github.com/kubernetes-sigs/external-dns) to automatically update DNS records instead of relying on a specific load balancer IP address or hostname. 
+
+
+

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -43,7 +43,7 @@ Ingress traffic starts at the ALB and reaches the Kubernetes nodes through each 
 #### IP mode
 Ingress traffic starts at the ALB and reaches the Kubernetes pods directly. CNIs must support directly accessible POD ip via [secondary IP addresses on ENI](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html).
 
-## Lifecycle of AWS Load Balancers
+## Lifecycle of AWS Load Balancers 
 
 !!! warning 
     The controller, generally, does not update load balancers after creation. 


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description

Customers may be confused or surprised when an annotation on a service is updated, and the configuration of the corresponding load balancer is not updated. Customers may also be surprised when the controller deletes and recreates a load balancer instead of attempting an in place update. 

This new section on load balancer lifecycle raises awareness of this issue, and offers some best practice reccommendations. 

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
