### PR TITLE
configure default client-side throttle for ELBv2 APIs

### DIFF
--- a/docs/deploy/configurations.md
+++ b/docs/deploy/configurations.md
@@ -129,10 +129,10 @@ Once disabled:
 
 ###  throttle config
 
-The default throttle config used is.
+Controller uses the following default throttle config:
 
 ```
-WAF Regional:^AssociateWebACL|DisassociateWebACL=0.5:1,WAF Regional:^GetWebACLForResource|ListResourcesForWebACL=1:1,WAFV2:^AssociateWebACL|DisassociateWebACL=0.5:1,WAFV2:^GetWebACLForResource|ListResourcesForWebACL=1:1
+WAF Regional:^AssociateWebACL|DisassociateWebACL=0.5:1,WAF Regional:^GetWebACLForResource|ListResourcesForWebACL=1:1,WAFV2:^AssociateWebACL|DisassociateWebACL=0.5:1,WAFV2:^GetWebACLForResource|ListResourcesForWebACL=1:1,Elastic Load Balancing v2:^RegisterTargets|^DeregisterTargets=4:20,Elastic Load Balancing v2:.*=10:40
 ```
 Client side throttling enables gradual scaling of the api calls. Additional throttle config can be specified via the `--aws-api-throttle` flag. You can get the ServiceID from the API definition in AWS SDK. For e.g, ELBv2 it is [Elastic Load Balancing v2](https://github.com/aws/aws-sdk-go/blob/main/models/apis/elasticloadbalancingv2/2015-12-01/api-2.json#L9).
 

--- a/pkg/aws/throttle/defaults.go
+++ b/pkg/aws/throttle/defaults.go
@@ -1,6 +1,7 @@
 package throttle
 
 import (
+	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/aws/aws-sdk-go/service/wafregional"
 	"github.com/aws/aws-sdk-go/service/wafv2"
 	"golang.org/x/time/rate"
@@ -33,6 +34,18 @@ func NewDefaultServiceOperationsThrottleConfig() *ServiceOperationsThrottleConfi
 					operationPtn: regexp.MustCompile("^GetWebACLForResource|ListResourcesForWebACL"),
 					r:            rate.Limit(1),
 					burst:        1,
+				},
+			},
+			elbv2.ServiceID: {
+				{
+					operationPtn: regexp.MustCompile("^RegisterTargets|^DeregisterTargets"),
+					r:            rate.Limit(4),
+					burst:        20,
+				},
+				{
+					operationPtn: regexp.MustCompile(".*"),
+					r:            rate.Limit(10),
+					burst:        40,
 				},
 			},
 		},

--- a/pkg/ingress/group_loader.go
+++ b/pkg/ingress/group_loader.go
@@ -152,7 +152,7 @@ func (m *defaultGroupLoader) checkGroupMembershipType(ctx context.Context, group
 			}
 			return groupMembershipTypeNone, ClassifiedIngress{}, nil
 		}
-		
+
 		// tolerate errInvalidIngressGroup error since an Ingress with a wrong IngressGroup name means to leave the IngressGroup anyway.
 		if errors.Is(err, errInvalidIngressGroup) {
 			if hasGroupFinalizer {


### PR DESCRIPTION
### Issue
Fixes: #2809
<!-- Please link the GitHub issues related to this PR, if available -->

### Description
Specify default client side throttle configuration for ELBv2 APIs. This configuration will help the controller avoid potential throttling during ELBv2 api calls thus avoiding the tgb reconcile failures.
<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
