### PR TITLE
Use apimachinery conventions for ingress validation errors

### DIFF
--- a/pkg/annotations/parser.go
+++ b/pkg/annotations/parser.go
@@ -3,9 +3,10 @@ package annotations
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/pkg/errors"
 	"strconv"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 type ParseOptions struct {
@@ -49,8 +50,8 @@ type Parser interface {
 	ParseStringSliceAnnotation(annotation string, value *[]string, annotations map[string]string, opts ...ParseOption) bool
 
 	// ParseJSONAnnotation parses json value into the given interface
-	// returns true if the annotation exists and parser error if any
-	ParseJSONAnnotation(annotation string, value interface{}, annotations map[string]string, opts ...ParseOption) (bool, error)
+	// returns true and the matched annotation key if the annotation exists and parser error if any
+	ParseJSONAnnotation(annotation string, value interface{}, annotations map[string]string, opts ...ParseOption) (bool, string, error)
 
 	// ParseStringMapAnnotation parses comma separated key=value pairs into a map
 	// returns true if the annotation exists
@@ -115,16 +116,16 @@ func (p *suffixAnnotationParser) ParseStringSliceAnnotation(annotation string, v
 	return true
 }
 
-func (p *suffixAnnotationParser) ParseJSONAnnotation(annotation string, value interface{}, annotations map[string]string, opts ...ParseOption) (bool, error) {
+func (p *suffixAnnotationParser) ParseJSONAnnotation(annotation string, value interface{}, annotations map[string]string, opts ...ParseOption) (bool, string, error) {
 	raw := ""
 	exists, matchedKey := p.parseStringAnnotation(annotation, &raw, annotations, opts...)
 	if !exists {
-		return false, nil
+		return false, "", nil
 	}
 	if err := json.Unmarshal([]byte(raw), value); err != nil {
-		return true, errors.Wrapf(err, "failed to parse json annotation, %v: %v", matchedKey, raw)
+		return true, matchedKey, errors.Wrapf(err, "failed to parse json annotation, %v: %v", matchedKey, raw)
 	}
-	return true, nil
+	return true, matchedKey, nil
 }
 
 func (p *suffixAnnotationParser) ParseStringMapAnnotation(annotation string, value *map[string]string, annotations map[string]string, opts ...ParseOption) (bool, error) {

--- a/pkg/annotations/parser_test.go
+++ b/pkg/annotations/parser_test.go
@@ -2,8 +2,9 @@ package annotations
 
 import (
 	"errors"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_annotationParser_ParseStringAnnotation(t *testing.T) {
@@ -379,7 +380,7 @@ func Test_serviceAnnotationParser_ParseJSONAnnotation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			parser := NewSuffixAnnotationParser(tt.prefix)
 			value := objStruct{}
-			exists, err := parser.ParseJSONAnnotation(tt.suffix, &value, tt.annotations, tt.opts...)
+			exists, _, err := parser.ParseJSONAnnotation(tt.suffix, &value, tt.annotations, tt.opts...)
 			if tt.wantError {
 				assert.True(t, err != nil)
 			} else {
@@ -434,7 +435,7 @@ func Test_serviceAnnotationParser_ParseBoolAnnotation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			parser := NewSuffixAnnotationParser(tt.prefix)
 			value := false
-			exists, err := parser.ParseJSONAnnotation(tt.suffix, &value, tt.annotations, tt.opts...)
+			exists, _, err := parser.ParseJSONAnnotation(tt.suffix, &value, tt.annotations, tt.opts...)
 			if tt.wantError {
 				assert.True(t, err != nil)
 			} else {

--- a/pkg/ingress/auth_config_builder.go
+++ b/pkg/ingress/auth_config_builder.go
@@ -2,6 +2,7 @@ package ingress
 
 import (
 	"context"
+
 	"github.com/pkg/errors"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
 )
@@ -95,7 +96,7 @@ func (b *defaultAuthConfigBuilder) buildAuthType(_ context.Context, svcAndIngAnn
 
 func (b *defaultAuthConfigBuilder) buildAuthIDPConfigCognito(_ context.Context, svcAndIngAnnotations map[string]string) (*AuthIDPConfigCognito, error) {
 	authIDP := AuthIDPConfigCognito{}
-	exists, err := b.annotationParser.ParseJSONAnnotation(annotations.IngressSuffixAuthIDPCognito, &authIDP, svcAndIngAnnotations)
+	exists, _, err := b.annotationParser.ParseJSONAnnotation(annotations.IngressSuffixAuthIDPCognito, &authIDP, svcAndIngAnnotations)
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +108,7 @@ func (b *defaultAuthConfigBuilder) buildAuthIDPConfigCognito(_ context.Context, 
 
 func (b *defaultAuthConfigBuilder) buildAuthIDPConfigOIDC(_ context.Context, svcAndIngAnnotations map[string]string) (*AuthIDPConfigOIDC, error) {
 	authIDP := AuthIDPConfigOIDC{}
-	exists, err := b.annotationParser.ParseJSONAnnotation(annotations.IngressSuffixAuthIDPOIDC, &authIDP, svcAndIngAnnotations)
+	exists, _, err := b.annotationParser.ParseJSONAnnotation(annotations.IngressSuffixAuthIDPOIDC, &authIDP, svcAndIngAnnotations)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ingress/class_loader.go
+++ b/pkg/ingress/class_loader.go
@@ -25,8 +25,11 @@ const (
 	defaultClassAnnotation = "ingressclass.kubernetes.io/is-default-class"
 )
 
-// ErrInvalidIngressClass is an sentinel error that represents the IngressClass configuration for Ingress is invalid.
+// ErrInvalidIngressClass is a sentinel error that represents the IngressClass configuration for Ingress is invalid.
 var ErrInvalidIngressClass = errors.New("invalid ingress class")
+
+// ErrIngressClassNotFound is a sentinel error that indicates the IngressClass for an Ingress is not found.
+var ErrIngressClassNotFound = errors.New("ingress class not found")
 
 // ClassLoader loads IngressClass configurations for Ingress.
 type ClassLoader interface {
@@ -89,7 +92,7 @@ func (l *defaultClassLoader) Load(ctx context.Context, ing *networking.Ingress) 
 	ingClass := &networking.IngressClass{}
 	if err := l.client.Get(ctx, ingClassKey, ingClass); err != nil {
 		if apierrors.IsNotFound(err) {
-			return ClassConfiguration{}, fmt.Errorf("%w: %v", ErrInvalidIngressClass, err.Error())
+			return ClassConfiguration{}, fmt.Errorf("%w: %v", ErrIngressClassNotFound, err.Error())
 		}
 		return ClassConfiguration{}, err
 	}

--- a/pkg/ingress/class_loader_test.go
+++ b/pkg/ingress/class_loader_test.go
@@ -243,7 +243,7 @@ func Test_defaultClassLoader_Load(t *testing.T) {
 					},
 				},
 			},
-			wantErr: errors.New("invalid ingress class: ingressclasses.networking.k8s.io \"awesome-class\" not found"),
+			wantErr: errors.New("ingress class not found: ingressclasses.networking.k8s.io \"awesome-class\" not found"),
 		},
 		{
 			name: "when IngressClass found and belong to other controller",

--- a/pkg/ingress/enhanced_backend_builder.go
+++ b/pkg/ingress/enhanced_backend_builder.go
@@ -160,7 +160,7 @@ func (b *defaultEnhancedBackendBuilder) Build(ctx context.Context, ing *networki
 func (b *defaultEnhancedBackendBuilder) buildConditions(_ context.Context, ingAnnotation map[string]string, svcName string) ([]RuleCondition, error) {
 	var conditions []RuleCondition
 	annotationKey := fmt.Sprintf("conditions.%v", svcName)
-	_, err := b.annotationParser.ParseJSONAnnotation(annotationKey, &conditions, ingAnnotation)
+	_, _, err := b.annotationParser.ParseJSONAnnotation(annotationKey, &conditions, ingAnnotation)
 	if err != nil {
 		return nil, err
 	}
@@ -176,7 +176,7 @@ func (b *defaultEnhancedBackendBuilder) buildConditions(_ context.Context, ingAn
 func (b *defaultEnhancedBackendBuilder) buildActionViaAnnotation(ctx context.Context, ingAnnotation map[string]string, svcName string) (Action, error) {
 	action := Action{}
 	annotationKey := fmt.Sprintf("actions.%v", svcName)
-	exists, err := b.annotationParser.ParseJSONAnnotation(annotationKey, &action, ingAnnotation)
+	exists, _, err := b.annotationParser.ParseJSONAnnotation(annotationKey, &action, ingAnnotation)
 	if err != nil {
 		return Action{}, err
 	}

--- a/pkg/ingress/group_loader.go
+++ b/pkg/ingress/group_loader.go
@@ -145,7 +145,7 @@ func (m *defaultGroupLoader) checkGroupMembershipType(ctx context.Context, group
 		// tolerate ErrInvalidIngressClass for Ingresses that hasn't belongs to the group yet.
 		// for Ingresses that was belongs to the group, we error out to avoid remove the Ingress from IngressGroup since the IngressClass might be accidentally modified.
 		// see https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2731
-		if errors.Is(err, ErrInvalidIngressClass) {
+		if errors.Is(err, ErrInvalidIngressClass) || errors.Is(err, ErrIngressClassNotFound) {
 			if hasGroupFinalizer {
 				return groupMembershipTypeNone, ClassifiedIngress{}, errors.Wrapf(err, "Ingress has invalid IngressClass configuration")
 			}

--- a/pkg/ingress/group_loader_test.go
+++ b/pkg/ingress/group_loader_test.go
@@ -1704,7 +1704,7 @@ func Test_defaultGroupLoader_loadGroupIDIfAnyHelper(t *testing.T) {
 			},
 			wantClassifiedIng: ClassifiedIngress{},
 			wantGroupID:       nil,
-			wantErr:           errors.New("invalid ingress class: ingressclasses.networking.k8s.io \"ing-class\" not found"),
+			wantErr:           errors.New("ingress class not found: ingressclasses.networking.k8s.io \"ing-class\" not found"),
 		},
 		{
 			name: "ingress isn't matched by controller's class",
@@ -2051,7 +2051,7 @@ func Test_defaultGroupLoader_classifyIngress(t *testing.T) {
 				},
 				IngClassConfig: ClassConfiguration{},
 			},
-			wantErr: errors.New("invalid ingress class: ingressclasses.networking.k8s.io \"ing-class\" not found"),
+			wantErr: errors.New("ingress class not found: ingressclasses.networking.k8s.io \"ing-class\" not found"),
 		},
 		{
 			name: "no class specified - manageIngressesWithoutIngressClass is set",


### PR DESCRIPTION
### Issue

N/A

### Description

Use the apimachinery error types for validation failures. These allow returning multiple failures at once and integrate better with tooling such as `kubectl edit`.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:
