### PR TITLE
Validate Ingress condition annotations

### DIFF
--- a/pkg/ingress/config_types.go
+++ b/pkg/ingress/config_types.go
@@ -322,7 +322,7 @@ type RuleCondition struct {
 	SourceIPConfig *SourceIPConditionConfig `json:"sourceIPConfig"`
 }
 
-func (c *RuleCondition) validate() error {
+func (c *RuleCondition) Validate() error {
 	switch c.Field {
 	case RuleConditionFieldHostHeader:
 		if c.HostHeaderConfig == nil {

--- a/pkg/ingress/enhanced_backend_builder.go
+++ b/pkg/ingress/enhanced_backend_builder.go
@@ -165,7 +165,7 @@ func (b *defaultEnhancedBackendBuilder) buildConditions(_ context.Context, ingAn
 		return nil, err
 	}
 	for _, condition := range conditions {
-		if err := condition.validate(); err != nil {
+		if err := condition.Validate(); err != nil {
 			return nil, err
 		}
 	}

--- a/webhooks/networking/ingress_validator_test.go
+++ b/webhooks/networking/ingress_validator_test.go
@@ -3,6 +3,7 @@ package networking
 import (
 	"context"
 	awssdk "github.com/aws/aws-sdk-go/aws"
+	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -777,6 +778,122 @@ func Test_ingressValidator_checkIngressClassUsage(t *testing.T) {
 				classLoader: ingress.NewDefaultClassLoader(k8sClient),
 			}
 			err := v.checkIngressClassUsage(ctx, tt.args.ing, tt.args.oldIng)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_ingressValidator_checkIngressAnnotationConditions(t *testing.T) {
+	type fields struct {
+		disableIngressGroupAnnotation bool
+	}
+	type args struct {
+		ing *networking.Ingress
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr error
+	}{
+		{
+			name: "ingress has valid condition",
+			fields: fields{
+				disableIngressGroupAnnotation: false,
+			},
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns-1",
+						Name:      "ing-1",
+						Annotations: map[string]string{
+							"alb.ingress.kubernetes.io/condition.svc-1": `[{"field":"query-string","queryStringConfig":{"values":[{"key":"paramA","value":"paramAValue"}]}}]`,
+						},
+					},
+					Spec: networking.IngressSpec{
+						Rules: []networking.IngressRule{
+							{
+								IngressRuleValue: networking.IngressRuleValue{
+									HTTP: &networking.HTTPIngressRuleValue{
+										Paths: []networking.HTTPIngressPath{
+											{
+												Path: "/ing-1-path",
+												Backend: networking.IngressBackend{
+													Service: &networking.IngressServiceBackend{
+														Name: "svc-1",
+														Port: networking.ServiceBackendPort{
+															Name: "https",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "ingress has invalid condition",
+			fields: fields{
+				disableIngressGroupAnnotation: false,
+			},
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns-1",
+						Name:      "ing-1",
+						Annotations: map[string]string{
+							"alb.ingress.kubernetes.io/conditions.svc-1": `[{"field":"query-string","queryStringConfig":{"values":[{"key":"paramA","value":""}]}}]`,
+						},
+					},
+					Spec: networking.IngressSpec{
+						Rules: []networking.IngressRule{
+							{
+								IngressRuleValue: networking.IngressRuleValue{
+									HTTP: &networking.HTTPIngressRuleValue{
+										Paths: []networking.HTTPIngressPath{
+											{
+												Path: "/ing-1-path",
+												Backend: networking.IngressBackend{
+													Service: &networking.IngressServiceBackend{
+														Name: "svc-1",
+														Port: networking.ServiceBackendPort{
+															Name: "https",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: errors.New("ignoring Ingress ns-1/ing-1 since invalid alb.ingress.kubernetes.io/conditions.svc-1 annotation: invalid queryStringConfig: value cannot be empty"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			annotationParser := annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io")
+			classAnnotationMatcher := ingress.NewDefaultClassAnnotationMatcher("alb")
+			v := &ingressValidator{
+				annotationParser:              annotationParser,
+				classAnnotationMatcher:        classAnnotationMatcher,
+				disableIngressGroupAnnotation: tt.fields.disableIngressGroupAnnotation,
+				logger:                        logr.Discard(),
+			}
+			err := v.checkIngressAnnotationConditions(tt.args.ing)
 			if tt.wantErr != nil {
 				assert.EqualError(t, err, tt.wantErr.Error())
 			} else {


### PR DESCRIPTION
### Issue

#2042 

### Description

Earlier if at least 1 ingress in the group has an invalid annotation the rest of the ingresses in the group aren't took into account during building listener rules.

I've handled the condition validation error separately to prevent the termination of the process of the building listener rules for valid ingresses if such an error occurs.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
