### PR TITLE
Fix typo of a comment in pkg/networking/subnet_resolver.go

### DIFF
--- a/pkg/networking/subnet_resolver.go
+++ b/pkg/networking/subnet_resolver.go
@@ -99,7 +99,7 @@ type SubnetsResolver interface {
 	// Discovery candidate includes all subnets within the clusterVPC. Additionally,
 	//   * for internet-facing Load Balancer, "kubernetes.io/role/elb" tag must be present.
 	//   * for internal Load Balancer, "kubernetes.io/role/internal-elb" tag must be present.
-	//   * if SubnetClusterTagCheck is enabled, subnets within the clusterVPC must contain no cluster tag at all
+	//   * if SubnetsClusterTagCheck is enabled, subnets within the clusterVPC must contain no cluster tag at all
 	//     or contain the "kubernetes.io/cluster/<cluster_name>" tag for the current cluster
 	// If multiple subnets are found for specific AZ, one subnet is chosen based on the lexical order of subnetID.
 	ResolveViaDiscovery(ctx context.Context, opts ...SubnetsResolveOption) ([]*ec2sdk.Subnet, error)


### PR DESCRIPTION
### Issue

N/A

### Description

Fixed a typo: `SubnetClusterTagCheck` -> `SubnetsClusterTagCheck`

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
