### PR TITLE
fix: check default ingclass when ingclass is nill

### DIFF
--- a/pkg/ingress/class_loader.go
+++ b/pkg/ingress/class_loader.go
@@ -3,6 +3,7 @@ package ingress
 import (
 	"context"
 	"fmt"
+
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1"
@@ -20,6 +21,8 @@ const (
 	ingressClassControllerALB = "ingress.k8s.aws/alb"
 	// the Kind for IngressClassParams CRD.
 	ingressClassParamsKind = "IngressClassParams"
+	// default class from ingressClass
+	defaultClassAnnotation = "ingressclass.kubernetes.io/is-default-class"
 )
 
 // ErrInvalidIngressClass is an sentinel error that represents the IngressClass configuration for Ingress is invalid.
@@ -43,9 +46,40 @@ type defaultClassLoader struct {
 	client client.Client
 }
 
+// GetDefaultIngressClass returns the default IngressClass from the list of IngressClasses.
+// If multiple IngressClasses are marked as the default, it returns an error.
+func (l *defaultClassLoader) GetDefaultIngressClass(ctx context.Context) (string, error) {
+	var defaultClass string
+	var defaultClassFound bool
+	ingClassList := &networking.IngressClassList{}
+	if err := l.client.List(ctx, ingClassList); err != nil {
+		return "", fmt.Errorf("failed to fetch ingressClasses, %v", err.Error())
+	}
+	for _, ingressClass := range ingClassList.Items {
+		if ingressClass.Annotations[defaultClassAnnotation] == "true" {
+			if defaultClassFound {
+				return "", errors.Errorf("multiple default IngressClasses found")
+			}
+			defaultClass = ingressClass.GetName()
+			defaultClassFound = true
+		}
+	}
+
+	return defaultClass, nil
+}
+
 func (l *defaultClassLoader) Load(ctx context.Context, ing *networking.Ingress) (ClassConfiguration, error) {
+
 	if ing.Spec.IngressClassName == nil {
-		return ClassConfiguration{}, fmt.Errorf("%w: %v", ErrInvalidIngressClass, "spec.ingressClassName is nil")
+		defaultClass, err := l.GetDefaultIngressClass(ctx)
+		if err != nil {
+			return ClassConfiguration{}, err
+		}
+		if defaultClass != "" {
+			ing.Spec.IngressClassName = &defaultClass
+		} else {
+			return ClassConfiguration{}, err
+		}
 	}
 
 	ingClassKey := types.NamespacedName{Name: *ing.Spec.IngressClassName}

--- a/pkg/ingress/class_loader.go
+++ b/pkg/ingress/class_loader.go
@@ -78,7 +78,7 @@ func (l *defaultClassLoader) Load(ctx context.Context, ing *networking.Ingress) 
 		if defaultClass != "" {
 			ing.Spec.IngressClassName = &defaultClass
 		} else {
-			return ClassConfiguration{}, err
+			return ClassConfiguration{}, nil
 		}
 	}
 

--- a/pkg/ingress/class_loader.go
+++ b/pkg/ingress/class_loader.go
@@ -48,12 +48,13 @@ type defaultClassLoader struct {
 
 // GetDefaultIngressClass returns the default IngressClass from the list of IngressClasses.
 // If multiple IngressClasses are marked as the default, it returns an error.
+// If no IngressClass is marked as the default, it returns an empty string.
 func (l *defaultClassLoader) GetDefaultIngressClass(ctx context.Context) (string, error) {
 	var defaultClass string
 	var defaultClassFound bool
 	ingClassList := &networking.IngressClassList{}
 	if err := l.client.List(ctx, ingClassList); err != nil {
-		return "", fmt.Errorf("failed to fetch ingressClasses, %v", err.Error())
+		return "", fmt.Errorf("%w: fetching ingressClasses: %v", ErrInvalidIngressClass, err.Error())
 	}
 	for _, ingressClass := range ingClassList.Items {
 		if ingressClass.Annotations[defaultClassAnnotation] == "true" {

--- a/pkg/ingress/class_loader_test.go
+++ b/pkg/ingress/class_loader_test.go
@@ -2,6 +2,8 @@ package ingress
 
 import (
 	"context"
+	"testing"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
@@ -18,7 +20,6 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/webhook"
 	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-	"testing"
 )
 
 func Test_defaultClassLoader_Load(t *testing.T) {
@@ -59,7 +60,7 @@ func Test_defaultClassLoader_Load(t *testing.T) {
 					},
 				},
 			},
-			wantErr: errors.New("invalid ingress class: spec.ingressClassName is nil"),
+			wantErr: nil,
 		},
 		{
 			name: "when IngressClass not found",

--- a/pkg/ingress/class_loader_test.go
+++ b/pkg/ingress/class_loader_test.go
@@ -89,6 +89,30 @@ func Test_defaultClassLoader_Load(t *testing.T) {
 			wantErr: nil,
 		},
 		{
+			name: "when IngressClassName unspecified - Default class unspecified",
+			env: env{
+				nsList: []*corev1.Namespace{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "awesome-ns",
+						},
+					},
+				},
+			},
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "awesome-ns",
+						Name:      "awesome-ing",
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: nil,
+					},
+				},
+			},
+			want: ClassConfiguration{},
+		},
+		{
 			name: "when IngressClassName unspecified - Multiple default classes specified",
 			env: env{
 				nsList: []*corev1.Namespace{

--- a/pkg/ingress/group_loader.go
+++ b/pkg/ingress/group_loader.go
@@ -81,7 +81,6 @@ func (m *defaultGroupLoader) Load(ctx context.Context, groupID GroupID) (Group, 
 	if err := m.client.List(ctx, ingList); err != nil {
 		return Group{}, err
 	}
-
 	var members []ClassifiedIngress
 	var inactiveMembers []*networking.Ingress
 	for index := range ingList.Items {
@@ -207,17 +206,15 @@ func (m *defaultGroupLoader) classifyIngress(ctx context.Context, ing *networkin
 			IngClassConfig: ClassConfiguration{},
 		}, false, nil
 	}
-
-	if ing.Spec.IngressClassName != nil {
-		ingClassConfig, err := m.classLoader.Load(ctx, ing)
-		if err != nil {
-			return ClassifiedIngress{
-				Ing:            ing,
-				IngClassConfig: ClassConfiguration{},
-			}, false, err
-		}
-
-		if matchesIngressClass := ingClassConfig.IngClass != nil && ingClassConfig.IngClass.Spec.Controller == ingressClassControllerALB; matchesIngressClass {
+	ingClassConfig, err := m.classLoader.Load(ctx, ing)
+	if err != nil {
+		return ClassifiedIngress{
+			Ing:            ing,
+			IngClassConfig: ClassConfiguration{},
+		}, false, err
+	}
+	if matchesIngressClass := ingClassConfig.IngClass != nil; matchesIngressClass {
+		if ingClassConfig.IngClass.Spec.Controller == ingressClassControllerALB {
 			return ClassifiedIngress{
 				Ing:            ing,
 				IngClassConfig: ingClassConfig,

--- a/pkg/ingress/group_loader.go
+++ b/pkg/ingress/group_loader.go
@@ -206,6 +206,7 @@ func (m *defaultGroupLoader) classifyIngress(ctx context.Context, ing *networkin
 			IngClassConfig: ClassConfiguration{},
 		}, false, nil
 	}
+
 	ingClassConfig, err := m.classLoader.Load(ctx, ing)
 	if err != nil {
 		return ClassifiedIngress{
@@ -213,22 +214,17 @@ func (m *defaultGroupLoader) classifyIngress(ctx context.Context, ing *networkin
 			IngClassConfig: ClassConfiguration{},
 		}, false, err
 	}
-	if matchesIngressClass := ingClassConfig.IngClass != nil; matchesIngressClass {
-		if ingClassConfig.IngClass.Spec.Controller == ingressClassControllerALB {
-			return ClassifiedIngress{
-				Ing:            ing,
-				IngClassConfig: ingClassConfig,
-			}, true, nil
-		}
+
+	if matchesIngressClass := ingClassConfig.IngClass != nil && ingClassConfig.IngClass.Spec.Controller == ingressClassControllerALB; matchesIngressClass {
 		return ClassifiedIngress{
 			Ing:            ing,
 			IngClassConfig: ingClassConfig,
-		}, false, nil
+		}, true, nil
 	}
 
 	return ClassifiedIngress{
 		Ing:            ing,
-		IngClassConfig: ClassConfiguration{},
+		IngClassConfig: ingClassConfig,
 	}, m.manageIngressesWithoutIngressClass, nil
 }
 


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description
Per the documentation, the default ingress class is the one with the` ingressclass.kubernetes.io/is-default-class` annotation
So if the `ingressClassName` is `nil` we should check for the default ingress class.

To reproduce the issue:
1-  Set alb `ingressClass` as a default
2- Create an ingress without any `ingressClassName` and `kubernetes.io/ingress.class`
3- It won't create an alb in AWS but by this PR it will create because the default is alb



<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->
I check the default ingress with `GetDefaultIngressClass` function.
### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
