### PR TITLE
refactor e2e tests

### DIFF
--- a/scripts/run-e2e-test.sh
+++ b/scripts/run-e2e-test.sh
@@ -9,6 +9,12 @@ GINKGO_TEST_BUILD="$SCRIPT_DIR/../test/build"
 
 source "$SCRIPT_DIR"/lib/common.sh
 
+# the corresponding accounts for AWS isolated regions
+BJS_PREFIX="918309763551.dkr.ecr.cn-north-1.amazonaws.com.cn"
+ZHY_PREFIX="961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn"
+DCA_PREFIX="639420080494.dkr.ecr.us-iso-east-1.c2s.ic.gov"
+LCK_PREFIX="517467847110.dkr.ecr.us-isob-east-1.sc2s.sgov.gov"
+
 function toggle_windows_scheduling(){
   schedule=$1
   nodes=$(kubectl get nodes -l kubernetes.io/os=windows | tail -n +2 | cut -d' ' -f1)
@@ -61,12 +67,17 @@ if [[ $REGION == "cn-north-1" || $REGION == "cn-northwest-1" ]];then
 fi
 
 if [[ $REGION == "cn-north-1" ]];then
-  IMAGE="918309763551.dkr.ecr.cn-north-1.amazonaws.com.cn/amazon/aws-load-balancer-controller"
+  PREFIX=$BJS_PREFIX
 elif [[ $REGION == "cn-northwest-1" ]];then
-  IMAGE="961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn/amazon/aws-load-balancer-controller"
+  PREFIX=$ZHY_PREFIX
+elif [[ $REGION == "us-iso-east-1" ]];then
+  PREFIX=$DCA_PREFIX
+elif [[ $REGION == "us-isob-east-1" ]];then
+  PREFIX=$LCK_PREFIX
 else
-  IMAGE="602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-load-balancer-controller"
+  PREFIX="602401143452.dkr.ecr.us-west-2.amazonaws.com"
 fi
+IMAGE="$PREFIX/amazon/aws-load-balancer-controller"
 
 echo "IMAGE: $IMAGE"
 echo "create IAM policy document file"

--- a/test/e2e/ingress/multi_path_backend.go
+++ b/test/e2e/ingress/multi_path_backend.go
@@ -206,7 +206,7 @@ func (s *multiPathBackendStack) buildResourceStacks(namespacedResourcesCFGs map[
 }
 
 func (s *multiPathBackendStack) buildResourceStack(ns *corev1.Namespace, resourcesCFG NamespacedResourcesConfig, f *framework.Framework) (*resourceStack, map[string]*networking.Ingress) {
-	dpByBackendID, svcByBackendID := s.buildBackendResources(ns, resourcesCFG.BackendCFGs)
+	dpByBackendID, svcByBackendID := s.buildBackendResources(ns, resourcesCFG.BackendCFGs, f.Options.AWSRegion)
 	ingByIngID := s.buildIngressResources(ns, resourcesCFG.IngCFGs, svcByBackendID, f)
 
 	dps := make([]*appsv1.Deployment, 0, len(dpByBackendID))
@@ -282,18 +282,19 @@ func (s *multiPathBackendStack) buildIngressResource(ns *corev1.Namespace, ingID
 	return ing
 }
 
-func (s *multiPathBackendStack) buildBackendResources(ns *corev1.Namespace, backendCFGs map[string]BackendConfig) (map[string]*appsv1.Deployment, map[string]*corev1.Service) {
+func (s *multiPathBackendStack) buildBackendResources(ns *corev1.Namespace, backendCFGs map[string]BackendConfig, awsRegion string) (map[string]*appsv1.Deployment, map[string]*corev1.Service) {
 	dpByBackendID := make(map[string]*appsv1.Deployment, len(backendCFGs))
 	svcByBackendID := make(map[string]*corev1.Service, len(backendCFGs))
 	for backendID, backendCFG := range backendCFGs {
-		dp, svc := s.buildBackendResource(ns, backendID, backendCFG)
+		dp, svc := s.buildBackendResource(ns, backendID, backendCFG, awsRegion)
 		dpByBackendID[backendID] = dp
 		svcByBackendID[backendID] = svc
 	}
 	return dpByBackendID, svcByBackendID
 }
 
-func (s *multiPathBackendStack) buildBackendResource(ns *corev1.Namespace, backendID string, backendCFG BackendConfig) (*appsv1.Deployment, *corev1.Service) {
+func (s *multiPathBackendStack) buildBackendResource(ns *corev1.Namespace, backendID string, backendCFG BackendConfig, awsRegion string) (*appsv1.Deployment, *corev1.Service) {
+	dpImage := utils.GetDeploymentImage(awsRegion, utils.DefaultColortellerImage)
 	dp := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ns.Name,
@@ -316,7 +317,7 @@ func (s *multiPathBackendStack) buildBackendResource(ns *corev1.Namespace, backe
 					Containers: []corev1.Container{
 						{
 							Name:  "app",
-							Image: utils.ColortellerImage,
+							Image: dpImage,
 							Ports: []corev1.ContainerPort{
 								{
 									ContainerPort: 8080,

--- a/test/e2e/ingress/vanilla_ingress_test.go
+++ b/test/e2e/ingress/vanilla_ingress_test.go
@@ -73,7 +73,7 @@ var _ = Describe("vanilla ingress tests", func() {
 		It("[ingress-class] with IngressClass configured with 'ingress.k8s.aws/alb' controller, one ALB shall be created and functional", func() {
 			appBuilder := manifest.NewFixedResponseServiceBuilder()
 			ingBuilder := manifest.NewIngressBuilder()
-			dp, svc := appBuilder.Build(sandboxNS.Name, "app")
+			dp, svc := appBuilder.Build(sandboxNS.Name, "app", tf.Options.AWSRegion)
 			ingBackend := networking.IngressBackend{
 				Service: &networking.IngressServiceBackend{
 					Name: svc.Name,
@@ -119,7 +119,7 @@ var _ = Describe("vanilla ingress tests", func() {
 		It("with 'kubernetes.io/ingress.class' annotation set to 'alb', one ALB shall be created and functional", func() {
 			appBuilder := manifest.NewFixedResponseServiceBuilder()
 			ingBuilder := manifest.NewIngressBuilder()
-			dp, svc := appBuilder.Build(sandboxNS.Name, "app")
+			dp, svc := appBuilder.Build(sandboxNS.Name, "app", tf.Options.AWSRegion)
 			ingBackend := networking.IngressBackend{
 				Service: &networking.IngressServiceBackend{
 					Name: svc.Name,
@@ -159,7 +159,7 @@ var _ = Describe("vanilla ingress tests", func() {
 		It("[ingress-class] with IngressClass configured with 'nginx' controller, no ALB shall be created", func() {
 			appBuilder := manifest.NewFixedResponseServiceBuilder()
 			ingBuilder := manifest.NewIngressBuilder()
-			dp, svc := appBuilder.Build(sandboxNS.Name, "app")
+			dp, svc := appBuilder.Build(sandboxNS.Name, "app", tf.Options.AWSRegion)
 			ingBackend := networking.IngressBackend{
 				Service: &networking.IngressServiceBackend{
 					Name: svc.Name,
@@ -198,7 +198,7 @@ var _ = Describe("vanilla ingress tests", func() {
 		It("with 'kubernetes.io/ingress.class' annotation set to 'nginx', no ALB shall be created", func() {
 			appBuilder := manifest.NewFixedResponseServiceBuilder()
 			ingBuilder := manifest.NewIngressBuilder()
-			dp, svc := appBuilder.Build(sandboxNS.Name, "app")
+			dp, svc := appBuilder.Build(sandboxNS.Name, "app", tf.Options.AWSRegion)
 			ingBackend := networking.IngressBackend{
 				Service: &networking.IngressServiceBackend{
 					Name: svc.Name,
@@ -229,7 +229,7 @@ var _ = Describe("vanilla ingress tests", func() {
 		It("without IngressClass or 'kubernetes.io/ingress.class' annotation, no ALB shall be created", func() {
 			appBuilder := manifest.NewFixedResponseServiceBuilder()
 			ingBuilder := manifest.NewIngressBuilder()
-			dp, svc := appBuilder.Build(sandboxNS.Name, "app")
+			dp, svc := appBuilder.Build(sandboxNS.Name, "app", tf.Options.AWSRegion)
 			ingBackend := networking.IngressBackend{
 				Service: &networking.IngressServiceBackend{
 					Name: svc.Name,
@@ -261,7 +261,7 @@ var _ = Describe("vanilla ingress tests", func() {
 		It("with 'alb.ingress.kubernetes.io/load-balancer-name' annotation explicitly specified, one ALB shall be created and functional", func() {
 			appBuilder := manifest.NewFixedResponseServiceBuilder()
 			ingBuilder := manifest.NewIngressBuilder()
-			dp, svc := appBuilder.Build(sandboxNS.Name, "app")
+			dp, svc := appBuilder.Build(sandboxNS.Name, "app", tf.Options.AWSRegion)
 			ingBackend := networking.IngressBackend{
 				Service: &networking.IngressServiceBackend{
 					Name: svc.Name,
@@ -309,7 +309,7 @@ var _ = Describe("vanilla ingress tests", func() {
 		It("with 'alb.ingress.kubernetes.io/target-type' annotation explicitly specified, one ALB shall be created and functional", func() {
 			appBuilder := manifest.NewFixedResponseServiceBuilder().WithTargetPortName("e2e-targetport")
 			ingBuilder := manifest.NewIngressBuilder()
-			dp, svc := appBuilder.Build(sandboxNS.Name, "app")
+			dp, svc := appBuilder.Build(sandboxNS.Name, "app", tf.Options.AWSRegion)
 			ingBackend := networking.IngressBackend{
 				Service: &networking.IngressServiceBackend{
 					Name: svc.Name,
@@ -360,7 +360,7 @@ var _ = Describe("vanilla ingress tests", func() {
 		It("with 'alb.ingress.kubernetes.io/target-type' annotation explicitly specified, and endPointSlices enabled, one ALB shall be created and functional", func() {
 			appBuilder := manifest.NewFixedResponseServiceBuilder().WithTargetPortName("e2e-targetport")
 			ingBuilder := manifest.NewIngressBuilder()
-			dp, svc := appBuilder.Build(sandboxNS.Name, "app")
+			dp, svc := appBuilder.Build(sandboxNS.Name, "app", tf.Options.AWSRegion)
 			ingBackend := networking.IngressBackend{
 				Service: &networking.IngressServiceBackend{
 					Name: svc.Name,
@@ -401,8 +401,8 @@ var _ = Describe("vanilla ingress tests", func() {
 		It("with annotation based actions, one ALB shall be created and functional", func() {
 			appBuilder := manifest.NewFixedResponseServiceBuilder()
 			ingBuilder := manifest.NewIngressBuilder()
-			dp1, svc1 := appBuilder.WithHTTPBody("app-1").Build(sandboxNS.Name, "app-1")
-			dp2, svc2 := appBuilder.WithHTTPBody("app-2").Build(sandboxNS.Name, "app-2")
+			dp1, svc1 := appBuilder.WithHTTPBody("app-1").Build(sandboxNS.Name, "app-1", tf.Options.AWSRegion)
+			dp2, svc2 := appBuilder.WithHTTPBody("app-2").Build(sandboxNS.Name, "app-2", tf.Options.AWSRegion)
 			ingResponse503Backend := networking.IngressBackend{
 				Service: &networking.IngressServiceBackend{
 					Name: "response-503",

--- a/test/e2e/service/nlb_instance_target.go
+++ b/test/e2e/service/nlb_instance_target.go
@@ -8,11 +8,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework"
+	"sigs.k8s.io/aws-load-balancer-controller/test/framework/utils"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
-	defaultTestImage   = "public.ecr.aws/l6m2t8p7/hello-multi:latest"
 	appContainerPort   = 80
 	defaultNumReplicas = 3
 	defaultName        = "instance-e2e"
@@ -23,7 +23,7 @@ type NLBInstanceTestStack struct {
 }
 
 func (s *NLBInstanceTestStack) Deploy(ctx context.Context, f *framework.Framework, svcAnnotations map[string]string) error {
-	dp := s.buildDeploymentSpec()
+	dp := s.buildDeploymentSpec(f.Options.AWSRegion)
 	svc := s.buildServiceSpec(ctx, svcAnnotations)
 	s.resourceStack = NewResourceStack(dp, svc, "service-instance-e2e", false)
 
@@ -82,12 +82,13 @@ func (s *NLBInstanceTestStack) ApplyNodeLabels(ctx context.Context, f *framework
 	return nil
 }
 
-func (s *NLBInstanceTestStack) buildDeploymentSpec() *appsv1.Deployment {
+func (s *NLBInstanceTestStack) buildDeploymentSpec(awsRegion string) *appsv1.Deployment {
 	numReplicas := int32(defaultNumReplicas)
 	labels := map[string]string{
 		"app.kubernetes.io/name":     "multi-port",
 		"app.kubernetes.io/instance": defaultName,
 	}
+	dpImage := utils.GetDeploymentImage(awsRegion, utils.DefaultHelloImage)
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: defaultName,
@@ -106,7 +107,7 @@ func (s *NLBInstanceTestStack) buildDeploymentSpec() *appsv1.Deployment {
 						{
 							Name:            "app",
 							ImagePullPolicy: corev1.PullAlways,
-							Image:           defaultTestImage,
+							Image:           dpImage,
 							Ports: []corev1.ContainerPort{
 								{
 									ContainerPort: appContainerPort,

--- a/test/e2e/service/nlb_ip_target_test.go
+++ b/test/e2e/service/nlb_ip_target_test.go
@@ -23,7 +23,6 @@ var _ = Describe("k8s service reconciled by the aws load balancer", func() {
 		labels      map[string]string
 		stack       NLBIPTestStack
 	)
-
 	BeforeEach(func() {
 		ctx = context.Background()
 		numReplicas = 3
@@ -33,6 +32,7 @@ var _ = Describe("k8s service reconciled by the aws load balancer", func() {
 			"app.kubernetes.io/name":     "multi-port",
 			"app.kubernetes.io/instance": name,
 		}
+		dpImage := utils.GetDeploymentImage(tf.Options.AWSRegion, utils.DefaultHelloImage)
 		deployment = &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
@@ -51,7 +51,7 @@ var _ = Describe("k8s service reconciled by the aws load balancer", func() {
 							{
 								Name:            "app",
 								ImagePullPolicy: corev1.PullAlways,
-								Image:           defaultTestImage,
+								Image:           dpImage,
 								Ports: []corev1.ContainerPort{
 									{
 										ContainerPort: appContainerPort,

--- a/test/framework/manifest/fixed_response_service_builder.go
+++ b/test/framework/manifest/fixed_response_service_builder.go
@@ -68,15 +68,16 @@ func (b *fixedResponseServiceBuilder) WithServiceAnnotations(svcAnnotations map[
 	return b
 }
 
-func (b *fixedResponseServiceBuilder) Build(namespace string, name string) (*appsv1.Deployment, *corev1.Service) {
-	dp := b.buildDeployment(namespace, name)
+func (b *fixedResponseServiceBuilder) Build(namespace string, name string, awsRegion string) (*appsv1.Deployment, *corev1.Service) {
+	dp := b.buildDeployment(namespace, name, awsRegion)
 	svc := b.buildService(namespace, name)
 	return dp, svc
 }
 
 // TODO: have a deployment builder that been called by this component :D.
-func (b *fixedResponseServiceBuilder) buildDeployment(namespace string, name string) *appsv1.Deployment {
+func (b *fixedResponseServiceBuilder) buildDeployment(namespace string, name string, awsRegion string) *appsv1.Deployment {
 	podLabels := b.buildPodLabels(name)
+	dpImage := utils.GetDeploymentImage(awsRegion, utils.DefaultColortellerImage)
 	dp := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
@@ -95,7 +96,7 @@ func (b *fixedResponseServiceBuilder) buildDeployment(namespace string, name str
 					Containers: []corev1.Container{
 						{
 							Name:  "app",
-							Image: utils.ColortellerImage,
+							Image: dpImage,
 							Ports: []corev1.ContainerPort{
 								{
 									Name:          b.targetPortName,

--- a/test/framework/utils/constants.go
+++ b/test/framework/utils/constants.go
@@ -1,5 +1,9 @@
 package utils
 
 const (
-	ColortellerImage = "public.ecr.aws/l6m2t8p7/colorteller:latest"
+	DefaultAWSAccount       = "617930562442.dkr.ecr.us-west-2.amazonaws.com"
+	DCAAccount              = "639420080494.dkr.ecr.us-iso-east-1.c2s.ic.gov"
+	LCKAccount              = "517467847110.dkr.ecr.us-isob-east-1.sc2s.sgov.gov"
+	DefaultHelloImage       = "networking-e2e-test-images/hello-multi:latest"
+	DefaultColortellerImage = "networking-e2e-test-images/colorteller:latest"
 )

--- a/test/framework/utils/image.go
+++ b/test/framework/utils/image.go
@@ -1,0 +1,12 @@
+package utils
+
+func GetDeploymentImage(awsRegion string, image string) string {
+	awsAccount := DefaultAWSAccount
+	if awsRegion == "us-iso-east-1" {
+		awsAccount = DCAAccount
+	} else if awsRegion == "us-isob-east-1" {
+		awsAccount = LCKAccount
+	}
+	dpImage := awsAccount + "/" + image
+	return dpImage
+}


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->
1. Refactor the e2e test suites and run-e2e-test.sh to differentiate AWS default region vs. isolated regions. The test will access images in ECRs of corresponding regions depending on which region the test is being running in. This change is for internal prow tests purpose. 
2. Move the images ```public.ecr.aws/l6m2t8p7/hello-multi:latest``` and ```public.ecr.aws/l6m2t8p7/colorteller:latest``` to private repos ```networking-e2e-test-images/hello-multi``` and ```networking-e2e-test-images/colorteller``` under AWS accounts for consistency. Grant access to all SP.
3. e2e tests passed in local for default region, will test in ADC region afterward with the help from ADC engineers.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
