### PR TITLE
Replace all deprecated sets.String with sets.Set

### DIFF
--- a/pkg/ingress/model_build_load_balancer.go
+++ b/pkg/ingress/model_build_load_balancer.go
@@ -89,7 +89,7 @@ func (t *defaultModelBuildTask) buildLoadBalancerSpec(ctx context.Context, liste
 var invalidLoadBalancerNamePattern = regexp.MustCompile("[[:^alnum:]]")
 
 func (t *defaultModelBuildTask) buildLoadBalancerName(_ context.Context, scheme elbv2model.LoadBalancerScheme) (string, error) {
-	explicitNames := sets.String{}
+	explicitNames := sets.Set[string]{}
 	for _, member := range t.ingGroup.Members {
 		rawName := ""
 		if exists := t.annotationParser.ParseStringAnnotation(annotations.IngressSuffixLoadBalancerName, &rawName, member.Ing.Annotations); !exists {
@@ -125,7 +125,7 @@ func (t *defaultModelBuildTask) buildLoadBalancerName(_ context.Context, scheme 
 }
 
 func (t *defaultModelBuildTask) buildLoadBalancerScheme(_ context.Context) (elbv2model.LoadBalancerScheme, error) {
-	explicitSchemes := sets.String{}
+	explicitSchemes := sets.Set[string]{}
 	for _, member := range t.ingGroup.Members {
 		if member.IngClassConfig.IngClassParams != nil && member.IngClassConfig.IngClassParams.Spec.Scheme != nil {
 			scheme := string(*member.IngClassConfig.IngClassParams.Spec.Scheme)

--- a/pkg/ingress/model_build_load_balancer_test.go
+++ b/pkg/ingress/model_build_load_balancer_test.go
@@ -243,7 +243,7 @@ func Test_defaultModelBuildTask_buildLoadBalancerTags(t *testing.T) {
 	type fields struct {
 		ingGroup            Group
 		defaultTags         map[string]string
-		externalManagedTags sets.String
+		externalManagedTags sets.Set[string]
 	}
 	tests := []struct {
 		name    string
@@ -434,7 +434,7 @@ func Test_defaultModelBuildTask_buildLoadBalancerTags(t *testing.T) {
 						},
 					},
 				},
-				externalManagedTags: sets.NewString("k3"),
+				externalManagedTags: sets.New("k3"),
 			},
 			want: map[string]string{
 				"k1": "v1",
@@ -470,7 +470,7 @@ func Test_defaultModelBuildTask_buildLoadBalancerTags(t *testing.T) {
 						},
 					},
 				},
-				externalManagedTags: sets.NewString("k2"),
+				externalManagedTags: sets.New("k2"),
 			},
 			wantErr: errors.New("failed build tags for Ingress awesome-ns/ing-2: external managed tag key k2 cannot be specified"),
 		},

--- a/pkg/ingress/model_build_managed_sg_test.go
+++ b/pkg/ingress/model_build_managed_sg_test.go
@@ -15,7 +15,7 @@ func Test_defaultModelBuildTask_buildManagedSecurityGroupTags(t *testing.T) {
 	type fields struct {
 		ingGroup            Group
 		defaultTags         map[string]string
-		externalManagedTags sets.String
+		externalManagedTags sets.Set[string]
 	}
 	tests := []struct {
 		name    string
@@ -206,7 +206,7 @@ func Test_defaultModelBuildTask_buildManagedSecurityGroupTags(t *testing.T) {
 						},
 					},
 				},
-				externalManagedTags: sets.NewString("k3"),
+				externalManagedTags: sets.New("k3"),
 			},
 			want: map[string]string{
 				"k1": "v1",
@@ -242,7 +242,7 @@ func Test_defaultModelBuildTask_buildManagedSecurityGroupTags(t *testing.T) {
 						},
 					},
 				},
-				externalManagedTags: sets.NewString("k2"),
+				externalManagedTags: sets.New("k2"),
 			},
 			wantErr: errors.New("failed build tags for Ingress awesome-ns/ing-2: external managed tag key k2 cannot be specified"),
 		},

--- a/pkg/ingress/model_build_tags_test.go
+++ b/pkg/ingress/model_build_tags_test.go
@@ -14,7 +14,7 @@ import (
 
 func Test_defaultModelBuildTask_buildIngressGroupResourceTags(t *testing.T) {
 	type fields struct {
-		externalManagedTags sets.String
+		externalManagedTags sets.Set[string]
 	}
 	type args struct {
 		ingList []ClassifiedIngress
@@ -29,7 +29,7 @@ func Test_defaultModelBuildTask_buildIngressGroupResourceTags(t *testing.T) {
 		{
 			name: "tags from multiple Ingress didn't collision",
 			fields: fields{
-				externalManagedTags: sets.NewString("tag-a", "tag-b"),
+				externalManagedTags: sets.New("tag-a", "tag-b"),
 			},
 			args: args{
 				ingList: []ClassifiedIngress{
@@ -66,7 +66,7 @@ func Test_defaultModelBuildTask_buildIngressGroupResourceTags(t *testing.T) {
 		{
 			name: "tags from multiple Ingress has collision",
 			fields: fields{
-				externalManagedTags: sets.NewString("tag-a", "tag-b"),
+				externalManagedTags: sets.New("tag-a", "tag-b"),
 			},
 			args: args{
 				ingList: []ClassifiedIngress{
@@ -117,7 +117,7 @@ func Test_defaultModelBuildTask_buildIngressGroupResourceTags(t *testing.T) {
 
 func Test_defaultModelBuildTask_buildIngressResourceTags(t *testing.T) {
 	type fields struct {
-		externalManagedTags sets.String
+		externalManagedTags sets.Set[string]
 	}
 	type args struct {
 		ing ClassifiedIngress
@@ -132,7 +132,7 @@ func Test_defaultModelBuildTask_buildIngressResourceTags(t *testing.T) {
 		{
 			name: "non-empty annotation tags from Ingress - collision with external-managed tags",
 			fields: fields{
-				externalManagedTags: sets.NewString("tag-a", "tag-b"),
+				externalManagedTags: sets.New("tag-a", "tag-b"),
 			},
 			args: args{
 				ing: ClassifiedIngress{
@@ -153,7 +153,7 @@ func Test_defaultModelBuildTask_buildIngressResourceTags(t *testing.T) {
 		{
 			name: "non-empty annotation tags from Ingress, non-empty IngressClass tags",
 			fields: fields{
-				externalManagedTags: sets.NewString("tag-a", "tag-b"),
+				externalManagedTags: sets.New("tag-a", "tag-b"),
 			},
 			args: args{
 				ing: ClassifiedIngress{
@@ -196,7 +196,7 @@ func Test_defaultModelBuildTask_buildIngressResourceTags(t *testing.T) {
 		{
 			name: "empty tags from Ingress, empty tags from IngressClass",
 			fields: fields{
-				externalManagedTags: sets.NewString("tag-a", "tag-b"),
+				externalManagedTags: sets.New("tag-a", "tag-b"),
 			},
 			args: args{
 				ing: ClassifiedIngress{
@@ -232,7 +232,7 @@ func Test_defaultModelBuildTask_buildIngressResourceTags(t *testing.T) {
 
 func Test_defaultModelBuildTask_buildIngressBackendResourceTags(t *testing.T) {
 	type fields struct {
-		externalManagedTags sets.String
+		externalManagedTags sets.Set[string]
 	}
 	type args struct {
 		ing     ClassifiedIngress
@@ -248,7 +248,7 @@ func Test_defaultModelBuildTask_buildIngressBackendResourceTags(t *testing.T) {
 		{
 			name: "non-empty annotation tags from Ingress & Service - Service tags takes priority",
 			fields: fields{
-				externalManagedTags: sets.NewString("tag-a", "tag-b"),
+				externalManagedTags: sets.New("tag-a", "tag-b"),
 			},
 			args: args{
 				ing: ClassifiedIngress{
@@ -282,7 +282,7 @@ func Test_defaultModelBuildTask_buildIngressBackendResourceTags(t *testing.T) {
 		{
 			name: "non-empty annotation tags from Ingress - collision with external-managed tags",
 			fields: fields{
-				externalManagedTags: sets.NewString("tag-a", "tag-b"),
+				externalManagedTags: sets.New("tag-a", "tag-b"),
 			},
 			args: args{
 				ing: ClassifiedIngress{
@@ -309,7 +309,7 @@ func Test_defaultModelBuildTask_buildIngressBackendResourceTags(t *testing.T) {
 		{
 			name: "non-empty annotation tags from Ingress, non-empty IngressClass tags",
 			fields: fields{
-				externalManagedTags: sets.NewString("tag-a", "tag-b"),
+				externalManagedTags: sets.New("tag-a", "tag-b"),
 			},
 			args: args{
 				ing: ClassifiedIngress{
@@ -358,7 +358,7 @@ func Test_defaultModelBuildTask_buildIngressBackendResourceTags(t *testing.T) {
 		{
 			name: "non-empty annotation tags from Service, non-empty IngressClass tags",
 			fields: fields{
-				externalManagedTags: sets.NewString("tag-a", "tag-b"),
+				externalManagedTags: sets.New("tag-a", "tag-b"),
 			},
 			args: args{
 				ing: ClassifiedIngress{
@@ -407,7 +407,7 @@ func Test_defaultModelBuildTask_buildIngressBackendResourceTags(t *testing.T) {
 		{
 			name: "non-empty annotation tags from Ingress and Service, non-empty IngressClass tags",
 			fields: fields{
-				externalManagedTags: sets.NewString("tag-a", "tag-b"),
+				externalManagedTags: sets.New("tag-a", "tag-b"),
 			},
 			args: args{
 				ing: ClassifiedIngress{
@@ -460,7 +460,7 @@ func Test_defaultModelBuildTask_buildIngressBackendResourceTags(t *testing.T) {
 		{
 			name: "empty tags from Ingress & Service, empty tags from IngressClass",
 			fields: fields{
-				externalManagedTags: sets.NewString("tag-a", "tag-b"),
+				externalManagedTags: sets.New("tag-a", "tag-b"),
 			},
 			args: args{
 				ing: ClassifiedIngress{
@@ -502,7 +502,7 @@ func Test_defaultModelBuildTask_buildIngressBackendResourceTags(t *testing.T) {
 
 func Test_defaultModelBuildTask_buildIngressClassResourceTags(t *testing.T) {
 	type fields struct {
-		externalManagedTags sets.String
+		externalManagedTags sets.Set[string]
 	}
 	type args struct {
 		ingClassConfig ClassConfiguration
@@ -517,7 +517,7 @@ func Test_defaultModelBuildTask_buildIngressClassResourceTags(t *testing.T) {
 		{
 			name: "non-empty ingressClassParams, non-empty tags - no collision",
 			fields: fields{
-				externalManagedTags: sets.NewString("tag-a", "tag-b"),
+				externalManagedTags: sets.New("tag-a", "tag-b"),
 			},
 			args: args{
 				ingClassConfig: ClassConfiguration{
@@ -548,7 +548,7 @@ func Test_defaultModelBuildTask_buildIngressClassResourceTags(t *testing.T) {
 		{
 			name: "non-empty ingressClassParams, non-empty tags - has collision",
 			fields: fields{
-				externalManagedTags: sets.NewString("tag-a", "tag-b"),
+				externalManagedTags: sets.New("tag-a", "tag-b"),
 			},
 			args: args{
 				ingClassConfig: ClassConfiguration{
@@ -576,7 +576,7 @@ func Test_defaultModelBuildTask_buildIngressClassResourceTags(t *testing.T) {
 		{
 			name: "non-empty ingressClassParams, empty tags",
 			fields: fields{
-				externalManagedTags: sets.NewString("tag-a", "tag-b"),
+				externalManagedTags: sets.New("tag-a", "tag-b"),
 			},
 			args: args{
 				ingClassConfig: ClassConfiguration{
@@ -595,7 +595,7 @@ func Test_defaultModelBuildTask_buildIngressClassResourceTags(t *testing.T) {
 		{
 			name: "empty ingressClassParams",
 			fields: fields{
-				externalManagedTags: sets.NewString("tag-a", "tag-b"),
+				externalManagedTags: sets.New("tag-a", "tag-b"),
 			},
 			args: args{
 				ingClassConfig: ClassConfiguration{
@@ -623,7 +623,7 @@ func Test_defaultModelBuildTask_buildIngressClassResourceTags(t *testing.T) {
 
 func Test_defaultModelBuildTask_validateTagCollisionWithExternalManagedTags(t *testing.T) {
 	type fields struct {
-		externalManagedTags sets.String
+		externalManagedTags sets.Set[string]
 	}
 	type args struct {
 		tags map[string]string
@@ -637,7 +637,7 @@ func Test_defaultModelBuildTask_validateTagCollisionWithExternalManagedTags(t *t
 		{
 			name: "non-empty externalManagedTags, non-empty tags - no collision",
 			fields: fields{
-				externalManagedTags: sets.NewString("tag-a", "tag-b"),
+				externalManagedTags: sets.New("tag-a", "tag-b"),
 			},
 			args: args{
 				tags: map[string]string{
@@ -650,7 +650,7 @@ func Test_defaultModelBuildTask_validateTagCollisionWithExternalManagedTags(t *t
 		{
 			name: "non-empty externalManagedTags, non-empty tags - has collision",
 			fields: fields{
-				externalManagedTags: sets.NewString("tag-a", "tag-b"),
+				externalManagedTags: sets.New("tag-a", "tag-b"),
 			},
 			args: args{
 				tags: map[string]string{
@@ -663,7 +663,7 @@ func Test_defaultModelBuildTask_validateTagCollisionWithExternalManagedTags(t *t
 		{
 			name: "non-empty externalManagedTags, empty tags",
 			fields: fields{
-				externalManagedTags: sets.NewString("tag-a", "tag-b"),
+				externalManagedTags: sets.New("tag-a", "tag-b"),
 			},
 			args: args{
 				tags: nil,
@@ -673,7 +673,7 @@ func Test_defaultModelBuildTask_validateTagCollisionWithExternalManagedTags(t *t
 		{
 			name: "empty externalManagedTags, non-empty tags",
 			fields: fields{
-				externalManagedTags: sets.NewString(),
+				externalManagedTags: sets.New[string](),
 			},
 			args: args{
 				tags: map[string]string{

--- a/pkg/ingress/model_build_target_group_test.go
+++ b/pkg/ingress/model_build_target_group_test.go
@@ -198,7 +198,7 @@ func Test_defaultModelBuildTask_buildTargetGroupPort(t *testing.T) {
 func Test_defaultModelBuildTask_buildTargetGroupTags(t *testing.T) {
 	type fields struct {
 		defaultTags         map[string]string
-		externalManagedTags sets.String
+		externalManagedTags sets.Set[string]
 	}
 	type args struct {
 		ing ClassifiedIngress

--- a/pkg/k8s/secrets_manager.go
+++ b/pkg/k8s/secrets_manager.go
@@ -50,7 +50,7 @@ type defaultSecretsManager struct {
 type secretItem struct {
 	store     cache.Store
 	rt        *cache.Reflector
-	ingresses sets.String
+	ingresses sets.Set[string]
 
 	stopCh chan struct{}
 }
@@ -60,7 +60,7 @@ func (m *defaultSecretsManager) MonitorSecrets(ingressGroupID string, secrets []
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
-	inputSecrets := make(sets.String)
+	inputSecrets := make(sets.Set[string])
 	for _, secret := range secrets {
 		inputSecrets.Insert(secret.String())
 		item, exists := m.secretMap[secret]
@@ -113,7 +113,7 @@ func (m *defaultSecretsManager) newReflector(namespace, name string) *secretItem
 	item := &secretItem{
 		store:     store,
 		rt:        rt,
-		ingresses: make(sets.String),
+		ingresses: sets.New[string](),
 		stopCh:    make(chan struct{}),
 	}
 	go item.startReflector()

--- a/pkg/service/model_build_listener.go
+++ b/pkg/service/model_build_listener.go
@@ -144,7 +144,7 @@ func validateTLSPortsSet(rawTLSPorts []string, ports []corev1.ServicePort) error
 	return nil
 }
 
-func (t *defaultModelBuildTask) buildTLSPortsSet(_ context.Context) (sets.String, error) {
+func (t *defaultModelBuildTask) buildTLSPortsSet(_ context.Context) (sets.Set[string], error) {
 	var rawTLSPorts []string
 
 	_ = t.annotationParser.ParseStringSliceAnnotation(annotations.SvcLBSuffixSSLPorts, &rawTLSPorts, t.service.Annotations)
@@ -155,7 +155,7 @@ func (t *defaultModelBuildTask) buildTLSPortsSet(_ context.Context) (sets.String
 		return nil, err
 	}
 
-	return sets.NewString(rawTLSPorts...), nil
+	return sets.New(rawTLSPorts...), nil
 }
 
 func (t *defaultModelBuildTask) buildBackendProtocol(_ context.Context) string {
@@ -186,7 +186,7 @@ func (t *defaultModelBuildTask) buildListenerALPNPolicy(ctx context.Context, lis
 
 type listenerConfig struct {
 	certificates    []elbv2model.Certificate
-	tlsPortsSet     sets.String
+	tlsPortsSet     sets.Set[string]
 	sslPolicy       *string
 	backendProtocol string
 }

--- a/pkg/service/model_build_listener_test.go
+++ b/pkg/service/model_build_listener_test.go
@@ -159,7 +159,7 @@ func Test_defaultModelBuilderTask_buildListenerConfig(t *testing.T) {
 			},
 			want: &listenerConfig{
 				certificates:    ([]elbv2model.Certificate)(nil),
-				tlsPortsSet:     sets.NewString("83"),
+				tlsPortsSet:     sets.New[string]("83"),
 				sslPolicy:       new(string),
 				backendProtocol: "",
 			},

--- a/pkg/service/model_build_load_balancer_test.go
+++ b/pkg/service/model_build_load_balancer_test.go
@@ -1247,7 +1247,7 @@ func Test_defaultModelBuildTask_buildAdditionalResourceTags(t *testing.T) {
 	type fields struct {
 		service             *corev1.Service
 		defaultTags         map[string]string
-		externalManagedTags sets.String
+		externalManagedTags sets.Set[string]
 	}
 	tests := []struct {
 		name    string
@@ -1334,7 +1334,7 @@ func Test_defaultModelBuildTask_buildAdditionalResourceTags(t *testing.T) {
 						},
 					},
 				},
-				externalManagedTags: sets.NewString("k4"),
+				externalManagedTags: sets.New("k4"),
 			},
 			want: map[string]string{
 				"k1": "v1",
@@ -1352,7 +1352,7 @@ func Test_defaultModelBuildTask_buildAdditionalResourceTags(t *testing.T) {
 						},
 					},
 				},
-				externalManagedTags: sets.NewString("k3", "k4"),
+				externalManagedTags: sets.New("k3", "k4"),
 			},
 			wantErr: errors.New("external managed tag key k3 cannot be specified on Service"),
 		},

--- a/pkg/service/model_builder.go
+++ b/pkg/service/model_builder.go
@@ -49,7 +49,7 @@ func NewDefaultModelBuilder(annotationParser annotations.Parser, subnetsResolver
 		clusterName:         clusterName,
 		vpcID:               vpcID,
 		defaultTags:         defaultTags,
-		externalManagedTags: sets.NewString(externalManagedTags...),
+		externalManagedTags: sets.New(externalManagedTags...),
 		defaultSSLPolicy:    defaultSSLPolicy,
 		defaultTargetType:   elbv2model.TargetType(defaultTargetType),
 		enableIPTargetType:  enableIPTargetType,
@@ -70,7 +70,7 @@ type defaultModelBuilder struct {
 	clusterName         string
 	vpcID               string
 	defaultTags         map[string]string
-	externalManagedTags sets.String
+	externalManagedTags sets.Set[string]
 	defaultSSLPolicy    string
 	defaultTargetType   elbv2model.TargetType
 	enableIPTargetType  bool
@@ -153,7 +153,7 @@ type defaultModelBuildTask struct {
 	existingLoadBalancer          *elbv2deploy.LoadBalancerWithTags
 
 	defaultTags                          map[string]string
-	externalManagedTags                  sets.String
+	externalManagedTags                  sets.Set[string]
 	defaultSSLPolicy                     string
 	defaultAccessLogS3Enabled            bool
 	defaultAccessLogsS3Bucket            string


### PR DESCRIPTION
Signed-off-by: smcavallo <smcavallo@hotmail.com>

### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description
 See - https://pkg.go.dev/k8s.io/apimachinery/pkg/util/sets@v0.26.3#String

This PR is for the sig/scheduling sets.String usage cleanup and moving over to the new generic Set type.
Here is a link to a similar change which was made in the kubernetes org ->  https://github.com/kubernetes/kubernetes/pull/116940

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:
