### PR TITLE
use a dedicated config to disable default pod affinity

### DIFF
--- a/helm/aws-load-balancer-controller/README.md
+++ b/helm/aws-load-balancer-controller/README.md
@@ -157,7 +157,7 @@ eksctl delete iamserviceaccount --cluster <cluster-name> --namespace kube-system
 Chart release v1.2.0 and later enables high availability configuration by default.
 - The default number of replicas is 2. You can pass`--set replicaCount=1` flag during chart installation to disable this. Due to leader election, only one controller will actively reconcile resources.
 - The default priority class for the controller pods is `system-cluster-critical`
-- Soft pod anti-affinity is enabled for controller pods with `topologyKey: kubernetes.io/hostname` if custom affinity is not configured
+- Soft pod anti-affinity is enabled for controller pods with `topologyKey: kubernetes.io/hostname` if you don't configure custom affinity and set `configureDefaultAffinity` to `true`
 - Pod disruption budget (PDB) has not been set by default. If you plan on running at least 2 controller pods, you can pass `--set podDisruptionBudget.maxUnavailable=1` flag during chart installation
 
 ## Configuration
@@ -176,7 +176,8 @@ The default values set by the application itself can be confirmed [here](https:/
 | `priorityClassName`                            | Controller pod priority class                                                                            | system-cluster-critical                                                            |
 | `nodeSelector`                                 | Node labels for controller pod assignment                                                                | `{}`                                                                               |
 | `tolerations`                                  | Controller pod toleration for taints                                                                     | `{}`                                                                               |
-| `affinity`                                     | Affinity for pod assignment (string or map) (soft affinity if string "default", set explicitly if map)   | `default`                                                                          |
+| `affinity`                                     | Affinity for pod assignment                                                                              | `{}`                                                                               |
+| `configureDefaultAffinity`                     | Configure soft pod anti-affinity if custom affinity is not configured                                    | `true`                                                                             |
 | `topologySpreadConstraints`                    | Topology Spread Constraints for pod assignment                                                           | `{}`                                                                               |
 | `deploymentAnnotations`                        | Annotations to add to deployment                                                                         | `{}`                                                                               |
 | `podAnnotations`                               | Annotations to add to each pod                                                                           | `{}`                                                                               |

--- a/helm/aws-load-balancer-controller/templates/deployment.yaml
+++ b/helm/aws-load-balancer-controller/templates/deployment.yaml
@@ -178,14 +178,10 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if kindIs "map" .Values.affinity }}
-      {{- with .Values.affinity }}
+      {{- if .Values.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- end }}
-      {{- if kindIs "string" .Values.affinity }}
-      {{- if eq .Values.affinity "default" }}
+        {{- toYaml .Values.affinity | nindent 8 }}
+      {{- else if .Values.configureDefaultAffinity }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -198,7 +194,6 @@ spec:
                   values:
                   - {{ include "aws-load-balancer-controller.name" . }}
               topologyKey: kubernetes.io/hostname
-      {{- end }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:

--- a/helm/aws-load-balancer-controller/values.yaml
+++ b/helm/aws-load-balancer-controller/values.yaml
@@ -68,15 +68,12 @@ nodeSelector: {}
 
 tolerations: []
 
-# affinity can be either a string or map.
-#
-# if affinity is a string, and if that string is "default", set an antiAffinity policy on
-# the podSpec to prevent colocation on the same node.
-#
-# if affinity is a map, set the affinity attribute on the podSpec with this exact value (do NOT
-# use the default, as described above).
-# affinity: {}
-affinity: default
+# affinity specifies a custom affinity for the controller pods
+affinity: {}
+
+# configureDefaultAffinity specifies whether to configure a default affinity for the controller pods to prevent
+# co-location on the same node. This will get ignored if you specify a custom affinity configuration.
+configureDefaultAffinity: true
 
 # topologySpreadConstraints is a stable feature of k8s v1.19 which provides the ability to
 # control how Pods are spread across your cluster among failure-domains such as regions, zones,


### PR DESCRIPTION
## Issue
Alternate fix for issue #2570
<!-- Please link the GitHub issues related to this PR, if available -->

### Description
This PR revert changes from #2576 and adds a separate helm value `configureDefaultAffinity` which controls whether to use the default affinity configuration for the controller pods. This value is true by default, so there is no changes in the behavior from prior version. In case of custom affinity configuration, this value gets ignored.

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
