### PR TITLE
update to discovery.k8s.io/v1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ all: controller
 
 # Run tests
 test: generate fmt vet manifests helm-lint
-	go test -race ./pkg/... ./webhooks/... -coverprofile cover.out
+	ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=go1.20 go test -race ./pkg/... ./webhooks/... -coverprofile cover.out
 
 # Build controller binary
 controller: generate fmt vet

--- a/controllers/elbv2/eventhandlers/endpointslices.go
+++ b/controllers/elbv2/eventhandlers/endpointslices.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
-	discv1 "k8s.io/api/discovery/v1beta1"
+	discv1 "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"

--- a/controllers/elbv2/eventhandlers/endpointslices_test.go
+++ b/controllers/elbv2/eventhandlers/endpointslices_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
-	discv1 "k8s.io/api/discovery/v1beta1"
+	discv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"

--- a/controllers/elbv2/targetgroupbinding_controller.go
+++ b/controllers/elbv2/targetgroupbinding_controller.go
@@ -24,7 +24,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	discv1 "k8s.io/api/discovery/v1beta1"
+	discv1 "k8s.io/api/discovery/v1"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/aws-load-balancer-controller/controllers/elbv2/eventhandlers"

--- a/pkg/backend/endpoint_resolver.go
+++ b/pkg/backend/endpoint_resolver.go
@@ -8,7 +8,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	discovery "k8s.io/api/discovery/v1beta1"
+	discovery "k8s.io/api/discovery/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"

--- a/pkg/backend/endpoint_resolver_test.go
+++ b/pkg/backend/endpoint_resolver_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
-	discovery "k8s.io/api/discovery/v1beta1"
+	discovery "k8s.io/api/discovery/v1"
 )
 
 func Test_defaultEndpointResolver_ResolvePodEndpoints(t *testing.T) {

--- a/pkg/backend/endpoint_types.go
+++ b/pkg/backend/endpoint_types.go
@@ -2,7 +2,7 @@ package backend
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	discv1 "k8s.io/api/discovery/v1beta1"
+	discv1 "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 )


### PR DESCRIPTION
### Issue
Fixes: https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/3071
<!-- Please link the GitHub issues related to this PR, if available -->

### Description
This is the cherry pick of the fix to v2.4 branch.

Controller uses discovery.k8s.io/v1beta1, which is not supported starting k8s v1.25 release. This PR updates the controller to use discovery.k8s.io/v1. As a result, the controller will no longer support k8s 1.20 or earlier release if EndpointSlices feature is enabled via the controller flag.

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
