### PR TITLE
Fix webhook port value

### DIFF
--- a/docs/deploy/installation.md
+++ b/docs/deploy/installation.md
@@ -138,7 +138,7 @@ curl -o iam-policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-lo
 
 ## Network Configuration
 
-Review the [worker nodes security group](https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html) docs. The node security group must permit incoming traffic on TCP port 9943 from the kubernetes control plane. This is needed for webhook access. 
+Review the [worker nodes security group](https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html) docs. The node security group must permit incoming traffic on TCP port 9443 from the kubernetes control plane. This is needed for webhook access. 
 
 If you use [eksctl](https://eksctl.io/usage/vpc-networking/), this is the default configuration. 
 


### PR DESCRIPTION
### Issue

Wrong webhook port indicated in [installation docs page](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/deploy/installation/#network-configuration).
<!-- Please link the GitHub issues related to this PR, if available -->

### Description

Updated port number to 9443 according to value set in code base.
<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
