### PR TITLE
Ability to reconfigure NLB target group health check

### DIFF
--- a/docs/deploy/configurations.md
+++ b/docs/deploy/configurations.md
@@ -158,4 +158,4 @@ They are a set of kye=value pairs that describe AWS load balance controller feat
 | EnableServiceController               | string                          | true           | Toggles support for `Service` type resources. |
 | EnableIPTargetType                    | string                          | true           | Used to toggle support for target-type `ip` across `Ingress` and `Service` type resources. |
 | SubnetsClusterTagCheck                | string                          | true           | Enable or disable the check for `kubernetes.io/cluster/${cluster-name}` during subnet auto-discovery |
-| NLBHealthCheckTimeout                 | string                          | true           | Enable or disable the use of `service.beta.kubernetes.io/aws-load-balancer-healthcheck-timeout` for `Service` type resources (NLB) |
+| NLBHealthCheckAdvancedConfiguration   | string                          | true           | Enable or disable advanced health check configuration for NLB, for example health check timeout |

--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -39,6 +39,7 @@
 | [service.beta.kubernetes.io/aws-load-balancer-healthcheck-unhealthy-threshold](#healthcheck-unhealthy-threshold) | integer | 3                         |                                                        |
 | [service.beta.kubernetes.io/aws-load-balancer-healthcheck-timeout](#healthcheck-timeout)         | integer                 | 10                        |                                                        |
 | [service.beta.kubernetes.io/aws-load-balancer-healthcheck-interval](#healthcheck-interval)       | integer                 | 10                        |                                                        |
+| [service.beta.kubernetes.io/aws-load-balancer-healthcheck-success-codes](#healthcheck-success-codes)       | string        |                           |                                                        |
 | [service.beta.kubernetes.io/aws-load-balancer-eip-allocations](#eip-allocations)                 | stringList              |                           | internet-facing lb only. Length must match the number of subnets|
 | [service.beta.kubernetes.io/aws-load-balancer-private-ipv4-addresses](#private-ipv4-addresses)   | stringList              |                           | internal lb only. Length must match the number of subnets |
 | [service.beta.kubernetes.io/aws-load-balancer-ipv6-addresses](#ipv6-addresses)                   | stringList              |                           | dualstack lb only. Length must match the number of subnets |
@@ -341,6 +342,12 @@ Health check on target groups can be configured with following annotations:
         service.beta.kubernetes.io/aws-load-balancer-healthcheck-interval: "10"
         ```
 
+- <a name="healthcheck-success-codes">`service.beta.kubernetes.io/aws-load-balancer-healthcheck-success-codes`</a> specifies the http success codes for the health check in case of http/https protocol.
+
+  !!!example
+  ```
+  service.beta.kubernetes.io/aws-load-balancer-healthcheck-success-codes: "200-399"
+  ```
 
 - <a name="healthcheck-timeout">`service.beta.kubernetes.io/aws-load-balancer-healthcheck-timeout`</a> specifies the target group health check timeout. The target has to respond within the timeout for a successful health check.
 

--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -39,7 +39,7 @@
 | [service.beta.kubernetes.io/aws-load-balancer-healthcheck-unhealthy-threshold](#healthcheck-unhealthy-threshold) | integer | 3                         |                                                        |
 | [service.beta.kubernetes.io/aws-load-balancer-healthcheck-timeout](#healthcheck-timeout)         | integer                 | 10                        |                                                        |
 | [service.beta.kubernetes.io/aws-load-balancer-healthcheck-interval](#healthcheck-interval)       | integer                 | 10                        |                                                        |
-| [service.beta.kubernetes.io/aws-load-balancer-healthcheck-success-codes](#healthcheck-success-codes)       | string        |                           |                                                        |
+| [service.beta.kubernetes.io/aws-load-balancer-healthcheck-success-codes](#healthcheck-success-codes)       | string        | 200-399                   |                                                        |
 | [service.beta.kubernetes.io/aws-load-balancer-eip-allocations](#eip-allocations)                 | stringList              |                           | internet-facing lb only. Length must match the number of subnets|
 | [service.beta.kubernetes.io/aws-load-balancer-private-ipv4-addresses](#private-ipv4-addresses)   | stringList              |                           | internal lb only. Length must match the number of subnets |
 | [service.beta.kubernetes.io/aws-load-balancer-ipv6-addresses](#ipv6-addresses)                   | stringList              |                           | dualstack lb only. Length must match the number of subnets |
@@ -344,10 +344,10 @@ Health check on target groups can be configured with following annotations:
 
 - <a name="healthcheck-success-codes">`service.beta.kubernetes.io/aws-load-balancer-healthcheck-success-codes`</a> specifies the http success codes for the health check in case of http/https protocol.
 
-  !!!example
-  ```
-  service.beta.kubernetes.io/aws-load-balancer-healthcheck-success-codes: "200-399"
-  ```
+    !!!example
+        ```
+        service.beta.kubernetes.io/aws-load-balancer-healthcheck-success-codes: "200-399"
+        ```
 
 - <a name="healthcheck-timeout">`service.beta.kubernetes.io/aws-load-balancer-healthcheck-timeout`</a> specifies the target group health check timeout. The target has to respond within the timeout for a successful health check.
 

--- a/pkg/annotations/constants.go
+++ b/pkg/annotations/constants.go
@@ -73,6 +73,7 @@ const (
 	SvcLBSuffixHCProtocol                    = "aws-load-balancer-healthcheck-protocol"
 	SvcLBSuffixHCPort                        = "aws-load-balancer-healthcheck-port"
 	SvcLBSuffixHCPath                        = "aws-load-balancer-healthcheck-path"
+	SvcLBSuffixHCSuccessCodes                = "aws-load-balancer-healthcheck-success-codes"
 	SvcLBSuffixTargetGroupAttributes         = "aws-load-balancer-target-group-attributes"
 	SvcLBSuffixSubnets                       = "aws-load-balancer-subnets"
 	SvcLBSuffixEIPAllocations                = "aws-load-balancer-eip-allocations"

--- a/pkg/config/feature_gates.go
+++ b/pkg/config/feature_gates.go
@@ -11,14 +11,14 @@ import (
 type Feature string
 
 const (
-	ListenerRulesTagging        Feature = "ListenerRulesTagging"
-	WeightedTargetGroups        Feature = "WeightedTargetGroups"
-	ServiceTypeLoadBalancerOnly Feature = "ServiceTypeLoadBalancerOnly"
-	EndpointsFailOpen           Feature = "EndpointsFailOpen"
-	EnableServiceController     Feature = "EnableServiceController"
-	EnableIPTargetType          Feature = "EnableIPTargetType"
-	SubnetsClusterTagCheck      Feature = "SubnetsClusterTagCheck"
-	NLBHealthCheckTimeout       Feature = "NLBHealthCheckTimeout"
+	ListenerRulesTagging         Feature = "ListenerRulesTagging"
+	WeightedTargetGroups         Feature = "WeightedTargetGroups"
+	ServiceTypeLoadBalancerOnly  Feature = "ServiceTypeLoadBalancerOnly"
+	EndpointsFailOpen            Feature = "EndpointsFailOpen"
+	EnableServiceController      Feature = "EnableServiceController"
+	EnableIPTargetType           Feature = "EnableIPTargetType"
+	SubnetsClusterTagCheck       Feature = "SubnetsClusterTagCheck"
+	NLBHealthCheckAdvancedConfig Feature = "NLBHealthCheckAdvancedConfig"
 )
 
 type FeatureGates interface {
@@ -46,14 +46,14 @@ type defaultFeatureGates struct {
 func NewFeatureGates() FeatureGates {
 	return &defaultFeatureGates{
 		featureState: map[Feature]bool{
-			ListenerRulesTagging:        true,
-			WeightedTargetGroups:        true,
-			ServiceTypeLoadBalancerOnly: false,
-			EndpointsFailOpen:           false,
-			EnableServiceController:     true,
-			EnableIPTargetType:          true,
-			SubnetsClusterTagCheck:      true,
-			NLBHealthCheckTimeout:       true,
+			ListenerRulesTagging:         true,
+			WeightedTargetGroups:         true,
+			ServiceTypeLoadBalancerOnly:  false,
+			EndpointsFailOpen:            false,
+			EnableServiceController:      true,
+			EnableIPTargetType:           true,
+			SubnetsClusterTagCheck:       true,
+			NLBHealthCheckAdvancedConfig: true,
 		},
 	}
 }

--- a/pkg/deploy/elbv2/target_group_synthesizer.go
+++ b/pkg/deploy/elbv2/target_group_synthesizer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/services"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/config"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/tracking"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/core"
 	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
@@ -14,12 +15,13 @@ import (
 
 // NewTargetGroupSynthesizer constructs targetGroupSynthesizer
 func NewTargetGroupSynthesizer(elbv2Client services.ELBV2, trackingProvider tracking.Provider, taggingManager TaggingManager,
-	tgManager TargetGroupManager, logger logr.Logger, stack core.Stack) *targetGroupSynthesizer {
+	tgManager TargetGroupManager, logger logr.Logger, featureGates config.FeatureGates, stack core.Stack) *targetGroupSynthesizer {
 	return &targetGroupSynthesizer{
 		elbv2Client:      elbv2Client,
 		trackingProvider: trackingProvider,
 		taggingManager:   taggingManager,
 		tgManager:        tgManager,
+		featureGates:     featureGates,
 		logger:           logger,
 		stack:            stack,
 		unmatchedSDKTGs:  nil,
@@ -32,6 +34,7 @@ type targetGroupSynthesizer struct {
 	trackingProvider tracking.Provider
 	taggingManager   TaggingManager
 	tgManager        TargetGroupManager
+	featureGates     config.FeatureGates
 	logger           logr.Logger
 
 	stack           core.Stack
@@ -45,7 +48,8 @@ func (s *targetGroupSynthesizer) Synthesize(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	matchedResAndSDKTGs, unmatchedResTGs, unmatchedSDKTGs, err := matchResAndSDKTargetGroups(resTGs, sdkTGs, s.trackingProvider.ResourceIDTagKey())
+	matchedResAndSDKTGs, unmatchedResTGs, unmatchedSDKTGs, err := matchResAndSDKTargetGroups(resTGs, sdkTGs,
+		s.trackingProvider.ResourceIDTagKey(), s.featureGates)
 	if err != nil {
 		return err
 	}
@@ -95,7 +99,7 @@ type resAndSDKTargetGroupPair struct {
 }
 
 func matchResAndSDKTargetGroups(resTGs []*elbv2model.TargetGroup, sdkTGs []TargetGroupWithTags,
-	resourceIDTagKey string) ([]resAndSDKTargetGroupPair, []*elbv2model.TargetGroup, []TargetGroupWithTags, error) {
+	resourceIDTagKey string, featureGates config.FeatureGates) ([]resAndSDKTargetGroupPair, []*elbv2model.TargetGroup, []TargetGroupWithTags, error) {
 	var matchedResAndSDKTGs []resAndSDKTargetGroupPair
 	var unmatchedResTGs []*elbv2model.TargetGroup
 	var unmatchedSDKTGs []TargetGroupWithTags
@@ -113,7 +117,7 @@ func matchResAndSDKTargetGroups(resTGs []*elbv2model.TargetGroup, sdkTGs []Targe
 		sdkTGs := sdkTGsByID[resID]
 		foundMatch := false
 		for _, sdkTG := range sdkTGs {
-			if isSDKTargetGroupRequiresReplacement(sdkTG, resTG) {
+			if isSDKTargetGroupRequiresReplacement(sdkTG, resTG, featureGates) {
 				unmatchedSDKTGs = append(unmatchedSDKTGs, sdkTG)
 				continue
 			}
@@ -158,7 +162,7 @@ func mapSDKTargetGroupByResourceID(sdkTGs []TargetGroupWithTags, resourceIDTagKe
 }
 
 // isSDKTargetGroupRequiresReplacement checks whether a sdk TargetGroup requires replacement to fulfill a TargetGroup resource.
-func isSDKTargetGroupRequiresReplacement(sdkTG TargetGroupWithTags, resTG *elbv2model.TargetGroup) bool {
+func isSDKTargetGroupRequiresReplacement(sdkTG TargetGroupWithTags, resTG *elbv2model.TargetGroup, featureGates config.FeatureGates) bool {
 	if string(resTG.Spec.TargetType) != awssdk.StringValue(sdkTG.TargetGroup.TargetType) {
 		return true
 	}
@@ -171,12 +175,12 @@ func isSDKTargetGroupRequiresReplacement(sdkTG TargetGroupWithTags, resTG *elbv2
 		}
 	}
 
-	return isSDKTargetGroupRequiresReplacementDueToNLBHealthCheck(sdkTG, resTG)
+	return isSDKTargetGroupRequiresReplacementDueToNLBHealthCheck(sdkTG, resTG, featureGates)
 }
 
 // most of the healthCheck settings for NLB targetGroups cannot be changed for now.
-func isSDKTargetGroupRequiresReplacementDueToNLBHealthCheck(sdkTG TargetGroupWithTags, resTG *elbv2model.TargetGroup) bool {
-	if resTG.Spec.HealthCheckConfig == nil {
+func isSDKTargetGroupRequiresReplacementDueToNLBHealthCheck(sdkTG TargetGroupWithTags, resTG *elbv2model.TargetGroup, featureGates config.FeatureGates) bool {
+	if resTG.Spec.HealthCheckConfig == nil || featureGates.Enabled(config.NLBHealthCheckAdvancedConfig) {
 		return false
 	}
 	if resTG.Spec.Protocol != elbv2model.ProtocolTCP && resTG.Spec.Protocol != elbv2model.ProtocolUDP &&

--- a/pkg/deploy/stack_deployer.go
+++ b/pkg/deploy/stack_deployer.go
@@ -47,6 +47,7 @@ func NewDefaultStackDeployer(cloud aws.Cloud, k8sClient client.Client,
 		wafv2WebACLAssociationManager:       wafv2.NewDefaultWebACLAssociationManager(cloud.WAFv2(), logger),
 		wafRegionalWebACLAssociationManager: wafregional.NewDefaultWebACLAssociationManager(cloud.WAFRegional(), logger),
 		shieldProtectionManager:             shield.NewDefaultProtectionManager(cloud.Shield(), logger),
+		featureGates:                        config.FeatureGates,
 		vpcID:                               cloud.VpcID(),
 		logger:                              logger,
 	}
@@ -71,6 +72,7 @@ type defaultStackDeployer struct {
 	wafv2WebACLAssociationManager       wafv2.WebACLAssociationManager
 	wafRegionalWebACLAssociationManager wafregional.WebACLAssociationManager
 	shieldProtectionManager             shield.ProtectionManager
+	featureGates                        config.FeatureGates
 	vpcID                               string
 
 	logger logr.Logger
@@ -85,7 +87,7 @@ type ResourceSynthesizer interface {
 func (d *defaultStackDeployer) Deploy(ctx context.Context, stack core.Stack) error {
 	synthesizers := []ResourceSynthesizer{
 		ec2.NewSecurityGroupSynthesizer(d.cloud.EC2(), d.trackingProvider, d.ec2TaggingManager, d.ec2SGManager, d.vpcID, d.logger, stack),
-		elbv2.NewTargetGroupSynthesizer(d.cloud.ELBV2(), d.trackingProvider, d.elbv2TaggingManager, d.elbv2TGManager, d.logger, stack),
+		elbv2.NewTargetGroupSynthesizer(d.cloud.ELBV2(), d.trackingProvider, d.elbv2TaggingManager, d.elbv2TGManager, d.logger, d.featureGates, stack),
 		elbv2.NewLoadBalancerSynthesizer(d.cloud.ELBV2(), d.trackingProvider, d.elbv2TaggingManager, d.elbv2LBManager, d.logger, stack),
 		elbv2.NewListenerSynthesizer(d.cloud.ELBV2(), d.elbv2TaggingManager, d.elbv2LSManager, d.logger, stack),
 		elbv2.NewListenerRuleSynthesizer(d.cloud.ELBV2(), d.elbv2TaggingManager, d.elbv2LRManager, d.logger, stack),

--- a/pkg/service/model_build_target_group.go
+++ b/pkg/service/model_build_target_group.go
@@ -102,10 +102,8 @@ func (t *defaultModelBuildTask) buildTargetGroupHealthCheckConfigDefault(ctx con
 	if err != nil {
 		return nil, err
 	}
-	var healthCheckPathPtr *string
-	if healthCheckProtocol != elbv2model.ProtocolTCP {
-		healthCheckPathPtr = t.buildTargetGroupHealthCheckPath(ctx, t.defaultHealthCheckPath)
-	}
+	healthCheckPathPtr := t.buildTargetGroupHealthCheckPath(ctx, t.defaultHealthCheckPath, healthCheckProtocol)
+	healthCheckMatcherPtr := t.buildTargetGroupHealthCheckMatcher(ctx, healthCheckProtocol)
 	healthCheckPort, err := t.buildTargetGroupHealthCheckPort(ctx, t.defaultHealthCheckPort)
 	if err != nil {
 		return nil, err
@@ -114,13 +112,11 @@ func (t *defaultModelBuildTask) buildTargetGroupHealthCheckConfigDefault(ctx con
 	if err != nil {
 		return nil, err
 	}
-	var healthCheckTimeoutSeconds *int64
-	if t.featureGates.Enabled(config.NLBHealthCheckTimeout) {
-		healthCheckTimeoutSeconds, err = t.buildTargetGroupHealthCheckTimeoutSeconds(ctx, t.defaultHealthCheckTimeout)
-		if err != nil {
-			return nil, err
-		}
+	healthCheckTimeoutSecondsPtr, err := t.buildTargetGroupHealthCheckTimeoutSeconds(ctx, t.defaultHealthCheckTimeout)
+	if err != nil {
+		return nil, err
 	}
+
 	healthyThresholdCount, err := t.buildTargetGroupHealthCheckHealthyThresholdCount(ctx, t.defaultHealthCheckHealthyThreshold)
 	if err != nil {
 		return nil, err
@@ -133,8 +129,9 @@ func (t *defaultModelBuildTask) buildTargetGroupHealthCheckConfigDefault(ctx con
 		Port:                    &healthCheckPort,
 		Protocol:                &healthCheckProtocol,
 		Path:                    healthCheckPathPtr,
+		Matcher:                 healthCheckMatcherPtr,
 		IntervalSeconds:         &intervalSeconds,
-		TimeoutSeconds:          healthCheckTimeoutSeconds,
+		TimeoutSeconds:          healthCheckTimeoutSecondsPtr,
 		HealthyThresholdCount:   &healthyThresholdCount,
 		UnhealthyThresholdCount: &unhealthyThresholdCount,
 	}, nil
@@ -145,10 +142,8 @@ func (t *defaultModelBuildTask) buildTargetGroupHealthCheckConfigForInstanceMode
 	if err != nil {
 		return nil, err
 	}
-	var healthCheckPathPtr *string
-	if healthCheckProtocol != elbv2model.ProtocolTCP {
-		healthCheckPathPtr = t.buildTargetGroupHealthCheckPath(ctx, t.defaultHealthCheckPathForInstanceModeLocal)
-	}
+	healthCheckPathPtr := t.buildTargetGroupHealthCheckPath(ctx, t.defaultHealthCheckPathForInstanceModeLocal, healthCheckProtocol)
+	healthCheckMatcherPtr := t.buildTargetGroupHealthCheckMatcher(ctx, healthCheckProtocol)
 	healthCheckPort, err := t.buildTargetGroupHealthCheckPort(ctx, t.defaultHealthCheckPortForInstanceModeLocal)
 	if err != nil {
 		return nil, err
@@ -157,12 +152,9 @@ func (t *defaultModelBuildTask) buildTargetGroupHealthCheckConfigForInstanceMode
 	if err != nil {
 		return nil, err
 	}
-	var healthCheckTimeoutSeconds *int64
-	if t.featureGates.Enabled(config.NLBHealthCheckTimeout) {
-		healthCheckTimeoutSeconds, err = t.buildTargetGroupHealthCheckTimeoutSeconds(ctx, t.defaultHealthCheckTimeoutForInstanceModeLocal)
-		if err != nil {
-			return nil, err
-		}
+	healthCheckTimeoutSecondsPtr, err := t.buildTargetGroupHealthCheckTimeoutSeconds(ctx, t.defaultHealthCheckTimeoutForInstanceModeLocal)
+	if err != nil {
+		return nil, err
 	}
 	healthyThresholdCount, err := t.buildTargetGroupHealthCheckHealthyThresholdCount(ctx, t.defaultHealthCheckHealthyThresholdForInstanceModeLocal)
 	if err != nil {
@@ -176,8 +168,9 @@ func (t *defaultModelBuildTask) buildTargetGroupHealthCheckConfigForInstanceMode
 		Port:                    &healthCheckPort,
 		Protocol:                &healthCheckProtocol,
 		Path:                    healthCheckPathPtr,
+		Matcher:                 healthCheckMatcherPtr,
 		IntervalSeconds:         &intervalSeconds,
-		TimeoutSeconds:          healthCheckTimeoutSeconds,
+		TimeoutSeconds:          healthCheckTimeoutSecondsPtr,
 		HealthyThresholdCount:   &healthyThresholdCount,
 		UnhealthyThresholdCount: &unhealthyThresholdCount,
 	}, nil
@@ -311,10 +304,25 @@ func (t *defaultModelBuildTask) buildTargetGroupHealthCheckProtocol(_ context.Co
 	}
 }
 
-func (t *defaultModelBuildTask) buildTargetGroupHealthCheckPath(_ context.Context, defaultHealthCheckPath string) *string {
+func (t *defaultModelBuildTask) buildTargetGroupHealthCheckPath(_ context.Context, defaultHealthCheckPath string, hcProtocol elbv2model.Protocol) *string {
+	if hcProtocol == elbv2model.ProtocolTCP {
+		return nil
+	}
 	healthCheckPath := defaultHealthCheckPath
 	t.annotationParser.ParseStringAnnotation(annotations.SvcLBSuffixHCPath, &healthCheckPath, t.service.Annotations)
 	return &healthCheckPath
+}
+func (t *defaultModelBuildTask) buildTargetGroupHealthCheckMatcher(_ context.Context, hcProtocol elbv2model.Protocol) *elbv2model.HealthCheckMatcher {
+	if hcProtocol == elbv2model.ProtocolTCP || !t.featureGates.Enabled(config.NLBHealthCheckAdvancedConfig) {
+		return nil
+	}
+	var rawHealthCheckMatcherSuccessCodes string
+	if !t.annotationParser.ParseStringAnnotation(annotations.SvcLBSuffixHCSuccessCodes, &rawHealthCheckMatcherSuccessCodes, t.service.Annotations) {
+		return nil
+	}
+	return &elbv2model.HealthCheckMatcher{
+		HTTPCode: &rawHealthCheckMatcherSuccessCodes,
+	}
 }
 
 func (t *defaultModelBuildTask) buildTargetGroupHealthCheckIntervalSeconds(_ context.Context, defaultHealthCheckInterval int64) (int64, error) {
@@ -327,6 +335,9 @@ func (t *defaultModelBuildTask) buildTargetGroupHealthCheckIntervalSeconds(_ con
 
 func (t *defaultModelBuildTask) buildTargetGroupHealthCheckTimeoutSeconds(_ context.Context, defaultHealthCheckTimeout int64) (*int64, error) {
 	timeoutSeconds := defaultHealthCheckTimeout
+	if !t.featureGates.Enabled(config.NLBHealthCheckAdvancedConfig) {
+		return &timeoutSeconds, nil
+	}
 	if _, err := t.annotationParser.ParseInt64Annotation(annotations.SvcLBSuffixHCTimeout, &timeoutSeconds, t.service.Annotations); err != nil {
 		return nil, err
 	}

--- a/pkg/service/model_build_target_group.go
+++ b/pkg/service/model_build_target_group.go
@@ -316,10 +316,8 @@ func (t *defaultModelBuildTask) buildTargetGroupHealthCheckMatcher(_ context.Con
 	if hcProtocol == elbv2model.ProtocolTCP || !t.featureGates.Enabled(config.NLBHealthCheckAdvancedConfig) {
 		return nil
 	}
-	var rawHealthCheckMatcherSuccessCodes string
-	if !t.annotationParser.ParseStringAnnotation(annotations.SvcLBSuffixHCSuccessCodes, &rawHealthCheckMatcherSuccessCodes, t.service.Annotations) {
-		return nil
-	}
+	rawHealthCheckMatcherSuccessCodes := t.defaultHealthCheckMatcherHTTPCode
+	_ = t.annotationParser.ParseStringAnnotation(annotations.SvcLBSuffixHCSuccessCodes, &rawHealthCheckMatcherSuccessCodes, t.service.Annotations)
 	return &elbv2model.HealthCheckMatcher{
 		HTTPCode: &rawHealthCheckMatcherSuccessCodes,
 	}

--- a/pkg/service/model_build_target_group_test.go
+++ b/pkg/service/model_build_target_group_test.go
@@ -202,6 +202,7 @@ func Test_defaultModelBuilderTask_buildTargetHealthCheck(t *testing.T) {
 						"service.beta.kubernetes.io/aws-load-balancer-healthcheck-timeout":             "30",
 						"service.beta.kubernetes.io/aws-load-balancer-healthcheck-healthy-threshold":   "2",
 						"service.beta.kubernetes.io/aws-load-balancer-healthcheck-unhealthy-threshold": "2",
+						"service.beta.kubernetes.io/aws-load-balancer-healthcheck-success-codes":       "200-220,231,250-300,301,302",
 					},
 				},
 			},
@@ -214,11 +215,14 @@ func Test_defaultModelBuilderTask_buildTargetHealthCheck(t *testing.T) {
 				TimeoutSeconds:          aws.Int64(30),
 				HealthyThresholdCount:   aws.Int64(2),
 				UnhealthyThresholdCount: aws.Int64(2),
+				Matcher: &elbv2.HealthCheckMatcher{
+					HTTPCode: aws.String("200-220,231,250-300,301,302"),
+				},
 			},
 			targetType: elbv2.TargetTypeInstance,
 		},
 		{
-			testName: "default path",
+			testName: "default path and matcher code",
 			svc: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
@@ -235,6 +239,9 @@ func Test_defaultModelBuilderTask_buildTargetHealthCheck(t *testing.T) {
 				TimeoutSeconds:          aws.Int64(10),
 				HealthyThresholdCount:   aws.Int64(3),
 				UnhealthyThresholdCount: aws.Int64(3),
+				Matcher: &elbv2.HealthCheckMatcher{
+					HTTPCode: aws.String("200-399"),
+				},
 			},
 			targetType: elbv2.TargetTypeIP,
 		},
@@ -312,6 +319,9 @@ func Test_defaultModelBuilderTask_buildTargetHealthCheck(t *testing.T) {
 				TimeoutSeconds:          aws.Int64(6),
 				HealthyThresholdCount:   aws.Int64(2),
 				UnhealthyThresholdCount: aws.Int64(2),
+				Matcher: &elbv2.HealthCheckMatcher{
+					HTTPCode: aws.String("200-399"),
+				},
 			},
 			targetType: elbv2.TargetTypeInstance,
 		},
@@ -364,6 +374,7 @@ func Test_defaultModelBuilderTask_buildTargetHealthCheck(t *testing.T) {
 				defaultHealthCheckTimeout:            10,
 				defaultHealthCheckHealthyThreshold:   3,
 				defaultHealthCheckUnhealthyThreshold: 3,
+				defaultHealthCheckMatcherHTTPCode:    "200-399",
 
 				defaultHealthCheckProtocolForInstanceModeLocal:           elbv2.ProtocolHTTP,
 				defaultHealthCheckPortForInstanceModeLocal:               strconv.FormatInt(int64(int(tt.svc.Spec.HealthCheckNodePort)), 10),

--- a/pkg/service/model_builder.go
+++ b/pkg/service/model_builder.go
@@ -109,6 +109,7 @@ func (b *defaultModelBuilder) Build(ctx context.Context, service *corev1.Service
 		defaultHealthCheckTimeout:            10,
 		defaultHealthCheckHealthyThreshold:   3,
 		defaultHealthCheckUnhealthyThreshold: 3,
+		defaultHealthCheckMatcherHTTPCode:    "200-399",
 		defaultIPv4SourceRanges:              []string{"0.0.0.0/0"},
 		defaultIPv6SourceRanges:              []string{"::/0"},
 
@@ -166,6 +167,7 @@ type defaultModelBuildTask struct {
 	defaultHealthCheckTimeout            int64
 	defaultHealthCheckHealthyThreshold   int64
 	defaultHealthCheckUnhealthyThreshold int64
+	defaultHealthCheckMatcherHTTPCode    string
 	defaultDeletionProtectionEnabled     bool
 	defaultIPv4SourceRanges              []string
 	defaultIPv6SourceRanges              []string

--- a/pkg/service/model_builder_test.go
+++ b/pkg/service/model_builder_test.go
@@ -522,7 +522,10 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                 "intervalSeconds":10,
                 "timeoutSeconds":30,
                 "healthyThresholdCount":2,
-                "unhealthyThresholdCount":2
+                "unhealthyThresholdCount":2,
+                "matcher":{
+					"httpCode": "200-399"
+				}
              },
              "targetGroupAttributes":[
                 {
@@ -546,7 +549,10 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                 "intervalSeconds":10,
                 "timeoutSeconds":30,
                 "healthyThresholdCount":2,
-                "unhealthyThresholdCount":2
+                "unhealthyThresholdCount":2,
+                "matcher":{
+					"httpCode": "200-399"
+				}
              },
              "targetGroupAttributes":[
                 {
@@ -858,7 +864,10 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                 "intervalSeconds":10,
                 "timeoutSeconds":30,
                 "healthyThresholdCount":2,
-                "unhealthyThresholdCount":2
+                "unhealthyThresholdCount":2,
+                "matcher":{
+					"httpCode": "200-399"
+				}
              },
              "targetGroupAttributes":[
                 {
@@ -882,7 +891,10 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                 "intervalSeconds":10,
                 "timeoutSeconds":30,
                 "healthyThresholdCount":2,
-                "unhealthyThresholdCount":2
+                "unhealthyThresholdCount":2,
+                "matcher":{
+					"httpCode": "200-399"
+				}
              },
              "targetGroupAttributes":[
                 {
@@ -1460,7 +1472,10 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                 "intervalSeconds":10,
                 "timeoutSeconds":6,
                 "healthyThresholdCount":2,
-                "unhealthyThresholdCount":2
+                "unhealthyThresholdCount":2,
+                "matcher":{
+					"httpCode": "200-399"
+				}
              },
              "targetGroupAttributes":[
                 {
@@ -1484,7 +1499,10 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                 "intervalSeconds":10,
                 "timeoutSeconds":6,
                 "healthyThresholdCount":2,
-                "unhealthyThresholdCount":2
+                "unhealthyThresholdCount":2,
+                "matcher":{
+					"httpCode": "200-399"
+				}
              },
              "targetGroupAttributes":[
                 {


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->
Add the ability to reconfigure NLB target group health check settings without recreating the target group.

### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->
Due to limitations on the AWS NLB side, the AWS LB controller needed to delete and create a new NLB target group in case the health check settings were modified. With recent capability enhancements, the AWS NLB now allows reconfiguration of all of the target group health check attributes. This PR enables the controller to modify the NLB healthcheck configuration without having to delete the target groups.

We've introduced a feature flag `NLBHealthCheckAdvancedConfiguration` which is set to `true` by default. This feature flag can be used to revert to the legacy behavior if the NLB feature is not available in the given AZ.

Manual Tests:
- verified controller modifies the target group health check configuration without deleting existing target group
- for http/https health check, default http matcher is 200-399, and can be overridden via annotation
- controller re-uses existing target group with matching tags

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:
