### PR TITLE
refactor e2e framework and add env PROD_IMAGE_REGISTRY to test script

### DIFF
--- a/test/e2e/ingress/multi_path_backend.go
+++ b/test/e2e/ingress/multi_path_backend.go
@@ -206,7 +206,7 @@ func (s *multiPathBackendStack) buildResourceStacks(namespacedResourcesCFGs map[
 }
 
 func (s *multiPathBackendStack) buildResourceStack(ns *corev1.Namespace, resourcesCFG NamespacedResourcesConfig, f *framework.Framework) (*resourceStack, map[string]*networking.Ingress) {
-	dpByBackendID, svcByBackendID := s.buildBackendResources(ns, resourcesCFG.BackendCFGs, f.Options.AWSRegion)
+	dpByBackendID, svcByBackendID := s.buildBackendResources(ns, resourcesCFG.BackendCFGs, f.Options.TestImageRegistry)
 	ingByIngID := s.buildIngressResources(ns, resourcesCFG.IngCFGs, svcByBackendID, f)
 
 	dps := make([]*appsv1.Deployment, 0, len(dpByBackendID))
@@ -282,19 +282,19 @@ func (s *multiPathBackendStack) buildIngressResource(ns *corev1.Namespace, ingID
 	return ing
 }
 
-func (s *multiPathBackendStack) buildBackendResources(ns *corev1.Namespace, backendCFGs map[string]BackendConfig, awsRegion string) (map[string]*appsv1.Deployment, map[string]*corev1.Service) {
+func (s *multiPathBackendStack) buildBackendResources(ns *corev1.Namespace, backendCFGs map[string]BackendConfig, testImageRegistry string) (map[string]*appsv1.Deployment, map[string]*corev1.Service) {
 	dpByBackendID := make(map[string]*appsv1.Deployment, len(backendCFGs))
 	svcByBackendID := make(map[string]*corev1.Service, len(backendCFGs))
 	for backendID, backendCFG := range backendCFGs {
-		dp, svc := s.buildBackendResource(ns, backendID, backendCFG, awsRegion)
+		dp, svc := s.buildBackendResource(ns, backendID, backendCFG, testImageRegistry)
 		dpByBackendID[backendID] = dp
 		svcByBackendID[backendID] = svc
 	}
 	return dpByBackendID, svcByBackendID
 }
 
-func (s *multiPathBackendStack) buildBackendResource(ns *corev1.Namespace, backendID string, backendCFG BackendConfig, awsRegion string) (*appsv1.Deployment, *corev1.Service) {
-	dpImage := utils.GetDeploymentImage(awsRegion, utils.DefaultColortellerImage)
+func (s *multiPathBackendStack) buildBackendResource(ns *corev1.Namespace, backendID string, backendCFG BackendConfig, testImageRegistry string) (*appsv1.Deployment, *corev1.Service) {
+	dpImage := utils.GetDeploymentImage(testImageRegistry, utils.ColortellerImage)
 	dp := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ns.Name,

--- a/test/e2e/ingress/vanilla_ingress_test.go
+++ b/test/e2e/ingress/vanilla_ingress_test.go
@@ -73,7 +73,7 @@ var _ = Describe("vanilla ingress tests", func() {
 		It("[ingress-class] with IngressClass configured with 'ingress.k8s.aws/alb' controller, one ALB shall be created and functional", func() {
 			appBuilder := manifest.NewFixedResponseServiceBuilder()
 			ingBuilder := manifest.NewIngressBuilder()
-			dp, svc := appBuilder.Build(sandboxNS.Name, "app", tf.Options.AWSRegion)
+			dp, svc := appBuilder.Build(sandboxNS.Name, "app", tf.Options.TestImageRegistry)
 			ingBackend := networking.IngressBackend{
 				Service: &networking.IngressServiceBackend{
 					Name: svc.Name,
@@ -119,7 +119,7 @@ var _ = Describe("vanilla ingress tests", func() {
 		It("with 'kubernetes.io/ingress.class' annotation set to 'alb', one ALB shall be created and functional", func() {
 			appBuilder := manifest.NewFixedResponseServiceBuilder()
 			ingBuilder := manifest.NewIngressBuilder()
-			dp, svc := appBuilder.Build(sandboxNS.Name, "app", tf.Options.AWSRegion)
+			dp, svc := appBuilder.Build(sandboxNS.Name, "app", tf.Options.TestImageRegistry)
 			ingBackend := networking.IngressBackend{
 				Service: &networking.IngressServiceBackend{
 					Name: svc.Name,
@@ -159,7 +159,7 @@ var _ = Describe("vanilla ingress tests", func() {
 		It("[ingress-class] with IngressClass configured with 'nginx' controller, no ALB shall be created", func() {
 			appBuilder := manifest.NewFixedResponseServiceBuilder()
 			ingBuilder := manifest.NewIngressBuilder()
-			dp, svc := appBuilder.Build(sandboxNS.Name, "app", tf.Options.AWSRegion)
+			dp, svc := appBuilder.Build(sandboxNS.Name, "app", tf.Options.TestImageRegistry)
 			ingBackend := networking.IngressBackend{
 				Service: &networking.IngressServiceBackend{
 					Name: svc.Name,
@@ -198,7 +198,7 @@ var _ = Describe("vanilla ingress tests", func() {
 		It("with 'kubernetes.io/ingress.class' annotation set to 'nginx', no ALB shall be created", func() {
 			appBuilder := manifest.NewFixedResponseServiceBuilder()
 			ingBuilder := manifest.NewIngressBuilder()
-			dp, svc := appBuilder.Build(sandboxNS.Name, "app", tf.Options.AWSRegion)
+			dp, svc := appBuilder.Build(sandboxNS.Name, "app", tf.Options.TestImageRegistry)
 			ingBackend := networking.IngressBackend{
 				Service: &networking.IngressServiceBackend{
 					Name: svc.Name,
@@ -229,7 +229,7 @@ var _ = Describe("vanilla ingress tests", func() {
 		It("without IngressClass or 'kubernetes.io/ingress.class' annotation, no ALB shall be created", func() {
 			appBuilder := manifest.NewFixedResponseServiceBuilder()
 			ingBuilder := manifest.NewIngressBuilder()
-			dp, svc := appBuilder.Build(sandboxNS.Name, "app", tf.Options.AWSRegion)
+			dp, svc := appBuilder.Build(sandboxNS.Name, "app", tf.Options.TestImageRegistry)
 			ingBackend := networking.IngressBackend{
 				Service: &networking.IngressServiceBackend{
 					Name: svc.Name,
@@ -261,7 +261,7 @@ var _ = Describe("vanilla ingress tests", func() {
 		It("with 'alb.ingress.kubernetes.io/load-balancer-name' annotation explicitly specified, one ALB shall be created and functional", func() {
 			appBuilder := manifest.NewFixedResponseServiceBuilder()
 			ingBuilder := manifest.NewIngressBuilder()
-			dp, svc := appBuilder.Build(sandboxNS.Name, "app", tf.Options.AWSRegion)
+			dp, svc := appBuilder.Build(sandboxNS.Name, "app", tf.Options.TestImageRegistry)
 			ingBackend := networking.IngressBackend{
 				Service: &networking.IngressServiceBackend{
 					Name: svc.Name,
@@ -309,7 +309,7 @@ var _ = Describe("vanilla ingress tests", func() {
 		It("with 'alb.ingress.kubernetes.io/target-type' annotation explicitly specified, one ALB shall be created and functional", func() {
 			appBuilder := manifest.NewFixedResponseServiceBuilder().WithTargetPortName("e2e-targetport")
 			ingBuilder := manifest.NewIngressBuilder()
-			dp, svc := appBuilder.Build(sandboxNS.Name, "app", tf.Options.AWSRegion)
+			dp, svc := appBuilder.Build(sandboxNS.Name, "app", tf.Options.TestImageRegistry)
 			ingBackend := networking.IngressBackend{
 				Service: &networking.IngressServiceBackend{
 					Name: svc.Name,
@@ -360,7 +360,7 @@ var _ = Describe("vanilla ingress tests", func() {
 		It("with 'alb.ingress.kubernetes.io/target-type' annotation explicitly specified, and endPointSlices enabled, one ALB shall be created and functional", func() {
 			appBuilder := manifest.NewFixedResponseServiceBuilder().WithTargetPortName("e2e-targetport")
 			ingBuilder := manifest.NewIngressBuilder()
-			dp, svc := appBuilder.Build(sandboxNS.Name, "app", tf.Options.AWSRegion)
+			dp, svc := appBuilder.Build(sandboxNS.Name, "app", tf.Options.TestImageRegistry)
 			ingBackend := networking.IngressBackend{
 				Service: &networking.IngressServiceBackend{
 					Name: svc.Name,
@@ -401,8 +401,8 @@ var _ = Describe("vanilla ingress tests", func() {
 		It("with annotation based actions, one ALB shall be created and functional", func() {
 			appBuilder := manifest.NewFixedResponseServiceBuilder()
 			ingBuilder := manifest.NewIngressBuilder()
-			dp1, svc1 := appBuilder.WithHTTPBody("app-1").Build(sandboxNS.Name, "app-1", tf.Options.AWSRegion)
-			dp2, svc2 := appBuilder.WithHTTPBody("app-2").Build(sandboxNS.Name, "app-2", tf.Options.AWSRegion)
+			dp1, svc1 := appBuilder.WithHTTPBody("app-1").Build(sandboxNS.Name, "app-1", tf.Options.TestImageRegistry)
+			dp2, svc2 := appBuilder.WithHTTPBody("app-2").Build(sandboxNS.Name, "app-2", tf.Options.TestImageRegistry)
 			ingResponse503Backend := networking.IngressBackend{
 				Service: &networking.IngressServiceBackend{
 					Name: "response-503",

--- a/test/e2e/service/nlb_instance_target.go
+++ b/test/e2e/service/nlb_instance_target.go
@@ -23,7 +23,7 @@ type NLBInstanceTestStack struct {
 }
 
 func (s *NLBInstanceTestStack) Deploy(ctx context.Context, f *framework.Framework, svcAnnotations map[string]string) error {
-	dp := s.buildDeploymentSpec(f.Options.AWSRegion)
+	dp := s.buildDeploymentSpec(f.Options.TestImageRegistry)
 	svc := s.buildServiceSpec(ctx, svcAnnotations)
 	s.resourceStack = NewResourceStack(dp, svc, "service-instance-e2e", false)
 
@@ -82,13 +82,13 @@ func (s *NLBInstanceTestStack) ApplyNodeLabels(ctx context.Context, f *framework
 	return nil
 }
 
-func (s *NLBInstanceTestStack) buildDeploymentSpec(awsRegion string) *appsv1.Deployment {
+func (s *NLBInstanceTestStack) buildDeploymentSpec(testImageRegistry string) *appsv1.Deployment {
 	numReplicas := int32(defaultNumReplicas)
 	labels := map[string]string{
 		"app.kubernetes.io/name":     "multi-port",
 		"app.kubernetes.io/instance": defaultName,
 	}
-	dpImage := utils.GetDeploymentImage(awsRegion, utils.DefaultHelloImage)
+	dpImage := utils.GetDeploymentImage(testImageRegistry, utils.HelloImage)
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: defaultName,

--- a/test/e2e/service/nlb_ip_target_test.go
+++ b/test/e2e/service/nlb_ip_target_test.go
@@ -32,7 +32,7 @@ var _ = Describe("k8s service reconciled by the aws load balancer", func() {
 			"app.kubernetes.io/name":     "multi-port",
 			"app.kubernetes.io/instance": name,
 		}
-		dpImage := utils.GetDeploymentImage(tf.Options.AWSRegion, utils.DefaultHelloImage)
+		dpImage := utils.GetDeploymentImage(tf.Options.TestImageRegistry, utils.HelloImage)
 		deployment = &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,

--- a/test/framework/manifest/fixed_response_service_builder.go
+++ b/test/framework/manifest/fixed_response_service_builder.go
@@ -68,16 +68,16 @@ func (b *fixedResponseServiceBuilder) WithServiceAnnotations(svcAnnotations map[
 	return b
 }
 
-func (b *fixedResponseServiceBuilder) Build(namespace string, name string, awsRegion string) (*appsv1.Deployment, *corev1.Service) {
-	dp := b.buildDeployment(namespace, name, awsRegion)
+func (b *fixedResponseServiceBuilder) Build(namespace string, name string, testImageRegistry string) (*appsv1.Deployment, *corev1.Service) {
+	dp := b.buildDeployment(namespace, name, testImageRegistry)
 	svc := b.buildService(namespace, name)
 	return dp, svc
 }
 
 // TODO: have a deployment builder that been called by this component :D.
-func (b *fixedResponseServiceBuilder) buildDeployment(namespace string, name string, awsRegion string) *appsv1.Deployment {
+func (b *fixedResponseServiceBuilder) buildDeployment(namespace string, name string, testImageRegistry string) *appsv1.Deployment {
 	podLabels := b.buildPodLabels(name)
-	dpImage := utils.GetDeploymentImage(awsRegion, utils.DefaultColortellerImage)
+	dpImage := utils.GetDeploymentImage(testImageRegistry, utils.ColortellerImage)
 	dp := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,

--- a/test/framework/options.go
+++ b/test/framework/options.go
@@ -25,9 +25,10 @@ type Options struct {
 	ControllerImage string
 
 	// Additional parameters for e2e tests
-	S3BucketName    string
-	CertificateARNs string
-	IPFamily        string
+	S3BucketName      string
+	CertificateARNs   string
+	IPFamily          string
+	TestImageRegistry string
 }
 
 func (options *Options) BindFlags() {
@@ -41,6 +42,7 @@ func (options *Options) BindFlags() {
 	flag.StringVar(&options.S3BucketName, "s3-bucket-name", "", `S3 bucket to use for testing load balancer access logging feature`)
 	flag.StringVar(&options.CertificateARNs, "certificate-arns", "", `Certificate ARNs to use for TLS listeners`)
 	flag.StringVar(&options.IPFamily, "ip-family", "IPv4", "the ip family used for the cluster, can be IPv4 or IPv6")
+	flag.StringVar(&options.TestImageRegistry, "test-image-registry", "617930562442.dkr.ecr.us-west-2.amazonaws.com", "the aws registry in test-infra-* accounts where e2e test images are stored")
 }
 
 func (options *Options) Validate() error {
@@ -55,6 +57,9 @@ func (options *Options) Validate() error {
 	}
 	if len(options.AWSVPCID) == 0 {
 		return errors.Errorf("%s must be set!", "aws-vpc-id")
+	}
+	if len(options.TestImageRegistry) == 0 {
+		return errors.Errorf("%s must be set!", "test-image-registry")
 	}
 	return nil
 }

--- a/test/framework/utils/constants.go
+++ b/test/framework/utils/constants.go
@@ -1,9 +1,6 @@
 package utils
 
 const (
-	DefaultAWSAccount       = "617930562442.dkr.ecr.us-west-2.amazonaws.com"
-	DCAAccount              = "639420080494.dkr.ecr.us-iso-east-1.c2s.ic.gov"
-	LCKAccount              = "517467847110.dkr.ecr.us-isob-east-1.sc2s.sgov.gov"
-	DefaultHelloImage       = "networking-e2e-test-images/hello-multi:latest"
-	DefaultColortellerImage = "networking-e2e-test-images/colorteller:latest"
+	HelloImage       = "networking-e2e-test-images/hello-multi:latest"
+	ColortellerImage = "networking-e2e-test-images/colorteller:latest"
 )

--- a/test/framework/utils/image.go
+++ b/test/framework/utils/image.go
@@ -1,12 +1,5 @@
 package utils
 
-func GetDeploymentImage(awsRegion string, image string) string {
-	awsAccount := DefaultAWSAccount
-	if awsRegion == "us-iso-east-1" {
-		awsAccount = DCAAccount
-	} else if awsRegion == "us-isob-east-1" {
-		awsAccount = LCKAccount
-	}
-	dpImage := awsAccount + "/" + image
-	return dpImage
+func GetDeploymentImage(registry string, image string) string {
+	return registry + "/" + image
 }


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->
1. This PR adds a new ENV ```PROD_IMAGE_REGISTRY``` in test script which will be passed from internal CI jobs. It will map the registries in ```build-prod-*``` accounts for LBC GA images.
2. The env ```TEST_IMAGE_REGISTRY``` maps the e2e test images in ```test-infra-*``` accounts across AWS partition.
3. This PR adds a new option ```TestImageRegistry``` in e2e framework with default value to the registry in test-infra account in us-west-2, so we can get rid of the constants in e2e framework by consuming the value of TEST_IMAGE_REGISTRY.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
