### PR TITLE
Fix to use a code block in the guide of ingress annotations

### DIFF
--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -635,7 +635,8 @@ Health check on target groups can be controlled with following annotations:
 - <a name="healthcheck-protocol">`alb.ingress.kubernetes.io/healthcheck-protocol`</a> specifies the protocol used when performing health check on targets.
 
     !!!example
-        ```alb.ingress.kubernetes.io/healthcheck-protocol: HTTPS
+        ```
+        alb.ingress.kubernetes.io/healthcheck-protocol: HTTPS
         ```
 
 - <a name="healthcheck-port">`alb.ingress.kubernetes.io/healthcheck-port`</a> specifies the port used when performing health check on targets.


### PR DESCRIPTION
### Issue

There is no `Copy to clipboard` button for `alb.ingress.kubernetes.io/healthcheck-protocol: HTTPS`.
Ref: https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/guide/ingress/annotations/#health-check

`Copy to clipboard` button is the following: 

<img width="146" alt="スクリーンショット 2022-11-12 2 41 31" src="https://user-images.githubusercontent.com/12394960/201398389-47c50767-ee95-48a0-b9dc-1f3ffce578cf.png">

### Description

Small fix
Enabled to copy a code to clipboard by fixing an inline example code into a code block as same as other examples

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
