### PR TITLE
Fix conciseLogger's incorrect call to variadic func

### DIFF
--- a/pkg/runtime/concise_logger.go
+++ b/pkg/runtime/concise_logger.go
@@ -17,7 +17,7 @@ type conciseLogger struct {
 }
 
 func (r *conciseLogger) WithValues(keysAndValues ...interface{}) logr.LogSink {
-	return &conciseLogger{r.LogSink.WithValues(keysAndValues)}
+	return &conciseLogger{r.LogSink.WithValues(keysAndValues...)}
 }
 
 func (r *conciseLogger) WithName(name string) logr.LogSink {


### PR DESCRIPTION
### Issue

Fixes #3063 

### Description

The adaptation of `conciseLogger` to the new go-logr API that was done in #2998 incorrectly modified the parameters of a call to a variadic receiver. This fixes that bug.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
