### PR TITLE
Doc: Add note for rename behavior of IngressGroup

### DIFF
--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -79,6 +79,13 @@ By default, Ingresses don't belong to any IngressGroup, and we treat it as a "im
         other Kubernetes users may create/modify their Ingresses to belong to the same IngressGroup, and can thus add more rules or overwrite existing rules with higher priority to the ALB for your Ingress.
 
         We'll add more fine-grained access-control in future versions.
+  
+    !!!warning "Rename behavior"
+        ALB is uniquely identified by it's tag `ingress.k8s.aws/stack`, whose value is the name of IngressGroup.
+
+        There is no way to rename an existing IngressGroup while keeping ALB. When the `groupName` of IngressGroup of Ingress is changed, the Ingress will be moved to corresponding IngressGroup and ALB. If target IngressGroup doesn't exist, a new ALB will be created.
+
+        If an IngressGroup has only one Ingress (or IngressGroup is not explicit specified), changing name of IngressGroup will cause recreation of Load Balancer. If an IngressGroup has no Ingress, the corrsponding ALB will be removed. In both cases, deletion protection of ALB will be ignored.
 
     !!!example
         ```

--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -80,12 +80,12 @@ By default, Ingresses don't belong to any IngressGroup, and we treat it as a "im
 
         We'll add more fine-grained access-control in future versions.
   
-    !!!warning "Rename behavior"
-        ALB is uniquely identified by it's tag `ingress.k8s.aws/stack`, whose value is the name of IngressGroup.
+    !!!note "Rename behavior"
+        The ALB for an IngressGroup is found by searching for an AWS tag `ingress.k8s.aws/stack` tag with the name of the IngressGroup as its value. For implicit IngressGroup, the value is `namespace/ingressname`.
 
-        There is no way to rename an existing IngressGroup while keeping ALB. When the `groupName` of IngressGroup of Ingress is changed, the Ingress will be moved to corresponding IngressGroup and ALB. If target IngressGroup doesn't exist, a new ALB will be created.
+        When the groupName of IngressGroup for Ingress is changed, the Ingress will be moved to new IngressGroup and supported by ALB for the new IngressGroup. If ALB for the new IngressGroup doesn't exist, a new ALB will be created.
 
-        If an IngressGroup has only one Ingress (or IngressGroup is not explicit specified), changing name of IngressGroup will cause recreation of Load Balancer. If an IngressGroup has no Ingress, the corrsponding ALB will be removed. In both cases, deletion protection of ALB will be ignored.
+        If an IngressGroup no longer contain any Ingresses, ALB for the IngressGroup will be deleted, and deletion protection of ALB will be ignored.
 
     !!!example
         ```

--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -81,11 +81,11 @@ By default, Ingresses don't belong to any IngressGroup, and we treat it as a "im
         We'll add more fine-grained access-control in future versions.
   
     !!!note "Rename behavior"
-        The ALB for an IngressGroup is found by searching for an AWS tag `ingress.k8s.aws/stack` tag with the name of the IngressGroup as its value. For implicit IngressGroup, the value is `namespace/ingressname`.
+        The ALB for an IngressGroup is found by searching for an AWS tag `ingress.k8s.aws/stack` tag with the name of the IngressGroup as its value. For an implicit IngressGroup, the value is `namespace/ingressname`.
 
-        When the groupName of IngressGroup for Ingress is changed, the Ingress will be moved to new IngressGroup and supported by ALB for the new IngressGroup. If ALB for the new IngressGroup doesn't exist, a new ALB will be created.
+        When the groupName of an IngressGroup for an Ingress is changed, the Ingress will be moved to a new IngressGroup and be supported by the ALB for the new IngressGroup. If the ALB for the new IngressGroup doesn't exist, a new ALB will be created.
 
-        If an IngressGroup no longer contain any Ingresses, ALB for the IngressGroup will be deleted, and deletion protection of ALB will be ignored.
+        If an IngressGroup no longer contains any Ingresses, the ALB for that IngressGroup will be deleted and any deletion protection of that ALB will be ignored.
 
     !!!example
         ```


### PR DESCRIPTION
### Issue

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2271
https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/3034

### Description

<!--
Please explain the changes you made here.

Help your reviewers my guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

Add a warning to describe rename behavior of IngressGroup. 

When rename a IngressGroup with only an Ingress, ALB will be recreated. Deletion protection will be ignored during recreate. However, this behavior is not documented and caused confuse and interruption of customer usage. 

By adding description about ALB to IngressGroup relationship and rename behavior, customer will have a clearer view on how IngressGroup run under the hood. 

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
