### PR TITLE
Add env secretKeyRef support

### DIFF
--- a/helm/aws-load-balancer-controller/Chart.yaml
+++ b/helm/aws-load-balancer-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.4.5
+version: 1.4.6
 appVersion: v2.4.4
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/helm/aws-load-balancer-controller/templates/deployment.yaml
+++ b/helm/aws-load-balancer-controller/templates/deployment.yaml
@@ -149,8 +149,16 @@ spec:
         {{- if .Values.env }}
         env:
         {{- range $key, $value := .Values.env }}
+        {{- if kindIs "map" $value }}
+        - name: {{ $key }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ $value.secretName }}
+              key: "{{ $value.secretKey }}"
+        {{- else }}
         - name: {{ $key }}
           value: "{{ $value }}"
+        {{- end }}
         {{- end }}
         {{- end }}
         command:

--- a/helm/aws-load-balancer-controller/values.yaml
+++ b/helm/aws-load-balancer-controller/values.yaml
@@ -232,6 +232,9 @@ livenessProbe:
 env:
   # ENV_1: ""
   # ENV_2: ""
+  # ENV_3:
+  #   secretName: ""
+  #   secretKey: ""
 
 # Specifies if aws-load-balancer-controller should be started in hostNetwork mode.
 #


### PR DESCRIPTION
### Description

This PR enables sensitive environment variables to be passed as secret references instead of plain text, e.g.:

```
env:
  AWS_SECRET_KEY: "" # PLAIN_TEXT_KEY
```

becomes:

```
env:
  AWS_SECRET_KEY:
    secretName: "" # Name of pre-existing secret
    secretKey: "" # Name of the key in pre-exiting secret"
```
 

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
