### PR TITLE
use multi-arch image for service e2e test

### DIFF
--- a/test/e2e/service/nlb_instance_target.go
+++ b/test/e2e/service/nlb_instance_target.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	defaultTestImage   = "kishorj/hello-multi:v1"
+	defaultTestImage   = "public.ecr.aws/l6m2t8p7/hello-multi:latest"
 	appContainerPort   = 80
 	defaultNumReplicas = 3
 	defaultName        = "instance-e2e"


### PR DESCRIPTION
### Issue
Fixes: #2891
use multi-arch image for service e2e test

<!-- Please link the GitHub issues related to this PR, if available -->

### Description
Build multi-arch image for the service e2e test app. Also use ECR public image instead of GH.
<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
