### PR TITLE
don't block TGB reconciliation loop on failed SG ingress reconciliation

### DIFF
--- a/pkg/k8s/events.go
+++ b/pkg/k8s/events.go
@@ -25,6 +25,7 @@ const (
 	TargetGroupBindingEventReasonFailedRemoveFinalizer  = "FailedRemoveFinalizer"
 	TargetGroupBindingEventReasonFailedUpdateStatus     = "FailedUpdateStatus"
 	TargetGroupBindingEventReasonFailedCleanup          = "FailedCleanup"
+	TargetGroupBindingEventReasonFailedNetworkReconcile = "FailedNetworkReconcile"
 	TargetGroupBindingEventReasonBackendNotFound        = "BackendNotFound"
 	TargetGroupBindingEventReasonSuccessfullyReconciled = "SuccessfullyReconciled"
 )

--- a/pkg/targetgroupbinding/networking_manager.go
+++ b/pkg/targetgroupbinding/networking_manager.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	libErrors "errors"
 
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -199,11 +200,12 @@ func (m *defaultNetworkingManager) reconcileWithIngressPermissionsPerSG(ctx cont
 	aggregatedIngressPermissionsPerSG := m.computeAggregatedIngressPermissionsPerSG(ctx)
 
 	permissionSelector := labels.SelectorFromSet(labels.Set{tgbNetworkingIPPermissionLabelKey: tgbNetworkingIPPermissionLabelValue})
+	sgReconciliationErrors := make([]error, 0)
 	for sgID, permissions := range aggregatedIngressPermissionsPerSG {
 		if err := m.sgReconciler.ReconcileIngress(ctx, sgID, permissions,
 			networking.WithPermissionSelector(permissionSelector),
 			networking.WithAuthorizeOnly(!computedForAllTGBs)); err != nil {
-			m.logger.Error(err, "Security group reconciliation", "SecurityGroupID", sgID)
+			sgReconciliationErrors = append(sgReconciliationErrors, err)
 			continue
 		}
 	}
@@ -212,6 +214,11 @@ func (m *defaultNetworkingManager) reconcileWithIngressPermissionsPerSG(ctx cont
 		if err := m.gcIngressPermissionsFromUnusedEndpointSGs(ctx, aggregatedIngressPermissionsPerSG); err != nil {
 			return err
 		}
+	}
+
+	if len(sgReconciliationErrors) > 0 {
+		err := libErrors.Join(sgReconciliationErrors...)
+		return err
 	}
 
 	return nil

--- a/pkg/targetgroupbinding/networking_manager.go
+++ b/pkg/targetgroupbinding/networking_manager.go
@@ -200,7 +200,7 @@ func (m *defaultNetworkingManager) reconcileWithIngressPermissionsPerSG(ctx cont
 	aggregatedIngressPermissionsPerSG := m.computeAggregatedIngressPermissionsPerSG(ctx)
 
 	permissionSelector := labels.SelectorFromSet(labels.Set{tgbNetworkingIPPermissionLabelKey: tgbNetworkingIPPermissionLabelValue})
-	sgReconciliationErrors := make([]error, 0)
+	var sgReconciliationErrors []error
 	for sgID, permissions := range aggregatedIngressPermissionsPerSG {
 		if err := m.sgReconciler.ReconcileIngress(ctx, sgID, permissions,
 			networking.WithPermissionSelector(permissionSelector),

--- a/pkg/targetgroupbinding/networking_manager.go
+++ b/pkg/targetgroupbinding/networking_manager.go
@@ -203,7 +203,8 @@ func (m *defaultNetworkingManager) reconcileWithIngressPermissionsPerSG(ctx cont
 		if err := m.sgReconciler.ReconcileIngress(ctx, sgID, permissions,
 			networking.WithPermissionSelector(permissionSelector),
 			networking.WithAuthorizeOnly(!computedForAllTGBs)); err != nil {
-			return err
+			m.logger.Error(err, "Security group reconciliation", "SecurityGroupID", sgID)
+			continue
 		}
 	}
 

--- a/pkg/targetgroupbinding/resource_manager.go
+++ b/pkg/targetgroupbinding/resource_manager.go
@@ -136,7 +136,6 @@ func (m *defaultResourceManager) reconcileWithIPTargetType(ctx context.Context, 
 	notDrainingTargets, drainingTargets := partitionTargetsByDrainingStatus(targets)
 	matchedEndpointAndTargets, unmatchedEndpoints, unmatchedTargets := matchPodEndpointWithTargets(endpoints, notDrainingTargets)
 
-
 	needNetworkingRequeue := false
 	if err := m.networkingManager.ReconcileForPodEndpoints(ctx, tgb, endpoints); err != nil {
 		m.eventRecorder.Event(tgb, corev1.EventTypeWarning, k8s.TargetGroupBindingEventReasonFailedNetworkReconcile, err.Error())


### PR DESCRIPTION
### Issue

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/3285

### Description

the controller performs an SG reconciliation step for all (cluster-wide) SGs gathered from all TGBs during the TGB reconciliation loop, before TG endpoints are reconciled: https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/d177c898ddd86071eecc2fd918d72ebfb0af7892/pkg/targetgroupbinding/resource_manager.go#L139-L141

the way the code is currently written, this means that any failure during SG reconciliation blocks reconciliation of all targets across the whole cluster. such a failure can be caused by something as innocuous as a SG being deleted before the associated TGB is deleted, or a SG being entered on a TGB erroneously. this can easily lead to severe outages if not remediated quickly.

this commit changes the method `reconcileWithIngressPermissionsPerSG` to not exit on a single failed SG ingress reconciliation - instead it will log the offending error and continue through the loop.

I tested this by setting up two TGBs, modifying one to have a non-existent ingress SG, deleting a target pod, then ensuring that the new target is reconciled. the new error message was also logged:
```
{"level":"error","ts":"2023-07-26T19:39:03Z","msg":"Security group reconciliation failed for SG","SecurityGroupID":"sg-0d904125da9f258a7","error":"InvalidGroup.NotFound: The security group 'sg-0b4935e438dcca2ee' does not exist\n\tstatus code: 400, request id: 34e0001c-c85e-4f6e-b7e1-c32093afe402"}
```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
