### PR TITLE
Remove inet.af/netaddr in favor of the modern netip module

### DIFF
--- a/pkg/networking/utils.go
+++ b/pkg/networking/utils.go
@@ -3,17 +3,14 @@ package networking
 import (
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	ec2sdk "github.com/aws/aws-sdk-go/service/ec2"
-	"inet.af/netaddr"
 	"net/netip"
 )
 
-// TODO: replace netaddr package with built-in netip package once golang 1.18 released: https://pkg.go.dev/net/netip@master#Prefix
-
 // ParseCIDRs will parse CIDRs in string format into parsed IPPrefix
-func ParseCIDRs(cidrs []string) ([]netaddr.IPPrefix, error) {
-	var ipPrefixes []netaddr.IPPrefix
+func ParseCIDRs(cidrs []string) ([]netip.Prefix, error) {
+	var ipPrefixes []netip.Prefix
 	for _, cidr := range cidrs {
-		ipPrefix, err := netaddr.ParseIPPrefix(cidr)
+		ipPrefix, err := netip.ParsePrefix(cidr)
 		if err != nil {
 			return nil, err
 		}
@@ -23,7 +20,7 @@ func ParseCIDRs(cidrs []string) ([]netaddr.IPPrefix, error) {
 }
 
 // IsIPWithinCIDRs checks whether specific IP is in IPv4 CIDR or IPv6 CIDRs.
-func IsIPWithinCIDRs(ip netaddr.IP, cidrs []netaddr.IPPrefix) bool {
+func IsIPWithinCIDRs(ip netip.Addr, cidrs []netip.Prefix) bool {
 	for _, cidr := range cidrs {
 		if cidr.Contains(ip) {
 			return true

--- a/pkg/networking/utils_test.go
+++ b/pkg/networking/utils_test.go
@@ -1,13 +1,13 @@
 package networking
 
 import (
+	"net/netip"
+	"testing"
+
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	ec2sdk "github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
-	"inet.af/netaddr"
-	"net/netip"
-	"testing"
 )
 
 func TestParseCIDRs(t *testing.T) {
@@ -17,7 +17,7 @@ func TestParseCIDRs(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    []netaddr.IPPrefix
+		want    []netip.Prefix
 		wantErr error
 	}{
 		{
@@ -25,8 +25,8 @@ func TestParseCIDRs(t *testing.T) {
 			args: args{
 				cidrs: []string{"192.168.5.100/16"},
 			},
-			want: []netaddr.IPPrefix{
-				netaddr.MustParseIPPrefix("192.168.5.100/16"),
+			want: []netip.Prefix{
+				netip.MustParsePrefix("192.168.5.100/16"),
 			},
 		},
 		{
@@ -34,9 +34,9 @@ func TestParseCIDRs(t *testing.T) {
 			args: args{
 				cidrs: []string{"192.168.5.100/16", "10.100.0.0/16"},
 			},
-			want: []netaddr.IPPrefix{
-				netaddr.MustParseIPPrefix("192.168.5.100/16"),
-				netaddr.MustParseIPPrefix("10.100.0.0/16"),
+			want: []netip.Prefix{
+				netip.MustParsePrefix("192.168.5.100/16"),
+				netip.MustParsePrefix("10.100.0.0/16"),
 			},
 		},
 		{
@@ -44,7 +44,7 @@ func TestParseCIDRs(t *testing.T) {
 			args: args{
 				cidrs: []string{"192.168.5.100/16", "10.100.0.0"},
 			},
-			wantErr: errors.New("netaddr.ParseIPPrefix(\"10.100.0.0\"): no '/'"),
+			wantErr: errors.New("netip.ParsePrefix(\"10.100.0.0\"): no '/'"),
 		},
 		{
 			name: "empty CIDRs",
@@ -76,8 +76,8 @@ func TestParseCIDRs(t *testing.T) {
 
 func TestIsIPWithinCIDRs(t *testing.T) {
 	type args struct {
-		ip    netaddr.IP
-		cidrs []netaddr.IPPrefix
+		ip    netip.Addr
+		cidrs []netip.Prefix
 	}
 	tests := []struct {
 		name string
@@ -87,11 +87,11 @@ func TestIsIPWithinCIDRs(t *testing.T) {
 		{
 			name: "ipv4 address within CIDRs",
 			args: args{
-				ip: netaddr.MustParseIP("192.168.1.42"),
-				cidrs: []netaddr.IPPrefix{
-					netaddr.MustParseIPPrefix("10.100.0.0/16"),
-					netaddr.MustParseIPPrefix("192.168.0.0/16"),
-					netaddr.MustParseIPPrefix("2600:1f14:f8c:2700::/56"),
+				ip: netip.MustParseAddr("192.168.1.42"),
+				cidrs: []netip.Prefix{
+					netip.MustParsePrefix("10.100.0.0/16"),
+					netip.MustParsePrefix("192.168.0.0/16"),
+					netip.MustParsePrefix("2600:1f14:f8c:2700::/56"),
 				},
 			},
 			want: true,
@@ -99,11 +99,11 @@ func TestIsIPWithinCIDRs(t *testing.T) {
 		{
 			name: "ipv4 address not within CIDRs",
 			args: args{
-				ip: netaddr.MustParseIP("172.16.1.42"),
-				cidrs: []netaddr.IPPrefix{
-					netaddr.MustParseIPPrefix("10.100.0.0/16"),
-					netaddr.MustParseIPPrefix("192.168.0.0/16"),
-					netaddr.MustParseIPPrefix("2600:1f14:f8c:2700::/56"),
+				ip: netip.MustParseAddr("172.16.1.42"),
+				cidrs: []netip.Prefix{
+					netip.MustParsePrefix("10.100.0.0/16"),
+					netip.MustParsePrefix("192.168.0.0/16"),
+					netip.MustParsePrefix("2600:1f14:f8c:2700::/56"),
 				},
 			},
 			want: false,
@@ -111,11 +111,11 @@ func TestIsIPWithinCIDRs(t *testing.T) {
 		{
 			name: "ipv6 address within CIDRs",
 			args: args{
-				ip: netaddr.MustParseIP("2600:1f14:f8c:2701:a740::"),
-				cidrs: []netaddr.IPPrefix{
-					netaddr.MustParseIPPrefix("10.100.0.0/16"),
-					netaddr.MustParseIPPrefix("2700:1f14:f8c:2700::/56"),
-					netaddr.MustParseIPPrefix("2600:1f14:f8c:2700::/56"),
+				ip: netip.MustParseAddr("2600:1f14:f8c:2701:a740::"),
+				cidrs: []netip.Prefix{
+					netip.MustParsePrefix("10.100.0.0/16"),
+					netip.MustParsePrefix("2700:1f14:f8c:2700::/56"),
+					netip.MustParsePrefix("2600:1f14:f8c:2700::/56"),
 				},
 			},
 			want: true,
@@ -123,11 +123,11 @@ func TestIsIPWithinCIDRs(t *testing.T) {
 		{
 			name: "ipv6 address not within CIDRs",
 			args: args{
-				ip: netaddr.MustParseIP("2800:1f14:f8c:2701:a740::"),
-				cidrs: []netaddr.IPPrefix{
-					netaddr.MustParseIPPrefix("10.100.0.0/16"),
-					netaddr.MustParseIPPrefix("2700:1f14:f8c:2700::/56"),
-					netaddr.MustParseIPPrefix("2600:1f14:f8c:2700::/56"),
+				ip: netip.MustParseAddr("2800:1f14:f8c:2701:a740::"),
+				cidrs: []netip.Prefix{
+					netip.MustParsePrefix("10.100.0.0/16"),
+					netip.MustParsePrefix("2700:1f14:f8c:2700::/56"),
+					netip.MustParsePrefix("2600:1f14:f8c:2700::/56"),
 				},
 			},
 			want: false,

--- a/pkg/targetgroupbinding/resource_manager.go
+++ b/pkg/targetgroupbinding/resource_manager.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"inet.af/netaddr"
+	"net/netip"
 	"time"
 
 	"k8s.io/client-go/tools/record"
@@ -389,7 +389,7 @@ func (m *defaultResourceManager) registerPodEndpoints(ctx context.Context, tgARN
 			Id:   awssdk.String(endpoint.IP),
 			Port: awssdk.Int64(endpoint.Port),
 		}
-		podIP, err := netaddr.ParseIP(endpoint.IP)
+		podIP, err := netip.ParseAddr(endpoint.IP)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description

This just eliminates the obsolete/deprecated use of inet.af/netaddr in favor of the builtin net/netip, which has an identical API.

### Checklist
- [x] Added tests that cover your change (if possible) (Updated, really)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:
