### PR TITLE
feat: NLB Certificate autodiscovery using ssl-domains annotations

### DIFF
--- a/controllers/service/service_controller.go
+++ b/controllers/service/service_controller.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/ingress"
+
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -43,10 +45,16 @@ func NewServiceReconciler(cloud aws.Cloud, k8sClient client.Client, eventRecorde
 	annotationParser := annotations.NewSuffixAnnotationParser(serviceAnnotationPrefix)
 	trackingProvider := tracking.NewDefaultProvider(serviceTagPrefix, controllerConfig.ClusterName)
 	serviceUtils := service.NewServiceUtils(annotationParser, serviceFinalizer, controllerConfig.ServiceConfig.LoadBalancerClass, controllerConfig.FeatureGates)
+	certDiscovery := ingress.NewACMCertDiscovery(cloud.ACM(), logger)
 	modelBuilder := service.NewDefaultModelBuilder(annotationParser, subnetsResolver, vpcInfoProvider, cloud.VpcID(), trackingProvider,
+<<<<<<< HEAD
 		elbv2TaggingManager, cloud.EC2(), controllerConfig.FeatureGates, controllerConfig.ClusterName, controllerConfig.DefaultTags, controllerConfig.ExternalManagedTags,
 		controllerConfig.DefaultSSLPolicy, controllerConfig.DefaultTargetType, controllerConfig.FeatureGates.Enabled(config.EnableIPTargetType), serviceUtils,
 		backendSGProvider, sgResolver, controllerConfig.EnableBackendSecurityGroup, controllerConfig.DisableRestrictedSGRules, logger)
+=======
+		elbv2TaggingManager, controllerConfig.FeatureGates, controllerConfig.ClusterName, controllerConfig.DefaultTags, controllerConfig.ExternalManagedTags,
+		controllerConfig.DefaultSSLPolicy, controllerConfig.DefaultTargetType, controllerConfig.FeatureGates.Enabled(config.EnableIPTargetType), serviceUtils, certDiscovery, logger)
+>>>>>>> 9a9e052 (Fix CertDiscovery logic for Service NLBs)
 	stackMarshaller := deploy.NewDefaultStackMarshaller()
 	stackDeployer := deploy.NewDefaultStackDeployer(cloud, k8sClient, networkingSGManager, networkingSGReconciler, elbv2TaggingManager, controllerConfig, serviceTagPrefix, logger)
 	return &serviceReconciler{

--- a/controllers/service/service_controller.go
+++ b/controllers/service/service_controller.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"sigs.k8s.io/aws-load-balancer-controller/pkg/ingress"
-
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -18,6 +16,7 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy"
 	elbv2deploy "sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/elbv2"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/tracking"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/ingress"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/core"
 	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
@@ -47,14 +46,9 @@ func NewServiceReconciler(cloud aws.Cloud, k8sClient client.Client, eventRecorde
 	serviceUtils := service.NewServiceUtils(annotationParser, serviceFinalizer, controllerConfig.ServiceConfig.LoadBalancerClass, controllerConfig.FeatureGates)
 	certDiscovery := ingress.NewACMCertDiscovery(cloud.ACM(), logger)
 	modelBuilder := service.NewDefaultModelBuilder(annotationParser, subnetsResolver, vpcInfoProvider, cloud.VpcID(), trackingProvider,
-<<<<<<< HEAD
 		elbv2TaggingManager, cloud.EC2(), controllerConfig.FeatureGates, controllerConfig.ClusterName, controllerConfig.DefaultTags, controllerConfig.ExternalManagedTags,
 		controllerConfig.DefaultSSLPolicy, controllerConfig.DefaultTargetType, controllerConfig.FeatureGates.Enabled(config.EnableIPTargetType), serviceUtils,
-		backendSGProvider, sgResolver, controllerConfig.EnableBackendSecurityGroup, controllerConfig.DisableRestrictedSGRules, logger)
-=======
-		elbv2TaggingManager, controllerConfig.FeatureGates, controllerConfig.ClusterName, controllerConfig.DefaultTags, controllerConfig.ExternalManagedTags,
-		controllerConfig.DefaultSSLPolicy, controllerConfig.DefaultTargetType, controllerConfig.FeatureGates.Enabled(config.EnableIPTargetType), serviceUtils, certDiscovery, logger)
->>>>>>> 9a9e052 (Fix CertDiscovery logic for Service NLBs)
+		backendSGProvider, sgResolver, controllerConfig.EnableBackendSecurityGroup, controllerConfig.DisableRestrictedSGRules, certDiscovery, logger)
 	stackMarshaller := deploy.NewDefaultStackMarshaller()
 	stackDeployer := deploy.NewDefaultStackDeployer(cloud, k8sClient, networkingSGManager, networkingSGReconciler, elbv2TaggingManager, controllerConfig, serviceTagPrefix, logger)
 	return &serviceReconciler{

--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -386,11 +386,11 @@ You can configure TLS support via the following annotations:
         service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-west-2:xxxxx:certificate/xxxxxxx
         ```
 
-- <a name="ssl-domains">`service.beta.kubernetes.io/aws-load-balancer-ssl-domains`</a> specifies the domain names for the NLB to which you want auto-discover the SSL certs.
+- <a name="ssl-domains">`service.beta.kubernetes.io/aws-load-balancer-ssl-domains`</a> specifies the domain names for which the controller will automatically discover TLS certificates.
 
     !!!note ""
-        When both the [ssl-cert](#ssl-cert) and [ssl-domains](#ssl-domains) are specified, `service.beta.kubernetes.io/aws-load-balancer-ssl-cert` annotation
-        takes precedence over the `service.beta.kubernetes.io/aws-load-balancer-ssl-domains`.
+        The `service.beta.kubernetes.io/aws-load-balancer-ssl-cert` annotation takes precedence
+        over the `service.beta.kubernetes.io/aws-load-balancer-ssl-domains` annotation.
 
     !!!example
         ```

--- a/pkg/annotations/constants.go
+++ b/pkg/annotations/constants.go
@@ -63,6 +63,7 @@ const (
 	SvcLBSuffixAccessLogS3BucketName                     = "aws-load-balancer-access-log-s3-bucket-name"
 	SvcLBSuffixAccessLogS3BucketPrefix                   = "aws-load-balancer-access-log-s3-bucket-prefix"
 	SvcLBSuffixCrossZoneLoadBalancingEnabled             = "aws-load-balancer-cross-zone-load-balancing-enabled"
+	SvcLBSuffixSSLDomains                                = "aws-load-balancer-ssl-domains"
 	SvcLBSuffixSSLCertificate                            = "aws-load-balancer-ssl-cert"
 	SvcLBSuffixSSLPorts                                  = "aws-load-balancer-ssl-ports"
 	SvcLBSuffixSSLNegotiationPolicy                      = "aws-load-balancer-ssl-negotiation-policy"

--- a/pkg/ingress/model_builder.go
+++ b/pkg/ingress/model_builder.go
@@ -110,7 +110,7 @@ type defaultModelBuilder struct {
 	logger logr.Logger
 }
 
-// build mode stack for a IngressGroup.
+// Build builds mode stack for a IngressGroup.
 func (b *defaultModelBuilder) Build(ctx context.Context, ingGroup Group) (core.Stack, *elbv2model.LoadBalancer, []types.NamespacedName, bool, error) {
 	stack := core.NewDefaultStack(core.StackID(ingGroup.ID))
 	task := &defaultModelBuildTask{

--- a/pkg/service/model_build_listener.go
+++ b/pkg/service/model_build_listener.go
@@ -125,7 +125,7 @@ func (t *defaultModelBuildTask) buildListenerCertificates(ctx context.Context) (
 	if t.annotationParser.ParseStringSliceAnnotation(annotations.SvcLBSuffixSSLDomains, &rawSSLDomains, t.service.Annotations) {
 		autoDiscoveredCertARNs, err := t.certDiscovery.Discover(ctx, rawSSLDomains)
 		if err != nil {
-			return certificates, err
+			return nil, err
 		}
 		for _, cert := range autoDiscoveredCertARNs {
 			certificates = append(certificates, elbv2model.Certificate{

--- a/pkg/service/model_build_listener.go
+++ b/pkg/service/model_build_listener.go
@@ -108,28 +108,30 @@ func (t *defaultModelBuildTask) buildSSLNegotiationPolicy(_ context.Context) *st
 	return &t.defaultSSLPolicy
 }
 
-func (t *defaultModelBuildTask) buildListenerCertificates(ctx context.Context) []elbv2model.Certificate {
+func (t *defaultModelBuildTask) buildListenerCertificates(ctx context.Context) ([]elbv2model.Certificate, error) {
 	var rawCertificateARNs []string
 	var rawSSLDomains []string
-	_ = t.annotationParser.ParseStringSliceAnnotation(annotations.SvcLBSuffixSSLCertificate, &rawCertificateARNs, t.service.Annotations)
-	_ = t.annotationParser.ParseStringSliceAnnotation(annotations.SvcLBSuffixSSLDomains, &rawSSLDomains, t.service.Annotations)
+	sslCertAnnotationExists := t.annotationParser.ParseStringSliceAnnotation(annotations.SvcLBSuffixSSLCertificate, &rawCertificateARNs, t.service.Annotations)
 
 	var certificates []elbv2model.Certificate
 	for _, cert := range rawCertificateARNs {
 		certificates = append(certificates, elbv2model.Certificate{CertificateARN: aws.String(cert)})
 	}
 
-	// TODO: Refactoring required
-	autoDiscoveredCertARNs, err := t.certDiscovery.Discover(ctx, rawSSLDomains)
-	if err != nil {
-		return certificates
+	// auto-discover ACM certs only if the ssl-domains annotation exists ssl-cert annotations is not present
+	// which means ssl-cert takes precedence over the auto-discovered cert/ss-domains annotation
+	if !sslCertAnnotationExists && t.annotationParser.ParseStringSliceAnnotation(annotations.SvcLBSuffixSSLDomains, &rawSSLDomains, t.service.Annotations) {
+		autoDiscoveredCertARNs, err := t.certDiscovery.Discover(ctx, rawSSLDomains)
+		if err != nil {
+			return certificates, err
+		}
+		for _, cert := range autoDiscoveredCertARNs {
+			certificates = append(certificates, elbv2model.Certificate{
+				CertificateARN: aws.String(cert),
+			})
+		}
 	}
-	for _, cert := range autoDiscoveredCertARNs {
-		certificates = append(certificates, elbv2model.Certificate{
-			CertificateARN: aws.String(cert),
-		})
-	}
-	return certificates
+	return certificates, nil
 }
 
 func validateTLSPortsSet(rawTLSPorts []string, ports []corev1.ServicePort) error {
@@ -205,7 +207,11 @@ type listenerConfig struct {
 }
 
 func (t *defaultModelBuildTask) buildListenerConfig(ctx context.Context) (*listenerConfig, error) {
-	certificates := t.buildListenerCertificates(ctx)
+	certificates, err := t.buildListenerCertificates(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	tlsPortsSet, err := t.buildTLSPortsSet(ctx)
 	if err != nil {
 		return nil, err

--- a/pkg/service/model_builder.go
+++ b/pkg/service/model_builder.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 
 	"github.com/go-logr/logr"
-	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/services"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/ingress"
 
 	"github.com/aws/aws-sdk-go/service/ec2"

--- a/pkg/service/model_builder.go
+++ b/pkg/service/model_builder.go
@@ -2,6 +2,9 @@ package service
 
 import (
 	"context"
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/services"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/ingress"
 	"strconv"
 	"sync"
 
@@ -41,7 +44,7 @@ func NewDefaultModelBuilder(annotationParser annotations.Parser, subnetsResolver
 	elbv2TaggingManager elbv2deploy.TaggingManager, ec2Client services.EC2, featureGates config.FeatureGates, clusterName string, defaultTags map[string]string,
 	externalManagedTags []string, defaultSSLPolicy string, defaultTargetType string, enableIPTargetType bool, serviceUtils ServiceUtils,
 	backendSGProvider networking.BackendSGProvider, sgResolver networking.SecurityGroupResolver, enableBackendSG bool,
-	disableRestrictedSGRules bool, logger logr.Logger) *defaultModelBuilder {
+	disableRestrictedSGRules bool, certDiscovery ingress.CertDiscovery, logger logr.Logger) *defaultModelBuilder {
 	return &defaultModelBuilder{
 		annotationParser:         annotationParser,
 		subnetsResolver:          subnetsResolver,
@@ -50,6 +53,7 @@ func NewDefaultModelBuilder(annotationParser annotations.Parser, subnetsResolver
 		elbv2TaggingManager:      elbv2TaggingManager,
 		featureGates:             featureGates,
 		serviceUtils:             serviceUtils,
+		certDiscovery:            certDiscovery,
 		clusterName:              clusterName,
 		vpcID:                    vpcID,
 		defaultTags:              defaultTags,
@@ -78,6 +82,7 @@ type defaultModelBuilder struct {
 	elbv2TaggingManager      elbv2deploy.TaggingManager
 	featureGates             config.FeatureGates
 	serviceUtils             ServiceUtils
+	certDiscovery            ingress.CertDiscovery
 	ec2Client                services.EC2
 	enableBackendSG          bool
 	disableRestrictedSGRules bool
@@ -165,6 +170,7 @@ type defaultModelBuildTask struct {
 	featureGates        config.FeatureGates
 	serviceUtils        ServiceUtils
 	enableIPTargetType  bool
+	certDiscovery       ingress.CertDiscovery
 	ec2Client           services.EC2
 	logger              logr.Logger
 

--- a/pkg/service/model_builder.go
+++ b/pkg/service/model_builder.go
@@ -5,9 +5,6 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/go-logr/logr"
-	"sigs.k8s.io/aws-load-balancer-controller/pkg/ingress"
-
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -18,6 +15,7 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/config"
 	elbv2deploy "sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/elbv2"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/tracking"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/ingress"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/core"
 	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"

--- a/pkg/service/model_builder.go
+++ b/pkg/service/model_builder.go
@@ -2,11 +2,12 @@ package service
 
 import (
 	"context"
+	"strconv"
+	"sync"
+
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/services"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/ingress"
-	"strconv"
-	"sync"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/go-logr/logr"

--- a/pkg/service/model_builder_test.go
+++ b/pkg/service/model_builder_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/ingress"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	elbv2sdk "github.com/aws/aws-sdk-go/service/elbv2"
@@ -6459,9 +6462,10 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 			} else {
 				enableIPTargetType = *tt.enableIPTargetType
 			}
+			certDiscovery := ingress.NewMockCertDiscovery(ctrl)
 			builder := NewDefaultModelBuilder(annotationParser, subnetsResolver, vpcInfoProvider, "vpc-xxx", trackingProvider, elbv2TaggingManager, ec2Client, featureGates,
 				"my-cluster", nil, nil, "ELBSecurityPolicy-2016-08", defaultTargetType, enableIPTargetType, serviceUtils,
-				backendSGProvider, sgResolver, tt.enableBackendSG, tt.disableRestrictedSGRules, logr.New(&log.NullLogSink{}))
+				backendSGProvider, sgResolver, tt.enableBackendSG, tt.disableRestrictedSGRules, certDiscovery, logr.New(&log.NullLogSink{}))
 			ctx := context.Background()
 			stack, _, _, err := builder.Build(ctx, tt.svc)
 			if tt.wantError {

--- a/pkg/service/model_builder_test.go
+++ b/pkg/service/model_builder_test.go
@@ -5,9 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-logr/logr"
-	"sigs.k8s.io/aws-load-balancer-controller/pkg/ingress"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	elbv2sdk "github.com/aws/aws-sdk-go/service/elbv2"
@@ -24,6 +21,7 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/elbv2"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/tracking"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/ingress"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/networking"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )


### PR DESCRIPTION
### Issue
#3210 

<!-- Please link the GitHub issues related to this PR, if available -->

### Description
<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->
- Added a new annotation `service.beta.kubernetes.io/aws-load-balancer-ssl-domains` which helps to reuse the `CertificateDiscovery` implementation done for Ingress.
- Auto discovery will happen only when the ssl-certs annotation not exists and ssl-domains annotation is provided. If both annotations are present, ssl-certs take precedence.


### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
