### PR TITLE
Fix validator for ingress rules without http paths

### DIFF
--- a/webhooks/networking/ingress_validator.go
+++ b/webhooks/networking/ingress_validator.go
@@ -174,6 +174,9 @@ func (v *ingressValidator) checkIngressClassUsage(ctx context.Context, ing *netw
 // checkGroupNameAnnotationUsage checks the validity of "conditions.${conditions-name}" annotation.
 func (v *ingressValidator) checkIngressAnnotationConditions(ing *networking.Ingress) error {
 	for _, rule := range ing.Spec.Rules {
+		if rule.HTTP == nil {
+			continue
+		}
 		for _, path := range rule.HTTP.Paths {
 			var conditions []ingress.RuleCondition
 			annotationKey := fmt.Sprintf("conditions.%v", path.Backend.Service.Name)

--- a/webhooks/networking/ingress_validator_test.go
+++ b/webhooks/networking/ingress_validator_test.go
@@ -883,6 +883,31 @@ func Test_ingressValidator_checkIngressAnnotationConditions(t *testing.T) {
 			},
 			wantErr: errors.New("ignoring Ingress ns-1/ing-1 since invalid alb.ingress.kubernetes.io/conditions.svc-1 annotation: invalid queryStringConfig: value cannot be empty"),
 		},
+		{
+			name: "ingress rule without HTTP path",
+			fields: fields{
+				disableIngressGroupAnnotation: false,
+			},
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns-1",
+						Name:      "ing-1",
+						Annotations: map[string]string{
+							"alb.ingress.kubernetes.io/condition.svc-1": `[{"field":"query-string","queryStringConfig":{"values":[{"key":"paramA","value":"paramAValue"}]}}]`,
+						},
+					},
+					Spec: networking.IngressSpec{
+						Rules: []networking.IngressRule{
+							{
+								Host: "host.example.com",
+							},
+						},
+					},
+				},
+			},
+			wantErr: nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### Issue
Fixes: #3158
<!-- Please link the GitHub issues related to this PR, if available -->

### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->
Ingress validator is not able to handle ingress rules without http path defined. This is introduced in PR #2735.

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
