### PR TITLE
Stop restricting branches for unit test action

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,9 +1,7 @@
 name: Unit Test
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+  - push
+  - pull_request
 jobs:
   build:
     name: Build


### PR DESCRIPTION
### Issue

N/A

### Description

Stop restricting the Unit Test GitHub Action to the `main` branch. This allows contributors to get CI signal before they submit a pull request.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
