### PR TITLE
Make Ingress validating webhook ignore ingresses not managed by AWS LBC

### DIFF
--- a/controllers/ingress/group_controller.go
+++ b/controllers/ingress/group_controller.go
@@ -65,7 +65,7 @@ func NewGroupReconciler(cloud aws.Cloud, k8sClient client.Client, eventRecorder 
 	stackMarshaller := deploy.NewDefaultStackMarshaller()
 	stackDeployer := deploy.NewDefaultStackDeployer(cloud, k8sClient, networkingSGManager, networkingSGReconciler,
 		controllerConfig, ingressTagPrefix, logger)
-	classLoader := ingress.NewDefaultClassLoader(k8sClient)
+	classLoader := ingress.NewDefaultClassLoader(k8sClient, true)
 	classAnnotationMatcher := ingress.NewDefaultClassAnnotationMatcher(controllerConfig.IngressConfig.IngressClass)
 	manageIngressesWithoutIngressClass := controllerConfig.IngressConfig.IngressClass == ""
 	groupLoader := ingress.NewDefaultGroupLoader(k8sClient, eventRecorder, annotationParser, classLoader, classAnnotationMatcher, manageIngressesWithoutIngressClass)

--- a/pkg/config/ingress_config.go
+++ b/pkg/config/ingress_config.go
@@ -15,14 +15,17 @@ const (
 
 // IngressConfig contains the configurations for the Ingress controller
 type IngressConfig struct {
-	// Name of the Ingress class this controller satisfies
-	// If empty, all Ingresses without ingress.class annotation, or ingress.class==alb get considered
+	// Name of the Ingress class this controller satisfies.
+	// If empty, all with a `kubernetes.io/ingress.class`
+	// annotation of `alb` get considered.
+	// Also, if empty, all ingresses without either a `kubernetes.io/ingress.class` annotation or
+	// an IngressClassName get considered.
 	IngressClass string
 
-	// DisableIngressClassAnnotation specifies whether to disable new usage of kubernetes.io/ingress.class annotation.
+	// DisableIngressClassAnnotation specifies whether to disable new use of the `kubernetes.io/ingress.class` annotation.
 	DisableIngressClassAnnotation bool
 
-	// DisableIngressGroupNameAnnotation specifies whether to disable new usage of alb.ingress.kubernetes.io/group.name annotation.
+	// DisableIngressGroupNameAnnotation specifies whether to disable new use of the `alb.ingress.kubernetes.io/group.name` annotation.
 	DisableIngressGroupNameAnnotation bool
 
 	// Max concurrent reconcile loops for Ingress objects

--- a/pkg/ingress/class_annotation_matcher.go
+++ b/pkg/ingress/class_annotation_matcher.go
@@ -10,7 +10,7 @@ type ClassAnnotationMatcher interface {
 }
 
 // NewDefaultClassAnnotationMatcher constructs new defaultClassAnnotationMatcher.
-func NewDefaultClassAnnotationMatcher(ingressClass string) *defaultClassAnnotationMatcher {
+func NewDefaultClassAnnotationMatcher(ingressClass string) ClassAnnotationMatcher {
 	return &defaultClassAnnotationMatcher{
 		ingressClass: ingressClass,
 	}

--- a/pkg/ingress/class_loader.go
+++ b/pkg/ingress/class_loader.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	// the controller name used in IngressClass for ALB.
-	ingressClassControllerALB = "ingress.k8s.aws/alb"
+	IngressClassControllerALB = "ingress.k8s.aws/alb"
 	// the Kind for IngressClassParams CRD.
 	ingressClassParamsKind = "IngressClassParams"
 	// default class from ingressClass
@@ -35,15 +35,17 @@ type ClassLoader interface {
 }
 
 // NewDefaultClassLoader constructs new defaultClassLoader instance.
-func NewDefaultClassLoader(client client.Client) *defaultClassLoader {
+func NewDefaultClassLoader(client client.Client, loadParams bool) ClassLoader {
 	return &defaultClassLoader{
-		client: client,
+		client:     client,
+		loadParams: loadParams,
 	}
 }
 
 // default implementation for ClassLoader
 type defaultClassLoader struct {
-	client client.Client
+	client     client.Client
+	loadParams bool
 }
 
 // GetDefaultIngressClass returns the default IngressClass from the list of IngressClasses.
@@ -91,7 +93,7 @@ func (l *defaultClassLoader) Load(ctx context.Context, ing *networking.Ingress) 
 		}
 		return ClassConfiguration{}, err
 	}
-	if ingClass.Spec.Controller != ingressClassControllerALB || ingClass.Spec.Parameters == nil {
+	if ingClass.Spec.Controller != IngressClassControllerALB || ingClass.Spec.Parameters == nil || !l.loadParams {
 		return ClassConfiguration{
 			IngClass: ingClass,
 		}, nil

--- a/pkg/ingress/class_loader_test.go
+++ b/pkg/ingress/class_loader_test.go
@@ -660,7 +660,8 @@ func Test_defaultClassLoader_Load(t *testing.T) {
 			}
 
 			l := &defaultClassLoader{
-				client: k8sClient,
+				client:     k8sClient,
+				loadParams: true,
 			}
 			got, err := l.Load(ctx, tt.args.ing)
 			if tt.wantErr != nil {
@@ -852,7 +853,8 @@ func Test_defaultClassLoader_validateIngressClassParamsNamespaceRestriction(t *t
 			}
 
 			l := &defaultClassLoader{
-				client: k8sClient,
+				client:     k8sClient,
+				loadParams: true,
 			}
 			if tt.args.admissionReq != nil {
 				ctx = webhook.ContextWithAdmissionRequest(ctx, *tt.args.admissionReq)

--- a/pkg/ingress/group_loader.go
+++ b/pkg/ingress/group_loader.go
@@ -219,7 +219,7 @@ func (m *defaultGroupLoader) classifyIngress(ctx context.Context, ing *networkin
 		return ClassifiedIngress{
 			Ing:            ing,
 			IngClassConfig: ingClassConfig,
-		}, ingClassConfig.IngClass.Spec.Controller == ingressClassControllerALB, nil
+		}, ingClassConfig.IngClass.Spec.Controller == IngressClassControllerALB, nil
 	}
 
 	return ClassifiedIngress{

--- a/pkg/ingress/group_loader.go
+++ b/pkg/ingress/group_loader.go
@@ -215,11 +215,11 @@ func (m *defaultGroupLoader) classifyIngress(ctx context.Context, ing *networkin
 		}, false, err
 	}
 
-	if matchesIngressClass := ingClassConfig.IngClass != nil && ingClassConfig.IngClass.Spec.Controller == ingressClassControllerALB; matchesIngressClass {
+	if ingClassConfig.IngClass != nil {
 		return ClassifiedIngress{
 			Ing:            ing,
 			IngClassConfig: ingClassConfig,
-		}, true, nil
+		}, ingClassConfig.IngClass.Spec.Controller == ingressClassControllerALB, nil
 	}
 
 	return ClassifiedIngress{

--- a/pkg/ingress/group_loader_test.go
+++ b/pkg/ingress/group_loader_test.go
@@ -2107,6 +2107,60 @@ func Test_defaultGroupLoader_classifyIngress(t *testing.T) {
 			},
 			wantIngressClassMatches: false,
 		},
+		{
+			name: "class specified via ingressClassName - mismatches - manageIngressesWithoutIngressClass is set",
+			env: env{
+				ingClassList: []*networking.IngressClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ing-class",
+						},
+						Spec: networking.IngressClassSpec{
+							Controller: "some.other/nginx",
+						},
+					},
+				},
+			},
+			fields: fields{
+				ingressClass:                       "",
+				manageIngressesWithoutIngressClass: true,
+			},
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:   "ing-ns",
+						Name:        "ing-name",
+						Annotations: map[string]string{},
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: awssdk.String("ing-class"),
+					},
+				},
+			},
+			wantClassifiedIng: ClassifiedIngress{
+				Ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:   "ing-ns",
+						Name:        "ing-name",
+						Annotations: map[string]string{},
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: awssdk.String("ing-class"),
+					},
+				},
+				IngClassConfig: ClassConfiguration{
+					IngClass: &networking.IngressClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ing-class",
+						},
+						Spec: networking.IngressClassSpec{
+							Controller: "some.other/nginx",
+						},
+					},
+				},
+			},
+			wantIngressClassMatches: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/ingress/group_loader_test.go
+++ b/pkg/ingress/group_loader_test.go
@@ -621,7 +621,7 @@ func Test_defaultGroupLoader_Load(t *testing.T) {
 			}
 
 			annotationParser := annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io")
-			classLoader := NewDefaultClassLoader(k8sClient)
+			classLoader := NewDefaultClassLoader(k8sClient, true)
 			classAnnotationMatcher := NewDefaultClassAnnotationMatcher("alb")
 			m := &defaultGroupLoader{
 				client:                             k8sClient,
@@ -1485,7 +1485,7 @@ func Test_defaultGroupLoader_checkGroupMembershipType(t *testing.T) {
 			}
 
 			annotationParser := annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io")
-			classLoader := NewDefaultClassLoader(k8sClient)
+			classLoader := NewDefaultClassLoader(k8sClient, true)
 			classAnnotationMatcher := NewDefaultClassAnnotationMatcher("alb")
 			m := &defaultGroupLoader{
 				client:                             k8sClient,
@@ -1759,7 +1759,7 @@ func Test_defaultGroupLoader_loadGroupIDIfAnyHelper(t *testing.T) {
 			}
 
 			annotationParser := annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io")
-			classLoader := NewDefaultClassLoader(k8sClient)
+			classLoader := NewDefaultClassLoader(k8sClient, true)
 			classAnnotationMatcher := NewDefaultClassAnnotationMatcher("alb")
 			m := &defaultGroupLoader{
 				client:                             k8sClient,
@@ -2176,7 +2176,7 @@ func Test_defaultGroupLoader_classifyIngress(t *testing.T) {
 			}
 
 			annotationParser := annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io")
-			classLoader := NewDefaultClassLoader(k8sClient)
+			classLoader := NewDefaultClassLoader(k8sClient, true)
 			classAnnotationMatcher := NewDefaultClassAnnotationMatcher(tt.fields.ingressClass)
 			m := &defaultGroupLoader{
 				client:                             k8sClient,

--- a/pkg/ingress/reference_indexer.go
+++ b/pkg/ingress/reference_indexer.go
@@ -103,7 +103,7 @@ func (i *defaultReferenceIndexer) BuildIngressClassRefIndexes(_ context.Context,
 }
 
 func (i *defaultReferenceIndexer) BuildIngressClassParamsRefIndexes(_ context.Context, ingClass *networking.IngressClass) []string {
-	if ingClass.Spec.Controller != ingressClassControllerALB || ingClass.Spec.Parameters == nil {
+	if ingClass.Spec.Controller != IngressClassControllerALB || ingClass.Spec.Parameters == nil {
 		return nil
 	}
 	if ingClass.Spec.Parameters.APIGroup == nil ||


### PR DESCRIPTION
### Issue

None

### Description

Makes the validating admission webhook for Ingress permit creation and modification all ingresses for which it is able to determine that it is not going to manage.

Also fixes a bug where LBC would incorrectly manage Ingresses with an IngressClassName specifying a different controller when LBC was configured to manage Ingresses without either annotation or IngressClassName.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
