### PR TITLE
Allow configuring the actual cluster DNS domain for the TLS certificate

### DIFF
--- a/helm/aws-load-balancer-controller/README.md
+++ b/helm/aws-load-balancer-controller/README.md
@@ -80,7 +80,7 @@ kubectl apply -k "github.com/aws/eks-charts/stable/aws-load-balancer-controller/
 
 If you are setting `enableCertManager: true` you need to have installed cert-manager and it's CRDs before installing this chart; to install [cert-manager](https://artifacthub.io/packages/helm/cert-manager/cert-manager) follow the installation guide.
 
-Set `clusterDomain` (default: `cluster.local`) to the actual DNS domain of your cluster.
+Set `cluster.dnsDomain` (default: `cluster.local`) to the actual DNS domain of your cluster to include the FQDN in requested TLS certificates.
 
 #### Installing the Prometheus Operator
 
@@ -173,6 +173,7 @@ The default values set by the application itself can be confirmed [here](https:/
 | `image.tag`                                    | image tag                                                                                                | `<VERSION>`                                                                        |
 | `image.pullPolicy`                             | image pull policy                                                                                        | `IfNotPresent`                                                                     |
 | `clusterName`                                  | Kubernetes cluster name                                                                                  | None                                                                               |
+| `cluster.dnsDomain`                            | DNS domain of the Kubernetes cluster, included in TLS certificate requests                               | `cluster.local`                                                                    |
 | `securityContext`                              | Set to security context for pod                                                                          | `{}`                                                                               |
 | `resources`                                    | Controller pod resource requests & limits                                                                | `{}`                                                                               |
 | `priorityClassName`                            | Controller pod priority class                                                                            | system-cluster-critical                                                            |

--- a/helm/aws-load-balancer-controller/README.md
+++ b/helm/aws-load-balancer-controller/README.md
@@ -80,6 +80,8 @@ kubectl apply -k "github.com/aws/eks-charts/stable/aws-load-balancer-controller/
 
 If you are setting `enableCertManager: true` you need to have installed cert-manager and it's CRDs before installing this chart; to install [cert-manager](https://artifacthub.io/packages/helm/cert-manager/cert-manager) follow the installation guide.
 
+Set `clusterDomain` (default: `cluster.local`) to the actual DNS domain of your cluster.
+
 #### Installing the Prometheus Operator
 
 If you are setting `serviceMonitor.enabled: true` you need to have installed the Prometheus Operator ServiceMonitor CRD before installing this chart and have the operator running to collect the metrics. The easiest way to do this is to install the [kube-prometheus-stack](https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack) Helm chart using the installation guide.

--- a/helm/aws-load-balancer-controller/templates/_helpers.tpl
+++ b/helm/aws-load-balancer-controller/templates/_helpers.tpl
@@ -105,7 +105,7 @@ caCert: {{ index $secret.data "ca.crt" }}
 clientCert: {{ index $secret.data "tls.crt" }}
 clientKey: {{ index $secret.data "tls.key" }}
 {{- else -}}
-{{- $altNames := list (printf "%s.%s" $serviceName .Release.Namespace) (printf "%s.%s.svc" $serviceName .Release.Namespace) (printf "%s.%s.svc.%s" $serviceName .Release.Namespace .Values.clusterDomain) -}}
+{{- $altNames := list (printf "%s.%s" $serviceName .Release.Namespace) (printf "%s.%s.svc" $serviceName .Release.Namespace) (printf "%s.%s.svc.%s" $serviceName .Release.Namespace .Values.cluster.dnsDomain) -}}
 {{- $ca := genCA "aws-load-balancer-controller-ca" 3650 -}}
 {{- $cert := genSignedCert (include "aws-load-balancer-controller.fullname" .) nil $altNames 3650 $ca -}}
 caCert: {{ $ca.Cert | b64enc }}

--- a/helm/aws-load-balancer-controller/templates/_helpers.tpl
+++ b/helm/aws-load-balancer-controller/templates/_helpers.tpl
@@ -105,7 +105,7 @@ caCert: {{ index $secret.data "ca.crt" }}
 clientCert: {{ index $secret.data "tls.crt" }}
 clientKey: {{ index $secret.data "tls.key" }}
 {{- else -}}
-{{- $altNames := list (printf "%s.%s" $serviceName .Release.Namespace) (printf "%s.%s.svc" $serviceName .Release.Namespace) (printf "%s.%s.svc.cluster.local" $serviceName .Release.Namespace) -}}
+{{- $altNames := list (printf "%s.%s" $serviceName .Release.Namespace) (printf "%s.%s.svc" $serviceName .Release.Namespace) (printf "%s.%s.svc.%s" $serviceName .Release.Namespace .Values.clusterDomain) -}}
 {{- $ca := genCA "aws-load-balancer-controller-ca" 3650 -}}
 {{- $cert := genSignedCert (include "aws-load-balancer-controller.fullname" .) nil $altNames 3650 $ca -}}
 caCert: {{ $ca.Cert | b64enc }}

--- a/helm/aws-load-balancer-controller/templates/webhook.yaml
+++ b/helm/aws-load-balancer-controller/templates/webhook.yaml
@@ -167,7 +167,7 @@ metadata:
 spec:
   dnsNames:
   - {{ template "aws-load-balancer-controller.webhookService" . }}.{{ .Release.Namespace }}.svc
-  - {{ template "aws-load-balancer-controller.webhookService" . }}.{{ .Release.Namespace }}.svc.cluster.local
+  - {{ template "aws-load-balancer-controller.webhookService" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
   issuerRef:
     kind: Issuer
     name: {{ template "aws-load-balancer-controller.namePrefix" . }}-selfsigned-issuer

--- a/helm/aws-load-balancer-controller/templates/webhook.yaml
+++ b/helm/aws-load-balancer-controller/templates/webhook.yaml
@@ -167,7 +167,7 @@ metadata:
 spec:
   dnsNames:
   - {{ template "aws-load-balancer-controller.webhookService" . }}.{{ .Release.Namespace }}.svc
-  - {{ template "aws-load-balancer-controller.webhookService" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
+  - {{ template "aws-load-balancer-controller.webhookService" . }}.{{ .Release.Namespace }}.svc.{{ .Values.cluster.dnsDomain }}
   issuerRef:
     kind: Issuer
     name: {{ template "aws-load-balancer-controller.namePrefix" . }}-selfsigned-issuer

--- a/helm/aws-load-balancer-controller/values.yaml
+++ b/helm/aws-load-balancer-controller/values.yaml
@@ -78,7 +78,7 @@ configureDefaultAffinity: true
 # topologySpreadConstraints is a stable feature of k8s v1.19 which provides the ability to
 # control how Pods are spread across your cluster among failure-domains such as regions, zones,
 # nodes, and other user-defined topology domains.
-# 
+#
 # more details here: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
 topologySpreadConstraints: {}
 
@@ -103,6 +103,9 @@ additionalLabels: {}
 
 # Enable cert-manager
 enableCertManager: false
+
+# Cluster DNS domain (required for generating the TLS certificates)
+clusterDomain: cluster.local
 
 # The ingress class this controller will satisfy. If not specified, controller will match all
 # ingresses without ingress class annotation and ingresses of type alb

--- a/helm/aws-load-balancer-controller/values.yaml
+++ b/helm/aws-load-balancer-controller/values.yaml
@@ -13,9 +13,6 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-# The name of the Kubernetes cluster. A non-empty value is required
-clusterName:
-
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
@@ -104,8 +101,13 @@ additionalLabels: {}
 # Enable cert-manager
 enableCertManager: false
 
-# Cluster DNS domain (required for generating the TLS certificates)
-clusterDomain: cluster.local
+# The name of the Kubernetes cluster. A non-empty value is required
+clusterName:
+
+# cluster contains configurations specific to the kubernetes cluster
+cluster:
+    # Cluster DNS domain (required for requesting TLS certificates)
+    dnsDomain: cluster.local
 
 # The ingress class this controller will satisfy. If not specified, controller will match all
 # ingresses without ingress class annotation and ingresses of type alb


### PR DESCRIPTION
### Description

Currently, the cluster DNS domain `cluster.local` is hard-coded in the Helm chart for the webhook TLS certificate. This change provides a config option that allows using the actual cluster domain.

This is a non-breaking change, i.e., the cluster DNS domain still defaults to `cluster.local`.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [X] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [X] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
