### PR TITLE
enable EndpointsFailOpen by default

### DIFF
--- a/docs/deploy/configurations.md
+++ b/docs/deploy/configurations.md
@@ -155,7 +155,7 @@ They are a set of kye=value pairs that describe AWS load balance controller feat
 | ListenerRulesTagging                  | string                          | true           | Enable or disable tagging AWS load balancer listeners and rules |
 | WeightedTargetGroups                  | string                          | true           | Enable or disable weighted target groups |
 | ServiceTypeLoadBalancerOnly           | string                          | false          | If enabled, controller will be limited to reconciling service of type `LoadBalancer`|
-| EndpointsFailOpen                     | string                          | false          | Enable or disable allowing endpoints with `ready:unknown` state in the target groups. |
+| EndpointsFailOpen                     | string                          | true           | Enable or disable allowing endpoints with `ready:unknown` state in the target groups. |
 | EnableServiceController               | string                          | true           | Toggles support for `Service` type resources. |
 | EnableIPTargetType                    | string                          | true           | Used to toggle support for target-type `ip` across `Ingress` and `Service` type resources. |
 | SubnetsClusterTagCheck                | string                          | true           | Enable or disable the check for `kubernetes.io/cluster/${cluster-name}` during subnet auto-discovery |

--- a/pkg/config/feature_gates.go
+++ b/pkg/config/feature_gates.go
@@ -49,7 +49,7 @@ func NewFeatureGates() FeatureGates {
 			ListenerRulesTagging:         true,
 			WeightedTargetGroups:         true,
 			ServiceTypeLoadBalancerOnly:  false,
-			EndpointsFailOpen:            false,
+			EndpointsFailOpen:            true,
 			EnableServiceController:      true,
 			EnableIPTargetType:           true,
 			SubnetsClusterTagCheck:       true,


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description
Enable EndpointsFailOpen by default in v2.5.0. The end user can still disable the feature gate if necessary.
<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
