### PR TITLE
Improve echo server example documentation

### DIFF
--- a/docs/deploy/installation.md
+++ b/docs/deploy/installation.md
@@ -170,12 +170,12 @@ We recommend using the Helm chart. This supports Fargate and facilitates updatin
 
     Helm install command for clusters with IRSA: 
     ```
-    helm install aws-load-balancer-controller eks/aws-load-balancer-controller -n kube-system --set clusterName=<cluster-name> --set serviceAccount.create=false --set serviceAccount.name=aws-load-balancer-controller
+    helm install aws-load-balancer-controller eks/aws-load-balancer-controller -n kube-system --set clusterName=<cluster-name> --set serviceAccount.create=false --set serviceAccount.name=aws-load-balancer-controller --set replicaCount=1
     ```
 
     Helm install command for clusters not using IRSA:
     ```
-    helm install aws-load-balancer-controller eks/aws-load-balancer-controller -n kube-system --set clusterName=<cluster-name>
+    helm install aws-load-balancer-controller eks/aws-load-balancer-controller -n kube-system --set clusterName=<cluster-name> --set replicaCount=1
     ```
 
 

--- a/docs/examples/echo_server.md
+++ b/docs/examples/echo_server.md
@@ -120,7 +120,7 @@ In this walkthrough, you'll
     !!!tip
         If you'd like to use external dns, alter the host field to a domain that you own in Route 53. Assuming you managed `example.com` in Route 53.
 
-    - Edit the `alb.ingress.kubernetes.io/subnets` annotation to include at least two subnets.
+    - Edit the `alb.ingress.kubernetes.io/subnets` annotation to include at least two subnets. Note that one Availability Zone (ex: us-west-2a) can only have at most 1 subnet.
         ```bash
         eksctl get cluster exciting-gopher-1534270749
         ```


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description

There are two issues when I go through the [echo server example](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/docs/examples/echo_server.md).

* First, as shown in the following figure, I added four subnets to the annotation `alb.ingress.kubernetes.io/subnets`. Two of them are in us-west-2a, and the other two are in us-west-2b. The controller will fail to reconcile it because one Availability Zone (ex: us-west-2a) can only have at most 1 subnet.
  <img width="1339" alt="Screen Shot 2022-10-25 at 3 41 57 PM" src="https://user-images.githubusercontent.com/20109646/198157788-2fbb579d-559a-423c-a514-f470595e9d66.png">

* Second, [echo server example](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/docs/examples/echo_server.md) uses the following `kubectl logs` command to verify whether the controller deployment is successful or not. However, the default `replicaCount` of the helm chart is 2, and thus the `kubectl logs` will report an error message.
  ```
  kubectl logs -n kube-system $(kubectl get po -n kube-system | egrep -o 'aws-load-balancer-controller[a-zA-Z0-9-]+')
  ```
  https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/ff5678516059591858a7c3864948166a4291d4e5/helm/aws-load-balancer-controller/values.yaml#L5

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
