### PR TITLE
Remove constrains of multiple TLS on certificate auto-discovery

### DIFF
--- a/pkg/ingress/cert_discovery.go
+++ b/pkg/ingress/cert_discovery.go
@@ -80,9 +80,6 @@ func (d *acmCertDiscovery) Discover(ctx context.Context, tlsHosts []string) ([]s
 			}
 		}
 
-		if len(certARNsForHost) > 1 {
-			return nil, errors.Errorf("multiple certificates found for host: %s, certARNs: %v", host, certARNsForHost)
-		}
 		if len(certARNsForHost) == 0 {
 			return nil, errors.Errorf("no certificate found for host: %s", host)
 		}


### PR DESCRIPTION
Co-authored-by: LechG <lech.gorlewicz@gmail.com>

### Issue
Fixes: #1598 

<!-- Please link the GitHub issues related to this PR, if available -->

### Description
This PR removes the constraint of single TLS certificate per host during auto-discovery. The controller will now unconditionally auto-discover all matching TLS certificates for the given host.  Auto-discovery can still be disabled by specifying the certificates manually via annotation.

The controller is backwards compatible since existing ingresses/groups that are treated valid have only one TLS certificate.

Manual test has been done by creating multiple certificates on the ACM for the same host: mijerryapp.fortest.com, create an ingress for this host, verify ALB gets created and all of the certs get added to the listener. The old controller did not work with the multiple certificates in place.

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
