### PR TITLE
Fix typo in mkdocs.yml file

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,7 +32,7 @@ nav:
           - Cognito Authentication: guide/tasks/cognito_authentication.md
           - SSL Redirect: guide/tasks/ssl_redirect.md
       - Use Cases:
-        - NLB TLS Termiation: guide/use_cases/nlb_tls_termination/index.md
+        - NLB TLS Termination: guide/use_cases/nlb_tls_termination/index.md
         - Externally Managed Load Balancer: guide/use_cases/self_managed_lb/index.md
   - Examples:
     - EchoServer: examples/echo_server.md


### PR DESCRIPTION
### Description

It's a very simple typo fix in the `mkdocs.yml` file.
