### PR TITLE
Add docker-push-w-buildx make target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:experimental
+ARG BASE_IMAGE
+ARG BUILD_IMAGE
+
+FROM --platform=${TARGETPLATFORM} $BUILD_IMAGE AS base
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN --mount=type=bind,target=. \
+    GOPROXY=direct go mod download
+
+FROM base AS build
+ARG TARGETOS
+ARG TARGETARCH
+ENV VERSION_PKG=sigs.k8s.io/aws-load-balancer-controller/pkg/version
+RUN --mount=type=bind,target=. \
+    --mount=type=cache,target=/root/.cache/go-build \
+    GIT_VERSION=$(git describe --tags --dirty --always) && \
+    GIT_COMMIT=$(git rev-parse HEAD) && \
+    BUILD_DATE=$(date +%Y-%m-%dT%H:%M:%S%z) && \
+    GOOS=${TARGETOS} GOARCH=${TARGETARCH} GO111MODULE=on \
+    CGO_CPPFLAGS="-D_FORTIFY_SOURCE=2" \
+    CGO_LDFLAGS="-Wl,-z,relro,-z,now" \
+    go build -buildmode=pie -tags 'osusergo,netgo,static_build' -ldflags="-s -w -linkmode=external -extldflags '-static-pie' -X ${VERSION_PKG}.GitVersion=${GIT_VERSION} -X ${VERSION_PKG}.GitCommit=${GIT_COMMIT} -X ${VERSION_PKG}.BuildDate=${BUILD_DATE}" -mod=readonly -a -o /out/controller main.go
+
+FROM $BASE_IMAGE as bin-unix
+
+COPY --from=build /out/controller /controller
+ENTRYPOINT ["/controller"]
+
+FROM bin-unix AS bin-linux
+FROM bin-unix AS bin-darwin
+
+FROM bin-${TARGETOS} as bin

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ IMG ?= public.ecr.aws/eks/aws-load-balancer-controller:v2.4.6
 # Image URL to use for builder stage in Docker build
 BUILD_IMAGE ?= public.ecr.aws/docker/library/golang:1.19.3
 # Image URL to use for base layer in Docker build
-BASE_IMAGE ?= public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:2022-07-27-1658910674.2
+BASE_IMAGE ?= public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:2023-02-22-1677092456.2
 IMG_PLATFORM ?= linux/amd64,linux/arm64
 # ECR doesn't appear to support SPDX SBOM
 IMG_SBOM ?= none

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@ MAKEFILE_PATH = $(dir $(realpath -s $(firstword $(MAKEFILE_LIST))))
 
 # Image URL to use all building/pushing image targets
 IMG ?= public.ecr.aws/eks/aws-load-balancer-controller:v2.4.6
+# Image URL to use for builder stage in Docker build
+BUILD_IMAGE ?= public.ecr.aws/docker/library/golang:1.19.3
+# Image URL to use for base layer in Docker build
+BASE_IMAGE ?= public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:2022-07-27-1658910674.2
 IMG_PLATFORM ?= linux/amd64,linux/arm64
 # ECR doesn't appear to support SPDX SBOM
 IMG_SBOM ?= none
@@ -90,6 +94,15 @@ aws-load-balancer-controller-push: ko
     GIT_COMMIT=$(shell git rev-parse HEAD)  \
     BUILD_DATE=$(shell date +%Y-%m-%dT%H:%M:%S%z) \
     ko build --tags $(word 2,$(subst :, ,${IMG})) --platform=${IMG_PLATFORM} --bare --sbom ${IMG_SBOM} .
+
+# Push the docker image using docker buildx
+docker-push-w-buildx:
+	docker buildx build . --target bin \
+        		--tag $(IMG) \
+				--build-arg BASE_IMAGE=$(BASE_IMAGE) \
+				--build-arg BUILD_IMAGE=$(BUILD_IMAGE) \
+				--push \
+        		--platform ${IMG_PLATFORM}
 
 # find or download controller-gen
 # download controller-gen if necessary


### PR DESCRIPTION
### Issue
N/A
<!-- Please link the GitHub issues related to this PR, if available -->

### Description
Repo `aws-load-balancer-controller` has chosen to use `ko` for container image build by default. This PR gives users an option to use docker buildx with customization on BUILD_IMAGE and BASE_IMAGE.

Having a fixed BUILD_IMAGE and BASE_IMAGE meaning building binary and images all in a controlled environment, which allows easier CVE management where a user can monitor BUILD_IMAGE and BASE_IMAGE constantly.

Note this is created to support internal pipelines since we want to be able to choose both golang and base image versions.

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- N/A Added tests that cover your change (if possible) 
- N/A Added/modified documentation as required (such as the `README.md`, or the `docs` directory) 
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- N/A Backfilled missing tests for code in same general area :tada: 
- [x] Refactored something and made the world a better place :star2:
