### PR TITLE
Verify generated files are up to date in merge check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ helm-lint:
 	${MAKEFILE_PATH}/test/helm/helm-lint.sh
 
 # Generate code
+.PHONY: generate
 generate: aws-sdk-model-override controller-gen mockgen
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 	MOCKGEN=$(MOCKGEN) ./scripts/gen_mocks.sh
@@ -161,8 +162,12 @@ lint:
 	echo "TODO"
 
 .PHONY: quick-ci
-quick-ci: verify-versions
+quick-ci: verify-versions verify-generate
 	echo "Done!"
+
+.PHONY: verify-generate
+verify-generate:
+	hack/verify-generate.sh
 
 .PHONY: verify-versions
 verify-versions:

--- a/hack/verify-generate.sh
+++ b/hack/verify-generate.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+make generate
+
+changed_files=$(git status --porcelain --untracked-files=no || true)
+if [ -n "${changed_files}" ]; then
+   echo "Detected that generated code is not up to date; run 'make generate'"
+   echo "changed files:"
+   printf "%s\n" "${changed_files}"
+   echo "git diff:"
+   git --no-pager diff
+   echo "To fix: run 'make generate'"
+   exit 1
+fi


### PR DESCRIPTION
### Issue

N/A

### Description

Adds to the CI checks a verification that files generated by `make generated` are up-to-date.

An example of a failure is in #3006.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
