### PR TITLE
fix the race condition in pod cache and endpoint resolver

### DIFF
--- a/controllers/ingress/eventhandlers/ingress_events.go
+++ b/controllers/ingress/eventhandlers/ingress_events.go
@@ -44,7 +44,7 @@ func (h *enqueueRequestsForIngressEvent) Update(e event.UpdateEvent, queue workq
 	//	1. Ingress annotation updates
 	//	2. Ingress spec updates
 	//	3. Ingress deletion
-	if ! equality.Semantic.DeepEqual(ingOld.ResourceVersion, ingNew.ResourceVersion) {
+	if !equality.Semantic.DeepEqual(ingOld.ResourceVersion, ingNew.ResourceVersion) {
 		if equality.Semantic.DeepEqual(ingOld.Annotations, ingNew.Annotations) &&
 			equality.Semantic.DeepEqual(ingOld.Spec, ingNew.Spec) &&
 			equality.Semantic.DeepEqual(ingOld.DeletionTimestamp.IsZero(), ingNew.DeletionTimestamp.IsZero()) {

--- a/controllers/service/eventhandlers/service_events.go
+++ b/controllers/service/eventhandlers/service_events.go
@@ -39,7 +39,7 @@ func (h *enqueueRequestsForServiceEvent) Update(e event.UpdateEvent, queue workq
 	oldSvc := e.ObjectOld.(*corev1.Service)
 	newSvc := e.ObjectNew.(*corev1.Service)
 
-	if ! equality.Semantic.DeepEqual(oldSvc.ResourceVersion, newSvc.ResourceVersion) {
+	if !equality.Semantic.DeepEqual(oldSvc.ResourceVersion, newSvc.ResourceVersion) {
 		if equality.Semantic.DeepEqual(oldSvc.Annotations, newSvc.Annotations) &&
 			equality.Semantic.DeepEqual(oldSvc.Spec, newSvc.Spec) &&
 			equality.Semantic.DeepEqual(oldSvc.DeletionTimestamp.IsZero(), newSvc.DeletionTimestamp.IsZero()) {

--- a/pkg/backend/endpoint_resolver.go
+++ b/pkg/backend/endpoint_resolver.go
@@ -166,7 +166,8 @@ func (r *defaultEndpointResolver) resolvePodEndpointsWithEndpointsData(ctx conte
 					return nil, false, err
 				}
 				if !exists {
-					r.logger.Info("ignore pod Endpoint with non-existent podInfo", "podKey", podKey.String())
+					r.logger.Info("the pod in endpoint is not found in pod cache yet, will keep retrying", "podKey", podKey.String())
+					containsPotentialReadyEndpoints = true
 					continue
 				}
 				podEndpoint := buildPodEndpoint(pod, epAddr, epPort)

--- a/pkg/backend/endpoint_resolver_test.go
+++ b/pkg/backend/endpoint_resolver_test.go
@@ -1240,7 +1240,7 @@ func Test_defaultEndpointResolver_ResolvePodEndpoints(t *testing.T) {
 					Pod:  pod4,
 				},
 			},
-			wantContainsPotentialReadyEndpoints: false,
+			wantContainsPotentialReadyEndpoints: true,
 		},
 		{
 			name: "service not found",


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->
https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/3299

### Description

<!--
Please explain the changes you made here.

Help your reviewers by guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->
The pod informer and endpoints informer works independently. In some edge case, the pod is created and exists in endpoints, but when we find the podIP in endpoints, the pod is not propagated in our informer cache yet. But in the code above we simply ignored it and never retries. (and since this pod has a readinessGate, it never became ready in endpoints so no further reconcile is triggered).

For now, We can fixe this by setting containsPotentialReadyEndpoints=true if the pod in endpoints is not found in pod cache yet (so there will be a retry later).

In the future, we'll add a pod event watcher to address this issue nicely, i.e. [this TODO](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/d1b8fbb0bc6b8b7639e0be06cfd6693751ac604d/pkg/backend/endpoint_resolver.go#L21)

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
