### PR TITLE
Merge rules per ingress by the same host, pathType and backend service

### DIFF
--- a/pkg/algorithm/integers.go
+++ b/pkg/algorithm/integers.go
@@ -1,0 +1,9 @@
+package algorithm
+
+// GetMin returns the smaller of x or y
+func GetMin(x, y int) int {
+	if x < y {
+		return x
+	}
+	return y
+}

--- a/pkg/ingress/model_build_listener_rules_test.go
+++ b/pkg/ingress/model_build_listener_rules_test.go
@@ -8,387 +8,7 @@ import (
 	"testing"
 )
 
-func Test_defaultModelBuildTask_getMergeRuleRefMaps(t *testing.T) {
-	type args struct {
-		rules []networking.IngressRule
-	}
-	tests := []struct {
-		name                 string
-		args                 args
-		wantMergePathsRefMap map[[4]string][]networking.HTTPIngressPath
-		wantPathToRuleMap    map[networking.HTTPIngressPath]int
-	}{
-		{
-			name: "2 rules with no host",
-			args: args{
-				rules: []networking.IngressRule{
-					{
-						Host: "",
-						IngressRuleValue: networking.IngressRuleValue{
-							HTTP: &networking.HTTPIngressRuleValue{
-								Paths: []networking.HTTPIngressPath{
-									{
-										Path:     "/pathA",
-										PathType: (*networking.PathType)(awssdk.String("Prefix")),
-										Backend: networking.IngressBackend{
-											Service: &networking.IngressServiceBackend{
-												Name: "svc-1",
-												Port: networking.ServiceBackendPort{
-													Number: 80,
-												},
-											},
-										},
-									},
-									{
-										Path:     "/pathB",
-										PathType: (*networking.PathType)(awssdk.String("Exact")),
-										Backend: networking.IngressBackend{
-											Service: &networking.IngressServiceBackend{
-												Name: "svc-2",
-												Port: networking.ServiceBackendPort{
-													Number: 80,
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-					{
-						Host: "",
-						IngressRuleValue: networking.IngressRuleValue{
-							HTTP: &networking.HTTPIngressRuleValue{
-								Paths: []networking.HTTPIngressPath{
-									{
-										Path:     "/pathC",
-										PathType: (*networking.PathType)(awssdk.String("Prefix")),
-										Backend: networking.IngressBackend{
-											Service: &networking.IngressServiceBackend{
-												Name: "svc-1",
-												Port: networking.ServiceBackendPort{
-													Number: 80,
-												},
-											},
-										},
-									},
-									{
-										Path:     "/pathD",
-										PathType: (*networking.PathType)(awssdk.String("Prefix")),
-										Backend: networking.IngressBackend{
-											Service: &networking.IngressServiceBackend{
-												Name: "svc-2",
-												Port: networking.ServiceBackendPort{
-													Number: 80,
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			wantMergePathsRefMap: map[[4]string][]networking.HTTPIngressPath{
-				{"", "Prefix", "svc-1", "80"}: {
-					{
-						Path:     "/pathA",
-						PathType: (*networking.PathType)(awssdk.String("Prefix")),
-						Backend: networking.IngressBackend{
-							Service: &networking.IngressServiceBackend{
-								Name: "svc-1",
-								Port: networking.ServiceBackendPort{
-									Number: 80,
-								},
-							},
-						},
-					},
-					{
-						Path:     "/pathC",
-						PathType: (*networking.PathType)(awssdk.String("Prefix")),
-						Backend: networking.IngressBackend{
-							Service: &networking.IngressServiceBackend{
-								Name: "svc-1",
-								Port: networking.ServiceBackendPort{
-									Number: 80,
-								},
-							},
-						},
-					},
-				},
-				{"", "Prefix", "svc-2", "80"}: {
-					{
-						Path:     "/pathD",
-						PathType: (*networking.PathType)(awssdk.String("Prefix")),
-						Backend: networking.IngressBackend{
-							Service: &networking.IngressServiceBackend{
-								Name: "svc-2",
-								Port: networking.ServiceBackendPort{
-									Number: 80,
-								},
-							},
-						},
-					},
-				},
-				{"", "Exact", "svc-2", "80"}: {
-					{
-						Path:     "/pathB",
-						PathType: (*networking.PathType)(awssdk.String("Exact")),
-						Backend: networking.IngressBackend{
-							Service: &networking.IngressServiceBackend{
-								Name: "svc-2",
-								Port: networking.ServiceBackendPort{
-									Number: 80,
-								},
-							},
-						},
-					},
-				},
-			},
-			wantPathToRuleMap: map[networking.HTTPIngressPath]int{
-				{
-					Path:     "/pathA",
-					PathType: (*networking.PathType)(awssdk.String("Prefix")),
-					Backend: networking.IngressBackend{
-						Service: &networking.IngressServiceBackend{
-							Name: "svc-1",
-							Port: networking.ServiceBackendPort{
-								Number: 80,
-							},
-						},
-					},
-				}: 0,
-				{
-					Path:     "/pathB",
-					PathType: (*networking.PathType)(awssdk.String("Exact")),
-					Backend: networking.IngressBackend{
-						Service: &networking.IngressServiceBackend{
-							Name: "svc-2",
-							Port: networking.ServiceBackendPort{
-								Number: 80,
-							},
-						},
-					},
-				}: 0,
-				{
-					Path:     "/pathC",
-					PathType: (*networking.PathType)(awssdk.String("Prefix")),
-					Backend: networking.IngressBackend{
-						Service: &networking.IngressServiceBackend{
-							Name: "svc-1",
-							Port: networking.ServiceBackendPort{
-								Number: 80,
-							},
-						},
-					},
-				}: 1,
-				{
-					Path:     "/pathD",
-					PathType: (*networking.PathType)(awssdk.String("Prefix")),
-					Backend: networking.IngressBackend{
-						Service: &networking.IngressServiceBackend{
-							Name: "svc-2",
-							Port: networking.ServiceBackendPort{
-								Number: 80,
-							},
-						},
-					},
-				}: 1,
-			},
-		},
-		{
-			name: "2 rules with different hosts",
-			args: args{
-				rules: []networking.IngressRule{
-					{
-						Host: "",
-						IngressRuleValue: networking.IngressRuleValue{
-							HTTP: &networking.HTTPIngressRuleValue{
-								Paths: []networking.HTTPIngressPath{
-									{
-										Path:     "/pathA",
-										PathType: (*networking.PathType)(awssdk.String("Prefix")),
-										Backend: networking.IngressBackend{
-											Service: &networking.IngressServiceBackend{
-												Name: "svc-1",
-												Port: networking.ServiceBackendPort{
-													Number: 80,
-												},
-											},
-										},
-									},
-									{
-										Path:     "/pathB",
-										PathType: (*networking.PathType)(awssdk.String("Exact")),
-										Backend: networking.IngressBackend{
-											Service: &networking.IngressServiceBackend{
-												Name: "svc-2",
-												Port: networking.ServiceBackendPort{
-													Number: 80,
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-					{
-						Host: "example.com",
-						IngressRuleValue: networking.IngressRuleValue{
-							HTTP: &networking.HTTPIngressRuleValue{
-								Paths: []networking.HTTPIngressPath{
-									{
-										Path:     "/pathC",
-										PathType: (*networking.PathType)(awssdk.String("Prefix")),
-										Backend: networking.IngressBackend{
-											Service: &networking.IngressServiceBackend{
-												Name: "svc-1",
-												Port: networking.ServiceBackendPort{
-													Number: 80,
-												},
-											},
-										},
-									},
-									{
-										Path:     "/pathD",
-										PathType: (*networking.PathType)(awssdk.String("Prefix")),
-										Backend: networking.IngressBackend{
-											Service: &networking.IngressServiceBackend{
-												Name: "svc-2",
-												Port: networking.ServiceBackendPort{
-													Number: 80,
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			wantMergePathsRefMap: map[[4]string][]networking.HTTPIngressPath{
-				{"", "Prefix", "svc-1", "80"}: {
-					{
-						Path:     "/pathA",
-						PathType: (*networking.PathType)(awssdk.String("Prefix")),
-						Backend: networking.IngressBackend{
-							Service: &networking.IngressServiceBackend{
-								Name: "svc-1",
-								Port: networking.ServiceBackendPort{
-									Number: 80,
-								},
-							},
-						},
-					},
-				},
-				{"", "Exact", "svc-2", "80"}: {
-					{
-						Path:     "/pathB",
-						PathType: (*networking.PathType)(awssdk.String("Exact")),
-						Backend: networking.IngressBackend{
-							Service: &networking.IngressServiceBackend{
-								Name: "svc-2",
-								Port: networking.ServiceBackendPort{
-									Number: 80,
-								},
-							},
-						},
-					},
-				},
-				{"example.com", "Prefix", "svc-1", "80"}: {
-					{
-						Path:     "/pathC",
-						PathType: (*networking.PathType)(awssdk.String("Prefix")),
-						Backend: networking.IngressBackend{
-							Service: &networking.IngressServiceBackend{
-								Name: "svc-1",
-								Port: networking.ServiceBackendPort{
-									Number: 80,
-								},
-							},
-						},
-					},
-				},
-				{"example.com", "Prefix", "svc-2", "80"}: {
-					{
-						Path:     "/pathD",
-						PathType: (*networking.PathType)(awssdk.String("Prefix")),
-						Backend: networking.IngressBackend{
-							Service: &networking.IngressServiceBackend{
-								Name: "svc-2",
-								Port: networking.ServiceBackendPort{
-									Number: 80,
-								},
-							},
-						},
-					},
-				},
-			},
-			wantPathToRuleMap: map[networking.HTTPIngressPath]int{
-				{
-					Path:     "/pathA",
-					PathType: (*networking.PathType)(awssdk.String("Prefix")),
-					Backend: networking.IngressBackend{
-						Service: &networking.IngressServiceBackend{
-							Name: "svc-1",
-							Port: networking.ServiceBackendPort{
-								Number: 80,
-							},
-						},
-					},
-				}: 0,
-				{
-					Path:     "/pathB",
-					PathType: (*networking.PathType)(awssdk.String("Exact")),
-					Backend: networking.IngressBackend{
-						Service: &networking.IngressServiceBackend{
-							Name: "svc-2",
-							Port: networking.ServiceBackendPort{
-								Number: 80,
-							},
-						},
-					},
-				}: 0,
-				{
-					Path:     "/pathC",
-					PathType: (*networking.PathType)(awssdk.String("Prefix")),
-					Backend: networking.IngressBackend{
-						Service: &networking.IngressServiceBackend{
-							Name: "svc-1",
-							Port: networking.ServiceBackendPort{
-								Number: 80,
-							},
-						},
-					},
-				}: 1,
-				{
-					Path:     "/pathD",
-					PathType: (*networking.PathType)(awssdk.String("Prefix")),
-					Backend: networking.IngressBackend{
-						Service: &networking.IngressServiceBackend{
-							Name: "svc-2",
-							Port: networking.ServiceBackendPort{
-								Number: 80,
-							},
-						},
-					},
-				}: 1,
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			task := &defaultModelBuildTask{}
-			got, _ := task.getMergeRuleRefMaps(tt.args.rules)
-			assert.Equal(t, got, tt.wantMergePathsRefMap, tt.wantPathToRuleMap)
-		})
-	}
-}
-
-func Test_defaultModelBuildTask_getRulesToMerge(t *testing.T) {
+func Test_defaultModelBuildTask_classifyRulesByHost(t *testing.T) {
 	type args struct {
 		rules []networking.IngressRule
 	}
@@ -732,7 +352,7 @@ func Test_defaultModelBuildTask_getRulesToMerge(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			task := &defaultModelBuildTask{}
-			gotRulesWithReplicateHosts, gotRulesWithUniquetHost, err := task.getRulesToMerge(tt.args.rules)
+			gotRulesWithReplicateHosts, gotRulesWithUniquetHost, err := task.classifyRulesByHost(tt.args.rules)
 			if tt.wantErr != nil {
 				assert.EqualError(t, err, tt.wantErr.Error())
 			} else {
@@ -744,18 +364,18 @@ func Test_defaultModelBuildTask_getRulesToMerge(t *testing.T) {
 	}
 }
 
-func Test_defaultModelBuildTask_buildMergedRules(t *testing.T) {
+func Test_defaultModelBuildTask_getMergeRuleRefMaps(t *testing.T) {
 	type args struct {
 		rules []networking.IngressRule
 	}
 	tests := []struct {
-		name            string
-		args            args
-		wantMergedRules []networking.IngressRule
-		wantErr         error
+		name                 string
+		args                 args
+		wantMergePathsRefMap map[[5]string][]networking.HTTPIngressPath
+		//wantPathToRuleMap    map[networking.HTTPIngressPath]int
 	}{
 		{
-			name: "2 rules with no host",
+			name: "2 rules with no host, different svc name and same port number",
 			args: args{
 				rules: []networking.IngressRule{
 					{
@@ -826,78 +446,115 @@ func Test_defaultModelBuildTask_buildMergedRules(t *testing.T) {
 					},
 				},
 			},
-			wantMergedRules: []networking.IngressRule{
-				{
-					Host: "",
-					IngressRuleValue: networking.IngressRuleValue{
-						HTTP: &networking.HTTPIngressRuleValue{
-							Paths: []networking.HTTPIngressPath{
-								{
-									Path:     "/pathA",
-									PathType: (*networking.PathType)(awssdk.String("Prefix")),
-									Backend: networking.IngressBackend{
-										Service: &networking.IngressServiceBackend{
-											Name: "svc-1",
-											Port: networking.ServiceBackendPort{
-												Number: 80,
-											},
-										},
-									},
+			wantMergePathsRefMap: map[[5]string][]networking.HTTPIngressPath{
+				{"", "Prefix", "svc-1", "", "80"}: {
+					{
+						Path:     "/pathA",
+						PathType: (*networking.PathType)(awssdk.String("Prefix")),
+						Backend: networking.IngressBackend{
+							Service: &networking.IngressServiceBackend{
+								Name: "svc-1",
+								Port: networking.ServiceBackendPort{
+									Number: 80,
 								},
-								{
-									Path:     "/pathC",
-									PathType: (*networking.PathType)(awssdk.String("Prefix")),
-									Backend: networking.IngressBackend{
-										Service: &networking.IngressServiceBackend{
-											Name: "svc-1",
-											Port: networking.ServiceBackendPort{
-												Number: 80,
-											},
-										},
-									},
-								},
-								{
-									Path:     "/pathB",
-									PathType: (*networking.PathType)(awssdk.String("Exact")),
-									Backend: networking.IngressBackend{
-										Service: &networking.IngressServiceBackend{
-											Name: "svc-2",
-											Port: networking.ServiceBackendPort{
-												Number: 80,
-											},
-										},
-									},
+							},
+						},
+					},
+					{
+						Path:     "/pathC",
+						PathType: (*networking.PathType)(awssdk.String("Prefix")),
+						Backend: networking.IngressBackend{
+							Service: &networking.IngressServiceBackend{
+								Name: "svc-1",
+								Port: networking.ServiceBackendPort{
+									Number: 80,
 								},
 							},
 						},
 					},
 				},
-				{
-					Host: "",
-					IngressRuleValue: networking.IngressRuleValue{
-						HTTP: &networking.HTTPIngressRuleValue{
-							Paths: []networking.HTTPIngressPath{
-								{
-									Path:     "/pathD",
-									PathType: (*networking.PathType)(awssdk.String("Prefix")),
-									Backend: networking.IngressBackend{
-										Service: &networking.IngressServiceBackend{
-											Name: "svc-2",
-											Port: networking.ServiceBackendPort{
-												Number: 80,
-											},
-										},
-									},
+				{"", "Prefix", "svc-2", "", "80"}: {
+					{
+						Path:     "/pathD",
+						PathType: (*networking.PathType)(awssdk.String("Prefix")),
+						Backend: networking.IngressBackend{
+							Service: &networking.IngressServiceBackend{
+								Name: "svc-2",
+								Port: networking.ServiceBackendPort{
+									Number: 80,
+								},
+							},
+						},
+					},
+				},
+				{"", "Exact", "svc-2", "", "80"}: {
+					{
+						Path:     "/pathB",
+						PathType: (*networking.PathType)(awssdk.String("Exact")),
+						Backend: networking.IngressBackend{
+							Service: &networking.IngressServiceBackend{
+								Name: "svc-2",
+								Port: networking.ServiceBackendPort{
+									Number: 80,
 								},
 							},
 						},
 					},
 				},
 			},
-			wantErr: nil,
+			//wantPathToRuleMap: map[networking.HTTPIngressPath]int{
+			//	{
+			//		Path:     "/pathA",
+			//		PathType: (*networking.PathType)(awssdk.String("Prefix")),
+			//		Backend: networking.IngressBackend{
+			//			Service: &networking.IngressServiceBackend{
+			//				Name: "svc-1",
+			//				Port: networking.ServiceBackendPort{
+			//					Number: 80,
+			//				},
+			//			},
+			//		},
+			//	}: 0,
+			//	{
+			//		Path:     "/pathB",
+			//		PathType: (*networking.PathType)(awssdk.String("Exact")),
+			//		Backend: networking.IngressBackend{
+			//			Service: &networking.IngressServiceBackend{
+			//				Name: "svc-2",
+			//				Port: networking.ServiceBackendPort{
+			//					Number: 80,
+			//				},
+			//			},
+			//		},
+			//	}: 0,
+			//	{
+			//		Path:     "/pathC",
+			//		PathType: (*networking.PathType)(awssdk.String("Prefix")),
+			//		Backend: networking.IngressBackend{
+			//			Service: &networking.IngressServiceBackend{
+			//				Name: "svc-1",
+			//				Port: networking.ServiceBackendPort{
+			//					Number: 80,
+			//				},
+			//			},
+			//		},
+			//	}: 1,
+			//	{
+			//		Path:     "/pathD",
+			//		PathType: (*networking.PathType)(awssdk.String("Prefix")),
+			//		Backend: networking.IngressBackend{
+			//			Service: &networking.IngressServiceBackend{
+			//				Name: "svc-2",
+			//				Port: networking.ServiceBackendPort{
+			//					Number: 80,
+			//				},
+			//			},
+			//		},
+			//	}: 1,
+			//},
 		},
 		{
-			name: "3 rules with 2 hosts",
+			name: "2 rules with different hosts",
 			args: args{
 				rules: []networking.IngressRule{
 					{
@@ -966,19 +623,164 @@ func Test_defaultModelBuildTask_buildMergedRules(t *testing.T) {
 							},
 						},
 					},
+				},
+			},
+			wantMergePathsRefMap: map[[5]string][]networking.HTTPIngressPath{
+				{"", "Prefix", "svc-1", "", "80"}: {
 					{
-						Host: "example.com",
+						Path:     "/pathA",
+						PathType: (*networking.PathType)(awssdk.String("Prefix")),
+						Backend: networking.IngressBackend{
+							Service: &networking.IngressServiceBackend{
+								Name: "svc-1",
+								Port: networking.ServiceBackendPort{
+									Number: 80,
+								},
+							},
+						},
+					},
+				},
+				{"", "Exact", "svc-2", "", "80"}: {
+					{
+						Path:     "/pathB",
+						PathType: (*networking.PathType)(awssdk.String("Exact")),
+						Backend: networking.IngressBackend{
+							Service: &networking.IngressServiceBackend{
+								Name: "svc-2",
+								Port: networking.ServiceBackendPort{
+									Number: 80,
+								},
+							},
+						},
+					},
+				},
+				{"example.com", "Prefix", "svc-1", "", "80"}: {
+					{
+						Path:     "/pathC",
+						PathType: (*networking.PathType)(awssdk.String("Prefix")),
+						Backend: networking.IngressBackend{
+							Service: &networking.IngressServiceBackend{
+								Name: "svc-1",
+								Port: networking.ServiceBackendPort{
+									Number: 80,
+								},
+							},
+						},
+					},
+				},
+				{"example.com", "Prefix", "svc-2", "", "80"}: {
+					{
+						Path:     "/pathD",
+						PathType: (*networking.PathType)(awssdk.String("Prefix")),
+						Backend: networking.IngressBackend{
+							Service: &networking.IngressServiceBackend{
+								Name: "svc-2",
+								Port: networking.ServiceBackendPort{
+									Number: 80,
+								},
+							},
+						},
+					},
+				},
+			},
+			//wantPathToRuleMap: map[networking.HTTPIngressPath]int{
+			//	{
+			//		Path:     "/pathA",
+			//		PathType: (*networking.PathType)(awssdk.String("Prefix")),
+			//		Backend: networking.IngressBackend{
+			//			Service: &networking.IngressServiceBackend{
+			//				Name: "svc-1",
+			//				Port: networking.ServiceBackendPort{
+			//					Number: 80,
+			//				},
+			//			},
+			//		},
+			//	}: 0,
+			//	{
+			//		Path:     "/pathB",
+			//		PathType: (*networking.PathType)(awssdk.String("Exact")),
+			//		Backend: networking.IngressBackend{
+			//			Service: &networking.IngressServiceBackend{
+			//				Name: "svc-2",
+			//				Port: networking.ServiceBackendPort{
+			//					Number: 80,
+			//				},
+			//			},
+			//		},
+			//	}: 0,
+			//	{
+			//		Path:     "/pathC",
+			//		PathType: (*networking.PathType)(awssdk.String("Prefix")),
+			//		Backend: networking.IngressBackend{
+			//			Service: &networking.IngressServiceBackend{
+			//				Name: "svc-1",
+			//				Port: networking.ServiceBackendPort{
+			//					Number: 80,
+			//				},
+			//			},
+			//		},
+			//	}: 1,
+			//	{
+			//		Path:     "/pathD",
+			//		PathType: (*networking.PathType)(awssdk.String("Prefix")),
+			//		Backend: networking.IngressBackend{
+			//			Service: &networking.IngressServiceBackend{
+			//				Name: "svc-2",
+			//				Port: networking.ServiceBackendPort{
+			//					Number: 80,
+			//				},
+			//			},
+			//		},
+			//	}: 1,
+			//},
+		},
+		{
+			name: "2 rules with different hosts, different svc name and different port name",
+			args: args{
+				rules: []networking.IngressRule{
+					{
+						Host: "example1.com",
 						IngressRuleValue: networking.IngressRuleValue{
 							HTTP: &networking.HTTPIngressRuleValue{
 								Paths: []networking.HTTPIngressPath{
 									{
-										Path:     "/pathE",
-										PathType: (*networking.PathType)(awssdk.String("Prefix")),
+										Path: "/pathA",
 										Backend: networking.IngressBackend{
 											Service: &networking.IngressServiceBackend{
 												Name: "svc-1",
 												Port: networking.ServiceBackendPort{
-													Number: 80,
+													Name: "http",
+												},
+											},
+										},
+									},
+									{
+										Path: "/pathB",
+										Backend: networking.IngressBackend{
+											Service: &networking.IngressServiceBackend{
+												Name: "svc-2",
+												Port: networking.ServiceBackendPort{
+													Name: "http",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						Host: "example2.com",
+						IngressRuleValue: networking.IngressRuleValue{
+							HTTP: &networking.HTTPIngressRuleValue{
+								Paths: []networking.HTTPIngressPath{
+									{
+										Path: "/pathC",
+										Backend: networking.IngressBackend{
+											Service: &networking.IngressServiceBackend{
+												Name: "svc-3",
+												Port: networking.ServiceBackendPort{
+													Name: "https",
 												},
 											},
 										},
@@ -989,552 +791,92 @@ func Test_defaultModelBuildTask_buildMergedRules(t *testing.T) {
 					},
 				},
 			},
-			wantMergedRules: []networking.IngressRule{
-				{
-					Host: "example.com",
-					IngressRuleValue: networking.IngressRuleValue{
-						HTTP: &networking.HTTPIngressRuleValue{
-							Paths: []networking.HTTPIngressPath{
-								{
-									Path:     "/pathC",
-									PathType: (*networking.PathType)(awssdk.String("Prefix")),
-									Backend: networking.IngressBackend{
-										Service: &networking.IngressServiceBackend{
-											Name: "svc-1",
-											Port: networking.ServiceBackendPort{
-												Number: 80,
-											},
-										},
-									},
-								},
-								{
-									Path:     "/pathE",
-									PathType: (*networking.PathType)(awssdk.String("Prefix")),
-									Backend: networking.IngressBackend{
-										Service: &networking.IngressServiceBackend{
-											Name: "svc-1",
-											Port: networking.ServiceBackendPort{
-												Number: 80,
-											},
-										},
-									},
-								},
-								{
-									Path:     "/pathD",
-									PathType: (*networking.PathType)(awssdk.String("Prefix")),
-									Backend: networking.IngressBackend{
-										Service: &networking.IngressServiceBackend{
-											Name: "svc-2",
-											Port: networking.ServiceBackendPort{
-												Number: 80,
-											},
-										},
-									},
+			wantMergePathsRefMap: map[[5]string][]networking.HTTPIngressPath{
+				{"example1.com", "", "svc-1", "http", "0"}: {
+					{
+						Path: "/pathA",
+						Backend: networking.IngressBackend{
+							Service: &networking.IngressServiceBackend{
+								Name: "svc-1",
+								Port: networking.ServiceBackendPort{
+									Name: "http",
 								},
 							},
 						},
 					},
 				},
-				{
-					Host: "",
-					IngressRuleValue: networking.IngressRuleValue{
-						HTTP: &networking.HTTPIngressRuleValue{
-							Paths: []networking.HTTPIngressPath{
-								{
-									Path:     "/pathA",
-									PathType: (*networking.PathType)(awssdk.String("Prefix")),
-									Backend: networking.IngressBackend{
-										Service: &networking.IngressServiceBackend{
-											Name: "svc-1",
-											Port: networking.ServiceBackendPort{
-												Number: 80,
-											},
-										},
-									},
+				{"example1.com", "", "svc-2", "http", "0"}: {
+					{
+						Path: "/pathB",
+						Backend: networking.IngressBackend{
+							Service: &networking.IngressServiceBackend{
+								Name: "svc-2",
+								Port: networking.ServiceBackendPort{
+									Name: "http",
 								},
-								{
-									Path:     "/pathB",
-									PathType: (*networking.PathType)(awssdk.String("Exact")),
-									Backend: networking.IngressBackend{
-										Service: &networking.IngressServiceBackend{
-											Name: "svc-2",
-											Port: networking.ServiceBackendPort{
-												Number: 80,
-											},
-										},
-									},
+							},
+						},
+					},
+				},
+				{"example2.com", "", "svc-3", "https", "0"}: {
+					{
+						Path: "/pathC",
+						Backend: networking.IngressBackend{
+							Service: &networking.IngressServiceBackend{
+								Name: "svc-3",
+								Port: networking.ServiceBackendPort{
+									Name: "https",
 								},
 							},
 						},
 					},
 				},
 			},
-			wantErr: nil,
+			//wantPathToRuleMap: map[networking.HTTPIngressPath]int{
+			//	{
+			//		Path: "/pathA",
+			//		Backend: networking.IngressBackend{
+			//			Service: &networking.IngressServiceBackend{
+			//				Name: "svc-1",
+			//				Port: networking.ServiceBackendPort{
+			//					Name: "http",
+			//				},
+			//			},
+			//		},
+			//	}: 0,
+			//	{
+			//		Path: "/pathB",
+			//		Backend: networking.IngressBackend{
+			//			Service: &networking.IngressServiceBackend{
+			//				Name: "svc-2",
+			//				Port: networking.ServiceBackendPort{
+			//					Name: "http",
+			//				},
+			//			},
+			//		},
+			//	}: 0,
+			//	{
+			//		Path: "/pathC",
+			//		Backend: networking.IngressBackend{
+			//			Service: &networking.IngressServiceBackend{
+			//				Name: "svc-3",
+			//				Port: networking.ServiceBackendPort{
+			//					Name: "https",
+			//				},
+			//			},
+			//		},
+			//	}: 1,
+			//},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			task := &defaultModelBuildTask{}
-			gotMergedRules, err := task.buildMergedRules(tt.args.rules)
-			if tt.wantErr != nil {
-				assert.EqualError(t, err, tt.wantErr.Error())
-			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, gotMergedRules, tt.wantMergedRules)
-			}
+			got := task.getMergeRuleRefMaps(tt.args.rules)
+			assert.Equal(t, got, tt.wantMergePathsRefMap)
 		})
 	}
 }
-
-//func Test_defaultModelBuildTask_buildMergedRules(t *testing.T) {
-//	type args struct {
-//		rules []networking.IngressRule
-//		mergePathsRefMap map[[4]string][]networking.HTTPIngressPath
-//		pathToRuleMap map[networking.HTTPIngressPath]int
-//	}
-//	tests := []struct {
-//		name string
-//		args args
-//		wantMergedRules []networking.IngressRule
-//	}{
-//		{
-//			name: "2 rules with no host",
-//			args: args{
-//				rules: []networking.IngressRule{
-//					{
-//						Host: "",
-//						IngressRuleValue: networking.IngressRuleValue{
-//							HTTP: &networking.HTTPIngressRuleValue{
-//								Paths: []networking.HTTPIngressPath{
-//									{
-//										Path: "/pathA",
-//										PathType: (*networking.PathType)(awssdk.String("Prefix")),
-//										Backend: networking.IngressBackend{
-//											Service: &networking.IngressServiceBackend{
-//												Name: "svc-1",
-//												Port: networking.ServiceBackendPort{
-//													Number: 80,
-//												},
-//											},
-//										},
-//									},
-//									{
-//										Path: "/pathB",
-//										PathType: (*networking.PathType)(awssdk.String("Exact")),
-//										Backend: networking.IngressBackend{
-//											Service: &networking.IngressServiceBackend{
-//												Name: "svc-2",
-//												Port: networking.ServiceBackendPort{
-//													Number: 80,
-//												},
-//											},
-//										},
-//									},
-//								},
-//							},
-//						},
-//					},
-//					{
-//						Host: "",
-//						IngressRuleValue: networking.IngressRuleValue{
-//							HTTP: &networking.HTTPIngressRuleValue{
-//								Paths: []networking.HTTPIngressPath{
-//									{
-//										Path: "/pathC",
-//										PathType: (*networking.PathType)(awssdk.String("Prefix")),
-//										Backend: networking.IngressBackend{
-//											Service: &networking.IngressServiceBackend{
-//												Name: "svc-1",
-//												Port: networking.ServiceBackendPort{
-//													Number: 80,
-//												},
-//											},
-//										},
-//									},
-//									{
-//										Path: "/pathD",
-//										PathType: (*networking.PathType)(awssdk.String("Prefix")),
-//										Backend: networking.IngressBackend{
-//											Service: &networking.IngressServiceBackend{
-//												Name: "svc-2",
-//												Port: networking.ServiceBackendPort{
-//													Number: 80,
-//												},
-//											},
-//										},
-//									},
-//								},
-//							},
-//						},
-//					},
-//				},
-//				mergePathsRefMap: map[[4]string][]networking.HTTPIngressPath{
-//					{"", "Prefix", "svc-1", "80"}: {
-//						{
-//							Path: "/pathA",
-//							PathType: (*networking.PathType)(awssdk.String("Prefix")),
-//							Backend: networking.IngressBackend{
-//								Service: &networking.IngressServiceBackend{
-//									Name: "svc-1",
-//									Port: networking.ServiceBackendPort{
-//										Number: 80,
-//									},
-//								},
-//							},
-//						},
-//						{
-//							Path: "/pathC",
-//							PathType: (*networking.PathType)(awssdk.String("Prefix")),
-//							Backend: networking.IngressBackend{
-//								Service: &networking.IngressServiceBackend{
-//									Name: "svc-1",
-//									Port: networking.ServiceBackendPort{
-//										Number: 80,
-//									},
-//								},
-//							},
-//						},
-//					},
-//					{"", "Prefix", "svc-2", "80"}: {
-//						{
-//							Path: "/pathD",
-//							PathType: (*networking.PathType)(awssdk.String("Prefix")),
-//							Backend: networking.IngressBackend{
-//								Service: &networking.IngressServiceBackend{
-//									Name: "svc-2",
-//									Port: networking.ServiceBackendPort{
-//										Number: 80,
-//									},
-//								},
-//							},
-//						},
-//					},
-//					{"", "Exact", "svc-2", "80"}: {
-//						{
-//							Path: "/pathB",
-//							PathType: (*networking.PathType)(awssdk.String("Exact")),
-//							Backend: networking.IngressBackend{
-//								Service: &networking.IngressServiceBackend{
-//									Name: "svc-2",
-//									Port: networking.ServiceBackendPort{
-//										Number: 80,
-//									},
-//								},
-//							},
-//						},
-//					},
-//				},
-//				pathToRuleMap: map[networking.HTTPIngressPath]int{
-//					{
-//						Path: "/pathA",
-//						PathType: (*networking.PathType)(awssdk.String("Prefix")),
-//						Backend: networking.IngressBackend{
-//							Service: &networking.IngressServiceBackend{
-//								Name: "svc-1",
-//								Port: networking.ServiceBackendPort{
-//									Number: 80,
-//								},
-//							},
-//						},
-//					}: 0,
-//					{
-//						Path: "/pathB",
-//						PathType: (*networking.PathType)(awssdk.String("Exact")),
-//						Backend: networking.IngressBackend{
-//							Service: &networking.IngressServiceBackend{
-//								Name: "svc-2",
-//								Port: networking.ServiceBackendPort{
-//									Number: 80,
-//								},
-//							},
-//						},
-//					}: 0,
-//					{
-//						Path: "/pathC",
-//						PathType: (*networking.PathType)(awssdk.String("Prefix")),
-//						Backend: networking.IngressBackend{
-//							Service: &networking.IngressServiceBackend{
-//								Name: "svc-1",
-//								Port: networking.ServiceBackendPort{
-//									Number: 80,
-//								},
-//							},
-//						},
-//					}: 1,
-//					{
-//						Path: "/pathD",
-//						PathType: (*networking.PathType)(awssdk.String("Prefix")),
-//						Backend: networking.IngressBackend{
-//							Service: &networking.IngressServiceBackend{
-//								Name: "svc-2",
-//								Port: networking.ServiceBackendPort{
-//									Number: 80,
-//								},
-//							},
-//						},
-//					}: 1,
-//				},
-//			},
-//			wantMergedRules: []networking.IngressRule{
-//				{
-//					Host: "",
-//					IngressRuleValue: networking.IngressRuleValue{
-//						HTTP: &networking.HTTPIngressRuleValue{
-//							Paths: []networking.HTTPIngressPath{
-//								{
-//									Path: "/pathA",
-//									PathType: (*networking.PathType)(awssdk.String("Prefix")),
-//									Backend: networking.IngressBackend{
-//										Service: &networking.IngressServiceBackend{
-//											Name: "svc-1",
-//											Port: networking.ServiceBackendPort{
-//												Number: 80,
-//											},
-//										},
-//									},
-//								},
-//								{
-//									Path: "/pathC",
-//									PathType: (*networking.PathType)(awssdk.String("Prefix")),
-//									Backend: networking.IngressBackend{
-//										Service: &networking.IngressServiceBackend{
-//											Name: "svc-1",
-//											Port: networking.ServiceBackendPort{
-//												Number: 80,
-//											},
-//										},
-//									},
-//								},
-//								{
-//									Path: "/pathB",
-//									PathType: (*networking.PathType)(awssdk.String("Exact")),
-//									Backend: networking.IngressBackend{
-//										Service: &networking.IngressServiceBackend{
-//											Name: "svc-2",
-//											Port: networking.ServiceBackendPort{
-//												Number: 80,
-//											},
-//										},
-//									},
-//								},
-//							},
-//						},
-//					},
-//				},
-//				{
-//					Host: "",
-//					IngressRuleValue: networking.IngressRuleValue{
-//						HTTP: &networking.HTTPIngressRuleValue{
-//							Paths: []networking.HTTPIngressPath{
-//								{
-//									Path: "/pathD",
-//									PathType: (*networking.PathType)(awssdk.String("Prefix")),
-//									Backend: networking.IngressBackend{
-//										Service: &networking.IngressServiceBackend{
-//											Name: "svc-2",
-//											Port: networking.ServiceBackendPort{
-//												Number: 80,
-//											},
-//										},
-//									},
-//								},
-//							},
-//						},
-//					},
-//				},
-//			},
-//		},
-//		{
-//			name: "2 rules with different hosts",
-//			args: args{
-//				rules: []networking.IngressRule{
-//					{
-//						Host: "",
-//						IngressRuleValue: networking.IngressRuleValue{
-//							HTTP: &networking.HTTPIngressRuleValue{
-//								Paths: []networking.HTTPIngressPath{
-//									{
-//										Path: "/pathA",
-//										PathType: (*networking.PathType)(awssdk.String("Prefix")),
-//										Backend: networking.IngressBackend{
-//											Service: &networking.IngressServiceBackend{
-//												Name: "svc-1",
-//												Port: networking.ServiceBackendPort{
-//													Number: 80,
-//												},
-//											},
-//										},
-//									},
-//									{
-//										Path: "/pathB",
-//										PathType: (*networking.PathType)(awssdk.String("Exact")),
-//										Backend: networking.IngressBackend{
-//											Service: &networking.IngressServiceBackend{
-//												Name: "svc-2",
-//												Port: networking.ServiceBackendPort{
-//													Number: 80,
-//												},
-//											},
-//										},
-//									},
-//								},
-//							},
-//						},
-//					},
-//					{
-//						Host: "example.com",
-//						IngressRuleValue: networking.IngressRuleValue{
-//							HTTP: &networking.HTTPIngressRuleValue{
-//								Paths: []networking.HTTPIngressPath{
-//									{
-//										Path: "/pathC",
-//										PathType: (*networking.PathType)(awssdk.String("Prefix")),
-//										Backend: networking.IngressBackend{
-//											Service: &networking.IngressServiceBackend{
-//												Name: "svc-1",
-//												Port: networking.ServiceBackendPort{
-//													Number: 80,
-//												},
-//											},
-//										},
-//									},
-//									{
-//										Path: "/pathD",
-//										PathType: (*networking.PathType)(awssdk.String("Prefix")),
-//										Backend: networking.IngressBackend{
-//											Service: &networking.IngressServiceBackend{
-//												Name: "svc-2",
-//												Port: networking.ServiceBackendPort{
-//													Number: 80,
-//												},
-//											},
-//										},
-//									},
-//								},
-//							},
-//						},
-//					},
-//				},
-//				mergePathsRefMap: map[[4]string][]networking.HTTPIngressPath{
-//					{"", "Prefix", "svc-1", "80"}: {
-//						{
-//							Path: "/pathA",
-//							PathType: (*networking.PathType)(awssdk.String("Prefix")),
-//							Backend: networking.IngressBackend{
-//								Service: &networking.IngressServiceBackend{
-//									Name: "svc-1",
-//									Port: networking.ServiceBackendPort{
-//										Number: 80,
-//									},
-//								},
-//							},
-//						},
-//					},
-//					{"", "Exact", "svc-2", "80"}: {
-//						{
-//							Path: "/pathB",
-//							PathType: (*networking.PathType)(awssdk.String("Exact")),
-//							Backend: networking.IngressBackend{
-//								Service: &networking.IngressServiceBackend{
-//									Name: "svc-2",
-//									Port: networking.ServiceBackendPort{
-//										Number: 80,
-//									},
-//								},
-//							},
-//						},
-//					},
-//					{"example.com", "Prefix", "svc-1", "80"}: {
-//						{
-//							Path: "/pathC",
-//							PathType: (*networking.PathType)(awssdk.String("Prefix")),
-//							Backend: networking.IngressBackend{
-//								Service: &networking.IngressServiceBackend{
-//									Name: "svc-1",
-//									Port: networking.ServiceBackendPort{
-//										Number: 80,
-//									},
-//								},
-//							},
-//						},
-//					},
-//					{"example.com", "Prefix", "svc-2", "80"}: {
-//						{
-//							Path: "/pathD",
-//							PathType: (*networking.PathType)(awssdk.String("Prefix")),
-//							Backend: networking.IngressBackend{
-//								Service: &networking.IngressServiceBackend{
-//									Name: "svc-2",
-//									Port: networking.ServiceBackendPort{
-//										Number: 80,
-//									},
-//								},
-//							},
-//						},
-//					},
-//				},
-//				pathToRuleMap: map[networking.HTTPIngressPath]int{
-//					{
-//						Path: "/pathA",
-//						PathType: (*networking.PathType)(awssdk.String("Prefix")),
-//						Backend: networking.IngressBackend{
-//							Service: &networking.IngressServiceBackend{
-//								Name: "svc-1",
-//								Port: networking.ServiceBackendPort{
-//									Number: 80,
-//								},
-//							},
-//						},
-//					}: 0,
-//					{
-//						Path: "/pathB",
-//						PathType: (*networking.PathType)(awssdk.String("Exact")),
-//						Backend: networking.IngressBackend{
-//							Service: &networking.IngressServiceBackend{
-//								Name: "svc-2",
-//								Port: networking.ServiceBackendPort{
-//									Number: 80,
-//								},
-//							},
-//						},
-//					}: 0,
-//					{
-//						Path: "/pathC",
-//						PathType: (*networking.PathType)(awssdk.String("Prefix")),
-//						Backend: networking.IngressBackend{
-//							Service: &networking.IngressServiceBackend{
-//								Name: "svc-1",
-//								Port: networking.ServiceBackendPort{
-//									Number: 80,
-//								},
-//							},
-//						},
-//					}: 1,
-//					{
-//						Path: "/pathD",
-//						PathType: (*networking.PathType)(awssdk.String("Prefix")),
-//						Backend: networking.IngressBackend{
-//							Service: &networking.IngressServiceBackend{
-//								Name: "svc-2",
-//								Port: networking.ServiceBackendPort{
-//									Number: 80,
-//								},
-//							},
-//						},
-//					}: 1,
-//				},
-//			},
-//			wantMergedRules
-//		},
-//	}
-//	for _, tt := range tests {
-//		t.Run(tt.name, func(t *testing.T) {
-//			task := &defaultModelBuildTask{}
-//			got, _ := task.buildMergedRules(tt.args.rules, tt.args.mergePathsRefMap, tt.args.pathToRuleMap)
-//			assert.Equal(t, got, tt.wantMergedRules)
-//		})
-//	}
-//}
 
 func Test_defaultModelBuildTask_sortIngressPath(t *testing.T) {
 	type args struct {

--- a/pkg/ingress/model_build_listener_rules_test.go
+++ b/pkg/ingress/model_build_listener_rules_test.go
@@ -358,7 +358,7 @@ func Test_defaultModelBuildTask_buildPathPatterns(t *testing.T) {
 	pathTypePrefix := networking.PathTypePrefix
 	pathTypeUnknown := networking.PathType("unknown")
 	type args struct {
-		path     string
+		paths    []string
 		pathType *networking.PathType
 	}
 	tests := []struct {
@@ -370,7 +370,7 @@ func Test_defaultModelBuildTask_buildPathPatterns(t *testing.T) {
 		{
 			name: "/* with empty pathType",
 			args: args{
-				path:     "/*",
+				paths:    []string{"/*"},
 				pathType: nil,
 			},
 			want: []string{"/*"},
@@ -378,7 +378,7 @@ func Test_defaultModelBuildTask_buildPathPatterns(t *testing.T) {
 		{
 			name: "/* with implementationSpecific pathType",
 			args: args{
-				path:     "/*",
+				paths:    []string{"/*"},
 				pathType: &pathTypeImplementationSpecific,
 			},
 			want: []string{"/*"},
@@ -386,7 +386,7 @@ func Test_defaultModelBuildTask_buildPathPatterns(t *testing.T) {
 		{
 			name: "/* with exact pathType",
 			args: args{
-				path:     "/*",
+				paths:    []string{"/*"},
 				pathType: &pathTypeExact,
 			},
 			wantErr: errors.New("exact path shouldn't contain wildcards: /*"),
@@ -394,7 +394,7 @@ func Test_defaultModelBuildTask_buildPathPatterns(t *testing.T) {
 		{
 			name: "/* with prefix pathType",
 			args: args{
-				path:     "/*",
+				paths:    []string{"/*"},
 				pathType: &pathTypePrefix,
 			},
 			wantErr: errors.New("prefix path shouldn't contain wildcards: /*"),
@@ -402,7 +402,7 @@ func Test_defaultModelBuildTask_buildPathPatterns(t *testing.T) {
 		{
 			name: "/abc/ with empty pathType",
 			args: args{
-				path:     "/abc/",
+				paths:    []string{"/abc/"},
 				pathType: nil,
 			},
 			want: []string{"/abc/"},
@@ -410,7 +410,7 @@ func Test_defaultModelBuildTask_buildPathPatterns(t *testing.T) {
 		{
 			name: "/abc/ with implementationSpecific pathType",
 			args: args{
-				path:     "/abc/",
+				paths:    []string{"/abc/"},
 				pathType: &pathTypeImplementationSpecific,
 			},
 			want: []string{"/abc/"},
@@ -418,7 +418,7 @@ func Test_defaultModelBuildTask_buildPathPatterns(t *testing.T) {
 		{
 			name: "/abc/ with exact pathType",
 			args: args{
-				path:     "/abc/",
+				paths:    []string{"/abc/"},
 				pathType: &pathTypeExact,
 			},
 			want: []string{"/abc/"},
@@ -426,7 +426,7 @@ func Test_defaultModelBuildTask_buildPathPatterns(t *testing.T) {
 		{
 			name: "/abc/ with prefix pathType",
 			args: args{
-				path:     "/abc/",
+				paths:    []string{"/abc/"},
 				pathType: &pathTypePrefix,
 			},
 			want: []string{"/abc", "/abc/*"},
@@ -434,7 +434,7 @@ func Test_defaultModelBuildTask_buildPathPatterns(t *testing.T) {
 		{
 			name: "/abc/ with unknown pathType",
 			args: args{
-				path:     "/abc/",
+				paths:    []string{"/abc/"},
 				pathType: &pathTypeUnknown,
 			},
 			wantErr: errors.New("unsupported pathType: unknown"),
@@ -443,7 +443,7 @@ func Test_defaultModelBuildTask_buildPathPatterns(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			task := &defaultModelBuildTask{}
-			got, err := task.buildPathPatterns(tt.args.path, tt.args.pathType)
+			got, err := task.buildPathPatterns(tt.args.paths, tt.args.pathType)
 			if tt.wantErr != nil {
 				assert.EqualError(t, err, tt.wantErr.Error())
 			} else {


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->
https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2203
https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2678

### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->
Merged the rules per ingress if:

- they are routing to the same services, and
- they have the same host, and
- they are of the same pathType

#### Tests
- Added unit tests
- Created Ingress with multiple rules, verified that paths were merged only when they have the same host, pathType and backend service. Also verified that when the count of the condition values exceed 5, the merged paths will flow over to a new rule in order to fulfill the current quota limit for rules.


### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
