### PR TITLE
Fix: error handling of load balancer deletion

### DIFF
--- a/pkg/deploy/elbv2/load_balancer_synthesizer.go
+++ b/pkg/deploy/elbv2/load_balancer_synthesizer.go
@@ -63,11 +63,14 @@ func (s *loadBalancerSynthesizer) Synthesize(ctx context.Context) error {
 	for _, sdkLB := range unmatchedSDKLBs {
 		if err := s.lbManager.Delete(ctx, sdkLB); err != nil {
 			errMessage := err.Error()
-			if strings.Contains(errMessage, "OperationNotPermitted") && strings.Contains(errMessage, "deletion protection") {
-				s.disableDeletionProtection(sdkLB.LoadBalancer)
-				if err = s.lbManager.Delete(ctx, sdkLB); err != nil {
-					return err
-				}
+			if !(strings.Contains(errMessage, "OperationNotPermitted") && strings.Contains(errMessage, "deletion protection")) {
+				return err
+			}
+			if err = s.disableDeletionProtection(sdkLB.LoadBalancer); err != nil {
+				return err
+			}
+			if err = s.lbManager.Delete(ctx, sdkLB); err != nil {
+				return err
 			}
 		}
 	}


### PR DESCRIPTION
### Issue

When a load balancer is deleted in LoadBalancerSynthesizer, errors other than "OperationNotPermitted: deletion protection" is ignored due to this change(#2172).
This change make the synthesizer return other errors as well.

### Description

When a load balancer is associated with VPC endpoint service, deletion would fail with ResourceInUse error.
However it can't catch the error and continue to delete other resources.
I think it should be failed otherwise other resources such as targetgroupbindings will be deleted.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
