### PR TITLE
fix the bug that evenhanlder ignores the update per sync-period

### DIFF
--- a/controllers/ingress/eventhandlers/ingress_events.go
+++ b/controllers/ingress/eventhandlers/ingress_events.go
@@ -44,10 +44,12 @@ func (h *enqueueRequestsForIngressEvent) Update(e event.UpdateEvent, queue workq
 	//	1. Ingress annotation updates
 	//	2. Ingress spec updates
 	//	3. Ingress deletion
-	if equality.Semantic.DeepEqual(ingOld.Annotations, ingNew.Annotations) &&
-		equality.Semantic.DeepEqual(ingOld.Spec, ingNew.Spec) &&
-		equality.Semantic.DeepEqual(ingOld.DeletionTimestamp.IsZero(), ingNew.DeletionTimestamp.IsZero()) {
-		return
+	if ! equality.Semantic.DeepEqual(ingOld.ResourceVersion, ingNew.ResourceVersion) {
+		if equality.Semantic.DeepEqual(ingOld.Annotations, ingNew.Annotations) &&
+			equality.Semantic.DeepEqual(ingOld.Spec, ingNew.Spec) &&
+			equality.Semantic.DeepEqual(ingOld.DeletionTimestamp.IsZero(), ingNew.DeletionTimestamp.IsZero()) {
+			return
+		}
 	}
 
 	h.enqueueIfBelongsToGroup(queue, ingNew)

--- a/controllers/service/eventhandlers/service_events.go
+++ b/controllers/service/eventhandlers/service_events.go
@@ -39,10 +39,12 @@ func (h *enqueueRequestsForServiceEvent) Update(e event.UpdateEvent, queue workq
 	oldSvc := e.ObjectOld.(*corev1.Service)
 	newSvc := e.ObjectNew.(*corev1.Service)
 
-	if equality.Semantic.DeepEqual(oldSvc.Annotations, newSvc.Annotations) &&
-		equality.Semantic.DeepEqual(oldSvc.Spec, newSvc.Spec) &&
-		equality.Semantic.DeepEqual(oldSvc.DeletionTimestamp.IsZero(), newSvc.DeletionTimestamp.IsZero()) {
-		return
+	if ! equality.Semantic.DeepEqual(oldSvc.ResourceVersion, newSvc.ResourceVersion) {
+		if equality.Semantic.DeepEqual(oldSvc.Annotations, newSvc.Annotations) &&
+			equality.Semantic.DeepEqual(oldSvc.Spec, newSvc.Spec) &&
+			equality.Semantic.DeepEqual(oldSvc.DeletionTimestamp.IsZero(), newSvc.DeletionTimestamp.IsZero()) {
+			return
+		}
 	}
 
 	h.enqueueManagedService(queue, newSvc)


### PR DESCRIPTION

### Issue

<!-- Please link the GitHub issues related to this PR, if available -->
https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/3264
https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2800
https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2515

### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->
Currently, there is a conflict between the controller runtime flag `--sync-period`, which is to force reconcile every fix interval, and the eventhandlers, which are to avoid unnecessary reconciles to optimize the AWS API usage. When the controller runtime sends an update event to the eventhandler per interval in `--sync-period`, the eventhandler will ignore the update event if there is no difference in the annotations/specs of the ingress or service. Therefore, if the end users made some manual modification to the resources managed by the controller as mentioned in the issues above, the controller could not revert since it does not reconcile under this situation.

We fix the bug by leveraging k8s resourceVersions -
- if the resourceVersions are the same between old and new objects, the controller will continue to reconcile; 
- if the resourceVersions do change, then the eventhandler continues to check the annotation and specs to see if it is an update event with real change in resources.

However, as the best practice, we do not recommend manual modification, nor should the users depend on the controller auto-reconciliation to heal the resources they changed, or to mitigate any security risks. Since no matter how frequent the controller reconciles, there should always be a gap.

#### Test

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
