### PR TITLE
test/framework: replace deprecated ioutil.ReadAll

### DIFF
--- a/test/framework/http/response.go
+++ b/test/framework/http/response.go
@@ -1,8 +1,8 @@
 package http
 
 import (
-	"io/ioutil"
 	gohttp "net/http"
+	"os"
 )
 
 type Response struct {
@@ -12,7 +12,7 @@ type Response struct {
 
 func buildResponse(resp *gohttp.Response) (Response, error) {
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := os.ReadAll(resp.Body)
 	if err != nil {
 		return Response{}, err
 	}

--- a/test/framework/http/response.go
+++ b/test/framework/http/response.go
@@ -1,8 +1,8 @@
 package http
 
 import (
+	"io"
 	gohttp "net/http"
-	"os"
 )
 
 type Response struct {
@@ -12,7 +12,7 @@ type Response struct {
 
 func buildResponse(resp *gohttp.Response) (Response, error) {
 	defer resp.Body.Close()
-	body, err := os.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return Response{}, err
 	}


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

[This package](https://pkg.go.dev/io/ioutil#ReadAll) is deprecated.
so, change to io/ioutil -> io

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
