### PR TITLE
Fix documentation typo s/Amzon/Amazon/

### DIFF
--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -775,7 +775,7 @@ In addition, you can use annotations to specify additional tags
         ```
 
 ## Addons
-- <a name="waf-acl-id">`alb.ingress.kubernetes.io/waf-acl-id`</a> specifies the identifier for the Amzon WAF web ACL.
+- <a name="waf-acl-id">`alb.ingress.kubernetes.io/waf-acl-id`</a> specifies the identifier for the Amazon WAF web ACL.
 
     !!!warning ""
         Only Regional WAF is supported.


### PR DESCRIPTION
### Issue

The documentation at https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/guide/ingress/annotations/#waf-acl-id has a typo, with the name "Amazon" misspelled.

### Description

Changes the string "Amzon" to "Amazon".