### PR TITLE
Add InboundCIDRs field to IngressClassParams

### DIFF
--- a/apis/elbv2/v1beta1/ingressclassparams_types.go
+++ b/apis/elbv2/v1beta1/ingressclassparams_types.go
@@ -99,6 +99,10 @@ type IngressClassParamsSpec struct {
 	// +optional
 	Scheme *LoadBalancerScheme `json:"scheme,omitempty"`
 
+	// InboundCIDRs specifies the CIDRs that are allowed to access the Ingresses that belong to IngressClass with this IngressClassParams.
+	// +optional
+	InboundCIDRs []string `json:"inboundCIDRs,omitempty"`
+
 	// SSLPolicy specifies the SSL Policy for all Ingresses that belong to IngressClass with this IngressClassParams.
 	// +optional
 	SSLPolicy string `json:"sslPolicy,omitEmpty"`

--- a/apis/elbv2/v1beta1/zz_generated.deepcopy.go
+++ b/apis/elbv2/v1beta1/zz_generated.deepcopy.go
@@ -133,6 +133,11 @@ func (in *IngressClassParamsSpec) DeepCopyInto(out *IngressClassParamsSpec) {
 		*out = new(LoadBalancerScheme)
 		**out = **in
 	}
+	if in.InboundCIDRs != nil {
+		in, out := &in.InboundCIDRs, &out.InboundCIDRs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Subnets != nil {
 		in, out := &in.Subnets, &out.Subnets
 		*out = new(SubnetSelector)

--- a/config/crd/bases/elbv2.k8s.aws_ingressclassparams.yaml
+++ b/config/crd/bases/elbv2.k8s.aws_ingressclassparams.yaml
@@ -61,6 +61,12 @@ spec:
                 required:
                 - name
                 type: object
+              inboundCIDRs:
+                description: InboundCIDRs specifies the CIDRs that are allowed to
+                  access the Ingresses that belong to IngressClass with this IngressClassParams.
+                items:
+                  type: string
+                type: array
               ipAddressType:
                 description: IPAddressType defines the ip address type for all Ingresses
                   that belong to IngressClass with this IngressClassParams.

--- a/docs/guide/ingress/ingress_class.md
+++ b/docs/guide/ingress/ingress_class.md
@@ -135,6 +135,11 @@ Cluster administrators can use the `scheme` field to restrict the scheme for all
 1. If `scheme` specified, all Ingresses with this IngressClass will have the specified scheme.
 2. If `scheme` un-specified, Ingresses with this IngressClass can continue to use `alb.ingress.kubernetes.io/scheme annotation` to specify scheme.
 
+#### spec.inboundCIDRs
+
+Cluster administrators can use the optional `inboundCIDRs` field to specify the CIDRs that are allowed to access the load balancers that belong to this IngressClass.
+If the field is specified, LBC will ignore the `alb.ingress.kubernetes.io/inbound-cidrs` annotation.
+
 #### spec.sslPolicy
 
 Cluster administrators can use the optional `sslPolicy` field to specify the SSL policy for the load balancers that belong to this IngressClass.

--- a/helm/aws-load-balancer-controller/crds/crds.yaml
+++ b/helm/aws-load-balancer-controller/crds/crds.yaml
@@ -60,6 +60,12 @@ spec:
                 required:
                 - name
                 type: object
+              inboundCIDRs:
+                description: InboundCIDRs specifies the CIDRs that are allowed to
+                  access the Ingresses that belong to IngressClass with this IngressClassParams.
+                items:
+                  type: string
+                type: array
               ipAddressType:
                 description: IPAddressType defines the ip address type for all Ingresses
                   that belong to IngressClass with this IngressClassParams.

--- a/pkg/ingress/model_builder_test.go
+++ b/pkg/ingress/model_builder_test.go
@@ -1477,6 +1477,132 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 }`,
 		},
 		{
+			name: "Ingress - inboundCIDRs in IngressClassParams",
+			env: env{
+				svcs: []*corev1.Service{ns_1_svc_1, ns_1_svc_2, ns_1_svc_3},
+			},
+			fields: fields{
+				resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
+				listLoadBalancersCalls:   []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
+				enableBackendSG:          true,
+			},
+			args: args{
+				ingGroup: Group{
+					ID: GroupID{Namespace: "ns-1", Name: "ing-1"},
+					Members: []ClassifiedIngress{
+						{
+							IngClassConfig: ClassConfiguration{
+								IngClassParams: &v1beta1.IngressClassParams{
+									Spec: v1beta1.IngressClassParamsSpec{
+										InboundCIDRs: []string{
+											"10.0.0.0/8",
+											"172.16.0.0/12",
+										},
+									},
+								},
+							},
+							Ing: &networking.Ingress{ObjectMeta: metav1.ObjectMeta{
+								Namespace: "ns-1",
+								Name:      "ing-1",
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/inbound-cidrs": "20.0.0.0/8",
+								},
+							},
+								Spec: networking.IngressSpec{
+									Rules: []networking.IngressRule{
+										{
+											Host: "app-1.example.com",
+											IngressRuleValue: networking.IngressRuleValue{
+												HTTP: &networking.HTTPIngressRuleValue{
+													Paths: []networking.HTTPIngressPath{
+														{
+															Path: "/svc-1",
+															Backend: networking.IngressBackend{
+																Service: &networking.IngressServiceBackend{
+																	Name: ns_1_svc_1.Name,
+																	Port: networking.ServiceBackendPort{
+																		Name: "http",
+																	},
+																},
+															},
+														},
+														{
+															Path: "/svc-2",
+															Backend: networking.IngressBackend{
+																Service: &networking.IngressServiceBackend{
+																	Name: ns_1_svc_2.Name,
+																	Port: networking.ServiceBackendPort{
+																		Name: "http",
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+										{
+											Host: "app-2.example.com",
+											IngressRuleValue: networking.IngressRuleValue{
+												HTTP: &networking.HTTPIngressRuleValue{
+													Paths: []networking.HTTPIngressPath{
+														{
+															Path: "/svc-3",
+															Backend: networking.IngressBackend{
+																Service: &networking.IngressServiceBackend{
+																	Name: ns_1_svc_3.Name,
+																	Port: networking.ServiceBackendPort{
+																		Name: "https",
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantStackPatch: `
+{
+	"resources": {
+		"AWS::EC2::SecurityGroup": {
+			"ManagedLBSecurityGroup": {
+				"spec": {
+					"ingress": [
+						{
+							"fromPort": 80,
+							"ipProtocol": "tcp",
+							"ipRanges": [
+								{
+									"cidrIP": "10.0.0.0/8"
+								}
+							],
+							"toPort": 80
+						},
+						{
+							"fromPort": 80,
+							"ipProtocol": "tcp",
+							"ipRanges": [
+								{
+									"cidrIP": "172.16.0.0/12"
+								}
+							],
+							"toPort": 80
+						}
+					]
+				}
+			}
+		}
+	}
+}`,
+		},
+		{
 			name: "Ingress - ssl-policy in IngressClassParams",
 			env: env{
 				svcs: []*corev1.Service{ns_1_svc_1, ns_1_svc_2, ns_1_svc_3},

--- a/webhooks/elbv2/ingressclassparams_validator_test.go
+++ b/webhooks/elbv2/ingressclassparams_validator_test.go
@@ -19,6 +19,72 @@ func Test_ingressClassParamsValidator_ValidateCreate(t *testing.T) {
 			obj:  &elbv2api.IngressClassParams{},
 		},
 		{
+			name: "inboundCIDRs is valid CIDR list",
+			obj: &elbv2api.IngressClassParams{
+				Spec: elbv2api.IngressClassParamsSpec{
+					InboundCIDRs: []string{
+						"10.0.0.0/8",
+						"2001:DB8::/32",
+					},
+				},
+			},
+		},
+		{
+			name: "inboundCIDRs IPv4 no length",
+			obj: &elbv2api.IngressClassParams{
+				Spec: elbv2api.IngressClassParamsSpec{
+					InboundCIDRs: []string{
+						"192.168.0.1",
+					},
+				},
+			},
+			wantErr: "spec.inboundCIDRs[0]: Invalid value: \"192.168.0.1\": Could not be parsed as a CIDR (did you mean \"192.168.0.1/32\")",
+		},
+		{
+			name: "inboundCIDRs IPv6 no length",
+			obj: &elbv2api.IngressClassParams{
+				Spec: elbv2api.IngressClassParamsSpec{
+					InboundCIDRs: []string{
+						"2001:DB8::",
+					},
+				},
+			},
+			wantErr: "spec.inboundCIDRs[0]: Invalid value: \"2001:DB8::\": Could not be parsed as a CIDR (did you mean \"2001:DB8::/64\")",
+		},
+		{
+			name: "inboundCIDRs bits outside prefix",
+			obj: &elbv2api.IngressClassParams{
+				Spec: elbv2api.IngressClassParamsSpec{
+					InboundCIDRs: []string{
+						"10.128.0.0/8",
+					},
+				},
+			},
+			wantErr: "spec.inboundCIDRs[0]: Invalid value: \"10.128.0.0/8\": Network contains bits outside prefix (did you mean \"10.0.0.0/8\")",
+		},
+		{
+			name: "inboundCIDRs empty string",
+			obj: &elbv2api.IngressClassParams{
+				Spec: elbv2api.IngressClassParamsSpec{
+					InboundCIDRs: []string{
+						"",
+					},
+				},
+			},
+			wantErr: "spec.inboundCIDRs[0]: Invalid value: \"\": Could not be parsed as a CIDR",
+		},
+		{
+			name: "inboundCIDRs domain",
+			obj: &elbv2api.IngressClassParams{
+				Spec: elbv2api.IngressClassParamsSpec{
+					InboundCIDRs: []string{
+						"invalid.example.com",
+					},
+				},
+			},
+			wantErr: "spec.inboundCIDRs[0]: Invalid value: \"invalid.example.com\": Could not be parsed as a CIDR",
+		},
+		{
 			name: "subnet is valid ID list",
 			obj: &elbv2api.IngressClassParams{
 				Spec: elbv2api.IngressClassParamsSpec{


### PR DESCRIPTION
### Issue

#2920

### Description

Adds an `inboundCIDRs` field to IngressClassParams, to allow overriding the `alb.ingress.kubernetes.io/inbound-cidrs` annotation for all Ingresses in an IngressClass.

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
