### PR TITLE
Start migration to leases for leader election

### DIFF
--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -20,3 +20,19 @@ rules:
       - get
       - update
       - patch
+  - apiGroups:
+    - "coordination.k8s.io"
+    resources:
+    - leases
+    verbs:
+    - create
+  - apiGroups:
+    - "coordination.k8s.io"
+    resources:
+    - leases
+    resourceNames:
+      - aws-load-balancer-controller-leader
+    verbs:
+      - get
+      - update
+      - patch

--- a/helm/aws-load-balancer-controller/templates/rbac.yaml
+++ b/helm/aws-load-balancer-controller/templates/rbac.yaml
@@ -14,6 +14,22 @@ rules:
   resources: [configmaps]
   resourceNames: [aws-load-balancer-controller-leader]
   verbs: [get, patch, update]
+- apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - leases
+  resourceNames:
+  - aws-load-balancer-controller-leader
+  verbs:
+  - get
+  - update
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/pkg/config/runtime_config.go
+++ b/pkg/config/runtime_config.go
@@ -118,7 +118,7 @@ func BuildRuntimeOptions(rtCfg RuntimeConfig, scheme *runtime.Scheme) ctrl.Optio
 		MetricsBindAddress:         rtCfg.MetricsBindAddress,
 		HealthProbeBindAddress:     rtCfg.HealthProbeBindAddress,
 		LeaderElection:             rtCfg.EnableLeaderElection,
-		LeaderElectionResourceLock: resourcelock.ConfigMapsResourceLock,
+		LeaderElectionResourceLock: resourcelock.ConfigMapsLeasesResourceLock,
 		LeaderElectionID:           rtCfg.LeaderElectionID,
 		LeaderElectionNamespace:    rtCfg.LeaderElectionNamespace,
 		Namespace:                  rtCfg.WatchNamespace,


### PR DESCRIPTION
### Issue

N/A

### Description

Configures leader election to use both ConfigMaps and Leases.

Migration to leases is long overdue. The most recent version of controller-runtime appears to not support  using only ConfigMaps.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
