### PR TITLE
[WIP] Skip processing an ingress that does not have a valid certificate for its hosts

### DIFF
--- a/pkg/ingress/cert_discovery.go
+++ b/pkg/ingress/cert_discovery.go
@@ -2,18 +2,18 @@ package ingress
 
 import (
 	"context"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/acm"
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/cache"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/services"
-	"strings"
-	"sync"
-	"time"
 )
 
 const (
@@ -81,7 +81,8 @@ func (d *acmCertDiscovery) Discover(ctx context.Context, tlsHosts []string) ([]s
 		}
 
 		if len(certARNsForHost) == 0 {
-			return nil, errors.Errorf("no certificate found for host: %s", host)
+			d.logger.Info("no certificate found for host", "host", host)
+			continue
 		}
 		certARNs.Insert(certARNsForHost...)
 	}

--- a/pkg/ingress/model_build_listener.go
+++ b/pkg/ingress/model_build_listener.go
@@ -140,6 +140,10 @@ func (t *defaultModelBuildTask) computeIngressListenPortConfigByPort(ctx context
 			inboundCIDRv6s: inboundCIDRV6s,
 		}
 		if protocol == elbv2model.ProtocolHTTPS {
+			if len(explicitTLSCertARNs) == 0 && len(inferredTLSCertARNs) == 0 {
+				t.logger.Info("no TLS cert ARNs found for ingress", "ingress", fmt.Sprintf("%s/%s", ing.Ing.Name, ing.Ing.Namespace))
+				continue
+			}
 			if len(explicitTLSCertARNs) == 0 {
 				cfg.tlsCerts = inferredTLSCertARNs
 			} else {


### PR DESCRIPTION
… 
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description

If a single ALB ingress in an ingress group includes a host that doesn't have a corresponding certificate in ACM, it will block successful deployment of the entire ingress group. Instead of this behavior, we can simply ignore the "bad ingress" and include log a message explaining that the ingress doesn't have a host that corresponds to a certificate. 

With the recent introduction of the fix for the syncPeriod parameter, I think it's safe to make this change because the load balancer controller will eventually try to perform certificate discovery and attachment after at most 10 hours (the default period), so if the "bad ingress" becomes an ingress that has a valid certificate for its hosts, it would eventually get processed successfully. Additionally, users can make the syncPeriod more frequent if needed.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
  - Integration testing
    - Test Case 1: Multiple ingresses in one group
      - ALB Ingress with no valid cert for host
        - <img width="345" alt="image" src="https://github.com/kubernetes-sigs/aws-load-balancer-controller/assets/51824962/a2802904-6fc0-45ca-b453-ce0919c63cc0">
      - ALB ingress with valid cert for host
        - <img width="256" alt="image" src="https://github.com/kubernetes-sigs/aws-load-balancer-controller/assets/51824962/4be07aaa-9f10-49b4-ad60-917578b9fdb8">
      - Bad ingress is ignored and good ingress is successfully processed and model is deployed
        - ![image](https://github.com/kubernetes-sigs/aws-load-balancer-controller/assets/51824962/5b25da52-e31a-4cef-bc18-4f0d3a641823)
    - Test Case 2: Single ingress in a group
      - ALB Ingress with no valid cert for host
        - 
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
