### PR TITLE
Replace "SSL" with "TLS" where possible in documentation

### DIFF
--- a/docs/examples/cognito-ingress-template.yaml
+++ b/docs/examples/cognito-ingress-template.yaml
@@ -46,12 +46,12 @@ metadata:
     # The subdomain name only is sufficient for `UserPoolDomain`
     # e.g. if `FQDN=app.auth.ap-northeast-1.amazoncognito.com` then `UserPoolDomain=app`
     alb.ingress.kubernetes.io/auth-idp-cognito: '{"UserPoolArn": "arn:aws:cognito-idp:<region>:<account-id>:userpool/<region><cognito-id>","UserPoolClientId":"<user-pool-client-id>","UserPoolDomain":"<user-pool-authentication-domain>"}'
-    # ACM certificate ARN for your SSL domain
+    # ACM certificate ARN for your TLS domain
     alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:<region>:<account-id>:certificate/<certificate-id>
 spec:
   ingressClassName: alb
   rules:
-    # If you are using ExternalDNS, this will become your applications FQDN
+    # If you are using ExternalDNS, this will become your application's FQDN
     - host: <FQDN>
       http:
         paths:

--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -550,7 +550,7 @@ Access control for LoadBalancer can be controlled with following annotations:
 ALB supports authentication with Cognito or OIDC. See [Authenticate Users Using an Application Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/listener-authenticate-users.html) for more details.
 
 !!!warning "HTTPS only"
-    Authentication is only supported for HTTPS listeners, see [SSL](#ssl) for configure HTTPS listener.
+    Authentication is only supported for HTTPS listeners. See [TLS](#tls) for configuring HTTPS listeners.
 
 - <a name="auth-type">`alb.ingress.kubernetes.io/auth-type`</a> specifies the authentication type on targets.
 
@@ -725,8 +725,8 @@ Health check on target groups can be controlled with following annotations:
         ```alb.ingress.kubernetes.io/unhealthy-threshold-count: '2'
         ```
 
-## SSL
-SSL support can be controlled with following annotations:
+## TLS
+TLS support can be controlled with the following annotations:
 
 - <a name="certificate-arn">`alb.ingress.kubernetes.io/certificate-arn`</a> specifies the ARN of one or more certificate managed by [AWS Certificate Manager](https://aws.amazon.com/certificate-manager)
 


### PR DESCRIPTION
### Issue

None

### Description

TLS has existed since 1999 and AWS no longer supports SSL. Updates use of "SSL" to "TLS", except where "SSL" is baked into annotation names or (in one case) still used as a section heading in referenced AWS documentation.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
