### PR TITLE
alpn-policy accept only string and not alpn-policy

### DIFF
--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -44,7 +44,7 @@
 | [service.beta.kubernetes.io/aws-load-balancer-ipv6-addresses](#ipv6-addresses)                   | stringList              |                           | dualstack lb only. Length must match the number of subnets |
 | [service.beta.kubernetes.io/aws-load-balancer-target-group-attributes](#target-group-attributes) | stringMap               |                           |                                                        |
 | [service.beta.kubernetes.io/aws-load-balancer-subnets](#subnets)                                 | stringList              |                           |                                                        |
-| [service.beta.kubernetes.io/aws-load-balancer-alpn-policy](#alpn-policy)                         | stringList              |                           |                                                        |
+| [service.beta.kubernetes.io/aws-load-balancer-alpn-policy](#alpn-policy)                         | string                  |                           |                                                        |
 | [service.beta.kubernetes.io/aws-load-balancer-target-node-labels](#target-node-labels)           | stringMap               |                           |                                                        |
 | [service.beta.kubernetes.io/aws-load-balancer-attributes](#load-balancer-attributes)             | stringMap               |                           |                                                        |
 | [service.beta.kubernetes.io/aws-load-balancer-manage-backend-security-group-rules](#manage-backend-sg-rules)  | boolean    | true                      |                                                        |


### PR DESCRIPTION
### Issue

fix typo documentation `service.beta.kubernetes.io/aws-load-balancer-alpn-policy`
### Description
we tended to use the annotation as a list to accept different policies and map them to listeners,
but while applying we got an error that it accepts only one value of 
`[HTTP1Only, HTTP2Only, HTTP2Optional, HTTP2Preferred, None]`

it would be nice if we have an annotation which accepts different alpn policies and not only one
something like 
`service.beta.kubernetes.io/aws-load-balancer-alpn-policies` with type StringMap so then we assign port to each alpn policy