### PR TITLE
Add validating webhook for IngressClass

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -131,3 +131,24 @@ webhooks:
         resources:
           - ingresses
     sideEffects: None
+  - admissionReviewVersions:
+      - v1beta1
+    clientConfig:
+      service:
+        name: webhook-service
+        namespace: system
+        path: /validate-networking-v1-ingressclass
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    name: vingressclass.elbv2.k8s.aws
+    rules:
+      - apiGroups:
+          - networking.k8s.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - ingressclasses
+    sideEffects: None

--- a/main.go
+++ b/main.go
@@ -156,6 +156,7 @@ func main() {
 	elbv2webhook.NewIngressClassParamsValidator().SetupWithManager(mgr)
 	elbv2webhook.NewTargetGroupBindingMutator(cloud.ELBV2(), ctrl.Log).SetupWithManager(mgr)
 	elbv2webhook.NewTargetGroupBindingValidator(mgr.GetClient(), cloud.ELBV2(), ctrl.Log).SetupWithManager(mgr)
+	networkingwebhook.NewIngressClassValidator(mgr.GetClient(), ctrl.Log).SetupWithManager(mgr)
 	networkingwebhook.NewIngressValidator(mgr.GetClient(), controllerCFG.IngressConfig, ctrl.Log).SetupWithManager(mgr)
 	//+kubebuilder:scaffold:builder
 

--- a/webhooks/networking/ingressclass_validator.go
+++ b/webhooks/networking/ingressclass_validator.go
@@ -1,0 +1,98 @@
+package networking
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	networking "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/ingress"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/webhook"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+const (
+	apiPathValidateNetworkingIngressClass = "/validate-networking-v1-ingressclass"
+)
+
+// NewIngressClassValidator returns a validator for IngressClass API.
+func NewIngressClassValidator(client client.Client, logger logr.Logger) *ingressClassValidator {
+	return &ingressClassValidator{
+		client: client,
+		logger: logger,
+	}
+}
+
+var _ webhook.Validator = &ingressClassValidator{}
+
+type ingressClassValidator struct {
+	client client.Client
+	logger logr.Logger
+}
+
+func (v *ingressClassValidator) Prototype(req admission.Request) (runtime.Object, error) {
+	return &networking.IngressClass{}, nil
+}
+
+func (v *ingressClassValidator) ValidateCreate(ctx context.Context, obj runtime.Object) error {
+	ingClass := obj.(*networking.IngressClass)
+	return v.validate(ctx, ingClass)
+}
+
+func (v *ingressClassValidator) ValidateUpdate(ctx context.Context, obj runtime.Object, oldObj runtime.Object) error {
+	ingClass := obj.(*networking.IngressClass)
+	return v.validate(ctx, ingClass)
+}
+
+func (v *ingressClassValidator) ValidateDelete(ctx context.Context, obj runtime.Object) error {
+	return nil
+}
+
+// checkIngressClass checks to see if this ingress is handled by this controller.
+func (v *ingressClassValidator) validate(ctx context.Context, ingClass *networking.IngressClass) error {
+	if ingClass.Spec.Controller != ingress.IngressClassControllerALB {
+		return nil
+	}
+
+	if ingClass.Spec.Parameters != nil {
+		fld := field.NewPath("spec", "parameters")
+		allErrs := field.ErrorList{}
+		if ingClass.Spec.Parameters.APIGroup == nil {
+			allErrs = append(allErrs, field.Required(fld.Child("apiGroup"), "must be \"elbv2.k8s.aws\""))
+		} else if (*ingClass.Spec.Parameters.APIGroup) != elbv2api.GroupVersion.Group {
+			allErrs = append(allErrs, field.Forbidden(fld.Child("apiGroup"), "must be \"elbv2.k8s.aws\""))
+		}
+		if ingClass.Spec.Parameters.Kind == "" {
+			allErrs = append(allErrs, field.Required(fld.Child("kind"), "must be \"IngressClassParams\""))
+		} else if ingClass.Spec.Parameters.Kind != "IngressClassParams" {
+			allErrs = append(allErrs, field.Forbidden(fld.Child("kind"), "must be \"IngressClassParams\""))
+		}
+
+		if len(allErrs) == 0 {
+			ingClassParamsKey := types.NamespacedName{Name: ingClass.Spec.Parameters.Name}
+			ingClassParams := &elbv2api.IngressClassParams{}
+			if err := v.client.Get(ctx, ingClassParamsKey, ingClassParams); err != nil {
+				if apierrors.IsNotFound(err) {
+					return field.NotFound(fld.Child("name"), ingClass.Spec.Parameters.Name)
+				}
+				return err
+			}
+		}
+
+		return allErrs.ToAggregate()
+	}
+
+	return nil
+}
+
+// +kubebuilder:webhook:path=/validate-networking-v1-ingressclass,mutating=false,failurePolicy=fail,groups=networking.k8s.io,resources=ingressclasses,verbs=create;update,versions=v1,name=vingressclass.elbv2.k8s.aws,sideEffects=None,matchPolicy=Equivalent,webhookVersions=v1,admissionReviewVersions=v1beta1
+
+func (v *ingressClassValidator) SetupWithManager(mgr ctrl.Manager) {
+	mgr.GetWebhookServer().Register(apiPathValidateNetworkingIngressClass, webhook.ValidatingWebhookForValidator(v))
+}

--- a/webhooks/networking/ingressclass_validator_test.go
+++ b/webhooks/networking/ingressclass_validator_test.go
@@ -1,0 +1,231 @@
+package networking
+
+import (
+	"context"
+	"testing"
+
+	awssdk "github.com/aws/aws-sdk-go/aws"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	networking "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
+	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func Test_ingressClassValidator(t *testing.T) {
+	tests := []struct {
+		name               string
+		ingClassParamsList []*elbv2api.IngressClassParams
+		ingClass           *networking.IngressClass
+		oldIngClass        *networking.IngressClass
+		wantErr            string
+	}{
+		{
+			name: "creation other controller",
+			ingClass: &networking.IngressClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "awesome-class",
+				},
+				Spec: networking.IngressClassSpec{
+					Controller: "not-us",
+					Parameters: &networking.IngressClassParametersReference{
+						APIGroup: awssdk.String("not-us"),
+						Kind:     "OtherParams",
+						Name:     "awesome-class-params",
+					},
+				},
+			},
+		},
+		{
+			name: "creation no params",
+			ingClass: &networking.IngressClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "awesome-class",
+				},
+				Spec: networking.IngressClassSpec{
+					Controller: "ingress.k8s.aws/alb",
+				},
+			},
+		},
+		{
+			name: "creation with params",
+			ingClass: &networking.IngressClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "awesome-class",
+				},
+				Spec: networking.IngressClassSpec{
+					Controller: "ingress.k8s.aws/alb",
+				},
+			},
+		},
+		{
+			name: "creation with params",
+			ingClass: &networking.IngressClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "awesome-class",
+				},
+				Spec: networking.IngressClassSpec{
+					Controller: "ingress.k8s.aws/alb",
+					Parameters: &networking.IngressClassParametersReference{
+						APIGroup: awssdk.String("elbv2.k8s.aws"),
+						Kind:     "IngressClassParams",
+						Name:     "awesome-class-params",
+					},
+				},
+			},
+			ingClassParamsList: []*elbv2api.IngressClassParams{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "awesome-class-params",
+					},
+				},
+			},
+		},
+		{
+			name: "creation missing apiGroup",
+			ingClass: &networking.IngressClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "awesome-class",
+				},
+				Spec: networking.IngressClassSpec{
+					Controller: "ingress.k8s.aws/alb",
+					Parameters: &networking.IngressClassParametersReference{
+						Kind: "IngressClassParams",
+						Name: "awesome-class-params",
+					},
+				},
+			},
+			ingClassParamsList: []*elbv2api.IngressClassParams{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "awesome-class-params",
+					},
+				},
+			},
+			wantErr: "spec.parameters.apiGroup: Required value: must be \"elbv2.k8s.aws\"",
+		},
+		{
+			name: "creation wrong apiGroup",
+			ingClass: &networking.IngressClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "awesome-class",
+				},
+				Spec: networking.IngressClassSpec{
+					Controller: "ingress.k8s.aws/alb",
+					Parameters: &networking.IngressClassParametersReference{
+						APIGroup: awssdk.String("other.k8s.aws"),
+						Kind:     "IngressClassParams",
+						Name:     "awesome-class-params",
+					},
+				},
+			},
+			ingClassParamsList: []*elbv2api.IngressClassParams{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "awesome-class-params",
+					},
+				},
+			},
+			wantErr: "spec.parameters.apiGroup: Forbidden: must be \"elbv2.k8s.aws\"",
+		},
+		{
+			name: "creation missing kind",
+			ingClass: &networking.IngressClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "awesome-class",
+				},
+				Spec: networking.IngressClassSpec{
+					Controller: "ingress.k8s.aws/alb",
+					Parameters: &networking.IngressClassParametersReference{
+						APIGroup: awssdk.String("elbv2.k8s.aws"),
+						Name:     "awesome-class-params",
+					},
+				},
+			},
+			ingClassParamsList: []*elbv2api.IngressClassParams{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "awesome-class-params",
+					},
+				},
+			},
+			wantErr: "spec.parameters.kind: Required value: must be \"IngressClassParams\"",
+		},
+		{
+			name: "creation wrong kind",
+			ingClass: &networking.IngressClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "awesome-class",
+				},
+				Spec: networking.IngressClassSpec{
+					Controller: "ingress.k8s.aws/alb",
+					Parameters: &networking.IngressClassParametersReference{
+						APIGroup: awssdk.String("elbv2.k8s.aws"),
+						Kind:     "OtherKind",
+						Name:     "awesome-class-params",
+					},
+				},
+			},
+			ingClassParamsList: []*elbv2api.IngressClassParams{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "awesome-class-params",
+					},
+				},
+			},
+			wantErr: "spec.parameters.kind: Forbidden: must be \"IngressClassParams\"",
+		},
+		{
+			name: "creation params not found",
+			ingClass: &networking.IngressClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "awesome-class",
+				},
+				Spec: networking.IngressClassSpec{
+					Controller: "ingress.k8s.aws/alb",
+					Parameters: &networking.IngressClassParametersReference{
+						APIGroup: awssdk.String("elbv2.k8s.aws"),
+						Kind:     "IngressClassParams",
+						Name:     "awesome-class-params",
+					},
+				},
+			},
+			wantErr: "spec.parameters.name: Not found: \"awesome-class-params\"",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			ctx := context.Background()
+			k8sSchema := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sSchema)
+			elbv2api.AddToScheme(k8sSchema)
+			k8sClient := testclient.NewClientBuilder().
+				WithScheme(k8sSchema).
+				Build()
+			for _, ingClassParams := range tt.ingClassParamsList {
+				assert.NoError(t, k8sClient.Create(ctx, ingClassParams.DeepCopy()))
+			}
+
+			v := &ingressClassValidator{
+				client: k8sClient,
+			}
+			var err error
+			if tt.oldIngClass == nil {
+				err = v.ValidateCreate(ctx, tt.ingClass)
+			} else {
+				err = v.ValidateUpdate(ctx, tt.ingClass, tt.oldIngClass)
+			}
+			if tt.wantErr != "" {
+				assert.EqualError(t, err, tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Issue

None

### Description

Adds a validating admission webhook for `IngressClass`. If the controller is LBC, validates that any
parameters are of the right apiGroup and kind and exist.

Does not yet add the new webhook to the Helm chart.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
