### PR TITLE
Use public ECR repository by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 MAKEFILE_PATH = $(dir $(realpath -s $(firstword $(MAKEFILE_LIST))))
 
 # Image URL to use all building/pushing image targets
-IMG ?= amazon/aws-alb-ingress-controller:v2.4.5
+IMG ?= public.ecr.aws/eks/aws-load-balancer-controller:v2.4.5
 
 CRD_OPTIONS ?= "crd:crdVersions=v1"
 

--- a/helm/aws-load-balancer-controller/README.md
+++ b/helm/aws-load-balancer-controller/README.md
@@ -169,7 +169,7 @@ The default values set by the application itself can be confirmed [here](https:/
 
 | Parameter                                      | Description                                                                                              | Default                                                                            |
 |------------------------------------------------| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| `image.repository`                             | image repository                                                                                         | `602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-load-balancer-controller` |
+| `image.repository`                             | image repository                                                                                         | `public.ecr.aws/eks/aws-load-balancer-controller` |
 | `image.tag`                                    | image tag                                                                                                | `<VERSION>`                                                                        |
 | `image.pullPolicy`                             | image pull policy                                                                                        | `IfNotPresent`                                                                     |
 | `clusterName`                                  | Kubernetes cluster name                                                                                  | None                                                                               |

--- a/helm/aws-load-balancer-controller/ci/values.yaml
+++ b/helm/aws-load-balancer-controller/ci/values.yaml
@@ -2,6 +2,6 @@
 
 region: us-west-2
 image:
-  repository: kishorj/aws-load-balancer-controller
-  tag: v2.0.0-rc1
+  repository: public.ecr.aws/eks/aws-load-balancer-controller
+  tag: v2.4.5
   pullPolicy: Always

--- a/helm/aws-load-balancer-controller/test.yaml
+++ b/helm/aws-load-balancer-controller/test.yaml
@@ -5,7 +5,7 @@
 replicaCount: 2
 
 image:
-  repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-load-balancer-controller
+  repository: public.ecr.aws/eks/aws-load-balancer-controller
   tag: v2.4.5
   pullPolicy: IfNotPresent
 

--- a/helm/aws-load-balancer-controller/values.yaml
+++ b/helm/aws-load-balancer-controller/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 2
 
 image:
-  repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-load-balancer-controller
+  repository: public.ecr.aws/eks/aws-load-balancer-controller
   tag: v2.4.5
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description
Use the public ECR repo public.ecr.aws/eks/aws-load-balancer-controller as the default for the controller helm chart.
<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
