### PR TITLE
Add GitHub Action for tagging releases and creating release branches 

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,25 @@
+name: tag-release
+
+on:
+  push:
+    branches:
+      - main
+      - 'release-*'
+    paths:
+      - version.txt
+
+jobs:
+  tag-release:
+    if: ${{ github.repository == 'kubernetes-sigs/aws-load-balancer-controller' }}
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - run: /usr/bin/git config --global user.email actions@github.com
+      - run: /usr/bin/git config --global user.name 'GitHub Actions Release Tagger'
+      - run: hack/tag-release.sh

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,17 @@
+# AWS Load Balancer Controller Release Process
+
+## Create the Release Commit
+
+Run `hack/set-version` to set the new version number and commit the resulting changes. 
+This is called the "release commit".
+
+## Merge the Release Commit
+
+Create a pull request with the release commit. Get it reviewed and merged to `main`.
+
+Upon merge to `main`, GitHub Actions will create a release tag for the new release.
+
+If the release is a ".0-beta.1" release, GitHub Actions will also create a release branch
+for the minor version.
+
+(Remaining steps in process yet to be documented.)

--- a/hack/tag-release.sh
+++ b/hack/tag-release.sh
@@ -1,0 +1,40 @@
+#!/bin/bash -xe
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+VERSION=$(cat version.txt)
+
+if [[ ! "${VERSION}" =~ ^([0-9]+[.][0-9]+)[.]([0-9]+)(-(alpha|beta)[.]([0-9]+))?$ ]]; then
+  echo "Version ${VERSION} must be 'X.Y.Z', 'X.Y.Z-alpha.N', or 'X.Y.Z-beta.N'"
+  exit 1
+fi
+
+MINOR=${BASH_REMATCH[1]}
+RELEASE_BRANCH="release-${MINOR}"
+
+if [ "$(git tag -l "v${VERSION}")" ]; then
+  echo "Tag v${VERSION} already exists"
+  exit 0
+fi
+
+git tag -a -m "Release ${VERSION}" "v${VERSION}"
+git push origin "v${VERSION}"
+
+if [[ ! "${VERSION}" =~ .0-beta.1$ ]]; then
+  exit 0
+fi
+
+git branch "${RELEASE_BRANCH}"
+git push origin "${RELEASE_BRANCH}"


### PR DESCRIPTION
### Issue

N/A

### Description

Adds automation for creating release tags and branches. This allows the decision to create a release to go through the standard code review process.

This also has code to create a release branch upon the creation of a `.0-beta.1` release. LBC doesn't currently create beta releases, so this code won't have effect unless it starts doing so. A possible change would be to have it also create a release branch with a `.0` stable release (if no such branch exists). That, however, would require a change in process to do all patch releases off of the release branch.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
