### PR TITLE
Add johngmyers as reviewer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,6 +4,7 @@ approvers:
 reviewers:
 - M00nF1sh
 - kishorj
+- johngmyers
 emeritus_approvers:
 - bigkraig
 - alejandrox1


### PR DESCRIPTION
Adds johngmyers as reviewer

Per the [requirements](https://github.com/kubernetes/community/blob/master/community-membership.md#requirements-1):

[x] member for at least 3 months
[x] Primary reviewer for at least 5 PRs to the codebase
#2950, #2942, #2425, #2963, #2988,
#2986
[x] Reviewed or merged at least 20 substantial PRs to the codebase
#2950, #2942, #2880, #2866, #2453,
#2435, #2433, #2425, #2442, #2500,
#2443, #2963, #2735, #2881, #2840,
#2987, #2988, #2992, #2993, #2955,
#2990,
[x] Knowledgeable about the codebase
[ ] Sponsored by a subproject approver
[ ] With no objections from other approvers
[x] Done through PR to update the OWNERS file
[x] May either self-nominate, be nominated by an approver in this subproject, or be nominated by a robot
