### PR TITLE
Added ssl-ports validation in case unused ports are introduced in the aws-load-balancer-ssl-ports annotation

### DIFF
--- a/pkg/service/model_build_listener_test.go
+++ b/pkg/service/model_build_listener_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
 	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
 )
@@ -83,6 +86,97 @@ func Test_defaultModelBuilderTask_buildListenerALPNPolicy(t *testing.T) {
 				assert.EqualError(t, err, tt.wantErr)
 			} else {
 				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func Test_defaultModelBuilderTask_buildListenerConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		svc     *corev1.Service
+		wantErr error
+		want    *listenerConfig
+	}{
+		{
+			name: "Service with unused ports in the ssl-ports annotation, Unused ports provided",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/aws-load-balancer-ssl-ports": "80, 85, 90, arbitrary-name",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeLoadBalancer,
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "http",
+							Port:       80,
+							TargetPort: intstr.FromInt(80),
+							Protocol:   corev1.ProtocolTCP,
+							NodePort:   31223,
+						},
+						{
+							Name:       "alt2",
+							Port:       83,
+							TargetPort: intstr.FromInt(8883),
+							Protocol:   corev1.ProtocolTCP,
+							NodePort:   32323,
+						},
+					},
+				},
+			},
+			wantErr: errors.New("Unused port in ssl-ports annotation [85 90 arbitrary-name]"),
+		},
+		{
+			name: "Service with unused ports in the ssl-ports annotation, No unused ports",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/aws-load-balancer-ssl-ports": "83",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeLoadBalancer,
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "http",
+							Port:       80,
+							TargetPort: intstr.FromInt(80),
+							Protocol:   corev1.ProtocolTCP,
+							NodePort:   31223,
+						},
+						{
+							Name:       "alt2",
+							Port:       83,
+							TargetPort: intstr.FromInt(8883),
+							Protocol:   corev1.ProtocolTCP,
+							NodePort:   32323,
+						},
+					},
+				},
+			},
+			want: &listenerConfig{
+				certificates:    ([]elbv2model.Certificate)(nil),
+				tlsPortsSet:     sets.NewString("83"),
+				sslPolicy:       new(string),
+				backendProtocol: "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := annotations.NewSuffixAnnotationParser("service.beta.kubernetes.io")
+			builder := &defaultModelBuildTask{
+				annotationParser: parser,
+				service:          tt.svc,
+			}
+			got, err := builder.buildListenerConfig(context.Background())
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
 				assert.Equal(t, tt.want, got)
 			}
 		})

--- a/test/e2e/service/nlb_ip_target_test.go
+++ b/test/e2e/service/nlb_ip_target_test.go
@@ -217,6 +217,18 @@ var _ = Describe("k8s service reconciled by the aws load balancer", func() {
 							TargetPort: intstr.FromInt(80),
 							Protocol:   corev1.ProtocolTCP,
 						},
+						{
+							Port:       443,
+							Name:       "https",
+							TargetPort: intstr.FromInt(443),
+							Protocol:   corev1.ProtocolTCP,
+						},
+						{
+							Port:       333,
+							Name:       "arbitrary-port",
+							TargetPort: intstr.FromInt(333),
+							Protocol:   corev1.ProtocolTCP,
+						},
 					},
 				},
 			}
@@ -245,10 +257,14 @@ var _ = Describe("k8s service reconciled by the aws load balancer", func() {
 					Scheme:     "internet-facing",
 					TargetType: "ip",
 					Listeners: map[string]string{
-						"80": "TLS",
+						"80":  "TLS",
+						"443": "TLS",
+						"333": "TLS",
 					},
 					TargetGroups: map[string]string{
-						"80": "TCP",
+						"80":  "TCP",
+						"443": "TCP",
+						"333": "TCP",
 					},
 					NumTargets: int(numReplicas),
 				})
@@ -272,10 +288,14 @@ var _ = Describe("k8s service reconciled by the aws load balancer", func() {
 					Scheme:     "internet-facing",
 					TargetType: "ip",
 					Listeners: map[string]string{
-						"80": "TCP",
+						"80":  "TCP",
+						"443": "TLS",
+						"333": "TLS",
 					},
 					TargetGroups: map[string]string{
-						"80": "TCP",
+						"80":  "TCP",
+						"443": "TCP",
+						"333": "TCP",
 					},
 					NumTargets: int(numReplicas),
 				})


### PR DESCRIPTION
### Issue

[Issue Link](https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2931)

fixes #2931

### Description

* Added tests infrastructure for the buildListenerConfig function
* Tested two cases -
    *  A case where all ports provided in the aws-load-balancer-ssl-ports annotation exists in the spec.Ports section
    * A case where part of the ports provided in the aws-load-balancer-ssl-ports annotation do not exist in spec.Ports section
* Added a validation function, which takes the array of ports provided in the annotation, and array of ports which is provided in the service's spec, and returns the list of unused ports, and an error if there are unused ports.
* Called the validation function from the buildTLSPortsSet function, and threw the error back in the hierarchy

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:
