### PR TITLE
Github action to scan deprecated apigroups

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,3 +33,19 @@ jobs:
       - name: make quick-ci
         run: |
           make quick-ci
+
+  deprecated-apigroups:
+    name: Detect deprecated apiGroups
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout latest commit
+        uses: actions/checkout@v3
+      - name: Download Pluto
+        run: |
+          version=$(curl -sL https://api.github.com/repos/FairwindsOps/pluto/releases/latest | jq -r ".tag_name")
+          number=${version:1}
+          wget https://github.com/FairwindsOps/pluto/releases/download/${version}/pluto_${number}_linux_amd64.tar.gz
+          sudo tar -C /usr/local -xzf pluto_${number}_linux_amd64.tar.gz
+      - name: Use pluto
+        run: |
+          /usr/local/pluto detect-files -d .


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->
GH action to scan deprecated apiGroups
### Description
Use Pluto to scan for deprecated k8s apiGroups
https://github.com/FairwindsOps/pluto
<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
