### PR TITLE
Add webhook for claiming load balancers without LoadBalancerClass

### DIFF
--- a/main.go
+++ b/main.go
@@ -151,6 +151,7 @@ func main() {
 	podReadinessGateInjector := inject.NewPodReadinessGate(controllerCFG.PodWebhookConfig,
 		mgr.GetClient(), ctrl.Log.WithName("pod-readiness-gate-injector"))
 	corewebhook.NewPodMutator(podReadinessGateInjector).SetupWithManager(mgr)
+	corewebhook.NewServiceMutator(controllerCFG.ServiceConfig.LoadBalancerClass, ctrl.Log).SetupWithManager(mgr)
 	elbv2webhook.NewIngressClassParamsValidator().SetupWithManager(mgr)
 	elbv2webhook.NewTargetGroupBindingMutator(cloud.ELBV2(), ctrl.Log).SetupWithManager(mgr)
 	elbv2webhook.NewTargetGroupBindingValidator(mgr.GetClient(), cloud.ELBV2(), ctrl.Log).SetupWithManager(mgr)

--- a/webhooks/core/service_mutator.go
+++ b/webhooks/core/service_mutator.go
@@ -1,0 +1,60 @@
+package core
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/webhook"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+const (
+	apiPathMutateService = "/mutate-v1-service"
+)
+
+// NewServiceMutator returns a mutator for Service.
+func NewServiceMutator(lbClass string, logger logr.Logger) *serviceMutator {
+	return &serviceMutator{
+		logger:            logger,
+		loadBalancerClass: lbClass,
+	}
+}
+
+var _ webhook.Mutator = &serviceMutator{}
+
+type serviceMutator struct {
+	logger            logr.Logger
+	loadBalancerClass string
+}
+
+func (m *serviceMutator) Prototype(_ admission.Request) (runtime.Object, error) {
+	return &corev1.Service{}, nil
+}
+
+func (m *serviceMutator) MutateCreate(ctx context.Context, obj runtime.Object) (runtime.Object, error) {
+	svc := obj.(*corev1.Service)
+	if svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
+		return svc, nil
+	}
+
+	if svc.Spec.LoadBalancerClass != nil && *svc.Spec.LoadBalancerClass != "" {
+		m.logger.Info("service already has loadBalancerClass, skipping", "service", svc.Name, "loadBalancerClass", *svc.Spec.LoadBalancerClass)
+		return svc, nil
+	}
+
+	svc.Spec.LoadBalancerClass = &m.loadBalancerClass
+	m.logger.Info("setting service loadBalancerClass", "service", svc.Name, "loadBalancerClass", m.loadBalancerClass)
+
+	return svc, nil
+}
+
+func (m *serviceMutator) MutateUpdate(ctx context.Context, obj runtime.Object, oldObj runtime.Object) (runtime.Object, error) {
+	return obj, nil
+}
+
+func (m *serviceMutator) SetupWithManager(mgr ctrl.Manager) {
+	mgr.GetWebhookServer().Register(apiPathMutateService, webhook.MutatingWebhookForMutator(m))
+}


### PR DESCRIPTION
### Description

Kubernetes on AWS have two service controllers, this one (LBC) and the one that sits with Cloud Controller Manager (CCM). The CCM repo has a significant amount of bugs/issues related to it, and the most common resolution is to refer the users to  LBC.

As a secondary issue, CCM will default, and only fully support classic ELBs.

A third issue is that in IPv6-only clusters, you _have_ to use NLBs, so the CCM controller doesn't work at all.

The requirements for a solution is something like this:
* There should be a migration path for existing clusters.
* Existing services should continue to work (i.e something still needs to support Classic ELBs) and preserve CCMs behavior.

I don't think implementing CCM's controller in LBC is all that feasible. And it may be a moving target, as behaviour in CCM may change as well.

The easiest solution I could think of is to add a webhook that mutates services, adding some annotations and LoadBalancerClass if none are set. This effectively makes LBC the default while CCM will continue to operate on existing services. Migrating an existing service would have to be done through deletion and recreation of the Service resource, but that would be the case today as well since LoadBalancerClass is immutable, and LBC has no way of just adopting an ELB from CCM.

This PR creates a proof of concept that makes the few cloud LB related e2e tests pass and does some minimal configuration of the appropriate annotations (e.g without service class set, the service should be internet-facing by default). More of the CCM annotations needs to be implemented here. There should also be an option to skip the mutation if a specific annotation is set if one really wants CCM to manage a specific service. A feature gate that just noops the webhook should also be added to allow the webhook configuration to exist in the cluster, but disable its functionality.

If this has merit, I can add this functionality, but right now I am just looking for input.


### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
