### PR TITLE
Controller cfg for backend sg rule management

### DIFF
--- a/controllers/ingress/group_controller.go
+++ b/controllers/ingress/group_controller.go
@@ -61,7 +61,7 @@ func NewGroupReconciler(cloud aws.Cloud, k8sClient client.Client, eventRecorder 
 		authConfigBuilder, enhancedBackendBuilder, trackingProvider, elbv2TaggingManager, controllerConfig.FeatureGates,
 		cloud.VpcID(), controllerConfig.ClusterName, controllerConfig.DefaultTags, controllerConfig.ExternalManagedTags,
 		controllerConfig.DefaultSSLPolicy, controllerConfig.DefaultTargetType, backendSGProvider, sgResolver,
-		controllerConfig.EnableBackendSecurityGroup, controllerConfig.EnableBackendSGRuleManagement, controllerConfig.DisableRestrictedSGRules,
+		controllerConfig.EnableBackendSecurityGroup, controllerConfig.ManageBackendSGRules, controllerConfig.DisableRestrictedSGRules,
 		controllerConfig.FeatureGates.Enabled(config.EnableIPTargetType), logger)
 	stackMarshaller := deploy.NewDefaultStackMarshaller()
 	stackDeployer := deploy.NewDefaultStackDeployer(cloud, k8sClient, networkingSGManager, networkingSGReconciler,

--- a/controllers/ingress/group_controller.go
+++ b/controllers/ingress/group_controller.go
@@ -61,7 +61,8 @@ func NewGroupReconciler(cloud aws.Cloud, k8sClient client.Client, eventRecorder 
 		authConfigBuilder, enhancedBackendBuilder, trackingProvider, elbv2TaggingManager, controllerConfig.FeatureGates,
 		cloud.VpcID(), controllerConfig.ClusterName, controllerConfig.DefaultTags, controllerConfig.ExternalManagedTags,
 		controllerConfig.DefaultSSLPolicy, controllerConfig.DefaultTargetType, backendSGProvider, sgResolver,
-		controllerConfig.EnableBackendSecurityGroup, controllerConfig.DisableRestrictedSGRules, controllerConfig.FeatureGates.Enabled(config.EnableIPTargetType), logger)
+		controllerConfig.EnableBackendSecurityGroup, controllerConfig.EnableBackendSGRuleManagement, controllerConfig.DisableRestrictedSGRules,
+		controllerConfig.FeatureGates.Enabled(config.EnableIPTargetType), logger)
 	stackMarshaller := deploy.NewDefaultStackMarshaller()
 	stackDeployer := deploy.NewDefaultStackDeployer(cloud, k8sClient, networkingSGManager, networkingSGReconciler,
 		controllerConfig, ingressTagPrefix, logger)

--- a/controllers/service/service_controller.go
+++ b/controllers/service/service_controller.go
@@ -44,7 +44,9 @@ func NewServiceReconciler(cloud aws.Cloud, k8sClient client.Client, eventRecorde
 	elbv2TaggingManager := elbv2.NewDefaultTaggingManager(cloud.ELBV2(), cloud.VpcID(), controllerConfig.FeatureGates, cloud.RGT(), logger)
 	serviceUtils := service.NewServiceUtils(annotationParser, serviceFinalizer, controllerConfig.ServiceConfig.LoadBalancerClass, controllerConfig.FeatureGates)
 	modelBuilder := service.NewDefaultModelBuilder(annotationParser, subnetsResolver, vpcInfoProvider, cloud.VpcID(), trackingProvider,
-		elbv2TaggingManager, controllerConfig.FeatureGates, controllerConfig.ClusterName, controllerConfig.DefaultTags, controllerConfig.ExternalManagedTags, controllerConfig.DefaultSSLPolicy, controllerConfig.DefaultTargetType, controllerConfig.FeatureGates.Enabled(config.EnableIPTargetType), serviceUtils)
+		elbv2TaggingManager, controllerConfig.FeatureGates, controllerConfig.ClusterName, controllerConfig.DefaultTags, controllerConfig.ExternalManagedTags,
+		controllerConfig.DefaultSSLPolicy, controllerConfig.DefaultTargetType, controllerConfig.FeatureGates.Enabled(config.EnableIPTargetType),
+		controllerConfig.EnableBackendSGRuleManagement, serviceUtils)
 	stackMarshaller := deploy.NewDefaultStackMarshaller()
 	stackDeployer := deploy.NewDefaultStackDeployer(cloud, k8sClient, networkingSGManager, networkingSGReconciler, controllerConfig, serviceTagPrefix, logger)
 	return &serviceReconciler{

--- a/controllers/service/service_controller.go
+++ b/controllers/service/service_controller.go
@@ -46,7 +46,7 @@ func NewServiceReconciler(cloud aws.Cloud, k8sClient client.Client, eventRecorde
 	modelBuilder := service.NewDefaultModelBuilder(annotationParser, subnetsResolver, vpcInfoProvider, cloud.VpcID(), trackingProvider,
 		elbv2TaggingManager, controllerConfig.FeatureGates, controllerConfig.ClusterName, controllerConfig.DefaultTags, controllerConfig.ExternalManagedTags,
 		controllerConfig.DefaultSSLPolicy, controllerConfig.DefaultTargetType, controllerConfig.FeatureGates.Enabled(config.EnableIPTargetType),
-		controllerConfig.EnableBackendSGRuleManagement, serviceUtils)
+		controllerConfig.ManageBackendSGRules, serviceUtils)
 	stackMarshaller := deploy.NewDefaultStackMarshaller()
 	stackDeployer := deploy.NewDefaultStackDeployer(cloud, k8sClient, networkingSGManager, networkingSGReconciler, controllerConfig, serviceTagPrefix, logger)
 	return &serviceReconciler{

--- a/docs/deploy/configurations.md
+++ b/docs/deploy/configurations.md
@@ -80,6 +80,7 @@ Currently, you can set only 1 namespace to watch in this flag. See [this Kuberne
 |[disable-ingress-group-name-annotation](#disable-ingress-group-name-annotation)  | boolean                         | false           | Disallow new use of the `alb.ingress.kubernetes.io/group.name` annotation |
 |disable-restricted-sg-rules            | boolean                         | false            | Disable the usage of restricted security group rules |
 |enable-backend-security-group          | boolean                         | true            | Enable sharing of security groups for backend traffic |
+|manage-backend-sg-rules                | boolean                         | true            | Enables controller to manage backend SG rules. If `false` controller won't manage the rules, if `true` controller will manage if the annotations on ingress/service don't disable managing. Defaults to `true` |
 |enable-endpoint-slices                 | boolean                         | false           | Use EndpointSlices instead of Endpoints for pod endpoint and TargetGroupBinding resolution for load balancers with IP targets. |
 |enable-leader-election                 | boolean                         | true            | Enable leader election for the load balancer controller manager. Enabling this will ensure there is only one active controller manager |
 |enable-pod-readiness-gate-inject       | boolean                         | true            | If enabled, targetHealth readiness gate will get injected to the pod spec for the matching endpoint pods |

--- a/pkg/config/controller_config.go
+++ b/pkg/config/controller_config.go
@@ -23,6 +23,7 @@ const (
 	flagTargetGroupBindingMaxExponentialBackoffDelay = "targetgroupbinding-max-exponential-backoff-delay"
 	flagDefaultSSLPolicy                             = "default-ssl-policy"
 	flagEnableBackendSG                              = "enable-backend-security-group"
+	flagEnableBackendSGRuleManagement                = "enable-backend-sg-rule-management"
 	flagBackendSecurityGroup                         = "backend-security-group"
 	flagEnableEndpointSlices                         = "enable-endpoint-slices"
 	flagDisableRestrictedSGRules                     = "disable-restricted-sg-rules"
@@ -31,6 +32,7 @@ const (
 	defaultMaxExponentialBackoffDelay                = time.Second * 1000
 	defaultSSLPolicy                                 = "ELBSecurityPolicy-2016-08"
 	defaultEnableBackendSG                           = true
+	defaultEnableBackendSGRuleManagement             = true
 	defaultEnableEndpointSlices                      = false
 	defaultDisableRestrictedSGRules                  = false
 )
@@ -91,6 +93,9 @@ type ControllerConfig struct {
 	// EnableBackendSecurityGroup specifies whether to use optimized security group rules
 	EnableBackendSecurityGroup bool
 
+	// EnableBackendSGRuleManagement specifies whether to manage backend security group rules
+	EnableBackendSGRuleManagement bool
+
 	// BackendSecurityGroups specifies the configured backend security group to use
 	// for optimized security group rules
 	BackendSecurityGroup string
@@ -122,6 +127,8 @@ func (cfg *ControllerConfig) BindFlags(fs *pflag.FlagSet) {
 		"Default SSL policy for load balancers listeners")
 	fs.BoolVar(&cfg.EnableBackendSecurityGroup, flagEnableBackendSG, defaultEnableBackendSG,
 		"Enable sharing of security groups for backend traffic")
+	fs.BoolVar(&cfg.EnableBackendSGRuleManagement, flagEnableBackendSGRuleManagement, defaultEnableBackendSGRuleManagement,
+		"Enable management of backend security group rules")
 	fs.StringVar(&cfg.BackendSecurityGroup, flagBackendSecurityGroup, "",
 		"Backend security group id to use for the ingress rules on the worker node SG")
 	fs.BoolVar(&cfg.EnableEndpointSlices, flagEnableEndpointSlices, defaultEnableEndpointSlices,

--- a/pkg/config/controller_config.go
+++ b/pkg/config/controller_config.go
@@ -23,7 +23,7 @@ const (
 	flagTargetGroupBindingMaxExponentialBackoffDelay = "targetgroupbinding-max-exponential-backoff-delay"
 	flagDefaultSSLPolicy                             = "default-ssl-policy"
 	flagEnableBackendSG                              = "enable-backend-security-group"
-	flagEnableBackendSGRuleManagement                = "enable-backend-sg-rule-management"
+	flagManageBackendSGRules                         = "manage-backend-sg-rules"
 	flagBackendSecurityGroup                         = "backend-security-group"
 	flagEnableEndpointSlices                         = "enable-endpoint-slices"
 	flagDisableRestrictedSGRules                     = "disable-restricted-sg-rules"
@@ -32,7 +32,7 @@ const (
 	defaultMaxExponentialBackoffDelay                = time.Second * 1000
 	defaultSSLPolicy                                 = "ELBSecurityPolicy-2016-08"
 	defaultEnableBackendSG                           = true
-	defaultEnableBackendSGRuleManagement             = true
+	defaultManageBackendSGRules                      = true
 	defaultEnableEndpointSlices                      = false
 	defaultDisableRestrictedSGRules                  = false
 )
@@ -93,8 +93,8 @@ type ControllerConfig struct {
 	// EnableBackendSecurityGroup specifies whether to use optimized security group rules
 	EnableBackendSecurityGroup bool
 
-	// EnableBackendSGRuleManagement specifies whether to manage backend security group rules
-	EnableBackendSGRuleManagement bool
+	// ManageBackendSGRules specifies whether to manage backend security group rules
+	ManageBackendSGRules bool
 
 	// BackendSecurityGroups specifies the configured backend security group to use
 	// for optimized security group rules
@@ -127,7 +127,7 @@ func (cfg *ControllerConfig) BindFlags(fs *pflag.FlagSet) {
 		"Default SSL policy for load balancers listeners")
 	fs.BoolVar(&cfg.EnableBackendSecurityGroup, flagEnableBackendSG, defaultEnableBackendSG,
 		"Enable sharing of security groups for backend traffic")
-	fs.BoolVar(&cfg.EnableBackendSGRuleManagement, flagEnableBackendSGRuleManagement, defaultEnableBackendSGRuleManagement,
+	fs.BoolVar(&cfg.ManageBackendSGRules, flagManageBackendSGRules, defaultManageBackendSGRules,
 		"Enable management of backend security group rules")
 	fs.StringVar(&cfg.BackendSecurityGroup, flagBackendSecurityGroup, "",
 		"Backend security group id to use for the ingress rules on the worker node SG")

--- a/pkg/ingress/model_build_load_balancer.go
+++ b/pkg/ingress/model_build_load_balancer.go
@@ -290,7 +290,7 @@ func (t *defaultModelBuildTask) buildLoadBalancerSecurityGroups(ctx context.Cont
 			backendSGIDToken = core.LiteralStringToken((backendSGID))
 			lbSGTokens = append(lbSGTokens, backendSGIDToken)
 		}
-		if t.enableBackendSGRuleManagement {
+		if t.manageBackendSGRules {
 			t.backendSGIDToken = backendSGIDToken
 		}
 		t.logger.Info("Auto Create SG", "LB SGs", lbSGTokens, "backend SG", backendSGIDToken)

--- a/pkg/ingress/model_builder.go
+++ b/pkg/ingress/model_builder.go
@@ -43,34 +43,35 @@ func NewDefaultModelBuilder(k8sClient client.Client, eventRecorder record.EventR
 	trackingProvider tracking.Provider, elbv2TaggingManager elbv2deploy.TaggingManager, featureGates config.FeatureGates,
 	vpcID string, clusterName string, defaultTags map[string]string, externalManagedTags []string, defaultSSLPolicy string, defaultTargetType string,
 	backendSGProvider networkingpkg.BackendSGProvider, sgResolver networkingpkg.SecurityGroupResolver,
-	enableBackendSG bool, disableRestrictedSGRules bool, enableIPTargetType bool, logger logr.Logger) *defaultModelBuilder {
+	enableBackendSG bool, enableBackendSGRuleManagement bool, disableRestrictedSGRules bool, enableIPTargetType bool, logger logr.Logger) *defaultModelBuilder {
 	certDiscovery := NewACMCertDiscovery(acmClient, logger)
 	ruleOptimizer := NewDefaultRuleOptimizer(logger)
 	return &defaultModelBuilder{
-		k8sClient:                k8sClient,
-		eventRecorder:            eventRecorder,
-		ec2Client:                ec2Client,
-		vpcID:                    vpcID,
-		clusterName:              clusterName,
-		annotationParser:         annotationParser,
-		subnetsResolver:          subnetsResolver,
-		backendSGProvider:        backendSGProvider,
-		sgResolver:               sgResolver,
-		certDiscovery:            certDiscovery,
-		authConfigBuilder:        authConfigBuilder,
-		enhancedBackendBuilder:   enhancedBackendBuilder,
-		ruleOptimizer:            ruleOptimizer,
-		trackingProvider:         trackingProvider,
-		elbv2TaggingManager:      elbv2TaggingManager,
-		featureGates:             featureGates,
-		defaultTags:              defaultTags,
-		externalManagedTags:      sets.NewString(externalManagedTags...),
-		defaultSSLPolicy:         defaultSSLPolicy,
-		defaultTargetType:        elbv2model.TargetType(defaultTargetType),
-		enableBackendSG:          enableBackendSG,
-		disableRestrictedSGRules: disableRestrictedSGRules,
-		enableIPTargetType:       enableIPTargetType,
-		logger:                   logger,
+		k8sClient:                     k8sClient,
+		eventRecorder:                 eventRecorder,
+		ec2Client:                     ec2Client,
+		vpcID:                         vpcID,
+		clusterName:                   clusterName,
+		annotationParser:              annotationParser,
+		subnetsResolver:               subnetsResolver,
+		backendSGProvider:             backendSGProvider,
+		sgResolver:                    sgResolver,
+		certDiscovery:                 certDiscovery,
+		authConfigBuilder:             authConfigBuilder,
+		enhancedBackendBuilder:        enhancedBackendBuilder,
+		ruleOptimizer:                 ruleOptimizer,
+		trackingProvider:              trackingProvider,
+		elbv2TaggingManager:           elbv2TaggingManager,
+		featureGates:                  featureGates,
+		defaultTags:                   defaultTags,
+		externalManagedTags:           sets.NewString(externalManagedTags...),
+		defaultSSLPolicy:              defaultSSLPolicy,
+		defaultTargetType:             elbv2model.TargetType(defaultTargetType),
+		enableBackendSG:               enableBackendSG,
+		enableBackendSGRuleManagement: enableBackendSGRuleManagement,
+		disableRestrictedSGRules:      disableRestrictedSGRules,
+		enableIPTargetType:            enableIPTargetType,
+		logger:                        logger,
 	}
 }
 
@@ -85,24 +86,25 @@ type defaultModelBuilder struct {
 	vpcID       string
 	clusterName string
 
-	annotationParser         annotations.Parser
-	subnetsResolver          networkingpkg.SubnetsResolver
-	backendSGProvider        networkingpkg.BackendSGProvider
-	sgResolver               networkingpkg.SecurityGroupResolver
-	certDiscovery            CertDiscovery
-	authConfigBuilder        AuthConfigBuilder
-	enhancedBackendBuilder   EnhancedBackendBuilder
-	ruleOptimizer            RuleOptimizer
-	trackingProvider         tracking.Provider
-	elbv2TaggingManager      elbv2deploy.TaggingManager
-	featureGates             config.FeatureGates
-	defaultTags              map[string]string
-	externalManagedTags      sets.String
-	defaultSSLPolicy         string
-	defaultTargetType        elbv2model.TargetType
-	enableBackendSG          bool
-	disableRestrictedSGRules bool
-	enableIPTargetType       bool
+	annotationParser              annotations.Parser
+	subnetsResolver               networkingpkg.SubnetsResolver
+	backendSGProvider             networkingpkg.BackendSGProvider
+	sgResolver                    networkingpkg.SecurityGroupResolver
+	certDiscovery                 CertDiscovery
+	authConfigBuilder             AuthConfigBuilder
+	enhancedBackendBuilder        EnhancedBackendBuilder
+	ruleOptimizer                 RuleOptimizer
+	trackingProvider              tracking.Provider
+	elbv2TaggingManager           elbv2deploy.TaggingManager
+	featureGates                  config.FeatureGates
+	defaultTags                   map[string]string
+	externalManagedTags           sets.String
+	defaultSSLPolicy              string
+	defaultTargetType             elbv2model.TargetType
+	enableBackendSG               bool
+	enableBackendSGRuleManagement bool
+	disableRestrictedSGRules      bool
+	enableIPTargetType            bool
 
 	logger logr.Logger
 }
@@ -111,26 +113,27 @@ type defaultModelBuilder struct {
 func (b *defaultModelBuilder) Build(ctx context.Context, ingGroup Group) (core.Stack, *elbv2model.LoadBalancer, []types.NamespacedName, bool, error) {
 	stack := core.NewDefaultStack(core.StackID(ingGroup.ID))
 	task := &defaultModelBuildTask{
-		k8sClient:                b.k8sClient,
-		eventRecorder:            b.eventRecorder,
-		ec2Client:                b.ec2Client,
-		vpcID:                    b.vpcID,
-		clusterName:              b.clusterName,
-		annotationParser:         b.annotationParser,
-		subnetsResolver:          b.subnetsResolver,
-		certDiscovery:            b.certDiscovery,
-		authConfigBuilder:        b.authConfigBuilder,
-		enhancedBackendBuilder:   b.enhancedBackendBuilder,
-		ruleOptimizer:            b.ruleOptimizer,
-		trackingProvider:         b.trackingProvider,
-		elbv2TaggingManager:      b.elbv2TaggingManager,
-		featureGates:             b.featureGates,
-		backendSGProvider:        b.backendSGProvider,
-		sgResolver:               b.sgResolver,
-		logger:                   b.logger,
-		enableBackendSG:          b.enableBackendSG,
-		disableRestrictedSGRules: b.disableRestrictedSGRules,
-		enableIPTargetType:       b.enableIPTargetType,
+		k8sClient:                     b.k8sClient,
+		eventRecorder:                 b.eventRecorder,
+		ec2Client:                     b.ec2Client,
+		vpcID:                         b.vpcID,
+		clusterName:                   b.clusterName,
+		annotationParser:              b.annotationParser,
+		subnetsResolver:               b.subnetsResolver,
+		certDiscovery:                 b.certDiscovery,
+		authConfigBuilder:             b.authConfigBuilder,
+		enhancedBackendBuilder:        b.enhancedBackendBuilder,
+		ruleOptimizer:                 b.ruleOptimizer,
+		trackingProvider:              b.trackingProvider,
+		elbv2TaggingManager:           b.elbv2TaggingManager,
+		featureGates:                  b.featureGates,
+		backendSGProvider:             b.backendSGProvider,
+		sgResolver:                    b.sgResolver,
+		logger:                        b.logger,
+		enableBackendSG:               b.enableBackendSG,
+		enableBackendSGRuleManagement: b.enableBackendSGRuleManagement,
+		disableRestrictedSGRules:      b.disableRestrictedSGRules,
+		enableIPTargetType:            b.enableIPTargetType,
 
 		ingGroup: ingGroup,
 		stack:    stack,
@@ -182,14 +185,15 @@ type defaultModelBuildTask struct {
 	featureGates           config.FeatureGates
 	logger                 logr.Logger
 
-	ingGroup                 Group
-	sslRedirectConfig        *SSLRedirectConfig
-	stack                    core.Stack
-	backendSGIDToken         core.StringToken
-	backendSGAllocated       bool
-	enableBackendSG          bool
-	disableRestrictedSGRules bool
-	enableIPTargetType       bool
+	ingGroup                      Group
+	sslRedirectConfig             *SSLRedirectConfig
+	stack                         core.Stack
+	backendSGIDToken              core.StringToken
+	backendSGAllocated            bool
+	enableBackendSG               bool
+	enableBackendSGRuleManagement bool
+	disableRestrictedSGRules      bool
+	enableIPTargetType            bool
 
 	defaultTags                               map[string]string
 	externalManagedTags                       sets.String
@@ -407,6 +411,10 @@ func (t *defaultModelBuildTask) getDeletionProtectionViaAnnotation(ing *networki
 }
 
 func (t *defaultModelBuildTask) buildManageSecurityGroupRulesFlag(_ context.Context) (bool, error) {
+	// don't manage if enableBackendSGRuleManagement controller config is false, else prefer the annotation value
+	if !t.enableBackendSGRuleManagement {
+		return false, nil
+	}
 	explicitManageSGRulesFlag := make(map[bool]struct{})
 	manageSGRules := false
 	for _, member := range t.ingGroup.Members {

--- a/pkg/ingress/model_builder.go
+++ b/pkg/ingress/model_builder.go
@@ -411,7 +411,7 @@ func (t *defaultModelBuildTask) getDeletionProtectionViaAnnotation(ing *networki
 }
 
 func (t *defaultModelBuildTask) buildManageSecurityGroupRulesFlag(_ context.Context) (bool, error) {
-	// don't manage if enableBackendSGRuleManagement controller config is false, else prefer the annotation value
+	// don't manage if enableBackendSGRuleManagement is false, else prefer the annotation value
 	if !t.enableBackendSGRuleManagement {
 		return false, nil
 	}

--- a/pkg/ingress/model_builder_test.go
+++ b/pkg/ingress/model_builder_test.go
@@ -454,11 +454,12 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 		err            error
 	}
 	type fields struct {
-		resolveViaDiscoveryCalls     []resolveViaDiscoveryCall
-		listLoadBalancersCalls       []listLoadBalancersCall
-		describeSecurityGroupsResult []describeSecurityGroupsResult
-		backendSecurityGroup         string
-		enableBackendSG              bool
+		resolveViaDiscoveryCalls      []resolveViaDiscoveryCall
+		listLoadBalancersCalls        []listLoadBalancersCall
+		describeSecurityGroupsResult  []describeSecurityGroupsResult
+		backendSecurityGroup          string
+		enableBackendSG               bool
+		enableBackendSGRuleManagement bool
 	}
 	type args struct {
 		ingGroup Group
@@ -617,9 +618,10 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 				svcs: []*corev1.Service{ns_1_svc_1, ns_1_svc_2, ns_1_svc_3},
 			},
 			fields: fields{
-				resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
-				listLoadBalancersCalls:   []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
-				enableBackendSG:          true,
+				resolveViaDiscoveryCalls:      []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
+				listLoadBalancersCalls:        []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
+				enableBackendSG:               true,
+				enableBackendSGRuleManagement: true,
 			},
 			args: args{
 				ingGroup: Group{
@@ -698,9 +700,10 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 				svcs: []*corev1.Service{ns_1_svc_1, ns_1_svc_2, ns_1_svc_3},
 			},
 			fields: fields{
-				resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
-				listLoadBalancersCalls:   []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
-				enableBackendSG:          false,
+				resolveViaDiscoveryCalls:      []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
+				listLoadBalancersCalls:        []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
+				enableBackendSG:               false,
+				enableBackendSGRuleManagement: true,
 			},
 			args: args{
 				ingGroup: Group{
@@ -900,9 +903,10 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 				svcs: []*corev1.Service{ns_1_svc_1, ns_1_svc_2, ns_1_svc_3},
 			},
 			fields: fields{
-				resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternetFacingLB},
-				listLoadBalancersCalls:   []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
-				enableBackendSG:          true,
+				resolveViaDiscoveryCalls:      []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternetFacingLB},
+				listLoadBalancersCalls:        []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
+				enableBackendSG:               true,
+				enableBackendSGRuleManagement: true,
 			},
 			args: args{
 				ingGroup: Group{
@@ -1004,9 +1008,10 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 				svcs: []*corev1.Service{ns_1_svc_1, ns_1_svc_2, ns_1_svc_3},
 			},
 			fields: fields{
-				resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternetFacingLB},
-				listLoadBalancersCalls:   []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
-				enableBackendSG:          true,
+				resolveViaDiscoveryCalls:      []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternetFacingLB},
+				listLoadBalancersCalls:        []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
+				enableBackendSG:               true,
+				enableBackendSGRuleManagement: true,
 			},
 			args: args{
 				ingGroup: Group{
@@ -1285,9 +1290,10 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 				svcs: []*corev1.Service{ns_1_svc_1, ns_1_svc_2, ns_1_svc_3},
 			},
 			fields: fields{
-				resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
-				listLoadBalancersCalls:   []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
-				enableBackendSG:          true,
+				resolveViaDiscoveryCalls:      []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
+				listLoadBalancersCalls:        []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
+				enableBackendSG:               true,
+				enableBackendSGRuleManagement: true,
 			},
 			args: args{
 				ingGroup: Group{
@@ -1482,9 +1488,10 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 				svcs: []*corev1.Service{ns_1_svc_1, ns_1_svc_2, ns_1_svc_3},
 			},
 			fields: fields{
-				resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
-				listLoadBalancersCalls:   []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
-				enableBackendSG:          true,
+				resolveViaDiscoveryCalls:      []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
+				listLoadBalancersCalls:        []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
+				enableBackendSG:               true,
+				enableBackendSGRuleManagement: true,
 			},
 			args: args{
 				ingGroup: Group{
@@ -1608,9 +1615,10 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 				svcs: []*corev1.Service{ns_1_svc_1, ns_1_svc_2, ns_1_svc_3},
 			},
 			fields: fields{
-				resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
-				listLoadBalancersCalls:   []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
-				enableBackendSG:          true,
+				resolveViaDiscoveryCalls:      []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
+				listLoadBalancersCalls:        []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
+				enableBackendSG:               true,
+				enableBackendSGRuleManagement: true,
 			},
 			args: args{
 				ingGroup: Group{
@@ -1934,7 +1942,8 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 						},
 					},
 				},
-				enableBackendSG: true,
+				enableBackendSG:               true,
+				enableBackendSGRuleManagement: true,
 			},
 			args: args{
 				ingGroup: Group{
@@ -2072,8 +2081,9 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 						},
 					},
 				},
-				backendSecurityGroup: "sg-backend",
-				enableBackendSG:      true,
+				backendSecurityGroup:          "sg-backend",
+				enableBackendSG:               true,
+				enableBackendSGRuleManagement: true,
 			},
 			args: args{
 				ingGroup: Group{
@@ -2211,8 +2221,9 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 						},
 					},
 				},
-				backendSecurityGroup: "sg-backend",
-				enableBackendSG:      false,
+				backendSecurityGroup:          "sg-backend",
+				enableBackendSG:               false,
+				enableBackendSGRuleManagement: true,
 			},
 			args: args{
 				ingGroup: Group{
@@ -2267,9 +2278,10 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 				svcs: []*corev1.Service{ns_1_svc_ipv6},
 			},
 			fields: fields{
-				resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
-				listLoadBalancersCalls:   []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
-				enableBackendSG:          true,
+				resolveViaDiscoveryCalls:      []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
+				listLoadBalancersCalls:        []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
+				enableBackendSG:               true,
+				enableBackendSGRuleManagement: true,
 			},
 			args: args{
 				ingGroup: Group{
@@ -2464,9 +2476,10 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 				svcs: []*corev1.Service{ns_1_svc_ipv6},
 			},
 			fields: fields{
-				resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
-				listLoadBalancersCalls:   []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
-				enableBackendSG:          true,
+				resolveViaDiscoveryCalls:      []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
+				listLoadBalancersCalls:        []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
+				enableBackendSG:               true,
+				enableBackendSGRuleManagement: true,
 			},
 			args: args{
 				ingGroup: Group{
@@ -2517,9 +2530,10 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 			},
 			enableIPTargetType: awssdk.Bool(false),
 			fields: fields{
-				resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
-				listLoadBalancersCalls:   []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
-				enableBackendSG:          true,
+				resolveViaDiscoveryCalls:      []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
+				listLoadBalancersCalls:        []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
+				enableBackendSG:               true,
+				enableBackendSGRuleManagement: true,
 			},
 			args: args{
 				ingGroup: Group{
@@ -2569,9 +2583,10 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 				svcs: []*corev1.Service{svcWithNamedTargetPort},
 			},
 			fields: fields{
-				resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
-				listLoadBalancersCalls:   []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
-				enableBackendSG:          true,
+				resolveViaDiscoveryCalls:      []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
+				listLoadBalancersCalls:        []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
+				enableBackendSG:               true,
+				enableBackendSGRuleManagement: true,
 			},
 			args: args{
 				ingGroup: Group{
@@ -2730,9 +2745,10 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 				svcs: []*corev1.Service{svcWithNamedTargetPort},
 			},
 			fields: fields{
-				resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
-				listLoadBalancersCalls:   []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
-				enableBackendSG:          true,
+				resolveViaDiscoveryCalls:      []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
+				listLoadBalancersCalls:        []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
+				enableBackendSG:               true,
+				enableBackendSGRuleManagement: true,
 			},
 			args: args{
 				ingGroup: Group{
@@ -2935,24 +2951,25 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 			}
 
 			b := &defaultModelBuilder{
-				k8sClient:              k8sClient,
-				eventRecorder:          eventRecorder,
-				ec2Client:              ec2Client,
-				vpcID:                  vpcID,
-				clusterName:            clusterName,
-				annotationParser:       annotationParser,
-				subnetsResolver:        subnetsResolver,
-				sgResolver:             sgResolver,
-				backendSGProvider:      backendSGProvider,
-				certDiscovery:          certDiscovery,
-				authConfigBuilder:      authConfigBuilder,
-				enhancedBackendBuilder: enhancedBackendBuilder,
-				ruleOptimizer:          ruleOptimizer,
-				trackingProvider:       trackingProvider,
-				elbv2TaggingManager:    elbv2TaggingManager,
-				enableBackendSG:        tt.fields.enableBackendSG,
-				featureGates:           config.NewFeatureGates(),
-				logger:                 logr.New(&log.NullLogSink{}),
+				k8sClient:                     k8sClient,
+				eventRecorder:                 eventRecorder,
+				ec2Client:                     ec2Client,
+				vpcID:                         vpcID,
+				clusterName:                   clusterName,
+				annotationParser:              annotationParser,
+				subnetsResolver:               subnetsResolver,
+				sgResolver:                    sgResolver,
+				backendSGProvider:             backendSGProvider,
+				certDiscovery:                 certDiscovery,
+				authConfigBuilder:             authConfigBuilder,
+				enhancedBackendBuilder:        enhancedBackendBuilder,
+				ruleOptimizer:                 ruleOptimizer,
+				trackingProvider:              trackingProvider,
+				elbv2TaggingManager:           elbv2TaggingManager,
+				enableBackendSG:               tt.fields.enableBackendSG,
+				enableBackendSGRuleManagement: tt.fields.enableBackendSGRuleManagement,
+				featureGates:                  config.NewFeatureGates(),
+				logger:                        logr.New(&log.NullLogSink{}),
 
 				defaultSSLPolicy:  "ELBSecurityPolicy-2016-08",
 				defaultTargetType: elbv2model.TargetType(defaultTargetType),

--- a/pkg/ingress/model_builder_test.go
+++ b/pkg/ingress/model_builder_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	ec2sdk "github.com/aws/aws-sdk-go/service/ec2"
 	elbv2sdk "github.com/aws/aws-sdk-go/service/elbv2"
@@ -454,12 +455,12 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 		err            error
 	}
 	type fields struct {
-		resolveViaDiscoveryCalls      []resolveViaDiscoveryCall
-		listLoadBalancersCalls        []listLoadBalancersCall
-		describeSecurityGroupsResult  []describeSecurityGroupsResult
-		backendSecurityGroup          string
-		enableBackendSG               bool
-		enableBackendSGRuleManagement bool
+		resolveViaDiscoveryCalls     []resolveViaDiscoveryCall
+		listLoadBalancersCalls       []listLoadBalancersCall
+		describeSecurityGroupsResult []describeSecurityGroupsResult
+		backendSecurityGroup         string
+		enableBackendSG              bool
+		manageBackendSGRules         *bool
 	}
 	type args struct {
 		ingGroup Group
@@ -618,10 +619,9 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 				svcs: []*corev1.Service{ns_1_svc_1, ns_1_svc_2, ns_1_svc_3},
 			},
 			fields: fields{
-				resolveViaDiscoveryCalls:      []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
-				listLoadBalancersCalls:        []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
-				enableBackendSG:               true,
-				enableBackendSGRuleManagement: true,
+				resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
+				listLoadBalancersCalls:   []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
+				enableBackendSG:          true,
 			},
 			args: args{
 				ingGroup: Group{
@@ -700,10 +700,9 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 				svcs: []*corev1.Service{ns_1_svc_1, ns_1_svc_2, ns_1_svc_3},
 			},
 			fields: fields{
-				resolveViaDiscoveryCalls:      []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
-				listLoadBalancersCalls:        []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
-				enableBackendSG:               false,
-				enableBackendSGRuleManagement: true,
+				resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
+				listLoadBalancersCalls:   []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
+				enableBackendSG:          false,
 			},
 			args: args{
 				ingGroup: Group{
@@ -903,10 +902,9 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 				svcs: []*corev1.Service{ns_1_svc_1, ns_1_svc_2, ns_1_svc_3},
 			},
 			fields: fields{
-				resolveViaDiscoveryCalls:      []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternetFacingLB},
-				listLoadBalancersCalls:        []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
-				enableBackendSG:               true,
-				enableBackendSGRuleManagement: true,
+				resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternetFacingLB},
+				listLoadBalancersCalls:   []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
+				enableBackendSG:          true,
 			},
 			args: args{
 				ingGroup: Group{
@@ -1008,10 +1006,9 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 				svcs: []*corev1.Service{ns_1_svc_1, ns_1_svc_2, ns_1_svc_3},
 			},
 			fields: fields{
-				resolveViaDiscoveryCalls:      []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternetFacingLB},
-				listLoadBalancersCalls:        []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
-				enableBackendSG:               true,
-				enableBackendSGRuleManagement: true,
+				resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternetFacingLB},
+				listLoadBalancersCalls:   []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
+				enableBackendSG:          true,
 			},
 			args: args{
 				ingGroup: Group{
@@ -1290,10 +1287,9 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 				svcs: []*corev1.Service{ns_1_svc_1, ns_1_svc_2, ns_1_svc_3},
 			},
 			fields: fields{
-				resolveViaDiscoveryCalls:      []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
-				listLoadBalancersCalls:        []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
-				enableBackendSG:               true,
-				enableBackendSGRuleManagement: true,
+				resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
+				listLoadBalancersCalls:   []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
+				enableBackendSG:          true,
 			},
 			args: args{
 				ingGroup: Group{
@@ -1488,10 +1484,9 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 				svcs: []*corev1.Service{ns_1_svc_1, ns_1_svc_2, ns_1_svc_3},
 			},
 			fields: fields{
-				resolveViaDiscoveryCalls:      []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
-				listLoadBalancersCalls:        []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
-				enableBackendSG:               true,
-				enableBackendSGRuleManagement: true,
+				resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
+				listLoadBalancersCalls:   []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
+				enableBackendSG:          true,
 			},
 			args: args{
 				ingGroup: Group{
@@ -1615,10 +1610,9 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 				svcs: []*corev1.Service{ns_1_svc_1, ns_1_svc_2, ns_1_svc_3},
 			},
 			fields: fields{
-				resolveViaDiscoveryCalls:      []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
-				listLoadBalancersCalls:        []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
-				enableBackendSG:               true,
-				enableBackendSGRuleManagement: true,
+				resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
+				listLoadBalancersCalls:   []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
+				enableBackendSG:          true,
 			},
 			args: args{
 				ingGroup: Group{
@@ -1942,8 +1936,7 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 						},
 					},
 				},
-				enableBackendSG:               true,
-				enableBackendSGRuleManagement: true,
+				enableBackendSG: true,
 			},
 			args: args{
 				ingGroup: Group{
@@ -2081,9 +2074,8 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 						},
 					},
 				},
-				backendSecurityGroup:          "sg-backend",
-				enableBackendSG:               true,
-				enableBackendSGRuleManagement: true,
+				backendSecurityGroup: "sg-backend",
+				enableBackendSG:      true,
 			},
 			args: args{
 				ingGroup: Group{
@@ -2221,9 +2213,8 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 						},
 					},
 				},
-				backendSecurityGroup:          "sg-backend",
-				enableBackendSG:               false,
-				enableBackendSGRuleManagement: true,
+				backendSecurityGroup: "sg-backend",
+				enableBackendSG:      false,
 			},
 			args: args{
 				ingGroup: Group{
@@ -2289,9 +2280,9 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 						},
 					},
 				},
-				backendSecurityGroup:          "sg-backend",
-				enableBackendSG:               true,
-				enableBackendSGRuleManagement: false,
+				backendSecurityGroup: "sg-backend",
+				enableBackendSG:      true,
+				manageBackendSGRules: aws.Bool(false),
 			},
 			args: args{
 				ingGroup: Group{
@@ -2419,11 +2410,11 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 				svcs: []*corev1.Service{ns_1_svc_1, ns_1_svc_2, ns_1_svc_3},
 			},
 			fields: fields{
-				resolveViaDiscoveryCalls:      []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
-				listLoadBalancersCalls:        []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
-				backendSecurityGroup:          "sg-backend",
-				enableBackendSG:               true,
-				enableBackendSGRuleManagement: false,
+				resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
+				listLoadBalancersCalls:   []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
+				backendSecurityGroup:     "sg-backend",
+				enableBackendSG:          true,
+				manageBackendSGRules:     aws.Bool(false),
 			},
 			args: args{
 				ingGroup: Group{
@@ -2569,11 +2560,11 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 				svcs: []*corev1.Service{ns_1_svc_1, ns_1_svc_2, ns_1_svc_3},
 			},
 			fields: fields{
-				resolveViaDiscoveryCalls:      []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
-				listLoadBalancersCalls:        []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
-				backendSecurityGroup:          "sg-backend",
-				enableBackendSG:               false,
-				enableBackendSGRuleManagement: false,
+				resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
+				listLoadBalancersCalls:   []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
+				backendSecurityGroup:     "sg-backend",
+				enableBackendSG:          false,
+				manageBackendSGRules:     aws.Bool(false),
 			},
 			args: args{
 				ingGroup: Group{
@@ -2718,10 +2709,9 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 				svcs: []*corev1.Service{ns_1_svc_ipv6},
 			},
 			fields: fields{
-				resolveViaDiscoveryCalls:      []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
-				listLoadBalancersCalls:        []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
-				enableBackendSG:               true,
-				enableBackendSGRuleManagement: true,
+				resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
+				listLoadBalancersCalls:   []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
+				enableBackendSG:          true,
 			},
 			args: args{
 				ingGroup: Group{
@@ -2916,10 +2906,9 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 				svcs: []*corev1.Service{ns_1_svc_ipv6},
 			},
 			fields: fields{
-				resolveViaDiscoveryCalls:      []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
-				listLoadBalancersCalls:        []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
-				enableBackendSG:               true,
-				enableBackendSGRuleManagement: true,
+				resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
+				listLoadBalancersCalls:   []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
+				enableBackendSG:          true,
 			},
 			args: args{
 				ingGroup: Group{
@@ -2970,10 +2959,9 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 			},
 			enableIPTargetType: awssdk.Bool(false),
 			fields: fields{
-				resolveViaDiscoveryCalls:      []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
-				listLoadBalancersCalls:        []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
-				enableBackendSG:               true,
-				enableBackendSGRuleManagement: true,
+				resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
+				listLoadBalancersCalls:   []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
+				enableBackendSG:          true,
 			},
 			args: args{
 				ingGroup: Group{
@@ -3023,10 +3011,9 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 				svcs: []*corev1.Service{svcWithNamedTargetPort},
 			},
 			fields: fields{
-				resolveViaDiscoveryCalls:      []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
-				listLoadBalancersCalls:        []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
-				enableBackendSG:               true,
-				enableBackendSGRuleManagement: true,
+				resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
+				listLoadBalancersCalls:   []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
+				enableBackendSG:          true,
 			},
 			args: args{
 				ingGroup: Group{
@@ -3185,10 +3172,9 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 				svcs: []*corev1.Service{svcWithNamedTargetPort},
 			},
 			fields: fields{
-				resolveViaDiscoveryCalls:      []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
-				listLoadBalancersCalls:        []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
-				enableBackendSG:               true,
-				enableBackendSGRuleManagement: true,
+				resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
+				listLoadBalancersCalls:   []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
+				enableBackendSG:          true,
 			},
 			args: args{
 				ingGroup: Group{
@@ -3389,27 +3375,31 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 			if defaultTargetType == "" {
 				defaultTargetType = "instance"
 			}
+			manageBackendSGRules := true
+			if tt.fields.manageBackendSGRules != nil {
+				manageBackendSGRules = *tt.fields.manageBackendSGRules
+			}
 
 			b := &defaultModelBuilder{
-				k8sClient:                     k8sClient,
-				eventRecorder:                 eventRecorder,
-				ec2Client:                     ec2Client,
-				vpcID:                         vpcID,
-				clusterName:                   clusterName,
-				annotationParser:              annotationParser,
-				subnetsResolver:               subnetsResolver,
-				sgResolver:                    sgResolver,
-				backendSGProvider:             backendSGProvider,
-				certDiscovery:                 certDiscovery,
-				authConfigBuilder:             authConfigBuilder,
-				enhancedBackendBuilder:        enhancedBackendBuilder,
-				ruleOptimizer:                 ruleOptimizer,
-				trackingProvider:              trackingProvider,
-				elbv2TaggingManager:           elbv2TaggingManager,
-				enableBackendSG:               tt.fields.enableBackendSG,
-				enableBackendSGRuleManagement: tt.fields.enableBackendSGRuleManagement,
-				featureGates:                  config.NewFeatureGates(),
-				logger:                        logr.New(&log.NullLogSink{}),
+				k8sClient:              k8sClient,
+				eventRecorder:          eventRecorder,
+				ec2Client:              ec2Client,
+				vpcID:                  vpcID,
+				clusterName:            clusterName,
+				annotationParser:       annotationParser,
+				subnetsResolver:        subnetsResolver,
+				sgResolver:             sgResolver,
+				backendSGProvider:      backendSGProvider,
+				certDiscovery:          certDiscovery,
+				authConfigBuilder:      authConfigBuilder,
+				enhancedBackendBuilder: enhancedBackendBuilder,
+				ruleOptimizer:          ruleOptimizer,
+				trackingProvider:       trackingProvider,
+				elbv2TaggingManager:    elbv2TaggingManager,
+				enableBackendSG:        tt.fields.enableBackendSG,
+				manageBackendSGRules:   manageBackendSGRules,
+				featureGates:           config.NewFeatureGates(),
+				logger:                 logr.New(&log.NullLogSink{}),
 
 				defaultSSLPolicy:  "ELBSecurityPolicy-2016-08",
 				defaultTargetType: elbv2model.TargetType(defaultTargetType),

--- a/pkg/service/model_build_target_group.go
+++ b/pkg/service/model_build_target_group.go
@@ -611,6 +611,10 @@ func (t *defaultModelBuildTask) buildHealthCheckNetworkingIngressRules(trafficSo
 }
 
 func (t *defaultModelBuildTask) buildManageSecurityGroupRulesFlag(_ context.Context) (bool, error) {
+	// don't manage if enableBackendSGRuleManagement is false, else prefer the annotation value
+	if !t.enableBackendSGRuleManagement {
+		return false, nil
+	}
 	var rawEnabled bool
 	exists, err := t.annotationParser.ParseBoolAnnotation(annotations.SvcLBSuffixManageSGRules, &rawEnabled, t.service.Annotations)
 	if err != nil {

--- a/pkg/service/model_build_target_group.go
+++ b/pkg/service/model_build_target_group.go
@@ -611,8 +611,8 @@ func (t *defaultModelBuildTask) buildHealthCheckNetworkingIngressRules(trafficSo
 }
 
 func (t *defaultModelBuildTask) buildManageSecurityGroupRulesFlag(_ context.Context) (bool, error) {
-	// don't manage if enableBackendSGRuleManagement is false, else prefer the annotation value
-	if !t.enableBackendSGRuleManagement {
+	// don't manage if manageBackendSGRules is false, else prefer the annotation value
+	if !t.manageBackendSGRules {
 		return false, nil
 	}
 	var rawEnabled bool

--- a/pkg/service/model_build_target_group_test.go
+++ b/pkg/service/model_build_target_group_test.go
@@ -1070,6 +1070,20 @@ func Test_defaultModelBuilderTask_buildTargetGroupBindingNetworking(t *testing.T
 			ipAddressType: elbv2.TargetGroupIPAddressTypeIPv4,
 			want:          nil,
 		},
+		{
+			name:                          "with manage backend SG disabled via controller config",
+			enableBackendSGRuleManagement: aws.Bool(false),
+			svc:                           &corev1.Service{},
+			tgPort:                        port80,
+			hcPort:                        port808,
+			subnets: []*ec2.Subnet{{
+				CidrBlock: aws.String("172.16.0.0/19"),
+				SubnetId:  aws.String("az-1"),
+			}},
+			tgProtocol:    corev1.ProtocolTCP,
+			ipAddressType: elbv2.TargetGroupIPAddressTypeIPv4,
+			want:          nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/service/model_build_target_group_test.go
+++ b/pkg/service/model_build_target_group_test.go
@@ -402,16 +402,17 @@ func Test_defaultModelBuilderTask_buildTargetGroupBindingNetworking(t *testing.T
 	trafficPort := intstr.FromString("traffic-port")
 
 	tests := []struct {
-		name                string
-		svc                 *corev1.Service
-		tgPort              intstr.IntOrString
-		hcPort              intstr.IntOrString
-		subnets             []*ec2.Subnet
-		tgProtocol          corev1.Protocol
-		ipAddressType       elbv2.TargetGroupIPAddressType
-		preserveClientIP    bool
-		defaultSourceRanges []string
-		want                *elbv2.TargetGroupBindingNetworking
+		name                          string
+		svc                           *corev1.Service
+		tgPort                        intstr.IntOrString
+		hcPort                        intstr.IntOrString
+		subnets                       []*ec2.Subnet
+		tgProtocol                    corev1.Protocol
+		ipAddressType                 elbv2.TargetGroupIPAddressType
+		preserveClientIP              bool
+		enableBackendSGRuleManagement *bool
+		defaultSourceRanges           []string
+		want                          *elbv2.TargetGroupBindingNetworking
 	}{
 		{
 			name: "udp-service with source ranges",
@@ -1073,7 +1074,16 @@ func Test_defaultModelBuilderTask_buildTargetGroupBindingNetworking(t *testing.T
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			parser := annotations.NewSuffixAnnotationParser("service.beta.kubernetes.io")
-			builder := &defaultModelBuildTask{service: tt.svc, annotationParser: parser, ec2Subnets: tt.subnets}
+			enableBackendSGRuleManagement := true
+			if tt.enableBackendSGRuleManagement != nil {
+				enableBackendSGRuleManagement = *tt.enableBackendSGRuleManagement
+			}
+			builder := &defaultModelBuildTask{
+				service:                       tt.svc,
+				annotationParser:              parser,
+				ec2Subnets:                    tt.subnets,
+				enableBackendSGRuleManagement: enableBackendSGRuleManagement,
+			}
 			port := corev1.ServicePort{
 				Protocol: tt.tgProtocol,
 			}

--- a/pkg/service/model_build_target_group_test.go
+++ b/pkg/service/model_build_target_group_test.go
@@ -402,17 +402,17 @@ func Test_defaultModelBuilderTask_buildTargetGroupBindingNetworking(t *testing.T
 	trafficPort := intstr.FromString("traffic-port")
 
 	tests := []struct {
-		name                          string
-		svc                           *corev1.Service
-		tgPort                        intstr.IntOrString
-		hcPort                        intstr.IntOrString
-		subnets                       []*ec2.Subnet
-		tgProtocol                    corev1.Protocol
-		ipAddressType                 elbv2.TargetGroupIPAddressType
-		preserveClientIP              bool
-		enableBackendSGRuleManagement *bool
-		defaultSourceRanges           []string
-		want                          *elbv2.TargetGroupBindingNetworking
+		name                 string
+		svc                  *corev1.Service
+		tgPort               intstr.IntOrString
+		hcPort               intstr.IntOrString
+		subnets              []*ec2.Subnet
+		tgProtocol           corev1.Protocol
+		ipAddressType        elbv2.TargetGroupIPAddressType
+		preserveClientIP     bool
+		manageBackendSGRules *bool
+		defaultSourceRanges  []string
+		want                 *elbv2.TargetGroupBindingNetworking
 	}{
 		{
 			name: "udp-service with source ranges",
@@ -1071,11 +1071,11 @@ func Test_defaultModelBuilderTask_buildTargetGroupBindingNetworking(t *testing.T
 			want:          nil,
 		},
 		{
-			name:                          "with manage backend SG disabled via controller config",
-			enableBackendSGRuleManagement: aws.Bool(false),
-			svc:                           &corev1.Service{},
-			tgPort:                        port80,
-			hcPort:                        port808,
+			name:                 "with manage backend SG disabled via controller config",
+			manageBackendSGRules: aws.Bool(false),
+			svc:                  &corev1.Service{},
+			tgPort:               port80,
+			hcPort:               port808,
 			subnets: []*ec2.Subnet{{
 				CidrBlock: aws.String("172.16.0.0/19"),
 				SubnetId:  aws.String("az-1"),
@@ -1088,15 +1088,15 @@ func Test_defaultModelBuilderTask_buildTargetGroupBindingNetworking(t *testing.T
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			parser := annotations.NewSuffixAnnotationParser("service.beta.kubernetes.io")
-			enableBackendSGRuleManagement := true
-			if tt.enableBackendSGRuleManagement != nil {
-				enableBackendSGRuleManagement = *tt.enableBackendSGRuleManagement
+			manageBackendSGRules := true
+			if tt.manageBackendSGRules != nil {
+				manageBackendSGRules = *tt.manageBackendSGRules
 			}
 			builder := &defaultModelBuildTask{
-				service:                       tt.svc,
-				annotationParser:              parser,
-				ec2Subnets:                    tt.subnets,
-				enableBackendSGRuleManagement: enableBackendSGRuleManagement,
+				service:              tt.svc,
+				annotationParser:     parser,
+				ec2Subnets:           tt.subnets,
+				manageBackendSGRules: manageBackendSGRules,
 			}
 			port := corev1.ServicePort{
 				Protocol: tt.tgProtocol,

--- a/pkg/service/model_builder.go
+++ b/pkg/service/model_builder.go
@@ -36,23 +36,25 @@ type ModelBuilder interface {
 // NewDefaultModelBuilder construct a new defaultModelBuilder
 func NewDefaultModelBuilder(annotationParser annotations.Parser, subnetsResolver networking.SubnetsResolver,
 	vpcInfoProvider networking.VPCInfoProvider, vpcID string, trackingProvider tracking.Provider,
-	elbv2TaggingManager elbv2deploy.TaggingManager, featureGates config.FeatureGates, clusterName string, defaultTags map[string]string,
-	externalManagedTags []string, defaultSSLPolicy string, defaultTargetType string, enableIPTargetType bool, serviceUtils ServiceUtils) *defaultModelBuilder {
+	elbv2TaggingManager elbv2deploy.TaggingManager, featureGates config.FeatureGates, clusterName string,
+	defaultTags map[string]string, externalManagedTags []string, defaultSSLPolicy string, defaultTargetType string,
+	enableIPTargetType bool, enableBackendSGRuleManagement bool, serviceUtils ServiceUtils) *defaultModelBuilder {
 	return &defaultModelBuilder{
-		annotationParser:    annotationParser,
-		subnetsResolver:     subnetsResolver,
-		vpcInfoProvider:     vpcInfoProvider,
-		trackingProvider:    trackingProvider,
-		elbv2TaggingManager: elbv2TaggingManager,
-		featureGates:        featureGates,
-		serviceUtils:        serviceUtils,
-		clusterName:         clusterName,
-		vpcID:               vpcID,
-		defaultTags:         defaultTags,
-		externalManagedTags: sets.NewString(externalManagedTags...),
-		defaultSSLPolicy:    defaultSSLPolicy,
-		defaultTargetType:   elbv2model.TargetType(defaultTargetType),
-		enableIPTargetType:  enableIPTargetType,
+		annotationParser:              annotationParser,
+		subnetsResolver:               subnetsResolver,
+		vpcInfoProvider:               vpcInfoProvider,
+		trackingProvider:              trackingProvider,
+		elbv2TaggingManager:           elbv2TaggingManager,
+		featureGates:                  featureGates,
+		serviceUtils:                  serviceUtils,
+		clusterName:                   clusterName,
+		vpcID:                         vpcID,
+		defaultTags:                   defaultTags,
+		externalManagedTags:           sets.NewString(externalManagedTags...),
+		defaultSSLPolicy:              defaultSSLPolicy,
+		defaultTargetType:             elbv2model.TargetType(defaultTargetType),
+		enableIPTargetType:            enableIPTargetType,
+		enableBackendSGRuleManagement: enableBackendSGRuleManagement,
 	}
 }
 
@@ -67,28 +69,30 @@ type defaultModelBuilder struct {
 	featureGates        config.FeatureGates
 	serviceUtils        ServiceUtils
 
-	clusterName         string
-	vpcID               string
-	defaultTags         map[string]string
-	externalManagedTags sets.String
-	defaultSSLPolicy    string
-	defaultTargetType   elbv2model.TargetType
-	enableIPTargetType  bool
+	clusterName                   string
+	vpcID                         string
+	defaultTags                   map[string]string
+	externalManagedTags           sets.String
+	defaultSSLPolicy              string
+	defaultTargetType             elbv2model.TargetType
+	enableIPTargetType            bool
+	enableBackendSGRuleManagement bool
 }
 
 func (b *defaultModelBuilder) Build(ctx context.Context, service *corev1.Service) (core.Stack, *elbv2model.LoadBalancer, error) {
 	stack := core.NewDefaultStack(core.StackID(k8s.NamespacedName(service)))
 	task := &defaultModelBuildTask{
-		clusterName:         b.clusterName,
-		vpcID:               b.vpcID,
-		annotationParser:    b.annotationParser,
-		subnetsResolver:     b.subnetsResolver,
-		vpcInfoProvider:     b.vpcInfoProvider,
-		trackingProvider:    b.trackingProvider,
-		elbv2TaggingManager: b.elbv2TaggingManager,
-		featureGates:        b.featureGates,
-		serviceUtils:        b.serviceUtils,
-		enableIPTargetType:  b.enableIPTargetType,
+		clusterName:                   b.clusterName,
+		vpcID:                         b.vpcID,
+		annotationParser:              b.annotationParser,
+		subnetsResolver:               b.subnetsResolver,
+		vpcInfoProvider:               b.vpcInfoProvider,
+		trackingProvider:              b.trackingProvider,
+		elbv2TaggingManager:           b.elbv2TaggingManager,
+		featureGates:                  b.featureGates,
+		serviceUtils:                  b.serviceUtils,
+		enableIPTargetType:            b.enableIPTargetType,
+		enableBackendSGRuleManagement: b.enableBackendSGRuleManagement,
 
 		service:   service,
 		stack:     stack,
@@ -131,16 +135,17 @@ func (b *defaultModelBuilder) Build(ctx context.Context, service *corev1.Service
 }
 
 type defaultModelBuildTask struct {
-	clusterName         string
-	vpcID               string
-	annotationParser    annotations.Parser
-	subnetsResolver     networking.SubnetsResolver
-	vpcInfoProvider     networking.VPCInfoProvider
-	trackingProvider    tracking.Provider
-	elbv2TaggingManager elbv2deploy.TaggingManager
-	featureGates        config.FeatureGates
-	serviceUtils        ServiceUtils
-	enableIPTargetType  bool
+	clusterName                   string
+	vpcID                         string
+	annotationParser              annotations.Parser
+	subnetsResolver               networking.SubnetsResolver
+	vpcInfoProvider               networking.VPCInfoProvider
+	trackingProvider              tracking.Provider
+	elbv2TaggingManager           elbv2deploy.TaggingManager
+	featureGates                  config.FeatureGates
+	serviceUtils                  ServiceUtils
+	enableIPTargetType            bool
+	enableBackendSGRuleManagement bool
 
 	service *corev1.Service
 

--- a/pkg/service/model_builder.go
+++ b/pkg/service/model_builder.go
@@ -38,23 +38,23 @@ func NewDefaultModelBuilder(annotationParser annotations.Parser, subnetsResolver
 	vpcInfoProvider networking.VPCInfoProvider, vpcID string, trackingProvider tracking.Provider,
 	elbv2TaggingManager elbv2deploy.TaggingManager, featureGates config.FeatureGates, clusterName string,
 	defaultTags map[string]string, externalManagedTags []string, defaultSSLPolicy string, defaultTargetType string,
-	enableIPTargetType bool, enableBackendSGRuleManagement bool, serviceUtils ServiceUtils) *defaultModelBuilder {
+	enableIPTargetType bool, manageBackendSGRules bool, serviceUtils ServiceUtils) *defaultModelBuilder {
 	return &defaultModelBuilder{
-		annotationParser:              annotationParser,
-		subnetsResolver:               subnetsResolver,
-		vpcInfoProvider:               vpcInfoProvider,
-		trackingProvider:              trackingProvider,
-		elbv2TaggingManager:           elbv2TaggingManager,
-		featureGates:                  featureGates,
-		serviceUtils:                  serviceUtils,
-		clusterName:                   clusterName,
-		vpcID:                         vpcID,
-		defaultTags:                   defaultTags,
-		externalManagedTags:           sets.NewString(externalManagedTags...),
-		defaultSSLPolicy:              defaultSSLPolicy,
-		defaultTargetType:             elbv2model.TargetType(defaultTargetType),
-		enableIPTargetType:            enableIPTargetType,
-		enableBackendSGRuleManagement: enableBackendSGRuleManagement,
+		annotationParser:     annotationParser,
+		subnetsResolver:      subnetsResolver,
+		vpcInfoProvider:      vpcInfoProvider,
+		trackingProvider:     trackingProvider,
+		elbv2TaggingManager:  elbv2TaggingManager,
+		featureGates:         featureGates,
+		serviceUtils:         serviceUtils,
+		clusterName:          clusterName,
+		vpcID:                vpcID,
+		defaultTags:          defaultTags,
+		externalManagedTags:  sets.NewString(externalManagedTags...),
+		defaultSSLPolicy:     defaultSSLPolicy,
+		defaultTargetType:    elbv2model.TargetType(defaultTargetType),
+		enableIPTargetType:   enableIPTargetType,
+		manageBackendSGRules: manageBackendSGRules,
 	}
 }
 
@@ -69,30 +69,30 @@ type defaultModelBuilder struct {
 	featureGates        config.FeatureGates
 	serviceUtils        ServiceUtils
 
-	clusterName                   string
-	vpcID                         string
-	defaultTags                   map[string]string
-	externalManagedTags           sets.String
-	defaultSSLPolicy              string
-	defaultTargetType             elbv2model.TargetType
-	enableIPTargetType            bool
-	enableBackendSGRuleManagement bool
+	clusterName          string
+	vpcID                string
+	defaultTags          map[string]string
+	externalManagedTags  sets.String
+	defaultSSLPolicy     string
+	defaultTargetType    elbv2model.TargetType
+	enableIPTargetType   bool
+	manageBackendSGRules bool
 }
 
 func (b *defaultModelBuilder) Build(ctx context.Context, service *corev1.Service) (core.Stack, *elbv2model.LoadBalancer, error) {
 	stack := core.NewDefaultStack(core.StackID(k8s.NamespacedName(service)))
 	task := &defaultModelBuildTask{
-		clusterName:                   b.clusterName,
-		vpcID:                         b.vpcID,
-		annotationParser:              b.annotationParser,
-		subnetsResolver:               b.subnetsResolver,
-		vpcInfoProvider:               b.vpcInfoProvider,
-		trackingProvider:              b.trackingProvider,
-		elbv2TaggingManager:           b.elbv2TaggingManager,
-		featureGates:                  b.featureGates,
-		serviceUtils:                  b.serviceUtils,
-		enableIPTargetType:            b.enableIPTargetType,
-		enableBackendSGRuleManagement: b.enableBackendSGRuleManagement,
+		clusterName:          b.clusterName,
+		vpcID:                b.vpcID,
+		annotationParser:     b.annotationParser,
+		subnetsResolver:      b.subnetsResolver,
+		vpcInfoProvider:      b.vpcInfoProvider,
+		trackingProvider:     b.trackingProvider,
+		elbv2TaggingManager:  b.elbv2TaggingManager,
+		featureGates:         b.featureGates,
+		serviceUtils:         b.serviceUtils,
+		enableIPTargetType:   b.enableIPTargetType,
+		manageBackendSGRules: b.manageBackendSGRules,
 
 		service:   service,
 		stack:     stack,
@@ -135,17 +135,17 @@ func (b *defaultModelBuilder) Build(ctx context.Context, service *corev1.Service
 }
 
 type defaultModelBuildTask struct {
-	clusterName                   string
-	vpcID                         string
-	annotationParser              annotations.Parser
-	subnetsResolver               networking.SubnetsResolver
-	vpcInfoProvider               networking.VPCInfoProvider
-	trackingProvider              tracking.Provider
-	elbv2TaggingManager           elbv2deploy.TaggingManager
-	featureGates                  config.FeatureGates
-	serviceUtils                  ServiceUtils
-	enableIPTargetType            bool
-	enableBackendSGRuleManagement bool
+	clusterName          string
+	vpcID                string
+	annotationParser     annotations.Parser
+	subnetsResolver      networking.SubnetsResolver
+	vpcInfoProvider      networking.VPCInfoProvider
+	trackingProvider     tracking.Provider
+	elbv2TaggingManager  elbv2deploy.TaggingManager
+	featureGates         config.FeatureGates
+	serviceUtils         ServiceUtils
+	enableIPTargetType   bool
+	manageBackendSGRules bool
 
 	service *corev1.Service
 

--- a/pkg/service/model_builder_test.go
+++ b/pkg/service/model_builder_test.go
@@ -96,18 +96,19 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 		sdkLBs: []elbv2.LoadBalancerWithTags{},
 	}
 	tests := []struct {
-		testName                     string
-		resolveViaDiscoveryCalls     []resolveViaDiscoveryCall
-		resolveViaNameOrIDSliceCalls []resolveViaNameOrIDSliceCall
-		listLoadBalancerCalls        []listLoadBalancerCall
-		fetchVPCInfoCalls            []fetchVPCInfoCall
-		defaultTargetType            string
-		enableIPTargetType           *bool
-		svc                          *corev1.Service
-		wantError                    bool
-		wantValue                    string
-		wantNumResources             int
-		restrictToTypeLoadBalancer   bool
+		testName                      string
+		resolveViaDiscoveryCalls      []resolveViaDiscoveryCall
+		resolveViaNameOrIDSliceCalls  []resolveViaNameOrIDSliceCall
+		listLoadBalancerCalls         []listLoadBalancerCall
+		fetchVPCInfoCalls             []fetchVPCInfoCall
+		defaultTargetType             string
+		enableIPTargetType            *bool
+		enableBackendSGRuleManagement *bool
+		svc                           *corev1.Service
+		wantError                     bool
+		wantValue                     string
+		wantNumResources              int
+		restrictToTypeLoadBalancer    bool
 	}{
 		{
 			testName: "Simple service",
@@ -2970,8 +2971,12 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 			} else {
 				enableIPTargetType = *tt.enableIPTargetType
 			}
+			enableBackendSGRuleManagement := true
+			if tt.enableBackendSGRuleManagement != nil {
+				enableBackendSGRuleManagement = *tt.enableBackendSGRuleManagement
+			}
 			builder := NewDefaultModelBuilder(annotationParser, subnetsResolver, vpcInfoProvider, "vpc-xxx", trackingProvider, elbv2TaggingManager, featureGates,
-				"my-cluster", nil, nil, "ELBSecurityPolicy-2016-08", defaultTargetType, enableIPTargetType, serviceUtils)
+				"my-cluster", nil, nil, "ELBSecurityPolicy-2016-08", defaultTargetType, enableIPTargetType, enableBackendSGRuleManagement, serviceUtils)
 			ctx := context.Background()
 			stack, _, err := builder.Build(ctx, tt.svc)
 			if tt.wantError {

--- a/pkg/service/model_builder_test.go
+++ b/pkg/service/model_builder_test.go
@@ -96,19 +96,19 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 		sdkLBs: []elbv2.LoadBalancerWithTags{},
 	}
 	tests := []struct {
-		testName                      string
-		resolveViaDiscoveryCalls      []resolveViaDiscoveryCall
-		resolveViaNameOrIDSliceCalls  []resolveViaNameOrIDSliceCall
-		listLoadBalancerCalls         []listLoadBalancerCall
-		fetchVPCInfoCalls             []fetchVPCInfoCall
-		defaultTargetType             string
-		enableIPTargetType            *bool
-		enableBackendSGRuleManagement *bool
-		svc                           *corev1.Service
-		wantError                     bool
-		wantValue                     string
-		wantNumResources              int
-		restrictToTypeLoadBalancer    bool
+		testName                     string
+		resolveViaDiscoveryCalls     []resolveViaDiscoveryCall
+		resolveViaNameOrIDSliceCalls []resolveViaNameOrIDSliceCall
+		listLoadBalancerCalls        []listLoadBalancerCall
+		fetchVPCInfoCalls            []fetchVPCInfoCall
+		defaultTargetType            string
+		enableIPTargetType           *bool
+		manageBackendSGRules         *bool
+		svc                          *corev1.Service
+		wantError                    bool
+		wantValue                    string
+		wantNumResources             int
+		restrictToTypeLoadBalancer   bool
 	}{
 		{
 			testName: "Simple service",
@@ -2932,8 +2932,8 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 			wantNumResources: 4,
 		},
 		{
-			testName:                      "with backend SG rule management disabled using controller config",
-			enableBackendSGRuleManagement: aws.Bool(false),
+			testName:             "with backend SG rule management disabled using controller config",
+			manageBackendSGRules: aws.Bool(false),
 			svc: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "manual-sg-rule",
@@ -3097,12 +3097,12 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 			} else {
 				enableIPTargetType = *tt.enableIPTargetType
 			}
-			enableBackendSGRuleManagement := true
-			if tt.enableBackendSGRuleManagement != nil {
-				enableBackendSGRuleManagement = *tt.enableBackendSGRuleManagement
+			manageBackendSGRules := true
+			if tt.manageBackendSGRules != nil {
+				manageBackendSGRules = *tt.manageBackendSGRules
 			}
 			builder := NewDefaultModelBuilder(annotationParser, subnetsResolver, vpcInfoProvider, "vpc-xxx", trackingProvider, elbv2TaggingManager, featureGates,
-				"my-cluster", nil, nil, "ELBSecurityPolicy-2016-08", defaultTargetType, enableIPTargetType, enableBackendSGRuleManagement, serviceUtils)
+				"my-cluster", nil, nil, "ELBSecurityPolicy-2016-08", defaultTargetType, enableIPTargetType, manageBackendSGRules, serviceUtils)
 			ctx := context.Background()
 			stack, _, err := builder.Build(ctx, tt.svc)
 			if tt.wantError {


### PR DESCRIPTION
### Issue
https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/3265

### Description
This PR introduces a controller config flag called `ManageBackendSGRules`. If the config is true (default) - controller behaves as before. If the config is `false` - controller wont manage the backend SG rules for both ingresses and services. Rules would still be created for controller managed frontend SGs for ingresses.

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
