### PR TITLE
add test coverage for endPointSlices

### DIFF
--- a/test/e2e/ingress/multi_path_backend_test.go
+++ b/test/e2e/ingress/multi_path_backend_test.go
@@ -24,7 +24,7 @@ var _ = Describe("test ingresses with multiple path and backends", func() {
 
 		if tf.Options.ControllerImage != "" {
 			By(fmt.Sprintf("ensure cluster installed with controller: %s", tf.Options.ControllerImage), func() {
-				err := tf.CTRLInstallationManager.UpgradeController(tf.Options.ControllerImage)
+				err := tf.CTRLInstallationManager.UpgradeController(tf.Options.ControllerImage, false)
 				Expect(err).NotTo(HaveOccurred())
 				time.Sleep(60 * time.Second)
 			})

--- a/test/framework/controller/installation_manager.go
+++ b/test/framework/controller/installation_manager.go
@@ -12,7 +12,7 @@ import (
 // InstallationManager is responsible for manage controller installation in cluster.
 type InstallationManager interface {
 	ResetController() error
-	UpgradeController(controllerImage string) error
+	UpgradeController(controllerImage string, enableEndPointSlices bool) error
 }
 
 // NewDefaultInstallationManager constructs new defaultInstallationManager.
@@ -53,7 +53,7 @@ func (m *defaultInstallationManager) ResetController() error {
 	return err
 }
 
-func (m *defaultInstallationManager) UpgradeController(controllerImage string) error {
+func (m *defaultInstallationManager) UpgradeController(controllerImage string, enableEndPointSlices bool) error {
 	imageRepo, imageTag, err := splitImageRepoAndTag(controllerImage)
 	if err != nil {
 		return err
@@ -65,6 +65,9 @@ func (m *defaultInstallationManager) UpgradeController(controllerImage string) e
 	}
 	vals["podLabels"] = map[string]string{
 		"revision": string(uuid.NewUUID()),
+	}
+	if enableEndPointSlices {
+		vals["enableEndpointSlices"] = true
 	}
 	_, err = m.helmReleaseManager.InstallOrUpgradeRelease(m.helmChart,
 		m.namespace, AWSLoadBalancerControllerHelmRelease, vals,


### PR DESCRIPTION
### Issues
https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/3071

### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->
Add the e2e test coverage with the feature endPointSlices enabled.

#### Tests
- Ran the e2e test on k8s 1.25 LBC v2.4.7, verified the test case passed.
- Negative test: ran the e2e test on k8s 1.25 LBC v2.4.6, where the API version `discovery.k8s.io/v1beta1` is not supported, and the test case failed.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
