### PR TITLE
check both sdkLS and resLS sslpolicy for nil

### DIFF
--- a/pkg/deploy/elbv2/listener_manager.go
+++ b/pkg/deploy/elbv2/listener_manager.go
@@ -158,8 +158,8 @@ func (m *defaultListenerManager) updateSDKListenerWithSettings(ctx context.Conte
 func (m *defaultListenerManager) updateSDKListenerWithExtraCertificates(ctx context.Context, resLS *elbv2model.Listener,
 	sdkLS ListenerWithTags, isNewSDKListener bool) error {
 	// if TLS is not supported, we shouldn't update
-	if sdkLS.Listener.SslPolicy == nil {
-		m.logger.V(1).Info("SDK Listener doesn't have SSL Policy set, we skip updating extra certs for non-TLS listener.")
+	if resLS.Spec.SSLPolicy == nil && sdkLS.Listener.SslPolicy == nil {
+		m.logger.V(1).Info("Res and Sdk Listener don't have SSL Policy set, we skip updating extra certs for non-TLS listener.")
 		return nil
 	}
 


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->
https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/3185

### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->
Check both sdkLS and resLS sslpolicy for nil when updating extra certificates for listeners. This PR fixes the edge case that when adding ssl certs to an existing service that has no ssl cert originally, the controller will not skip adding extra certs because of the sslpolicy is nil in sdkLS.

#### Tests
- Created a NLB with no ssl cert specified, then added multiple certs via annotation `service.beta.kubernetes.io/aws-load-balancer-ssl-cert`, verified all the certs got added to the listeners of the NLB successfully
- Created a ALB with no ssl cert specified, then added multiple certs via annotation `alb.ingress.kubernetes.io/certificate-arn`, verified all the certs got added to the listeners of the ALB successfully
### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
