### PR TITLE
Add SSLPolicy field to IngressClassParams

### DIFF
--- a/apis/elbv2/v1beta1/ingressclassparams_types.go
+++ b/apis/elbv2/v1beta1/ingressclassparams_types.go
@@ -99,6 +99,10 @@ type IngressClassParamsSpec struct {
 	// +optional
 	Scheme *LoadBalancerScheme `json:"scheme,omitempty"`
 
+	// SSLPolicy specifies the SSL Policy for all Ingresses that belong to IngressClass with this IngressClassParams.
+	// +optional
+	SSLPolicy string `json:"sslPolicy,omitEmpty"`
+
 	// Subnets defines the subnets for all Ingresses that belong to IngressClass with this IngressClassParams.
 	// +optional
 	Subnets *SubnetSelector `json:"subnets,omitempty"`

--- a/config/crd/bases/elbv2.k8s.aws_ingressclassparams.yaml
+++ b/config/crd/bases/elbv2.k8s.aws_ingressclassparams.yaml
@@ -140,6 +140,10 @@ spec:
                 - internal
                 - internet-facing
                 type: string
+              sslPolicy:
+                description: SSLPolicy specifies the SSL Policy for all Ingresses
+                  that belong to IngressClass with this IngressClassParams.
+                type: string
               subnets:
                 description: Subnets defines the subnets for all Ingresses that belong
                   to IngressClass with this IngressClassParams.

--- a/docs/guide/ingress/ingress_class.md
+++ b/docs/guide/ingress/ingress_class.md
@@ -138,7 +138,7 @@ Cluster administrators can use the `scheme` field to restrict the scheme for all
 #### spec.sslPolicy
 
 Cluster administrators can use the optional `sslPolicy` field to specify the SSL policy for the load balancers that belong to this IngressClass.
-If the field is specified, LBC will ignore the `alb.ingress.kubernetes.io/ssl-policy annotation` annotation.
+If the field is specified, LBC will ignore the `alb.ingress.kubernetes.io/ssl-policy` annotation.
 
 #### spec.subnets
 

--- a/docs/guide/ingress/ingress_class.md
+++ b/docs/guide/ingress/ingress_class.md
@@ -135,6 +135,11 @@ Cluster administrators can use the `scheme` field to restrict the scheme for all
 1. If `scheme` specified, all Ingresses with this IngressClass will have the specified scheme.
 2. If `scheme` un-specified, Ingresses with this IngressClass can continue to use `alb.ingress.kubernetes.io/scheme annotation` to specify scheme.
 
+#### spec.sslPolicy
+
+Cluster administrators can use the optional `sslPolicy` field to specify the SSL policy for the load balancers that belong to this IngressClass.
+If the field is specified, LBC will ignore the `alb.ingress.kubernetes.io/ssl-policy annotation` annotation.
+
 #### spec.subnets
 
 Cluster administrators can use the optional `subnets` field to specify the subnets for the load balancers that belong to this IngressClass.

--- a/helm/aws-load-balancer-controller/crds/crds.yaml
+++ b/helm/aws-load-balancer-controller/crds/crds.yaml
@@ -139,6 +139,10 @@ spec:
                 - internal
                 - internet-facing
                 type: string
+              sslPolicy:
+                description: SSLPolicy specifies the SSL Policy for all Ingresses
+                  that belong to IngressClass with this IngressClassParams.
+                type: string
               subnets:
                 description: Subnets defines the subnets for all Ingresses that belong
                   to IngressClass with this IngressClassParams.

--- a/pkg/ingress/model_builder.go
+++ b/pkg/ingress/model_builder.go
@@ -2,6 +2,8 @@ package ingress
 
 import (
 	"context"
+	"strconv"
+
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	elbv2sdk "github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/go-logr/logr"
@@ -21,7 +23,6 @@ import (
 	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
 	networkingpkg "sigs.k8s.io/aws-load-balancer-controller/pkg/networking"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strconv"
 )
 
 const (
@@ -227,7 +228,7 @@ func (t *defaultModelBuildTask) run(ctx context.Context) error {
 	listenPortConfigsByPort := make(map[int64][]listenPortConfigWithIngress)
 	for _, member := range t.ingGroup.Members {
 		ingKey := k8s.NamespacedName(member.Ing)
-		listenPortConfigByPortForIngress, err := t.computeIngressListenPortConfigByPort(ctx, member.Ing)
+		listenPortConfigByPortForIngress, err := t.computeIngressListenPortConfigByPort(ctx, &member)
 		if err != nil {
 			return errors.Wrapf(err, "ingress: %v", ingKey.String())
 		}

--- a/pkg/service/model_build_listener_test.go
+++ b/pkg/service/model_build_listener_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,7 +15,7 @@ func Test_defaultModelBuilderTask_buildListenerALPNPolicy(t *testing.T) {
 	tests := []struct {
 		name             string
 		svc              *corev1.Service
-		wantErr          error
+		wantErr          string
 		want             []string
 		listenerProtocol elbv2model.Protocol
 		targetProtocol   elbv2model.Protocol
@@ -66,7 +65,7 @@ func Test_defaultModelBuilderTask_buildListenerALPNPolicy(t *testing.T) {
 					},
 				},
 			},
-			wantErr:          errors.New("invalid ALPN policy unknown, policy must be one of [None, HTTP1Only, HTTP2Only, HTTP2Optional, HTTP2Preferred]"),
+			wantErr:          "invalid ALPN policy unknown, policy must be one of [None, HTTP1Only, HTTP2Only, HTTP2Optional, HTTP2Preferred]",
 			listenerProtocol: elbv2model.ProtocolTLS,
 			targetProtocol:   elbv2model.ProtocolTLS,
 		},
@@ -80,9 +79,10 @@ func Test_defaultModelBuilderTask_buildListenerALPNPolicy(t *testing.T) {
 				service:          tt.svc,
 			}
 			got, err := builder.buildListenerALPNPolicy(context.Background(), tt.listenerProtocol, tt.targetProtocol)
-			if tt.wantErr != nil {
-				assert.EqualError(t, err, tt.wantErr.Error())
+			if tt.wantErr != "" {
+				assert.EqualError(t, err, tt.wantErr)
 			} else {
+				assert.NoError(t, err)
 				assert.Equal(t, tt.want, got)
 			}
 		})


### PR DESCRIPTION
### Issue

#2920 

### Description

Adds a `sslPolicy` field to `IngressClassParams`, permitting an `IngressClass` to override the SSL policy for all `Ingresses` in the class.

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:
