### PR TITLE
fix typo for service client ip preservation & add available annotation

### DIFF
--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -411,7 +411,7 @@ Load balancer access can be controlled via following annotations:
 - <a name="lb-source-ranges">`service.beta.kubernetes.io/load-balancer-source-ranges`</a> specifies the CIDRs that are allowed to access the NLB.
 
     !!!tip
-        we recommend specifying CIDRs in the service `Spec.LoadBalancerSourceRanges` instead
+        we recommend specifying CIDRs in the service `Spec.loadBalancerSourceRanges` instead. preserve client IP is disabled by default for `IP` targets. if you want to enable client IP preservation, add `service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: preserve_client_ip.enabled=true`.
 
     !!!note "Default"
         - `0.0.0.0/0` will be used if the IPAddressType is "ipv4"
@@ -420,7 +420,7 @@ Load balancer access can be controlled via following annotations:
 
     !!!warning ""
         This annotation will be ignored in case preserve client IP is not enabled.
-        - preserve client IP is disabled by default for `IP` targets
+        - preserve client IP is disabled by default for `IP` targets.  
         - preserve client IP is enabled by default for `instance` targets
     
     !!!warning ""

--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -411,7 +411,7 @@ Load balancer access can be controlled via following annotations:
 - <a name="lb-source-ranges">`service.beta.kubernetes.io/load-balancer-source-ranges`</a> specifies the CIDRs that are allowed to access the NLB.
 
     !!!tip
-        we recommend specifying CIDRs in the service `Spec.loadBalancerSourceRanges` instead. preserve client IP is disabled by default for `IP` targets. if you want to enable client IP preservation, add `service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: preserve_client_ip.enabled=true`.
+        we recommend specifying CIDRs in the service `Spec.loadBalancerSourceRanges` instead. preserve client IP is disabled by default for `IP` targets. if you want to enable client IP preservation, add `service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: preserve_client_ip.enabled=true`
 
     !!!note "Default"
         - `0.0.0.0/0` will be used if the IPAddressType is "ipv4"
@@ -420,7 +420,7 @@ Load balancer access can be controlled via following annotations:
 
     !!!warning ""
         This annotation will be ignored in case preserve client IP is not enabled.
-        - preserve client IP is disabled by default for `IP` targets.  
+        - preserve client IP is disabled by default for `IP` targets
         - preserve client IP is enabled by default for `instance` targets
     
     !!!warning ""


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description

<!--
original Tip for Access control has a typo.
and if you use NLB ip mode, this Tip field is ignored by default. so in AWS document, they recommend to use following annotation.
```
service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: preserve_client_ip.enabled=true
```
so I add this for the Tip.

-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
