### PR TITLE
webhook: new flag to configure the webhook server's minimum TLS version

### DIFF
--- a/docs/deploy/configurations.md
+++ b/docs/deploy/configurations.md
@@ -106,6 +106,7 @@ Currently, you can set only 1 namespace to watch in this flag. See [this Kuberne
 |webhook-cert-dir                       | string                          | /tmp/k8s-webhook-server/serving-certs | The directory that contains the server key and certificate |
 |webhook-cert-file                      | string                          | tls.crt | The server certificate name |
 |webhook-key-file                       | string                          | tls.key | The server key name |
+|webhook-tls-min-version                | string                          | 1.3     | The minimum TLS version acceptable by the webhook server |
 
 
 ### disable-ingress-class-annotation

--- a/main.go
+++ b/main.go
@@ -91,7 +91,11 @@ func main() {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
 	}
-	config.ConfigureWebhookServer(controllerCFG.RuntimeConfig, mgr)
+	err = config.ConfigureWebhookServer(controllerCFG.RuntimeConfig, mgr)
+	if err != nil {
+		setupLog.Error(err, "unable to configure webhook server")
+		os.Exit(1)
+	}
 	clientSet, err := kubernetes.NewForConfig(mgr.GetConfig())
 	if err != nil {
 		setupLog.Error(err, "unable to obtain clientSet")


### PR DESCRIPTION
### Issue

N/A

### Description

The goal of this PR is to support environments where TLS versions other than `1.3` are still used, mainly FIPS enabled systems. The boringcrypto enabled builds check for the maximum FIPS TLS version [which is set to TLS1.2](https://github.com/golang/go/blob/0184fe5ece4f84fda9db04d2472b76efcaa8ef55/src/crypto/tls/boring.go#L24-L28).

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
