### PR TITLE
Add support for NLB security group

### DIFF
--- a/controllers/service/service_controller.go
+++ b/controllers/service/service_controller.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/aws-load-balancer-controller/controllers/service/eventhandlers"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
@@ -37,14 +38,17 @@ const (
 func NewServiceReconciler(cloud aws.Cloud, k8sClient client.Client, eventRecorder record.EventRecorder,
 	finalizerManager k8s.FinalizerManager, networkingSGManager networking.SecurityGroupManager,
 	networkingSGReconciler networking.SecurityGroupReconciler, subnetsResolver networking.SubnetsResolver,
-	vpcInfoProvider networking.VPCInfoProvider, controllerConfig config.ControllerConfig, logger logr.Logger) *serviceReconciler {
+	vpcInfoProvider networking.VPCInfoProvider, controllerConfig config.ControllerConfig,
+	backendSGProvider networking.BackendSGProvider, sgResolver networking.SecurityGroupResolver, logger logr.Logger) *serviceReconciler {
 
 	annotationParser := annotations.NewSuffixAnnotationParser(serviceAnnotationPrefix)
 	trackingProvider := tracking.NewDefaultProvider(serviceTagPrefix, controllerConfig.ClusterName)
 	elbv2TaggingManager := elbv2.NewDefaultTaggingManager(cloud.ELBV2(), cloud.VpcID(), controllerConfig.FeatureGates, cloud.RGT(), logger)
 	serviceUtils := service.NewServiceUtils(annotationParser, serviceFinalizer, controllerConfig.ServiceConfig.LoadBalancerClass, controllerConfig.FeatureGates)
 	modelBuilder := service.NewDefaultModelBuilder(annotationParser, subnetsResolver, vpcInfoProvider, cloud.VpcID(), trackingProvider,
-		elbv2TaggingManager, controllerConfig.FeatureGates, controllerConfig.ClusterName, controllerConfig.DefaultTags, controllerConfig.ExternalManagedTags, controllerConfig.DefaultSSLPolicy, controllerConfig.DefaultTargetType, controllerConfig.FeatureGates.Enabled(config.EnableIPTargetType), serviceUtils)
+		elbv2TaggingManager, cloud.EC2(), controllerConfig.FeatureGates, controllerConfig.ClusterName, controllerConfig.DefaultTags, controllerConfig.ExternalManagedTags,
+		controllerConfig.DefaultSSLPolicy, controllerConfig.DefaultTargetType, controllerConfig.FeatureGates.Enabled(config.EnableIPTargetType), serviceUtils,
+		backendSGProvider, sgResolver, controllerConfig.EnableBackendSecurityGroup, controllerConfig.DisableRestrictedSGRules)
 	stackMarshaller := deploy.NewDefaultStackMarshaller()
 	stackDeployer := deploy.NewDefaultStackDeployer(cloud, k8sClient, networkingSGManager, networkingSGReconciler, controllerConfig, serviceTagPrefix, logger)
 	return &serviceReconciler{
@@ -54,6 +58,7 @@ func NewServiceReconciler(cloud aws.Cloud, k8sClient client.Client, eventRecorde
 		annotationParser:  annotationParser,
 		loadBalancerClass: controllerConfig.ServiceConfig.LoadBalancerClass,
 		serviceUtils:      serviceUtils,
+		backendSGProvider: backendSGProvider,
 
 		modelBuilder:    modelBuilder,
 		stackMarshaller: stackMarshaller,
@@ -71,6 +76,7 @@ type serviceReconciler struct {
 	annotationParser  annotations.Parser
 	loadBalancerClass string
 	serviceUtils      service.ServiceUtils
+	backendSGProvider networking.BackendSGProvider
 
 	modelBuilder    service.ModelBuilder
 	stackMarshaller deploy.StackMarshaller
@@ -93,29 +99,29 @@ func (r *serviceReconciler) reconcile(ctx context.Context, req ctrl.Request) err
 	if err := r.k8sClient.Get(ctx, req.NamespacedName, svc); err != nil {
 		return client.IgnoreNotFound(err)
 	}
-	stack, lb, err := r.buildModel(ctx, svc)
+	stack, lb, backendSGRequired, err := r.buildModel(ctx, svc)
 	if err != nil {
 		return err
 	}
 	if lb == nil {
 		return r.cleanupLoadBalancerResources(ctx, svc, stack)
 	}
-	return r.reconcileLoadBalancerResources(ctx, svc, stack, lb)
+	return r.reconcileLoadBalancerResources(ctx, svc, stack, lb, backendSGRequired)
 }
 
-func (r *serviceReconciler) buildModel(ctx context.Context, svc *corev1.Service) (core.Stack, *elbv2model.LoadBalancer, error) {
-	stack, lb, err := r.modelBuilder.Build(ctx, svc)
+func (r *serviceReconciler) buildModel(ctx context.Context, svc *corev1.Service) (core.Stack, *elbv2model.LoadBalancer, bool, error) {
+	stack, lb, backendSGRequired, err := r.modelBuilder.Build(ctx, svc)
 	if err != nil {
 		r.eventRecorder.Event(svc, corev1.EventTypeWarning, k8s.ServiceEventReasonFailedBuildModel, fmt.Sprintf("Failed build model due to %v", err))
-		return nil, nil, err
+		return nil, nil, false, err
 	}
 	stackJSON, err := r.stackMarshaller.Marshal(stack)
 	if err != nil {
 		r.eventRecorder.Event(svc, corev1.EventTypeWarning, k8s.ServiceEventReasonFailedBuildModel, fmt.Sprintf("Failed build model due to %v", err))
-		return nil, nil, err
+		return nil, nil, false, err
 	}
 	r.logger.Info("successfully built model", "model", stackJSON)
-	return stack, lb, nil
+	return stack, lb, backendSGRequired, nil
 }
 
 func (r *serviceReconciler) deployModel(ctx context.Context, svc *corev1.Service, stack core.Stack) error {
@@ -128,7 +134,8 @@ func (r *serviceReconciler) deployModel(ctx context.Context, svc *corev1.Service
 	return nil
 }
 
-func (r *serviceReconciler) reconcileLoadBalancerResources(ctx context.Context, svc *corev1.Service, stack core.Stack, lb *elbv2model.LoadBalancer) error {
+func (r *serviceReconciler) reconcileLoadBalancerResources(ctx context.Context, svc *corev1.Service, stack core.Stack,
+	lb *elbv2model.LoadBalancer, backendSGRequired bool) error {
 	if err := r.finalizerManager.AddFinalizers(ctx, svc, serviceFinalizer); err != nil {
 		r.eventRecorder.Event(svc, corev1.EventTypeWarning, k8s.ServiceEventReasonFailedAddFinalizer, fmt.Sprintf("Failed add finalizer due to %v", err))
 		return err
@@ -140,6 +147,12 @@ func (r *serviceReconciler) reconcileLoadBalancerResources(ctx context.Context, 
 	lbDNS, err := lb.DNSName().Resolve(ctx)
 	if err != nil {
 		return err
+	}
+
+	if !backendSGRequired {
+		if err := r.backendSGProvider.Release(ctx, networking.ResourceTypeService, []types.NamespacedName{k8s.NamespacedName(svc)}); err != nil {
+			return err
+		}
 	}
 
 	if err = r.updateServiceStatus(ctx, lbDNS, svc); err != nil {
@@ -154,6 +167,9 @@ func (r *serviceReconciler) cleanupLoadBalancerResources(ctx context.Context, sv
 	if k8s.HasFinalizer(svc, serviceFinalizer) {
 		err := r.deployModel(ctx, svc, stack)
 		if err != nil {
+			return err
+		}
+		if err := r.backendSGProvider.Release(ctx, networking.ResourceTypeService, []types.NamespacedName{k8s.NamespacedName(svc)}); err != nil {
 			return err
 		}
 		if err = r.cleanupServiceStatus(ctx, svc); err != nil {

--- a/main.go
+++ b/main.go
@@ -117,7 +117,7 @@ func main() {
 		controllerCFG, backendSGProvider, sgResolver, ctrl.Log.WithName("controllers").WithName("ingress"))
 	svcReconciler := service.NewServiceReconciler(cloud, mgr.GetClient(), mgr.GetEventRecorderFor("service"),
 		finalizerManager, sgManager, sgReconciler, subnetResolver, vpcInfoProvider,
-		controllerCFG, ctrl.Log.WithName("controllers").WithName("service"))
+		controllerCFG, backendSGProvider, sgResolver, ctrl.Log.WithName("controllers").WithName("service"))
 	tgbReconciler := elbv2controller.NewTargetGroupBindingReconciler(mgr.GetClient(), mgr.GetEventRecorderFor("targetGroupBinding"),
 		finalizerManager, tgbResManager,
 		controllerCFG, ctrl.Log.WithName("controllers").WithName("targetGroupBinding"))

--- a/pkg/annotations/constants.go
+++ b/pkg/annotations/constants.go
@@ -82,5 +82,6 @@ const (
 	SvcLBSuffixALPNPolicy                    = "aws-load-balancer-alpn-policy"
 	SvcLBSuffixTargetNodeLabels              = "aws-load-balancer-target-node-labels"
 	SvcLBSuffixLoadBalancerAttributes        = "aws-load-balancer-attributes"
+	SvcLBSuffixLoadBalancerSecurityGroups    = "aws-load-balancer-security-groups"
 	SvcLBSuffixManageSGRules                 = "aws-load-balancer-manage-backend-security-group-rules"
 )

--- a/pkg/config/feature_gates.go
+++ b/pkg/config/feature_gates.go
@@ -20,6 +20,7 @@ const (
 	EnableRGTAPI                 Feature = "EnableRGTAPI"
 	SubnetsClusterTagCheck       Feature = "SubnetsClusterTagCheck"
 	NLBHealthCheckAdvancedConfig Feature = "NLBHealthCheckAdvancedConfig"
+	NLBSecurityGroup             Feature = "NLBSecurityGroup"
 )
 
 type FeatureGates interface {
@@ -56,6 +57,7 @@ func NewFeatureGates() FeatureGates {
 			EnableRGTAPI:                 false,
 			SubnetsClusterTagCheck:       true,
 			NLBHealthCheckAdvancedConfig: true,
+			NLBSecurityGroup:             true,
 		},
 	}
 }

--- a/pkg/networking/backend_sg_provider_test.go
+++ b/pkg/networking/backend_sg_provider_test.go
@@ -542,14 +542,6 @@ func Test_defaultBackendSGProvider_Release(t *testing.T) {
 					},
 				},
 				inactiveIngresses: []*networking.Ingress{ing},
-				deleteSGCalls: []deleteSecurityGroupWithContextCall{
-					{
-						req: &ec2sdk.DeleteSecurityGroupInput{
-							GroupId: awssdk.String("sg-autogen"),
-						},
-						resp: &ec2sdk.DeleteSecurityGroupOutput{},
-					},
-				},
 			},
 		},
 		{
@@ -727,15 +719,8 @@ func Test_defaultBackendSGProvider_Release(t *testing.T) {
 					},
 				},
 				inactiveIngresses: []*networking.Ingress{ing},
-				deleteSGCalls: []deleteSecurityGroupWithContextCall{
-					{
-						req: &ec2sdk.DeleteSecurityGroupInput{
-							GroupId: awssdk.String("sg-autogen"),
-						},
-						resp: &ec2sdk.DeleteSecurityGroupOutput{},
-					},
-				},
 			},
+			wantErr: errors.New("unable to list services: failed"),
 		},
 	}
 	for _, tt := range tests {
@@ -753,7 +738,7 @@ func Test_defaultBackendSGProvider_Release(t *testing.T) {
 			}
 			for _, item := range tt.fields.resourceMapItems {
 				var resourceType ResourceType = ResourceTypeIngress
-				if reflect.TypeOf(item).String() == "service" {
+				if reflect.TypeOf(item.key).String() == "*v1.Service" {
 					resourceType = ResourceTypeService
 				}
 				sgProvider.objectsMap.Store(getObjectKey(resourceType, k8s.NamespacedName(item.key)), item.value)

--- a/pkg/service/model_build_managed_sg.go
+++ b/pkg/service/model_build_managed_sg.go
@@ -1,0 +1,130 @@
+package service
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"regexp"
+	"strings"
+
+	awssdk "github.com/aws/aws-sdk-go/aws"
+	"github.com/pkg/errors"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/algorithm"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
+	ec2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/ec2"
+	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
+)
+
+const (
+	resourceIDManagedSecurityGroup = "ManagedLBSecurityGroup"
+)
+
+func (t *defaultModelBuildTask) buildManagedSecurityGroup(ctx context.Context, ipAddressType elbv2model.IPAddressType) (*ec2model.SecurityGroup, error) {
+	sgSpec, err := t.buildManagedSecurityGroupSpec(ctx, ipAddressType)
+	if err != nil {
+		return nil, err
+	}
+	sg := ec2model.NewSecurityGroup(t.stack, resourceIDManagedSecurityGroup, sgSpec)
+	return sg, nil
+}
+
+func (t *defaultModelBuildTask) buildManagedSecurityGroupSpec(ctx context.Context, ipAddressType elbv2model.IPAddressType) (ec2model.SecurityGroupSpec, error) {
+	name := t.buildManagedSecurityGroupName(ctx)
+	tags, err := t.buildManagedSecurityGroupTags(ctx)
+	if err != nil {
+		return ec2model.SecurityGroupSpec{}, err
+	}
+	ingressPermissions, err := t.buildManagedSecurityGroupIngressPermissions(ctx, ipAddressType)
+	if err != nil {
+		return ec2model.SecurityGroupSpec{}, err
+	}
+	return ec2model.SecurityGroupSpec{
+		GroupName:   name,
+		Description: "[k8s] Managed SecurityGroup for LoadBalancer",
+		Tags:        tags,
+		Ingress:     ingressPermissions,
+	}, nil
+}
+
+var invalidSecurityGroupNamePtn, _ = regexp.Compile("[[:^alnum:]]")
+
+func (t *defaultModelBuildTask) buildManagedSecurityGroupName(_ context.Context) string {
+	uuidHash := sha256.New()
+	_, _ = uuidHash.Write([]byte(t.clusterName))
+	_, _ = uuidHash.Write([]byte(t.service.Name))
+	_, _ = uuidHash.Write([]byte(t.service.Namespace))
+	_, _ = uuidHash.Write([]byte(t.service.UID))
+
+	uuid := hex.EncodeToString(uuidHash.Sum(nil))
+	sanitizedName := invalidSecurityGroupNamePtn.ReplaceAllString(t.service.Name, "")
+	sanitizedNamespace := invalidSecurityGroupNamePtn.ReplaceAllString(t.service.Namespace, "")
+	return fmt.Sprintf("k8s-%.8s-%.8s-%.10s", sanitizedNamespace, sanitizedName, uuid)
+}
+
+func (t *defaultModelBuildTask) buildManagedSecurityGroupIngressPermissions(ctx context.Context, ipAddressType elbv2model.IPAddressType) ([]ec2model.IPPermission, error) {
+	var permissions []ec2model.IPPermission
+	cidrs, err := t.buildCIDRsFromSourceRanges(ctx, ipAddressType)
+	if err != nil {
+		return nil, err
+	}
+	for _, port := range t.service.Spec.Ports {
+		listenPort := int64(port.Port)
+		for _, cidr := range cidrs {
+			if !strings.Contains(cidr, ":") {
+				permissions = append(permissions, ec2model.IPPermission{
+					IPProtocol: strings.ToLower(string(port.Protocol)),
+					FromPort:   awssdk.Int64(listenPort),
+					ToPort:     awssdk.Int64(listenPort),
+					IPRanges: []ec2model.IPRange{
+						{
+							CIDRIP: cidr,
+						},
+					},
+				})
+			} else {
+				permissions = append(permissions, ec2model.IPPermission{
+					IPProtocol: strings.ToLower(string(port.Protocol)),
+					FromPort:   awssdk.Int64(listenPort),
+					ToPort:     awssdk.Int64(listenPort),
+					IPv6Range: []ec2model.IPv6Range{
+						{
+							CIDRIPv6: cidr,
+						},
+					},
+				})
+			}
+		}
+	}
+	return permissions, nil
+}
+
+func (t *defaultModelBuildTask) buildCIDRsFromSourceRanges(_ context.Context, ipAddressType elbv2model.IPAddressType) ([]string, error) {
+	var cidrs []string
+	for _, cidr := range t.service.Spec.LoadBalancerSourceRanges {
+		cidrs = append(cidrs, cidr)
+	}
+	if len(cidrs) == 0 {
+		t.annotationParser.ParseStringSliceAnnotation(annotations.SvcLBSuffixSourceRanges, &cidrs, t.service.Annotations)
+	}
+	for _, cidr := range cidrs {
+		if strings.Contains(cidr, ":") && ipAddressType != elbv2model.IPAddressTypeDualStack {
+			return nil, errors.Errorf("unsupported v6 cidr %v when lb is not dualstack", cidr)
+		}
+	}
+	if len(cidrs) == 0 {
+		cidrs = append(cidrs, "0.0.0.0/0")
+		if ipAddressType == elbv2model.IPAddressTypeDualStack {
+			cidrs = append(cidrs, "::/0")
+		}
+	}
+	return cidrs, nil
+}
+
+func (t *defaultModelBuildTask) buildManagedSecurityGroupTags(ctx context.Context) (map[string]string, error) {
+	sgTags, err := t.buildAdditionalResourceTags(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return algorithm.MergeStringMap(t.defaultTags, sgTags), nil
+}

--- a/pkg/service/model_build_target_group.go
+++ b/pkg/service/model_build_target_group.go
@@ -262,7 +262,7 @@ func (t *defaultModelBuildTask) buildPreserveClientIPFlag(_ context.Context, tar
 
 // buildTargetGroupPort constructs the TargetGroup's port.
 // Note: TargetGroup's port is not in the data path as we always register targets with port specified.
-// so this settings don't really matter to our controller, and we do our best to use the most appropriate port as targetGroup's port to avoid UX confusing.
+// so this setting don't really matter to our controller, and we do our best to use the most appropriate port as targetGroup's port to avoid UX confusion.
 func (t *defaultModelBuildTask) buildTargetGroupPort(_ context.Context, targetType elbv2model.TargetType, svcPort corev1.ServicePort) int64 {
 	if targetType == elbv2model.TargetTypeInstance {
 		return int64(svcPort.NodePort)
@@ -408,15 +408,11 @@ func (t *defaultModelBuildTask) buildTargetGroupBindingSpec(ctx context.Context,
 	if targetType == elbv2api.TargetTypeInstance {
 		targetPort = intstr.FromInt(int(port.NodePort))
 	}
-	defaultSourceRanges, err := t.getDefaultIPSourceRanges(ctx, *targetGroup.Spec.IPAddressType, port.Protocol, scheme)
-	if err != nil {
-		return elbv2model.TargetGroupBindingResourceSpec{}, err
-	}
 	var tgbNetworking *elbv2model.TargetGroupBindingNetworking
 	if len(t.loadBalancer.Spec.SecurityGroups) == 0 {
-		tgbNetworking, err = t.buildTargetGroupBindingNetworkingLegacy(ctx, targetPort, *hc.Port, port, defaultSourceRanges, *targetGroup.Spec.IPAddressType)
+		tgbNetworking, err = t.buildTargetGroupBindingNetworkingLegacy(ctx, targetPort, *hc.Port, port, scheme, *targetGroup.Spec.IPAddressType)
 	} else {
-		tgbNetworking, err = t.buildTargetGroupBindingNetworking(ctx, port.Protocol, targetGroup.Spec.Port, *targetGroup.Spec.HealthCheckConfig.Port)
+		tgbNetworking, err = t.buildTargetGroupBindingNetworking(ctx, targetPort, *hc.Port, port)
 	}
 	if err != nil {
 		return elbv2model.TargetGroupBindingResourceSpec{}, err
@@ -442,60 +438,52 @@ func (t *defaultModelBuildTask) buildTargetGroupBindingSpec(ctx context.Context,
 	}, nil
 }
 
-func (t *defaultModelBuildTask) buildTargetGroupBindingNetworking(_ context.Context, tgProtocol corev1.Protocol, tgPort int64, healthCheckPort intstr.IntOrString) (*elbv2model.TargetGroupBindingNetworking, error) {
+func (t *defaultModelBuildTask) buildTargetGroupBindingNetworking(_ context.Context, tgPort intstr.IntOrString,
+	hcPort intstr.IntOrString, port corev1.ServicePort) (*elbv2model.TargetGroupBindingNetworking, error) {
 	if t.backendSGIDToken == nil {
 		return nil, nil
 	}
 	protocolTCP := elbv2api.NetworkingProtocolTCP
 	protocolUDP := elbv2api.NetworkingProtocolUDP
 
+	var ports []elbv2api.NetworkingPort
 	if t.disableRestrictedSGRules {
-		ports := []elbv2api.NetworkingPort{
-			{
-				Protocol: &protocolTCP,
-				Port:     nil,
-			},
-		}
-		if tgProtocol == corev1.ProtocolUDP {
+		ports = append(ports, elbv2api.NetworkingPort{
+			Protocol: &protocolTCP,
+			Port:     nil,
+		})
+		if port.Protocol == corev1.ProtocolUDP {
 			ports = append(ports, elbv2api.NetworkingPort{
 				Protocol: &protocolUDP,
 				Port:     nil,
 			})
 		}
-		return &elbv2model.TargetGroupBindingNetworking{
-			Ingress: []elbv2model.NetworkingIngressRule{
-				{
-					From: []elbv2model.NetworkingPeer{
-						{
-							SecurityGroup: &elbv2model.SecurityGroup{
-								GroupID: t.backendSGIDToken,
-							},
-						},
-					},
-					Ports: ports,
-				},
-			},
-		}, nil
-	}
+	} else {
+		switch port.Protocol {
+		case corev1.ProtocolTCP:
+			ports = append(ports, elbv2api.NetworkingPort{
+				Protocol: &protocolTCP,
+				Port:     &tgPort,
+			})
+		case corev1.ProtocolUDP:
+			ports = append(ports, elbv2api.NetworkingPort{
+				Protocol: &protocolUDP,
+				Port:     &tgPort,
+			})
+			if hcPort.String() == healthCheckPortTrafficPort || (hcPort.Type == intstr.Int && hcPort.IntValue() == tgPort.IntValue()) {
+				ports = append(ports, elbv2api.NetworkingPort{
+					Protocol: &protocolTCP,
+					Port:     &tgPort,
+				})
+			}
+		}
 
-	targetGroupPort := intstr.FromInt(int(tgPort))
-	ports := []elbv2api.NetworkingPort{
-		{
-			Protocol: &protocolTCP,
-			Port:     &targetGroupPort,
-		},
-	}
-	if tgProtocol == corev1.ProtocolUDP {
-		ports = append(ports, elbv2api.NetworkingPort{
-			Protocol: &protocolUDP,
-			Port:     &targetGroupPort,
-		})
-	}
-	if healthCheckPort.String() != healthCheckPortTrafficPort && (healthCheckPort.Type == intstr.Int && healthCheckPort.IntVal != int32(tgPort)) {
-		ports = append(ports, elbv2api.NetworkingPort{
-			Protocol: &protocolTCP,
-			Port:     &healthCheckPort,
-		})
+		if hcPort.String() != healthCheckPortTrafficPort && (hcPort.Type == intstr.Int && hcPort.IntValue() != tgPort.IntValue()) {
+			ports = append(ports, elbv2api.NetworkingPort{
+				Protocol: &protocolTCP,
+				Port:     &hcPort,
+			})
+		}
 	}
 	return &elbv2model.TargetGroupBindingNetworking{
 		Ingress: []elbv2model.NetworkingIngressRule{
@@ -513,20 +501,19 @@ func (t *defaultModelBuildTask) buildTargetGroupBindingNetworking(_ context.Cont
 	}, nil
 }
 
-func (t *defaultModelBuildTask) buildPeersFromSourceRangesConfiguration(_ context.Context, defaultSourceRanges []string) ([]elbv2model.NetworkingPeer, bool) {
+func (t *defaultModelBuildTask) getLoadBalancerSourceRanges(_ context.Context) []string {
 	var sourceRanges []string
-	var peers []elbv2model.NetworkingPeer
-	customSourceRangesConfigured := true
 	for _, cidr := range t.service.Spec.LoadBalancerSourceRanges {
 		sourceRanges = append(sourceRanges, cidr)
 	}
 	if len(sourceRanges) == 0 {
 		t.annotationParser.ParseStringSliceAnnotation(annotations.SvcLBSuffixSourceRanges, &sourceRanges, t.service.Annotations)
 	}
-	if len(sourceRanges) == 0 {
-		sourceRanges = defaultSourceRanges
-		customSourceRangesConfigured = false
-	}
+	return sourceRanges
+}
+
+func (t *defaultModelBuildTask) buildPeersFromSourceRangeCIDRs(_ context.Context, sourceRanges []string) []elbv2model.NetworkingPeer {
+	var peers []elbv2model.NetworkingPeer
 	for _, cidr := range sourceRanges {
 		peers = append(peers, elbv2model.NetworkingPeer{
 			IPBlock: &elbv2api.IPBlock{
@@ -534,11 +521,11 @@ func (t *defaultModelBuildTask) buildPeersFromSourceRangesConfiguration(_ contex
 			},
 		})
 	}
-	return peers, customSourceRangesConfigured
+	return peers
 }
 
 func (t *defaultModelBuildTask) buildTargetGroupBindingNetworkingLegacy(ctx context.Context, tgPort intstr.IntOrString,
-	hcPort intstr.IntOrString, port corev1.ServicePort, defaultSourceRanges []string, targetGroupIPAddressType elbv2model.TargetGroupIPAddressType) (*elbv2model.TargetGroupBindingNetworking, error) {
+	hcPort intstr.IntOrString, port corev1.ServicePort, scheme elbv2model.LoadBalancerScheme, targetGroupIPAddressType elbv2model.TargetGroupIPAddressType) (*elbv2model.TargetGroupBindingNetworking, error) {
 	manageBackendSGRules, err := t.buildManageSecurityGroupRulesFlagLegacy(ctx)
 	if err != nil {
 		return nil, err
@@ -547,20 +534,28 @@ func (t *defaultModelBuildTask) buildTargetGroupBindingNetworkingLegacy(ctx cont
 		return nil, nil
 	}
 	tgProtocol := port.Protocol
-	loadBalancerSubnetsSourceRanges := t.getLoadBalancerSubnetsSourceRanges(targetGroupIPAddressType)
 	networkingProtocol := elbv2api.NetworkingProtocolTCP
+	healthCheckProtocol := elbv2api.NetworkingProtocolTCP
 	if tgProtocol == corev1.ProtocolUDP {
 		networkingProtocol = elbv2api.NetworkingProtocolUDP
 	}
-	trafficSource := loadBalancerSubnetsSourceRanges
-	customSourceRangesConfigured := false
+	loadBalancerSubnetCIDRs := t.getLoadBalancerSubnetsSourceRanges(targetGroupIPAddressType)
+	trafficSource := loadBalancerSubnetCIDRs
+	defaultRangeUsed := false
 	if networkingProtocol == elbv2api.NetworkingProtocolUDP || t.preserveClientIP {
-		trafficSource, customSourceRangesConfigured = t.buildPeersFromSourceRangesConfiguration(ctx, defaultSourceRanges)
+		trafficSource = t.getLoadBalancerSourceRanges(ctx)
+		if len(trafficSource) == 0 {
+			trafficSource, err = t.getDefaultIPSourceRanges(ctx, targetGroupIPAddressType, port.Protocol, scheme)
+			if err != nil {
+				return nil, err
+			}
+			defaultRangeUsed = true
+		}
 	}
 	tgbNetworking := &elbv2model.TargetGroupBindingNetworking{
 		Ingress: []elbv2model.NetworkingIngressRule{
 			{
-				From: trafficSource,
+				From: t.buildPeersFromSourceRangeCIDRs(ctx, trafficSource),
 				Ports: []elbv2api.NetworkingPort{
 					{
 						Port:     &tgPort,
@@ -570,9 +565,21 @@ func (t *defaultModelBuildTask) buildTargetGroupBindingNetworkingLegacy(ctx cont
 			},
 		},
 	}
-	if hcIngressRules := t.buildHealthCheckNetworkingIngressRules(trafficSource, loadBalancerSubnetsSourceRanges, tgPort, hcPort, tgProtocol,
-		customSourceRangesConfigured); len(hcIngressRules) > 0 {
-		tgbNetworking.Ingress = append(tgbNetworking.Ingress, hcIngressRules...)
+	if healthCheckSourceCIDRs := t.buildHealthCheckSourceCIDRs(trafficSource, loadBalancerSubnetCIDRs, tgPort, hcPort,
+		tgProtocol, defaultRangeUsed); len(healthCheckSourceCIDRs) > 0 {
+		networkingHealthCheckPort := hcPort
+		if hcPort.String() == healthCheckPortTrafficPort {
+			networkingHealthCheckPort = tgPort
+		}
+		tgbNetworking.Ingress = append(tgbNetworking.Ingress, elbv2model.NetworkingIngressRule{
+			From: t.buildPeersFromSourceRangeCIDRs(ctx, healthCheckSourceCIDRs),
+			Ports: []elbv2api.NetworkingPort{
+				{
+					Port:     &networkingHealthCheckPort,
+					Protocol: &healthCheckProtocol,
+				},
+			},
+		})
 	}
 	return tgbNetworking, nil
 }
@@ -597,28 +604,18 @@ func (t *defaultModelBuildTask) getDefaultIPSourceRanges(ctx context.Context, ta
 	return defaultSourceRanges, nil
 }
 
-func (t *defaultModelBuildTask) getLoadBalancerSubnetsSourceRanges(targetGroupIPAddressType elbv2model.TargetGroupIPAddressType) []elbv2model.NetworkingPeer {
-	var subnetCIDRRanges []elbv2model.NetworkingPeer
+func (t *defaultModelBuildTask) getLoadBalancerSubnetsSourceRanges(targetGroupIPAddressType elbv2model.TargetGroupIPAddressType) []string {
+	var subnetCIDRs []string
 	for _, subnet := range t.ec2Subnets {
 		if targetGroupIPAddressType == elbv2model.TargetGroupIPAddressTypeIPv4 {
-			subnetCIDRRanges = append(subnetCIDRRanges, elbv2model.NetworkingPeer{
-				IPBlock: &elbv2api.IPBlock{
-					CIDR: aws.StringValue(subnet.CidrBlock),
-				},
-			})
+			subnetCIDRs = append(subnetCIDRs, aws.StringValue(subnet.CidrBlock))
 		} else {
 			for _, ipv6CIDRBlockAssoc := range subnet.Ipv6CidrBlockAssociationSet {
-				subnetCIDRRanges = append(subnetCIDRRanges, elbv2model.NetworkingPeer{
-					IPBlock: &elbv2api.IPBlock{
-						CIDR: aws.StringValue(ipv6CIDRBlockAssoc.Ipv6CidrBlock),
-					},
-				})
-
+				subnetCIDRs = append(subnetCIDRs, aws.StringValue(ipv6CIDRBlockAssoc.Ipv6CidrBlock))
 			}
 		}
 	}
-
-	return subnetCIDRRanges
+	return subnetCIDRs
 }
 
 func (t *defaultModelBuildTask) buildTargetGroupIPAddressType(_ context.Context, svc *corev1.Service) (elbv2model.TargetGroupIPAddressType, error) {
@@ -654,36 +651,23 @@ func (t *defaultModelBuildTask) buildTargetGroupBindingNodeSelector(_ context.Co
 	}, nil
 }
 
-func (t *defaultModelBuildTask) buildHealthCheckNetworkingIngressRules(trafficSource, hcSource []elbv2model.NetworkingPeer, tgPort, hcPort intstr.IntOrString,
-	tgProtocol corev1.Protocol, customSourceRanges bool) []elbv2model.NetworkingIngressRule {
+func (t *defaultModelBuildTask) buildHealthCheckSourceCIDRs(trafficSource, subnetCIDRs []string, tgPort, hcPort intstr.IntOrString,
+	tgProtocol corev1.Protocol, defaultRangeUsed bool) []string {
 	if tgProtocol != corev1.ProtocolUDP &&
 		(hcPort.String() == healthCheckPortTrafficPort || hcPort.IntValue() == tgPort.IntValue()) {
 		if !t.preserveClientIP {
-			return []elbv2model.NetworkingIngressRule{}
+			return nil
 		}
-		if !customSourceRanges {
-			return []elbv2model.NetworkingIngressRule{}
+		if defaultRangeUsed {
+			return nil
 		}
 		for _, src := range trafficSource {
-			if src.IPBlock.CIDR == "0.0.0.0/0" || src.IPBlock.CIDR == "::/0" {
-				return []elbv2model.NetworkingIngressRule{}
+			if src == "0.0.0.0/0" || src == "::/0" {
+				return nil
 			}
 		}
 	}
-	var healthCheckPorts []elbv2api.NetworkingPort
-	networkingProtocolTCP := elbv2api.NetworkingProtocolTCP
-	networkingHealthCheckPort := hcPort
-	if hcPort.String() == healthCheckPortTrafficPort {
-		networkingHealthCheckPort = tgPort
-	}
-	healthCheckPorts = append(healthCheckPorts, elbv2api.NetworkingPort{
-		Port:     &networkingHealthCheckPort,
-		Protocol: &networkingProtocolTCP,
-	})
-	return []elbv2model.NetworkingIngressRule{{
-		From:  hcSource,
-		Ports: healthCheckPorts,
-	}}
+	return subnetCIDRs
 }
 
 func (t *defaultModelBuildTask) buildManageSecurityGroupRulesFlagLegacy(_ context.Context) (bool, error) {

--- a/pkg/service/model_build_target_group_test.go
+++ b/pkg/service/model_build_target_group_test.go
@@ -1073,11 +1073,11 @@ func Test_defaultModelBuilderTask_buildTargetGroupBindingNetworking(t *testing.T
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			parser := annotations.NewSuffixAnnotationParser("service.beta.kubernetes.io")
-			builder := &defaultModelBuildTask{service: tt.svc, annotationParser: parser, ec2Subnets: tt.subnets}
+			builder := &defaultModelBuildTask{service: tt.svc, annotationParser: parser, ec2Subnets: tt.subnets, preserveClientIP: tt.preserveClientIP}
 			port := corev1.ServicePort{
 				Protocol: tt.tgProtocol,
 			}
-			got, _ := builder.buildTargetGroupBindingNetworking(context.Background(), tt.tgPort, tt.preserveClientIP, tt.hcPort, port, tt.defaultSourceRanges, tt.ipAddressType)
+			got, _ := builder.buildTargetGroupBindingNetworkingLegacy(context.Background(), tt.tgPort, tt.hcPort, port, tt.defaultSourceRanges, tt.ipAddressType)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/service/model_builder.go
+++ b/pkg/service/model_builder.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/services"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/config"
 	elbv2deploy "sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/elbv2"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/tracking"
@@ -30,42 +31,54 @@ const (
 // ModelBuilder builds the model stack for the service resource.
 type ModelBuilder interface {
 	// Build model stack for service
-	Build(ctx context.Context, service *corev1.Service) (core.Stack, *elbv2model.LoadBalancer, error)
+	Build(ctx context.Context, service *corev1.Service) (core.Stack, *elbv2model.LoadBalancer, bool, error)
 }
 
 // NewDefaultModelBuilder construct a new defaultModelBuilder
 func NewDefaultModelBuilder(annotationParser annotations.Parser, subnetsResolver networking.SubnetsResolver,
 	vpcInfoProvider networking.VPCInfoProvider, vpcID string, trackingProvider tracking.Provider,
-	elbv2TaggingManager elbv2deploy.TaggingManager, featureGates config.FeatureGates, clusterName string, defaultTags map[string]string,
-	externalManagedTags []string, defaultSSLPolicy string, defaultTargetType string, enableIPTargetType bool, serviceUtils ServiceUtils) *defaultModelBuilder {
+	elbv2TaggingManager elbv2deploy.TaggingManager, ec2Client services.EC2, featureGates config.FeatureGates, clusterName string, defaultTags map[string]string,
+	externalManagedTags []string, defaultSSLPolicy string, defaultTargetType string, enableIPTargetType bool, serviceUtils ServiceUtils,
+	backendSGProvider networking.BackendSGProvider, sgResolver networking.SecurityGroupResolver, enableBackendSG bool,
+	disableRestrictedSGRules bool) *defaultModelBuilder {
 	return &defaultModelBuilder{
-		annotationParser:    annotationParser,
-		subnetsResolver:     subnetsResolver,
-		vpcInfoProvider:     vpcInfoProvider,
-		trackingProvider:    trackingProvider,
-		elbv2TaggingManager: elbv2TaggingManager,
-		featureGates:        featureGates,
-		serviceUtils:        serviceUtils,
-		clusterName:         clusterName,
-		vpcID:               vpcID,
-		defaultTags:         defaultTags,
-		externalManagedTags: sets.NewString(externalManagedTags...),
-		defaultSSLPolicy:    defaultSSLPolicy,
-		defaultTargetType:   elbv2model.TargetType(defaultTargetType),
-		enableIPTargetType:  enableIPTargetType,
+		annotationParser:         annotationParser,
+		subnetsResolver:          subnetsResolver,
+		vpcInfoProvider:          vpcInfoProvider,
+		trackingProvider:         trackingProvider,
+		elbv2TaggingManager:      elbv2TaggingManager,
+		featureGates:             featureGates,
+		serviceUtils:             serviceUtils,
+		clusterName:              clusterName,
+		vpcID:                    vpcID,
+		defaultTags:              defaultTags,
+		externalManagedTags:      sets.NewString(externalManagedTags...),
+		defaultSSLPolicy:         defaultSSLPolicy,
+		defaultTargetType:        elbv2model.TargetType(defaultTargetType),
+		enableIPTargetType:       enableIPTargetType,
+		backendSGProvider:        backendSGProvider,
+		sgResolver:               sgResolver,
+		ec2Client:                ec2Client,
+		enableBackendSG:          enableBackendSG,
+		disableRestrictedSGRules: disableRestrictedSGRules,
 	}
 }
 
 var _ ModelBuilder = &defaultModelBuilder{}
 
 type defaultModelBuilder struct {
-	annotationParser    annotations.Parser
-	subnetsResolver     networking.SubnetsResolver
-	vpcInfoProvider     networking.VPCInfoProvider
-	trackingProvider    tracking.Provider
-	elbv2TaggingManager elbv2deploy.TaggingManager
-	featureGates        config.FeatureGates
-	serviceUtils        ServiceUtils
+	annotationParser         annotations.Parser
+	subnetsResolver          networking.SubnetsResolver
+	vpcInfoProvider          networking.VPCInfoProvider
+	backendSGProvider        networking.BackendSGProvider
+	sgResolver               networking.SecurityGroupResolver
+	trackingProvider         tracking.Provider
+	elbv2TaggingManager      elbv2deploy.TaggingManager
+	featureGates             config.FeatureGates
+	serviceUtils             ServiceUtils
+	ec2Client                services.EC2
+	enableBackendSG          bool
+	disableRestrictedSGRules bool
 
 	clusterName         string
 	vpcID               string
@@ -76,19 +89,24 @@ type defaultModelBuilder struct {
 	enableIPTargetType  bool
 }
 
-func (b *defaultModelBuilder) Build(ctx context.Context, service *corev1.Service) (core.Stack, *elbv2model.LoadBalancer, error) {
+func (b *defaultModelBuilder) Build(ctx context.Context, service *corev1.Service) (core.Stack, *elbv2model.LoadBalancer, bool, error) {
 	stack := core.NewDefaultStack(core.StackID(k8s.NamespacedName(service)))
 	task := &defaultModelBuildTask{
-		clusterName:         b.clusterName,
-		vpcID:               b.vpcID,
-		annotationParser:    b.annotationParser,
-		subnetsResolver:     b.subnetsResolver,
-		vpcInfoProvider:     b.vpcInfoProvider,
-		trackingProvider:    b.trackingProvider,
-		elbv2TaggingManager: b.elbv2TaggingManager,
-		featureGates:        b.featureGates,
-		serviceUtils:        b.serviceUtils,
-		enableIPTargetType:  b.enableIPTargetType,
+		clusterName:              b.clusterName,
+		vpcID:                    b.vpcID,
+		annotationParser:         b.annotationParser,
+		subnetsResolver:          b.subnetsResolver,
+		backendSGProvider:        b.backendSGProvider,
+		sgResolver:               b.sgResolver,
+		vpcInfoProvider:          b.vpcInfoProvider,
+		trackingProvider:         b.trackingProvider,
+		elbv2TaggingManager:      b.elbv2TaggingManager,
+		featureGates:             b.featureGates,
+		serviceUtils:             b.serviceUtils,
+		enableIPTargetType:       b.enableIPTargetType,
+		ec2Client:                b.ec2Client,
+		enableBackendSG:          b.enableBackendSG,
+		disableRestrictedSGRules: b.disableRestrictedSGRules,
 
 		service:   service,
 		stack:     stack,
@@ -125,9 +143,9 @@ func (b *defaultModelBuilder) Build(ctx context.Context, service *corev1.Service
 	}
 
 	if err := task.run(ctx); err != nil {
-		return nil, nil, err
+		return nil, nil, false, err
 	}
-	return task.stack, task.loadBalancer, nil
+	return task.stack, task.loadBalancer, task.backendSGAllocated, nil
 }
 
 type defaultModelBuildTask struct {
@@ -136,18 +154,26 @@ type defaultModelBuildTask struct {
 	annotationParser    annotations.Parser
 	subnetsResolver     networking.SubnetsResolver
 	vpcInfoProvider     networking.VPCInfoProvider
+	backendSGProvider   networking.BackendSGProvider
+	sgResolver          networking.SecurityGroupResolver
 	trackingProvider    tracking.Provider
 	elbv2TaggingManager elbv2deploy.TaggingManager
 	featureGates        config.FeatureGates
 	serviceUtils        ServiceUtils
 	enableIPTargetType  bool
+	ec2Client           services.EC2
 
 	service *corev1.Service
 
-	stack        core.Stack
-	loadBalancer *elbv2model.LoadBalancer
-	tgByResID    map[string]*elbv2model.TargetGroup
-	ec2Subnets   []*ec2.Subnet
+	stack                    core.Stack
+	loadBalancer             *elbv2model.LoadBalancer
+	tgByResID                map[string]*elbv2model.TargetGroup
+	ec2Subnets               []*ec2.Subnet
+	enableBackendSG          bool
+	disableRestrictedSGRules bool
+	backendSGIDToken         core.StringToken
+	backendSGAllocated       bool
+	preserveClientIP         bool
 
 	fetchExistingLoadBalancerOnce sync.Once
 	existingLoadBalancer          *elbv2deploy.LoadBalancerWithTags

--- a/pkg/service/model_builder_test.go
+++ b/pkg/service/model_builder_test.go
@@ -2278,7 +2278,10 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 				},
 			},
 			listLoadBalancerCalls: []listLoadBalancerCall{listLoadBalancerCallForEmptyLB},
-			wantError:             true,
+			featureGates: map[config.Feature]bool{
+				config.NLBSecurityGroup: false,
+			},
+			wantError: true,
 		},
 		{
 			testName: "deletion protection enabled error",
@@ -4920,10 +4923,6 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                                }
                             ],
                             "ports":[
-                               {
-								  "port": 31223,
-                                  "protocol":"TCP"
-                               },
 							   {
 								  "port": 31223,
                                   "protocol":"UDP"
@@ -4971,10 +4970,6 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                                }
                             ],
                             "ports":[
-                               {
-								  "port": 32323,
-                                  "protocol":"TCP"
-                               },
 							   {
 								  "port": 32323,
                                   "protocol":"UDP"

--- a/pkg/service/model_builder_test.go
+++ b/pkg/service/model_builder_test.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/services"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/config"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/elbv2"
@@ -38,6 +39,11 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 	type fetchVPCInfoCall struct {
 		wantVPCInfo networking.VPCInfo
 		err         error
+	}
+	type resolveSGViaNameOrIDCall struct {
+		args []string
+		want []string
+		err  error
 	}
 	cidrBlockStateAssociated := ec2.VpcCidrBlockStateCodeAssociated
 	resolveViaDiscoveryCallForOneSubnet := resolveViaDiscoveryCall{
@@ -103,11 +109,15 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 		fetchVPCInfoCalls            []fetchVPCInfoCall
 		defaultTargetType            string
 		enableIPTargetType           *bool
+		resolveSGViaNameOrIDCall     []resolveSGViaNameOrIDCall
+		backendSecurityGroup         string
+		enableBackendSG              bool
+		disableRestrictedSGRules     bool
 		svc                          *corev1.Service
 		wantError                    bool
 		wantValue                    string
 		wantNumResources             int
-		restrictToTypeLoadBalancer   bool
+		featureGates                 map[config.Feature]bool
 	}{
 		{
 			testName: "Simple service",
@@ -135,6 +145,10 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 			resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForOneSubnet},
 			listLoadBalancerCalls:    []listLoadBalancerCall{listLoadBalancerCallForEmptyLB},
 			wantError:                false,
+			wantNumResources:         4,
+			featureGates: map[config.Feature]bool{
+				config.NLBSecurityGroup: false,
+			},
 			wantValue: `
 {
  "id":"default/nlb-ip-svc-tls",
@@ -250,7 +264,6 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
  }
 }
 `,
-			wantNumResources: 4,
 		},
 		{
 			testName: "Dualstack service",
@@ -280,6 +293,9 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 			resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForOneSubnet},
 			listLoadBalancerCalls:    []listLoadBalancerCall{listLoadBalancerCallForEmptyLB},
 			wantError:                false,
+			featureGates: map[config.Feature]bool{
+				config.NLBSecurityGroup: false,
+			},
 			wantValue: `
 {
  "id":"default/nlb-ip-svc-tls",
@@ -438,6 +454,9 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 			resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForTwoSubnet},
 			listLoadBalancerCalls:    []listLoadBalancerCall{listLoadBalancerCallForEmptyLB},
 			wantError:                false,
+			featureGates: map[config.Feature]bool{
+				config.NLBSecurityGroup: false,
+			},
 			wantValue: `
 {
  "id":"default/nlb-ip-svc",
@@ -750,6 +769,9 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 			resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForThreeSubnet},
 			listLoadBalancerCalls:    []listLoadBalancerCall{listLoadBalancerCallForEmptyLB},
 			wantError:                false,
+			featureGates: map[config.Feature]bool{
+				config.NLBSecurityGroup: false,
+			},
 			wantValue: `
 {
  "id":"default/nlb-ip-svc-tls",
@@ -1056,6 +1078,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 					},
 				},
 			},
+			enableBackendSG: true,
 			wantValue: `
 {
 "id": "doesnt-exist/service-deleted",
@@ -1114,6 +1137,9 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 			},
 			listLoadBalancerCalls: []listLoadBalancerCall{listLoadBalancerCallForEmptyLB},
 			wantError:             false,
+			featureGates: map[config.Feature]bool{
+				config.NLBSecurityGroup: false,
+			},
 			wantValue: `
 {
  "id":"default/instance-mode",
@@ -1690,6 +1716,9 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 			resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForOneSubnet},
 			listLoadBalancerCalls:    []listLoadBalancerCall{listLoadBalancerCallForEmptyLB},
 			wantError:                false,
+			featureGates: map[config.Feature]bool{
+				config.NLBSecurityGroup: false,
+			},
 			wantValue: `
 {
  "id":"default/nlb-ip-svc-tls",
@@ -1867,6 +1896,9 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 			},
 			listLoadBalancerCalls: []listLoadBalancerCall{listLoadBalancerCallForEmptyLB},
 			wantNumResources:      4,
+			featureGates: map[config.Feature]bool{
+				config.NLBSecurityGroup: false,
+			},
 			wantValue: `
 {
   "id": "default/ip-target",
@@ -2036,7 +2068,10 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 				},
 			},
 			listLoadBalancerCalls: []listLoadBalancerCall{listLoadBalancerCallForEmptyLB},
-			wantNumResources:      4,
+			featureGates: map[config.Feature]bool{
+				config.NLBSecurityGroup: false,
+			},
+			wantNumResources: 4,
 			wantValue: `
 {
   "id": "default/default-ip-target",
@@ -2203,6 +2238,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 					},
 				},
 			},
+			enableBackendSG: false,
 			listLoadBalancerCalls: []listLoadBalancerCall{
 				{
 					sdkLBs: []elbv2.LoadBalancerWithTags{},
@@ -2234,6 +2270,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 					},
 				},
 			},
+			enableBackendSG:          true,
 			resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForOneSubnet},
 			fetchVPCInfoCalls: []fetchVPCInfoCall{
 				{
@@ -2272,7 +2309,8 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 					},
 				},
 			},
-			wantError: true,
+			enableBackendSG: true,
+			wantError:       true,
 		},
 		{
 			testName: "ipv6 service without dualstask",
@@ -2346,6 +2384,9 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 			resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForOneSubnet},
 			listLoadBalancerCalls:    []listLoadBalancerCall{listLoadBalancerCallForEmptyLB},
 			wantNumResources:         4,
+			featureGates: map[config.Feature]bool{
+				config.NLBSecurityGroup: false,
+			},
 			wantValue: `
 {
   "id": "default/traffic-local",
@@ -2492,6 +2533,9 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 			resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForOneSubnet},
 			listLoadBalancerCalls:    []listLoadBalancerCall{listLoadBalancerCallForEmptyLB},
 			wantNumResources:         4,
+			featureGates: map[config.Feature]bool{
+				config.NLBSecurityGroup: false,
+			},
 			wantValue: `
 {
   "id": "default/traffic-local",
@@ -2624,7 +2668,9 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 					Type: corev1.ServiceTypeNodePort,
 				},
 			},
-			restrictToTypeLoadBalancer: true,
+			featureGates: map[config.Feature]bool{
+				config.ServiceTypeLoadBalancerOnly: true,
+			},
 			wantValue: `
 {
 "id": "some-namespace/type-nodeport",
@@ -2689,6 +2735,9 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 				},
 			},
 			wantNumResources: 4,
+			featureGates: map[config.Feature]bool{
+				config.NLBSecurityGroup: false,
+			},
 			wantValue: `
 {
   "id": "awesome/lb-with-class",
@@ -2805,7 +2854,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 }`,
 		},
 		{
-			testName: "with backend SG rule management disabled",
+			testName: "with backend SG rule management disabled for legacy nlb",
 			svc: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "manual-sg-rule",
@@ -2829,9 +2878,33 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 					},
 				},
 			},
-			resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForOneSubnet},
-			listLoadBalancerCalls:    []listLoadBalancerCall{listLoadBalancerCallForEmptyLB},
-			wantError:                false,
+			resolveViaNameOrIDSliceCalls: []resolveViaNameOrIDSliceCall{
+				{
+					subnets: []*ec2.Subnet{
+						{
+							SubnetId:  aws.String("subnet-1"),
+							CidrBlock: aws.String("192.168.0.0/19"),
+						},
+					},
+				},
+			},
+			listLoadBalancerCalls: []listLoadBalancerCall{
+				{
+					sdkLBs: []elbv2.LoadBalancerWithTags{
+						{
+							LoadBalancer: &elbv2sdk.LoadBalancer{
+								Scheme: aws.String("internal"),
+								AvailabilityZones: []*elbv2sdk.AvailabilityZone{
+									{
+										SubnetId: aws.String("subnet-1"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantError: false,
 			wantValue: `
 {
  "id":"default/manual-sg-rule",
@@ -2930,12 +3003,3376 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 `,
 			wantNumResources: 4,
 		},
+		{
+			testName: "Simple service with NLB SG",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nlb-ip-svc-tls",
+					Namespace: "default",
+					UID:       "bdca2bd0-bfc6-449a-88a3-03451f05f18c",
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/aws-load-balancer-type": "nlb-ip",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Type:     corev1.ServiceTypeLoadBalancer,
+					Selector: map[string]string{"app": "hello"},
+					Ports: []corev1.ServicePort{
+						{
+							Port:       80,
+							TargetPort: intstr.FromInt(80),
+							Protocol:   corev1.ProtocolTCP,
+						},
+					},
+				},
+			},
+			disableRestrictedSGRules: true,
+			enableBackendSG:          true,
+			resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForOneSubnet},
+			listLoadBalancerCalls:    []listLoadBalancerCall{listLoadBalancerCallForEmptyLB},
+			backendSecurityGroup:     "sg-backend",
+			wantError:                false,
+			wantValue: `
+{
+ "id":"default/nlb-ip-svc-tls",
+ "resources":{
+    "AWS::EC2::SecurityGroup": {
+       "ManagedLBSecurityGroup": {
+          "spec": {
+             "groupName": "k8s-default-nlbipsvc-1da4b78715",
+             "description": "[k8s] Managed SecurityGroup for LoadBalancer",
+             "ingress": [
+                {
+                   "ipProtocol": "tcp",
+                   "fromPort": 80,
+                   "toPort": 80,
+                   "ipRanges": [
+                      {
+                         "cidrIP": "0.0.0.0/0"
+                      }
+                   ]
+                }
+             ]
+          }
+       }
+    },
+    "AWS::ElasticLoadBalancingV2::Listener":{
+       "80":{
+          "spec":{
+             "loadBalancerARN":{
+                "$ref":"#/resources/AWS::ElasticLoadBalancingV2::LoadBalancer/LoadBalancer/status/loadBalancerARN"
+             },
+             "port":80,
+             "protocol":"TCP",
+             "defaultActions":[
+                {
+                   "type":"forward",
+                   "forwardConfig":{
+                      "targetGroups":[
+                         {
+                            "targetGroupARN":{
+                               "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/default/nlb-ip-svc-tls:80/status/targetGroupARN"
+                            }
+                         }
+                      ]
+                   }
+                }
+             ]
+          }
+       }
+    },
+    "AWS::ElasticLoadBalancingV2::LoadBalancer":{
+       "LoadBalancer":{
+          "spec":{
+             "name":"k8s-default-nlbipsvc-6b0ba8ff70",
+             "type":"network",
+             "scheme":"internal",
+             "ipAddressType":"ipv4",
+             "subnetMapping":[
+                {
+                   "subnetID":"subnet-1"
+                }
+             ],
+           "securityGroups": [
+            {
+			   "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+            },
+            "sg-backend"
+		 ]
+          }
+       }
+    },
+    "AWS::ElasticLoadBalancingV2::TargetGroup":{
+       "default/nlb-ip-svc-tls:80":{
+          "spec":{
+             "name":"k8s-default-nlbipsvc-d4818dcd51",
+             "targetType":"ip",
+             "ipAddressType":"ipv4",
+             "port":80,
+             "protocol":"TCP",
+             "healthCheckConfig":{
+                "port":"traffic-port",
+                "protocol":"TCP",
+                "intervalSeconds":10,
+                "timeoutSeconds":10,
+                "healthyThresholdCount":3,
+                "unhealthyThresholdCount":3
+             },
+             "targetGroupAttributes":[
+                {
+                   "key":"proxy_protocol_v2.enabled",
+                   "value":"false"
+                }
+             ]
+          }
+       }
+    },
+    "K8S::ElasticLoadBalancingV2::TargetGroupBinding":{
+       "default/nlb-ip-svc-tls:80":{
+          "spec":{
+             "template":{
+                "metadata":{
+                   "name":"k8s-default-nlbipsvc-d4818dcd51",
+                   "namespace":"default",
+                   "creationTimestamp":null
+                },
+                "spec":{
+                   "targetGroupARN":{
+                      "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/default/nlb-ip-svc-tls:80/status/targetGroupARN"
+                   },
+                   "targetType":"ip",
+                   "ipAddressType":"ipv4",
+                   "serviceRef":{
+                      "name":"nlb-ip-svc-tls",
+                      "port":80
+                   },
+                   "networking":{
+                      "ingress":[
+                         {
+                            "from":[
+                               {
+                                  "securityGroup":{
+                                     "groupID":"sg-backend"
+                                  }
+                               }
+                            ],
+                            "ports":[
+                               {
+                                  "protocol":"TCP"
+                               }
+                            ]
+                         }
+                      ]
+                   }
+                }
+             }
+          }
+       }
+    }
+ }
+}
+`,
+			wantNumResources: 5,
+		},
+		{
+			testName: "Dualstack service with SG",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nlb-ip-svc-tls",
+					Namespace: "default",
+					UID:       "bdca2bd0-bfc6-449a-88a3-03451f05f18c",
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/aws-load-balancer-type":            "nlb-ip",
+						"service.beta.kubernetes.io/aws-load-balancer-ip-address-type": "dualstack",
+						"service.beta.kubernetes.io/aws-load-balancer-scheme":          "internet-facing",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Type:     corev1.ServiceTypeLoadBalancer,
+					Selector: map[string]string{"app": "hello"},
+					Ports: []corev1.ServicePort{
+						{
+							Port:       80,
+							TargetPort: intstr.FromInt(80),
+							Protocol:   corev1.ProtocolTCP,
+						},
+					},
+				},
+			},
+			enableBackendSG:          true,
+			resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForOneSubnet},
+			listLoadBalancerCalls:    []listLoadBalancerCall{listLoadBalancerCallForEmptyLB},
+			backendSecurityGroup:     "sg-backend",
+			wantError:                false,
+			wantValue: `
+{
+ "id":"default/nlb-ip-svc-tls",
+ "resources":{
+    "AWS::EC2::SecurityGroup": {
+       "ManagedLBSecurityGroup": {
+          "spec": {
+             "groupName": "k8s-default-nlbipsvc-1da4b78715",
+             "description": "[k8s] Managed SecurityGroup for LoadBalancer",
+             "ingress": [
+                {
+                   "ipProtocol": "tcp",
+                   "fromPort": 80,
+                   "toPort": 80,
+                   "ipRanges": [
+                      {
+                         "cidrIP": "0.0.0.0/0"
+                      }
+                   ]
+                },
+                {
+                   "ipProtocol": "tcp",
+                   "fromPort": 80,
+                   "toPort": 80,
+                   "ipv6Ranges": [
+                      {
+                         "cidrIPv6": "::/0"
+                      }
+                   ]
+                }
+             ]
+          }
+       }
+    },
+    "AWS::ElasticLoadBalancingV2::Listener":{
+       "80":{
+          "spec":{
+             "loadBalancerARN":{
+                "$ref":"#/resources/AWS::ElasticLoadBalancingV2::LoadBalancer/LoadBalancer/status/loadBalancerARN"
+             },
+             "port":80,
+             "protocol":"TCP",
+             "defaultActions":[
+                {
+                   "type":"forward",
+                   "forwardConfig":{
+                      "targetGroups":[
+                         {
+                            "targetGroupARN":{
+                               "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/default/nlb-ip-svc-tls:80/status/targetGroupARN"
+                            }
+                         }
+                      ]
+                   }
+                }
+             ]
+          }
+       }
+    },
+    "AWS::ElasticLoadBalancingV2::LoadBalancer":{
+       "LoadBalancer":{
+          "spec":{
+             "name":"k8s-default-nlbipsvc-4d831c6ca6",
+             "type":"network",
+             "scheme":"internet-facing",
+             "ipAddressType":"dualstack",
+             "subnetMapping":[
+                {
+                   "subnetID":"subnet-1"
+                }
+             ],
+           "securityGroups": [
+            {
+			   "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+            },
+            "sg-backend"
+		 ]
+          }
+       }
+    },
+    "AWS::ElasticLoadBalancingV2::TargetGroup":{
+       "default/nlb-ip-svc-tls:80":{
+          "spec":{
+             "name":"k8s-default-nlbipsvc-d4818dcd51",
+             "targetType":"ip",
+             "ipAddressType":"ipv4",
+             "port":80,
+             "protocol":"TCP",
+             "healthCheckConfig":{
+                "port":"traffic-port",
+                "protocol":"TCP",
+                "intervalSeconds":10,
+                "timeoutSeconds":10,
+                "healthyThresholdCount":3,
+                "unhealthyThresholdCount":3
+             },
+             "targetGroupAttributes":[
+                {
+                   "key":"proxy_protocol_v2.enabled",
+                   "value":"false"
+                }
+             ]
+          }
+       }
+    },
+    "K8S::ElasticLoadBalancingV2::TargetGroupBinding":{
+       "default/nlb-ip-svc-tls:80":{
+          "spec":{
+             "template":{
+                "metadata":{
+                   "name":"k8s-default-nlbipsvc-d4818dcd51",
+                   "namespace":"default",
+                   "creationTimestamp":null
+                },
+                "spec":{
+                   "targetGroupARN":{
+                      "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/default/nlb-ip-svc-tls:80/status/targetGroupARN"
+                   },
+                   "targetType":"ip",
+                   "ipAddressType":"ipv4",
+                   "serviceRef":{
+                      "name":"nlb-ip-svc-tls",
+                      "port":80
+                   },
+                   "networking":{
+                      "ingress":[
+                         {
+                            "from":[
+                               {
+                                  "securityGroup":{
+                                     "groupID":"sg-backend"
+                                  }
+                               }
+                            ],
+                            "ports":[
+                               {
+								  "port": 80,
+                                  "protocol":"TCP"
+                               }
+                            ]
+                         }
+                      ]
+                   }
+                }
+             }
+          }
+       }
+    }
+ }
+}
+`,
+			wantNumResources: 5,
+		},
+		{
+			testName: "Multiple listeners, multiple target groups with SG",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nlb-ip-svc",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/aws-load-balancer-type":                            "nlb-ip",
+						"service.beta.kubernetes.io/aws-load-balancer-scheme":                          "internal",
+						"service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol":            "HTTP",
+						"service.beta.kubernetes.io/aws-load-balancer-healthcheck-port":                "8888",
+						"service.beta.kubernetes.io/aws-load-balancer-healthcheck-path":                "/healthz",
+						"service.beta.kubernetes.io/aws-load-balancer-healthcheck-interval":            "10",
+						"service.beta.kubernetes.io/aws-load-balancer-healthcheck-timeout":             "30",
+						"service.beta.kubernetes.io/aws-load-balancer-healthcheck-healthy-threshold":   "2",
+						"service.beta.kubernetes.io/aws-load-balancer-healthcheck-unhealthy-threshold": "2",
+					},
+					UID: "7ab4be33-11c2-4a7b-b655-7add8affab36",
+				},
+				Spec: corev1.ServiceSpec{
+					Type:     corev1.ServiceTypeLoadBalancer,
+					Selector: map[string]string{"app": "hello"},
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "http",
+							Port:       80,
+							TargetPort: intstr.FromInt(80),
+							Protocol:   corev1.ProtocolTCP,
+						},
+						{
+							Name:       "alt2",
+							Port:       83,
+							TargetPort: intstr.FromInt(80),
+							Protocol:   corev1.ProtocolTCP,
+						},
+					},
+				},
+			},
+			enableBackendSG:          true,
+			resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForTwoSubnet},
+			listLoadBalancerCalls:    []listLoadBalancerCall{listLoadBalancerCallForEmptyLB},
+			backendSecurityGroup:     "sg-backend",
+			wantError:                false,
+			wantValue: `
+{
+ "id":"default/nlb-ip-svc",
+ "resources":{
+    "AWS::EC2::SecurityGroup": {
+       "ManagedLBSecurityGroup": {
+          "spec": {
+             "groupName": "k8s-default-nlbipsvc-51de41384e",
+             "description": "[k8s] Managed SecurityGroup for LoadBalancer",
+             "ingress": [
+                {
+                   "ipProtocol": "tcp",
+                   "fromPort": 80,
+                   "toPort": 80,
+                   "ipRanges": [
+                      {
+                         "cidrIP": "0.0.0.0/0"
+                      }
+                   ]
+                },
+                {
+                   "ipProtocol": "tcp",
+                   "fromPort": 83,
+                   "toPort": 83,
+                   "ipRanges": [
+                      {
+                         "cidrIP": "0.0.0.0/0"
+                      }
+                   ]
+                }
+             ]
+          }
+       }
+    },
+    "AWS::ElasticLoadBalancingV2::Listener":{
+       "80":{
+          "spec":{
+             "loadBalancerARN":{
+                "$ref":"#/resources/AWS::ElasticLoadBalancingV2::LoadBalancer/LoadBalancer/status/loadBalancerARN"
+             },
+             "port":80,
+             "protocol":"TCP",
+             "defaultActions":[
+                {
+                   "type":"forward",
+                   "forwardConfig":{
+                      "targetGroups":[
+                         {
+                            "targetGroupARN":{
+                               "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/default/nlb-ip-svc:80/status/targetGroupARN"
+                            }
+                         }
+                      ]
+                   }
+                }
+             ]
+          }
+       },
+       "83":{
+          "spec":{
+             "loadBalancerARN":{
+                "$ref":"#/resources/AWS::ElasticLoadBalancingV2::LoadBalancer/LoadBalancer/status/loadBalancerARN"
+             },
+             "port":83,
+             "protocol":"TCP",
+             "defaultActions":[
+                {
+                   "type":"forward",
+                   "forwardConfig":{
+                      "targetGroups":[
+                         {
+                            "targetGroupARN":{
+                               "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/default/nlb-ip-svc:83/status/targetGroupARN"
+                            }
+                         }
+                      ]
+                   }
+                }
+             ]
+          }
+       }
+    },
+    "AWS::ElasticLoadBalancingV2::LoadBalancer":{
+       "LoadBalancer":{
+          "spec":{
+             "name":"k8s-default-nlbipsvc-518cdfc227",
+             "type":"network",
+             "scheme":"internal",
+             "ipAddressType":"ipv4",
+             "subnetMapping":[
+                {
+                   "subnetID":"subnet-1"
+                },
+                {
+                   "subnetID":"subnet-2"
+                }
+             ],
+             "securityGroups": [
+               {
+			     "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+               },
+               "sg-backend"
+		     ]
+          }
+       }
+    },
+    "AWS::ElasticLoadBalancingV2::TargetGroup":{
+       "default/nlb-ip-svc:80":{
+          "spec":{
+             "name":"k8s-default-nlbipsvc-62f81639fc",
+             "targetType":"ip",
+             "ipAddressType":"ipv4",
+             "port":80,
+             "protocol":"TCP",
+             "healthCheckConfig":{
+                "port":8888,
+                "protocol":"HTTP",
+                "path":"/healthz",
+                "intervalSeconds":10,
+                "timeoutSeconds":30,
+                "healthyThresholdCount":2,
+                "unhealthyThresholdCount":2,
+                "matcher":{
+					"httpCode": "200-399"
+				}
+             },
+             "targetGroupAttributes":[
+                {
+                   "key":"proxy_protocol_v2.enabled",
+                   "value":"false"
+                }
+             ]
+          }
+       },
+       "default/nlb-ip-svc:83":{
+          "spec":{
+             "name":"k8s-default-nlbipsvc-3ede6b28b6",
+             "targetType":"ip",
+             "ipAddressType":"ipv4",
+             "port":80,
+             "protocol":"TCP",
+             "healthCheckConfig":{
+                "port":8888,
+                "protocol":"HTTP",
+                "path":"/healthz",
+                "intervalSeconds":10,
+                "timeoutSeconds":30,
+                "healthyThresholdCount":2,
+                "unhealthyThresholdCount":2,
+                "matcher":{
+					"httpCode": "200-399"
+				}
+             },
+             "targetGroupAttributes":[
+                {
+                   "key":"proxy_protocol_v2.enabled",
+                   "value":"false"
+                }
+             ]
+          }
+       }
+    },
+    "K8S::ElasticLoadBalancingV2::TargetGroupBinding":{
+       "default/nlb-ip-svc:80":{
+          "spec":{
+             "template":{
+                "metadata":{
+                   "name":"k8s-default-nlbipsvc-62f81639fc",
+                   "namespace":"default",
+                   "creationTimestamp":null
+                },
+                "spec":{
+                   "targetGroupARN":{
+                      "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/default/nlb-ip-svc:80/status/targetGroupARN"
+                   },
+                   "targetType":"ip",
+                   "ipAddressType":"ipv4",
+                   "serviceRef":{
+                      "name":"nlb-ip-svc",
+                      "port":80
+                   },
+                   "networking":{
+                      "ingress":[
+                         {
+                            "from":[
+                               {
+                                  "securityGroup":{
+                                     "groupID":"sg-backend"
+                                  }
+                               }
+                            ],
+                            "ports":[
+							   {
+							      "port": 80,
+                                  "protocol":"TCP"
+                               },
+							   {
+							      "port": 8888,
+                                  "protocol":"TCP"
+                               }
+                            ]
+                         }
+                      ]
+                   }
+                }
+             }
+          }
+       },
+       "default/nlb-ip-svc:83":{
+          "spec":{
+             "template":{
+                "metadata":{
+                   "name":"k8s-default-nlbipsvc-3ede6b28b6",
+                   "namespace":"default",
+                   "creationTimestamp":null
+                },
+                "spec":{
+                   "targetGroupARN":{
+                      "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/default/nlb-ip-svc:83/status/targetGroupARN"
+                   },
+                   "targetType":"ip",
+                   "ipAddressType":"ipv4",
+                   "serviceRef":{
+                      "name":"nlb-ip-svc",
+                      "port":83
+                   },
+                   "networking":{
+                      "ingress":[
+                         {
+                            "from":[
+                               {
+                                  "securityGroup":{
+                                     "groupID":"sg-backend"
+                                  }
+                               }
+                            ],
+                            "ports":[
+                               {
+							      "port": 80,
+                                  "protocol":"TCP"
+                               },
+							   {
+							      "port": 8888,
+                                  "protocol":"TCP"
+                               }
+                            ]
+                         }
+                      ]
+                   }
+                }
+             }
+          }
+       }
+    }
+ }
+}
+`,
+			wantNumResources: 8,
+		},
+		{
+			testName: "TLS and access logging annotations with SG",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nlb-ip-svc-tls",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/aws-load-balancer-type":                              "nlb-ip",
+						"service.beta.kubernetes.io/aws-load-balancer-internal":                          "false",
+						"service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol":              "HTTP",
+						"service.beta.kubernetes.io/aws-load-balancer-healthcheck-port":                  "80",
+						"service.beta.kubernetes.io/aws-load-balancer-healthcheck-path":                  "/healthz",
+						"service.beta.kubernetes.io/aws-load-balancer-healthcheck-interval":              "10",
+						"service.beta.kubernetes.io/aws-load-balancer-healthcheck-timeout":               "30",
+						"service.beta.kubernetes.io/aws-load-balancer-healthcheck-healthy-threshold":     "2",
+						"service.beta.kubernetes.io/aws-load-balancer-healthcheck-unhealthy-threshold":   "2",
+						"service.beta.kubernetes.io/aws-load-balancer-access-log-enabled":                "true",
+						"service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-name":         "nlb-bucket",
+						"service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix":       "bkt-pfx",
+						"service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled": "true",
+						"service.beta.kubernetes.io/aws-load-balancer-ssl-ports":                         "83",
+						"service.beta.kubernetes.io/aws-load-balancer-ssl-cert":                          "certArn1,certArn2",
+					},
+					UID: "7ab4be33-11c2-4a7b-b655-7add8affab36",
+				},
+				Spec: corev1.ServiceSpec{
+					Type:     corev1.ServiceTypeLoadBalancer,
+					Selector: map[string]string{"app": "hello"},
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "http",
+							Port:       80,
+							TargetPort: intstr.FromInt(80),
+							Protocol:   corev1.ProtocolTCP,
+						},
+						{
+							Name:       "alt2",
+							Port:       83,
+							TargetPort: intstr.FromInt(8883),
+							Protocol:   corev1.ProtocolTCP,
+						},
+					},
+				},
+			},
+			enableBackendSG:          true,
+			resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForThreeSubnet},
+			listLoadBalancerCalls:    []listLoadBalancerCall{listLoadBalancerCallForEmptyLB},
+			backendSecurityGroup:     "sg-backend",
+			wantError:                false,
+			wantValue: `
+{
+ "id":"default/nlb-ip-svc-tls",
+ "resources":{
+    "AWS::EC2::SecurityGroup": {
+       "ManagedLBSecurityGroup": {
+          "spec": {
+             "groupName": "k8s-default-nlbipsvc-1b1762b6f6",
+             "description": "[k8s] Managed SecurityGroup for LoadBalancer",
+             "ingress": [
+                {
+                   "ipProtocol": "tcp",
+                   "fromPort": 80,
+                   "toPort": 80,
+                   "ipRanges": [
+                      {
+                         "cidrIP": "0.0.0.0/0"
+                      }
+                   ]
+                },
+                {
+                   "ipProtocol": "tcp",
+                   "fromPort": 83,
+                   "toPort": 83,
+                   "ipRanges": [
+                      {
+                         "cidrIP": "0.0.0.0/0"
+                      }
+                   ]
+                }
+             ]
+          }
+       }
+    },
+    "AWS::ElasticLoadBalancingV2::Listener":{
+       "80":{
+          "spec":{
+             "loadBalancerARN":{
+                "$ref":"#/resources/AWS::ElasticLoadBalancingV2::LoadBalancer/LoadBalancer/status/loadBalancerARN"
+             },
+             "port":80,
+             "protocol":"TCP",
+             "defaultActions":[
+                {
+                   "type":"forward",
+                   "forwardConfig":{
+                      "targetGroups":[
+                         {
+                            "targetGroupARN":{
+                               "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/default/nlb-ip-svc-tls:80/status/targetGroupARN"
+                            }
+                         }
+                      ]
+                   }
+                }
+             ]
+          }
+       },
+       "83":{
+          "spec":{
+             "loadBalancerARN":{
+                "$ref":"#/resources/AWS::ElasticLoadBalancingV2::LoadBalancer/LoadBalancer/status/loadBalancerARN"
+             },
+             "port":83,
+             "protocol":"TLS",
+             "sslPolicy": "ELBSecurityPolicy-2016-08",
+             "defaultActions":[
+                {
+                   "type":"forward",
+                   "forwardConfig":{
+                      "targetGroups":[
+                         {
+                            "targetGroupARN":{
+                               "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/default/nlb-ip-svc-tls:83/status/targetGroupARN"
+                            }
+                         }
+                      ]
+                   }
+                }
+             ],
+             "certificates":[
+                {
+                   "certificateARN":"certArn1"
+                },
+                {
+                   "certificateARN":"certArn2"
+                }
+             ]
+          }
+       }
+    },
+    "AWS::ElasticLoadBalancingV2::LoadBalancer":{
+       "LoadBalancer":{
+          "spec":{
+             "name":"k8s-default-nlbipsvc-33e41aa671",
+             "type":"network",
+             "scheme":"internet-facing",
+             "ipAddressType":"ipv4",
+             "subnetMapping":[
+                {
+                   "subnetID":"subnet-1"
+                },
+                {
+                   "subnetID":"subnet-2"
+                },
+                {
+                   "subnetID":"subnet-3"
+                }
+             ],
+             "loadBalancerAttributes":[
+                {
+                   "key":"access_logs.s3.bucket",
+                   "value":"nlb-bucket"
+                },
+                {
+                   "key":"access_logs.s3.enabled",
+                   "value":"true"
+                },
+                {
+                   "key":"access_logs.s3.prefix",
+                   "value":"bkt-pfx"
+                },
+                {
+                   "key":"load_balancing.cross_zone.enabled",
+                   "value":"true"
+                }
+             ],
+           "securityGroups": [
+            {
+			   "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+            },
+            "sg-backend"
+		 ]
+          }
+       }
+    },
+    "AWS::ElasticLoadBalancingV2::TargetGroup":{
+       "default/nlb-ip-svc-tls:80":{
+          "spec":{
+             "name":"k8s-default-nlbipsvc-62f81639fc",
+             "targetType":"ip",
+             "ipAddressType":"ipv4",
+             "port":80,
+             "protocol":"TCP",
+             "healthCheckConfig":{
+                "port":80,
+                "protocol":"HTTP",
+                "path":"/healthz",
+                "intervalSeconds":10,
+                "timeoutSeconds":30,
+                "healthyThresholdCount":2,
+                "unhealthyThresholdCount":2,
+                "matcher":{
+					"httpCode": "200-399"
+				}
+             },
+             "targetGroupAttributes":[
+                {
+                   "key":"proxy_protocol_v2.enabled",
+                   "value":"false"
+                }
+             ]
+          }
+       },
+       "default/nlb-ip-svc-tls:83":{
+          "spec":{
+             "name":"k8s-default-nlbipsvc-77ea0c7734",
+             "targetType":"ip",
+             "ipAddressType":"ipv4",
+             "port":8883,
+             "protocol":"TCP",
+             "healthCheckConfig":{
+                "port":80,
+                "protocol":"HTTP",
+                "path":"/healthz",
+                "intervalSeconds":10,
+                "timeoutSeconds":30,
+                "healthyThresholdCount":2,
+                "unhealthyThresholdCount":2,
+                "matcher":{
+					"httpCode": "200-399"
+				}
+             },
+             "targetGroupAttributes":[
+                {
+                   "key":"proxy_protocol_v2.enabled",
+                   "value":"false"
+                }
+             ]
+          }
+       }
+    },
+    "K8S::ElasticLoadBalancingV2::TargetGroupBinding":{
+       "default/nlb-ip-svc-tls:80":{
+          "spec":{
+             "template":{
+                "metadata":{
+                   "name":"k8s-default-nlbipsvc-62f81639fc",
+                   "namespace":"default",
+                   "creationTimestamp":null
+                },
+                "spec":{
+                   "targetGroupARN":{
+                      "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/default/nlb-ip-svc-tls:80/status/targetGroupARN"
+                   },
+                   "targetType":"ip",
+                   "ipAddressType":"ipv4",
+                   "serviceRef":{
+                      "name":"nlb-ip-svc-tls",
+                      "port":80
+                   },
+                   "networking":{
+                      "ingress":[
+                         {
+                            "from":[
+                               {
+                                  "securityGroup":{
+                                     "groupID":"sg-backend"
+                                  }
+                               }
+                            ],
+                            "ports":[
+                               {
+								  "port": 80,
+                                  "protocol":"TCP"
+                               }
+                            ]
+                         }
+                      ]
+                   }
+                }
+             }
+          }
+       },
+       "default/nlb-ip-svc-tls:83":{
+          "spec":{
+             "template":{
+                "metadata":{
+                   "name":"k8s-default-nlbipsvc-77ea0c7734",
+                   "namespace":"default",
+                   "creationTimestamp":null
+                },
+                "spec":{
+                   "targetGroupARN":{
+                      "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/default/nlb-ip-svc-tls:83/status/targetGroupARN"
+                   },
+                   "targetType":"ip",
+                   "ipAddressType":"ipv4",
+                   "serviceRef":{
+                      "name":"nlb-ip-svc-tls",
+                      "port":83
+                   },
+                   "networking":{
+                      "ingress":[
+                         {
+                            "from":[
+                               {
+                                  "securityGroup":{
+                                     "groupID":"sg-backend"
+                                  }
+                               }
+                            ],
+                            "ports":[
+                               {
+								  "port": 8883,
+                                  "protocol":"TCP"
+                               },
+							   {
+								  "port": 80,
+                                  "protocol":"TCP"
+                               }
+                            ]
+                         }
+                      ]
+                   }
+                }
+             }
+          }
+       }
+    }
+ }
+}
+`,
+			wantNumResources: 8,
+		},
+		{
+			testName: "Instance mode, external traffic policy cluster with SG",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "instance-mode",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/aws-load-balancer-type":            "external",
+						"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "instance",
+					},
+					UID: "2dc098f0-ae33-4378-af7b-83e2a0424495",
+				},
+				Spec: corev1.ServiceSpec{
+					ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeCluster,
+					Type:                  corev1.ServiceTypeLoadBalancer,
+					Selector:              map[string]string{"app": "hello"},
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "http",
+							Port:       80,
+							TargetPort: intstr.FromInt(80),
+							Protocol:   corev1.ProtocolTCP,
+							NodePort:   31223,
+						},
+						{
+							Name:       "alt2",
+							Port:       83,
+							TargetPort: intstr.FromInt(8883),
+							Protocol:   corev1.ProtocolTCP,
+							NodePort:   32323,
+						},
+					},
+				},
+			},
+			enableBackendSG:          false,
+			disableRestrictedSGRules: true,
+			resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForThreeSubnet},
+			fetchVPCInfoCalls: []fetchVPCInfoCall{
+				{
+					wantVPCInfo: networking.VPCInfo{
+						CidrBlockAssociationSet: []*ec2.VpcCidrBlockAssociation{
+							{
+								CidrBlock: aws.String("192.168.0.0/16"),
+								CidrBlockState: &ec2.VpcCidrBlockState{
+									State: &cidrBlockStateAssociated,
+								},
+							},
+						},
+					},
+				},
+			},
+			listLoadBalancerCalls: []listLoadBalancerCall{listLoadBalancerCallForEmptyLB},
+			wantError:             false,
+			wantValue: `
+{
+ "id":"default/instance-mode",
+ "resources":{
+    "AWS::EC2::SecurityGroup": {
+       "ManagedLBSecurityGroup": {
+          "spec": {
+             "groupName": "k8s-default-instance-38fe420757",
+             "description": "[k8s] Managed SecurityGroup for LoadBalancer",
+             "ingress": [
+                {
+                   "ipProtocol": "tcp",
+                   "fromPort": 80,
+                   "toPort": 80,
+                   "ipRanges": [
+                      {
+                         "cidrIP": "0.0.0.0/0"
+                      }
+                   ]
+                },
+                {
+                   "ipProtocol": "tcp",
+                   "fromPort": 83,
+                   "toPort": 83,
+                   "ipRanges": [
+                      {
+                         "cidrIP": "0.0.0.0/0"
+                      }
+                   ]
+                }
+             ]
+          }
+       }
+    },
+    "AWS::ElasticLoadBalancingV2::Listener":{
+       "80":{
+          "spec":{
+             "loadBalancerARN":{
+                "$ref":"#/resources/AWS::ElasticLoadBalancingV2::LoadBalancer/LoadBalancer/status/loadBalancerARN"
+             },
+             "port":80,
+             "protocol":"TCP",
+             "defaultActions":[
+                {
+                   "type":"forward",
+                   "forwardConfig":{
+                      "targetGroups":[
+                         {
+                            "targetGroupARN":{
+                               "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/default/instance-mode:80/status/targetGroupARN"
+                            }
+                         }
+                      ]
+                   }
+                }
+             ]
+          }
+       },
+       "83":{
+          "spec":{
+             "loadBalancerARN":{
+                "$ref":"#/resources/AWS::ElasticLoadBalancingV2::LoadBalancer/LoadBalancer/status/loadBalancerARN"
+             },
+             "port":83,
+             "protocol":"TCP",
+             "defaultActions":[
+                {
+                   "type":"forward",
+                   "forwardConfig":{
+                      "targetGroups":[
+                         {
+                            "targetGroupARN":{
+                               "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/default/instance-mode:83/status/targetGroupARN"
+                            }
+                         }
+                      ]
+                   }
+                }
+             ]
+          }
+       }
+    },
+    "AWS::ElasticLoadBalancingV2::LoadBalancer":{
+       "LoadBalancer":{
+          "spec":{
+             "name":"k8s-default-instance-7ca1de7e6c",
+             "type":"network",
+             "scheme":"internal",
+             "ipAddressType":"ipv4",
+             "subnetMapping":[
+                {
+                   "subnetID":"subnet-1"
+                },
+                {
+                   "subnetID":"subnet-2"
+                },
+                {
+                   "subnetID":"subnet-3"
+                }
+             ],
+           "securityGroups": [
+            {
+			   "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+            }
+		 ]
+          }
+       }
+    },
+    "AWS::ElasticLoadBalancingV2::TargetGroup":{
+       "default/instance-mode:80":{
+          "spec":{
+             "name":"k8s-default-instance-0c68c79423",
+             "targetType":"instance",
+             "ipAddressType":"ipv4",
+             "port":31223,
+             "protocol":"TCP",
+             "healthCheckConfig":{
+                "port": "traffic-port",
+                "protocol":"TCP",
+                "intervalSeconds":10,
+                "timeoutSeconds":10,
+                "healthyThresholdCount":3,
+                "unhealthyThresholdCount":3
+             },
+             "targetGroupAttributes":[
+                {
+                   "key":"proxy_protocol_v2.enabled",
+                   "value":"false"
+                }
+             ]
+          }
+       },
+       "default/instance-mode:83":{
+          "spec":{
+             "name":"k8s-default-instance-c200165858",
+             "targetType":"instance",
+             "ipAddressType":"ipv4",
+             "port":32323,
+             "protocol":"TCP",
+             "healthCheckConfig":{
+                "port":"traffic-port",
+                "protocol":"TCP",
+                "intervalSeconds":10,
+                "timeoutSeconds":10,
+                "healthyThresholdCount":3,
+                "unhealthyThresholdCount":3
+             },
+             "targetGroupAttributes":[
+                {
+                   "key":"proxy_protocol_v2.enabled",
+                   "value":"false"
+                }
+             ]
+          }
+       }
+    },
+    "K8S::ElasticLoadBalancingV2::TargetGroupBinding":{
+       "default/instance-mode:80":{
+          "spec":{
+             "template":{
+                "metadata":{
+                   "name":"k8s-default-instance-0c68c79423",
+                   "namespace":"default",
+                   "creationTimestamp":null
+                },
+                "spec":{
+                   "targetGroupARN":{
+                      "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/default/instance-mode:80/status/targetGroupARN"
+                   },
+                   "targetType":"instance",
+                   "ipAddressType":"ipv4",
+                   "serviceRef":{
+                      "name":"instance-mode",
+                      "port":80
+                   },
+                   "networking":{
+                      "ingress":[
+                         {
+                            "from":[
+                               {
+                                  "securityGroup":{
+									"groupID": {
+										"$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+									}
+                                  }
+                               }
+                            ],
+                            "ports":[
+                               {
+                                  "protocol":"TCP"
+                               }
+                            ]
+                         }
+                      ]
+                   }
+                }
+             }
+          }
+       },
+       "default/instance-mode:83":{
+          "spec":{
+             "template":{
+                "metadata":{
+                   "name":"k8s-default-instance-c200165858",
+                   "namespace":"default",
+                   "creationTimestamp":null
+                },
+                "spec":{
+                   "targetGroupARN":{
+                      "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/default/instance-mode:83/status/targetGroupARN"
+                   },
+                   "targetType":"instance",
+                   "ipAddressType":"ipv4",
+                   "serviceRef":{
+                      "name":"instance-mode",
+                      "port":83
+                   },
+                   "networking":{
+                      "ingress":[
+                         {
+                            "from":[
+                               {
+                                  "securityGroup":{
+                                     "groupID": {
+									"$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+								 }
+                                  }
+                               }
+                            ],
+                            "ports":[
+                               {
+                                  "protocol":"TCP"
+                               }
+                            ]
+                         }
+                      ]
+                   }
+                }
+             }
+          }
+       }
+    }
+ }
+}
+`,
+			wantNumResources: 8,
+		},
+		{
+			testName: "Instance mode, external traffic policy local with SG",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "traffic-local",
+					Namespace: "app",
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/aws-load-balancer-type":            "external",
+						"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "instance",
+					},
+					UID: "2dc098f0-ae33-4378-af7b-83e2a0424495",
+				},
+				Spec: corev1.ServiceSpec{
+					ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
+					Type:                  corev1.ServiceTypeLoadBalancer,
+					Selector:              map[string]string{"app": "hello"},
+					HealthCheckNodePort:   29123,
+					LoadBalancerSourceRanges: []string{
+						"10.20.0.0/16",
+						"1.2.3.4/19",
+					},
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "http",
+							Port:       80,
+							TargetPort: intstr.FromInt(80),
+							Protocol:   corev1.ProtocolTCP,
+							NodePort:   31223,
+						},
+						{
+							Name:       "alt2",
+							Port:       83,
+							TargetPort: intstr.FromInt(8883),
+							Protocol:   corev1.ProtocolTCP,
+							NodePort:   32323,
+						},
+					},
+				},
+				Status: corev1.ServiceStatus{
+					LoadBalancer: corev1.LoadBalancerStatus{
+						Ingress: []corev1.LoadBalancerIngress{
+							{
+								Hostname: "k8s-existing-nlb",
+							},
+						},
+					},
+				},
+			},
+			enableBackendSG:              false,
+			resolveViaNameOrIDSliceCalls: []resolveViaNameOrIDSliceCall{resolveViaNameOrIDSliceCallForThreeSubnet},
+			listLoadBalancerCalls: []listLoadBalancerCall{
+				{
+					sdkLBs: []elbv2.LoadBalancerWithTags{
+						{
+							LoadBalancer: &elbv2sdk.LoadBalancer{
+								Scheme:         aws.String("internet-facing"),
+								SecurityGroups: []*string{aws.String("sg-lb")},
+							},
+						},
+					},
+				},
+			},
+			wantError: false,
+			wantValue: `
+{
+ "id":"app/traffic-local",
+ "resources":{
+    "AWS::EC2::SecurityGroup": {
+       "ManagedLBSecurityGroup": {
+          "spec": {
+             "groupName": "k8s-app-trafficl-7b81fc143c",
+             "description": "[k8s] Managed SecurityGroup for LoadBalancer",
+             "ingress": [
+                {
+                   "ipProtocol": "tcp",
+                   "fromPort": 80,
+                   "toPort": 80,
+                   "ipRanges": [
+                      {
+                         "cidrIP": "10.20.0.0/16"
+                      }
+                   ]
+                },
+                {
+                   "ipProtocol": "tcp",
+                   "fromPort": 80,
+                   "toPort": 80,
+                   "ipRanges": [
+                      {
+                         "cidrIP": "1.2.3.4/19"
+                      }
+                   ]
+                },
+                {
+                   "ipProtocol": "tcp",
+                   "fromPort": 83,
+                   "toPort": 83,
+                   "ipRanges": [
+                      {
+                         "cidrIP": "10.20.0.0/16"
+                      }
+                   ]
+                },
+                {
+                   "ipProtocol": "tcp",
+                   "fromPort": 83,
+                   "toPort": 83,
+                   "ipRanges": [
+                      {
+                         "cidrIP": "1.2.3.4/19"
+                      }
+                   ]
+                }
+             ]
+          }
+       }
+    },
+    "AWS::ElasticLoadBalancingV2::Listener":{
+       "80":{
+          "spec":{
+             "loadBalancerARN":{
+                "$ref":"#/resources/AWS::ElasticLoadBalancingV2::LoadBalancer/LoadBalancer/status/loadBalancerARN"
+             },
+             "port":80,
+             "protocol":"TCP",
+             "defaultActions":[
+                {
+                   "type":"forward",
+                   "forwardConfig":{
+                      "targetGroups":[
+                         {
+                            "targetGroupARN":{
+                               "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/app/traffic-local:80/status/targetGroupARN"
+                            }
+                         }
+                      ]
+                   }
+                }
+             ]
+          }
+       },
+       "83":{
+          "spec":{
+             "loadBalancerARN":{
+                "$ref":"#/resources/AWS::ElasticLoadBalancingV2::LoadBalancer/LoadBalancer/status/loadBalancerARN"
+             },
+             "port":83,
+             "protocol":"TCP",
+             "defaultActions":[
+                {
+                   "type":"forward",
+                   "forwardConfig":{
+                      "targetGroups":[
+                         {
+                            "targetGroupARN":{
+                               "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/app/traffic-local:83/status/targetGroupARN"
+                            }
+                         }
+                      ]
+                   }
+                }
+             ]
+          }
+       }
+    },
+    "AWS::ElasticLoadBalancingV2::LoadBalancer":{
+       "LoadBalancer":{
+          "spec":{
+             "name":"k8s-app-trafficl-2af705447d",
+             "type":"network",
+             "scheme":"internet-facing",
+             "ipAddressType":"ipv4",
+             "subnetMapping":[
+                {
+                   "subnetID":"subnet-1"
+                },
+                {
+                   "subnetID":"subnet-2"
+                },
+                {
+                   "subnetID":"subnet-3"
+                }
+             ],
+           "securityGroups": [
+            {
+			   "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+            }
+		 ]
+          }
+       }
+    },
+    "AWS::ElasticLoadBalancingV2::TargetGroup":{
+       "app/traffic-local:80":{
+          "spec":{
+             "name":"k8s-app-trafficl-d2b8571b2f",
+             "targetType":"instance",
+             "ipAddressType":"ipv4",
+             "port":31223,
+             "protocol":"TCP",
+             "healthCheckConfig":{
+                "port": 29123,
+                "protocol":"HTTP",
+			    "path":"/healthz",
+                "intervalSeconds":10,
+                "timeoutSeconds":6,
+                "healthyThresholdCount":2,
+                "unhealthyThresholdCount":2,
+                "matcher":{
+					"httpCode": "200-399"
+				}
+             },
+             "targetGroupAttributes":[
+                {
+                   "key":"proxy_protocol_v2.enabled",
+                   "value":"false"
+                }
+             ]
+          }
+       },
+       "app/traffic-local:83":{
+          "spec":{
+             "name":"k8s-app-trafficl-4be0ac1fb8",
+             "targetType":"instance",
+             "ipAddressType":"ipv4",
+             "port":32323,
+             "protocol":"TCP",
+             "healthCheckConfig":{
+                "port": 29123,
+                "protocol":"HTTP",
+			    "path":"/healthz",
+                "intervalSeconds":10,
+                "timeoutSeconds":6,
+                "healthyThresholdCount":2,
+                "unhealthyThresholdCount":2,
+                "matcher":{
+					"httpCode": "200-399"
+				}
+             },
+             "targetGroupAttributes":[
+                {
+                   "key":"proxy_protocol_v2.enabled",
+                   "value":"false"
+                }
+             ]
+          }
+       }
+    },
+    "K8S::ElasticLoadBalancingV2::TargetGroupBinding":{
+       "app/traffic-local:80":{
+          "spec":{
+             "template":{
+                "metadata":{
+                   "name":"k8s-app-trafficl-d2b8571b2f",
+                   "namespace":"app",
+                   "creationTimestamp":null
+                },
+                "spec":{
+                   "targetGroupARN":{
+                      "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/app/traffic-local:80/status/targetGroupARN"
+                   },
+                   "targetType":"instance",
+                   "ipAddressType":"ipv4",
+                   "serviceRef":{
+                      "name":"traffic-local",
+                      "port":80
+                   },
+                   "networking":{
+                      "ingress":[
+                         {
+                            "from":[
+                               {
+                                  "securityGroup":{
+                                     "groupID": {
+									"$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+								 }
+                                  }
+                               }
+                            ],
+                            "ports":[
+                               {
+								  "port": 31223,
+                                  "protocol":"TCP"
+                               },
+							   {
+							      "port": 29123,
+                                  "protocol":"TCP"
+                               }
+                            ]
+                         }
+                      ]
+                   }
+                }
+             }
+          }
+       },
+       "app/traffic-local:83":{
+          "spec":{
+             "template":{
+                "metadata":{
+                   "name":"k8s-app-trafficl-4be0ac1fb8",
+                   "namespace":"app",
+                   "creationTimestamp":null
+                },
+                "spec":{
+                   "targetGroupARN":{
+                      "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/app/traffic-local:83/status/targetGroupARN"
+                   },
+                   "targetType":"instance",
+                   "ipAddressType":"ipv4",
+                   "serviceRef":{
+                      "name":"traffic-local",
+                      "port":83
+                   },
+                   "networking":{
+                      "ingress":[
+                         {
+                            "from":[
+                               {
+                                  "securityGroup":{
+									"groupID": {
+										"$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+								 	}
+                                  }
+                               }
+                            ],
+                            "ports":[
+                               {
+								  "port": 32323,
+                                  "protocol":"TCP"
+                               },
+							   {
+								  "port": 29123,
+                                  "protocol":"TCP"
+                               }
+                            ]
+                         }
+                      ]
+                   }
+                }
+             }
+          }
+       }
+    }
+ }
+}
+`,
+			wantNumResources: 8,
+		},
+		{
+			testName: "Instance mode, external traffic policy local, UDP as protocol with SG",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "traffic-local",
+					Namespace: "app",
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/aws-load-balancer-type":            "external",
+						"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "instance",
+					},
+					UID: "2dc098f0-ae33-4378-af7b-83e2a0424495",
+				},
+				Spec: corev1.ServiceSpec{
+					ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
+					Type:                  corev1.ServiceTypeLoadBalancer,
+					Selector:              map[string]string{"app": "hello"},
+					HealthCheckNodePort:   29123,
+					LoadBalancerSourceRanges: []string{
+						"10.20.0.0/16",
+						"1.2.3.4/19",
+					},
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "http",
+							Port:       80,
+							TargetPort: intstr.FromInt(80),
+							Protocol:   corev1.ProtocolUDP,
+							NodePort:   31223,
+						},
+						{
+							Name:       "alt2",
+							Port:       83,
+							TargetPort: intstr.FromInt(8883),
+							Protocol:   corev1.ProtocolUDP,
+							NodePort:   32323,
+						},
+					},
+				},
+				Status: corev1.ServiceStatus{
+					LoadBalancer: corev1.LoadBalancerStatus{
+						Ingress: []corev1.LoadBalancerIngress{
+							{
+								Hostname: "k8s-existing-nlb",
+							},
+						},
+					},
+				},
+			},
+			enableBackendSG:              false,
+			resolveViaNameOrIDSliceCalls: []resolveViaNameOrIDSliceCall{resolveViaNameOrIDSliceCallForThreeSubnet},
+			listLoadBalancerCalls: []listLoadBalancerCall{
+				{
+					sdkLBs: []elbv2.LoadBalancerWithTags{
+						{
+							LoadBalancer: &elbv2sdk.LoadBalancer{
+								Scheme:         aws.String("internet-facing"),
+								SecurityGroups: []*string{aws.String("sg-lb")},
+							},
+						},
+					},
+				},
+			},
+			wantError: false,
+			wantValue: `
+{
+ "id":"app/traffic-local",
+ "resources":{
+    "AWS::EC2::SecurityGroup": {
+       "ManagedLBSecurityGroup": {
+          "spec": {
+             "groupName": "k8s-app-trafficl-7b81fc143c",
+             "description": "[k8s] Managed SecurityGroup for LoadBalancer",
+             "ingress": [
+                {
+                   "ipProtocol": "udp",
+                   "fromPort": 80,
+                   "toPort": 80,
+                   "ipRanges": [
+                      {
+                         "cidrIP": "10.20.0.0/16"
+                      }
+                   ]
+                },
+                {
+                   "ipProtocol": "udp",
+                   "fromPort": 80,
+                   "toPort": 80,
+                   "ipRanges": [
+                      {
+                         "cidrIP": "1.2.3.4/19"
+                      }
+                   ]
+                },
+                {
+                   "ipProtocol": "udp",
+                   "fromPort": 83,
+                   "toPort": 83,
+                   "ipRanges": [
+                      {
+                         "cidrIP": "10.20.0.0/16"
+                      }
+                   ]
+                },
+                {
+                   "ipProtocol": "udp",
+                   "fromPort": 83,
+                   "toPort": 83,
+                   "ipRanges": [
+                      {
+                         "cidrIP": "1.2.3.4/19"
+                      }
+                   ]
+                }
+             ]
+          }
+       }
+    },
+    "AWS::ElasticLoadBalancingV2::Listener":{
+       "80":{
+          "spec":{
+             "loadBalancerARN":{
+                "$ref":"#/resources/AWS::ElasticLoadBalancingV2::LoadBalancer/LoadBalancer/status/loadBalancerARN"
+             },
+             "port":80,
+             "protocol":"UDP",
+             "defaultActions":[
+                {
+                   "type":"forward",
+                   "forwardConfig":{
+                      "targetGroups":[
+                         {
+                            "targetGroupARN":{
+                               "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/app/traffic-local:80/status/targetGroupARN"
+                            }
+                         }
+                      ]
+                   }
+                }
+             ]
+          }
+       },
+       "83":{
+          "spec":{
+             "loadBalancerARN":{
+                "$ref":"#/resources/AWS::ElasticLoadBalancingV2::LoadBalancer/LoadBalancer/status/loadBalancerARN"
+             },
+             "port":83,
+             "protocol":"UDP",
+             "defaultActions":[
+                {
+                   "type":"forward",
+                   "forwardConfig":{
+                      "targetGroups":[
+                         {
+                            "targetGroupARN":{
+                               "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/app/traffic-local:83/status/targetGroupARN"
+                            }
+                         }
+                      ]
+                   }
+                }
+             ]
+          }
+       }
+    },
+    "AWS::ElasticLoadBalancingV2::LoadBalancer":{
+       "LoadBalancer":{
+          "spec":{
+             "name":"k8s-app-trafficl-2af705447d",
+             "type":"network",
+             "scheme":"internet-facing",
+             "ipAddressType":"ipv4",
+             "subnetMapping":[
+                {
+                   "subnetID":"subnet-1"
+                },
+                {
+                   "subnetID":"subnet-2"
+                },
+                {
+                   "subnetID":"subnet-3"
+                }
+             ],
+           "securityGroups": [
+            {
+			   "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+            }
+		 ]
+          }
+       }
+    },
+    "AWS::ElasticLoadBalancingV2::TargetGroup":{
+       "app/traffic-local:80":{
+          "spec":{
+             "name":"k8s-app-trafficl-5f852f95c2",
+             "targetType":"instance",
+             "ipAddressType":"ipv4",
+             "port":31223,
+             "protocol":"UDP",
+             "healthCheckConfig":{
+                "port": 29123,
+                "protocol":"HTTP",
+				"path":"/healthz",
+                "intervalSeconds":10,
+                "timeoutSeconds":6,
+                "healthyThresholdCount":2,
+                "unhealthyThresholdCount":2,
+                "matcher":{
+					"httpCode": "200-399"
+				}
+             },
+             "targetGroupAttributes":[
+                {
+                   "key":"proxy_protocol_v2.enabled",
+                   "value":"false"
+                }
+             ]
+          }
+       },
+       "app/traffic-local:83":{
+          "spec":{
+             "name":"k8s-app-trafficl-5eafb7edb6",
+             "targetType":"instance",
+             "ipAddressType":"ipv4",
+             "port":32323,
+             "protocol":"UDP",
+             "healthCheckConfig":{
+                "port": 29123,
+                "protocol":"HTTP",
+				"path":"/healthz",
+                "intervalSeconds":10,
+                "timeoutSeconds":6,
+                "healthyThresholdCount":2,
+                "unhealthyThresholdCount":2,
+                "matcher":{
+					"httpCode": "200-399"
+				}
+             },
+             "targetGroupAttributes":[
+                {
+                   "key":"proxy_protocol_v2.enabled",
+                   "value":"false"
+                }
+             ]
+          }
+       }
+    },
+    "K8S::ElasticLoadBalancingV2::TargetGroupBinding":{
+       "app/traffic-local:80":{
+          "spec":{
+             "template":{
+                "metadata":{
+                   "name":"k8s-app-trafficl-5f852f95c2",
+                   "namespace":"app",
+                   "creationTimestamp":null
+                },
+                "spec":{
+                   "targetGroupARN":{
+                      "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/app/traffic-local:80/status/targetGroupARN"
+                   },
+                   "targetType":"instance",
+                   "ipAddressType":"ipv4",
+                   "serviceRef":{
+                      "name":"traffic-local",
+                      "port":80
+                   },
+                   "networking":{
+                      "ingress":[
+                         {
+                            "from":[
+                               {
+                                  "securityGroup":{
+                                     "groupID": {
+									    "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+								     }
+                                  }
+                               }
+                            ],
+                            "ports":[
+                               {
+								  "port": 31223,
+                                  "protocol":"TCP"
+                               },
+							   {
+								  "port": 31223,
+                                  "protocol":"UDP"
+                               },
+							   {
+							      "port": 29123,
+                                  "protocol":"TCP"
+                               }
+                            ]
+                         }
+                      ]
+                   }
+                }
+             }
+          }
+       },
+       "app/traffic-local:83":{
+          "spec":{
+             "template":{
+                "metadata":{
+                   "name":"k8s-app-trafficl-5eafb7edb6",
+                   "namespace":"app",
+                   "creationTimestamp":null
+                },
+                "spec":{
+                   "targetGroupARN":{
+                      "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/app/traffic-local:83/status/targetGroupARN"
+                   },
+                   "targetType":"instance",
+                   "ipAddressType":"ipv4",
+                   "serviceRef":{
+                      "name":"traffic-local",
+                      "port":83
+                   },
+                   "networking":{
+                      "ingress":[
+                         {
+                            "from":[
+                               {
+                                  "securityGroup":{
+									"groupID": {
+										"$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+								 	}
+                                  }
+                               }
+                            ],
+                            "ports":[
+                               {
+								  "port": 32323,
+                                  "protocol":"TCP"
+                               },
+							   {
+								  "port": 32323,
+                                  "protocol":"UDP"
+                               },
+							   {
+								  "port": 29123,
+                                  "protocol":"TCP"
+                               }
+                            ]
+                         }
+                      ]
+                   }
+                }
+             }
+          }
+       }
+    }
+ }
+}
+`,
+			wantNumResources: 8,
+		},
+		{
+			testName: "additional resource tags with SG",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nlb-ip-svc-tls",
+					Namespace: "default",
+					UID:       "bdca2bd0-bfc6-449a-88a3-03451f05f18c",
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/aws-load-balancer-type":                     "nlb-ip",
+						"service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags": "resource.tag1=value1,tag2/purpose=test.2",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Type:     corev1.ServiceTypeLoadBalancer,
+					Selector: map[string]string{"app": "hello"},
+					Ports: []corev1.ServicePort{
+						{
+							Port:       80,
+							TargetPort: intstr.FromInt(80),
+							Protocol:   corev1.ProtocolTCP,
+						},
+					},
+				},
+			},
+			enableBackendSG:          true,
+			disableRestrictedSGRules: true,
+			resolveViaNameOrIDSliceCalls: []resolveViaNameOrIDSliceCall{
+				{
+					subnets: []*ec2.Subnet{
+						{
+							SubnetId:  aws.String("subnet-1"),
+							CidrBlock: aws.String("192.168.0.0/19"),
+						},
+					},
+				},
+			},
+			listLoadBalancerCalls: []listLoadBalancerCall{
+				{
+					sdkLBs: []elbv2.LoadBalancerWithTags{
+						{
+							LoadBalancer: &elbv2sdk.LoadBalancer{
+								Scheme: aws.String("internal"),
+							},
+						},
+					},
+				},
+			},
+			wantError: false,
+			wantValue: `
+{
+ "id":"default/nlb-ip-svc-tls",
+ "resources":{
+    "AWS::ElasticLoadBalancingV2::Listener":{
+       "80":{
+          "spec":{
+             "loadBalancerARN":{
+                "$ref":"#/resources/AWS::ElasticLoadBalancingV2::LoadBalancer/LoadBalancer/status/loadBalancerARN"
+             },
+             "port":80,
+             "protocol":"TCP",
+             "tags": {
+               "tag2/purpose": "test.2",
+               "resource.tag1": "value1"
+             },
+             "defaultActions":[
+                {
+                   "type":"forward",
+                   "forwardConfig":{
+                      "targetGroups":[
+                         {
+                            "targetGroupARN":{
+                               "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/default/nlb-ip-svc-tls:80/status/targetGroupARN"
+                            }
+                         }
+                      ]
+                   }
+                }
+             ]
+          }
+       }
+    },
+    "AWS::ElasticLoadBalancingV2::LoadBalancer":{
+       "LoadBalancer":{
+          "spec":{
+             "name":"k8s-default-nlbipsvc-6b0ba8ff70",
+             "type":"network",
+             "scheme":"internal",
+             "ipAddressType":"ipv4",
+             "subnetMapping":[
+                {
+                   "subnetID":"subnet-1"
+                }
+             ],
+             "tags": {
+               "tag2/purpose": "test.2",
+               "resource.tag1": "value1"
+             }
+          }
+       }
+    },
+    "AWS::ElasticLoadBalancingV2::TargetGroup":{
+       "default/nlb-ip-svc-tls:80":{
+          "spec":{
+             "name":"k8s-default-nlbipsvc-d4818dcd51",
+             "targetType":"ip",
+             "ipAddressType":"ipv4",
+             "port":80,
+             "protocol":"TCP",
+             "tags": {
+               "tag2/purpose": "test.2",
+               "resource.tag1": "value1"
+             },
+             "healthCheckConfig":{
+                "port":"traffic-port",
+                "protocol":"TCP",
+                "intervalSeconds":10,
+				"timeoutSeconds": 10,
+                "healthyThresholdCount":3,
+                "unhealthyThresholdCount":3
+             },
+             "targetGroupAttributes":[
+                {
+                   "key":"proxy_protocol_v2.enabled",
+                   "value":"false"
+                }
+             ]
+          }
+       }
+    },
+    "K8S::ElasticLoadBalancingV2::TargetGroupBinding":{
+       "default/nlb-ip-svc-tls:80":{
+          "spec":{
+             "template":{
+                "metadata":{
+                   "name":"k8s-default-nlbipsvc-d4818dcd51",
+                   "namespace":"default",
+                   "creationTimestamp":null
+                },
+                "spec":{
+                   "targetGroupARN":{
+                      "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/default/nlb-ip-svc-tls:80/status/targetGroupARN"
+                   },
+                   "targetType":"ip",
+                   "ipAddressType":"ipv4",
+                   "serviceRef":{
+                      "name":"nlb-ip-svc-tls",
+                      "port":80
+                   },
+                   "networking":{
+                      "ingress":[
+                         {
+                            "from":[
+                               {
+                                  "ipBlock":{
+                                     "cidr":"192.168.0.0/19"
+                                  }
+                               }
+                            ],
+                            "ports":[
+                               {
+                                  "protocol":"TCP",
+                                  "port":80
+                               }
+                            ]
+                         }
+                      ]
+                   }
+                }
+             }
+          }
+       }
+    }
+ }
+}
+`,
+			wantNumResources: 4,
+		},
+		{
+			testName: "ip target, preserve client IP, scheme internal with SG",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ip-target",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/aws-load-balancer-type":                    "external",
+						"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type":         "ip",
+						"service.beta.kubernetes.io/aws-load-balancer-target-group-attributes": "preserve_client_ip.enabled=true",
+					},
+					UID: "7ab4be33-11c2-4a7b-b622-7add8affab36",
+				},
+				Spec: corev1.ServiceSpec{
+					Type:     corev1.ServiceTypeLoadBalancer,
+					Selector: map[string]string{"app": "hello"},
+					Ports: []corev1.ServicePort{
+						{
+							Port:       80,
+							TargetPort: intstr.FromInt(80),
+							Protocol:   corev1.ProtocolTCP,
+						},
+					},
+				},
+			},
+			enableBackendSG:          true,
+			resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForOneSubnet},
+			fetchVPCInfoCalls: []fetchVPCInfoCall{
+				{
+					wantVPCInfo: networking.VPCInfo{
+						CidrBlockAssociationSet: []*ec2.VpcCidrBlockAssociation{
+							{
+								CidrBlock: aws.String("192.160.0.0/16"),
+								CidrBlockState: &ec2.VpcCidrBlockState{
+									State: &cidrBlockStateAssociated,
+								},
+							},
+							{
+								CidrBlock: aws.String("100.64.0.0/16"),
+								CidrBlockState: &ec2.VpcCidrBlockState{
+									State: &cidrBlockStateAssociated,
+								},
+							},
+						},
+					},
+				},
+			},
+			backendSecurityGroup:  "sg-backend",
+			listLoadBalancerCalls: []listLoadBalancerCall{listLoadBalancerCallForEmptyLB},
+			wantNumResources:      5,
+			wantValue: `
+{
+  "id": "default/ip-target",
+  "resources": {
+    "AWS::EC2::SecurityGroup": {
+       "ManagedLBSecurityGroup": {
+          "spec": {
+             "groupName": "k8s-default-iptarget-b58c2e5bdf",
+             "description": "[k8s] Managed SecurityGroup for LoadBalancer",
+             "ingress": [
+                {
+                   "ipProtocol": "tcp",
+                   "fromPort": 80,
+                   "toPort": 80,
+                   "ipRanges": [
+                      {
+                         "cidrIP": "0.0.0.0/0"
+                      }
+                   ]
+                }
+             ]
+          }
+       }
+    },
+    "AWS::ElasticLoadBalancingV2::Listener": {
+      "80": {
+        "spec": {
+          "protocol": "TCP",
+          "defaultActions": [
+            {
+              "forwardConfig": {
+                "targetGroups": [
+                  {
+                    "targetGroupARN": {
+                      "$ref": "#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/default/ip-target:80/status/targetGroupARN"
+                    }
+                  }
+                ]
+              },
+              "type": "forward"
+            }
+          ],
+          "loadBalancerARN": {
+            "$ref": "#/resources/AWS::ElasticLoadBalancingV2::LoadBalancer/LoadBalancer/status/loadBalancerARN"
+          },
+          "port": 80
+        }
+      }
+    },
+    "K8S::ElasticLoadBalancingV2::TargetGroupBinding": {
+      "default/ip-target:80": {
+        "spec": {
+          "template": {
+            "spec": {
+              "targetType": "ip",
+              "ipAddressType":"ipv4",
+              "targetGroupARN": {
+                "$ref": "#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/default/ip-target:80/status/targetGroupARN"
+              },
+              "networking": {
+                "ingress": [
+                  {
+                    "from": [
+                      {
+                        "securityGroup":{
+                          "groupID":"sg-backend"
+                        }
+					  }
+                    ],
+                    "ports": [
+                      {
+                        "protocol": "TCP",
+                        "port": 80
+                      }
+                    ]
+                  }
+                ]
+              },
+              "serviceRef": {
+                "name": "ip-target",
+                "port": 80
+              }
+            },
+            "metadata": {
+              "creationTimestamp": null,
+              "namespace": "default",
+              "name": "k8s-default-iptarget-cc40ce9c73"
+            }
+          }
+        }
+      }
+    },
+    "AWS::ElasticLoadBalancingV2::LoadBalancer": {
+      "LoadBalancer": {
+        "spec": {
+          "ipAddressType": "ipv4",
+          "name": "k8s-default-iptarget-b44ef5a42d",
+          "subnetMapping": [
+            {
+              "subnetID": "subnet-1"
+            }
+          ],
+          "securityGroups": [
+            {
+		     "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+            },
+            "sg-backend"
+		  ],
+          "scheme": "internal",
+          "type": "network"
+        }
+      }
+    },
+    "AWS::ElasticLoadBalancingV2::TargetGroup": {
+      "default/ip-target:80": {
+        "spec": {
+          "targetType": "ip",
+          "ipAddressType":"ipv4",
+          "protocol": "TCP",
+          "name": "k8s-default-iptarget-cc40ce9c73",
+          "healthCheckConfig": {
+            "healthyThresholdCount": 3,
+            "unhealthyThresholdCount": 3,
+            "protocol": "TCP",
+            "port": "traffic-port",
+			"timeoutSeconds": 10,
+            "intervalSeconds": 10
+          },
+          "targetGroupAttributes": [
+            {
+              "value": "true",
+              "key": "preserve_client_ip.enabled"
+            },
+            {
+              "value": "false",
+              "key": "proxy_protocol_v2.enabled"
+            }
+          ],
+          "port": 80
+        }
+      }
+    }
+  }
+}
+`,
+		},
+		{
+			testName: "ipv6 for NLB with SG",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "traffic-local",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/aws-load-balancer-type":            "external",
+						"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "instance",
+						"service.beta.kubernetes.io/aws-load-balancer-ip-address-type": "dualstack",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Type:       corev1.ServiceTypeLoadBalancer,
+					Selector:   map[string]string{"app": "hello"},
+					IPFamilies: []corev1.IPFamily{corev1.IPv6Protocol},
+					Ports: []corev1.ServicePort{
+						{
+							Port:       80,
+							TargetPort: intstr.FromInt(80),
+							Protocol:   corev1.ProtocolTCP,
+							NodePort:   32332,
+						},
+					},
+				},
+			},
+			fetchVPCInfoCalls: []fetchVPCInfoCall{
+				{
+					wantVPCInfo: networking.VPCInfo{
+						Ipv6CidrBlockAssociationSet: []*ec2.VpcIpv6CidrBlockAssociation{
+							{
+								Ipv6CidrBlock: aws.String("2600:1fe3:3c0:1d00::/56"),
+								Ipv6CidrBlockState: &ec2.VpcCidrBlockState{
+									State: &cidrBlockStateAssociated,
+								},
+							},
+						},
+					},
+				},
+			},
+			resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForOneSubnet},
+			listLoadBalancerCalls:    []listLoadBalancerCall{listLoadBalancerCallForEmptyLB},
+			wantNumResources:         5,
+			wantValue: `
+{
+  "id": "default/traffic-local",
+  "resources": {
+    "AWS::EC2::SecurityGroup": {
+      "ManagedLBSecurityGroup": {
+        "spec": {
+          "groupName": "k8s-default-trafficl-27d98646ec",
+          "description": "[k8s] Managed SecurityGroup for LoadBalancer",
+          "ingress": [
+            {
+              "ipProtocol": "tcp",
+              "fromPort": 80,
+              "toPort": 80,
+              "ipRanges": [
+                {
+                  "cidrIP": "0.0.0.0/0"
+                }
+              ]
+            },
+            {
+              "ipProtocol": "tcp",
+              "fromPort": 80,
+              "toPort": 80,
+              "ipv6Ranges": [
+                {
+                  "cidrIPv6": "::/0"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "AWS::ElasticLoadBalancingV2::Listener": {
+      "80": {
+        "spec": {
+          "loadBalancerARN": {
+            "$ref": "#/resources/AWS::ElasticLoadBalancingV2::LoadBalancer/LoadBalancer/status/loadBalancerARN"
+          },
+          "port": 80,
+          "protocol": "TCP",
+          "defaultActions": [
+            {
+              "type": "forward",
+              "forwardConfig": {
+                "targetGroups": [
+                  {
+                    "targetGroupARN": {
+                      "$ref": "#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/default/traffic-local:80/status/targetGroupARN"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "AWS::ElasticLoadBalancingV2::LoadBalancer": {
+      "LoadBalancer": {
+        "spec": {
+          "name": "k8s-default-trafficl-6652458428",
+          "type": "network",
+          "scheme": "internal",
+          "ipAddressType": "dualstack",
+          "subnetMapping": [
+            {
+              "subnetID": "subnet-1"
+            }
+          ],
+          "securityGroups": [
+            {
+              "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+            }
+          ]
+        }
+      }
+    },
+    "AWS::ElasticLoadBalancingV2::TargetGroup": {
+      "default/traffic-local:80": {
+        "spec": {
+          "name": "k8s-default-trafficl-060a48475d",
+          "targetType": "instance",
+          "port": 32332,
+          "protocol": "TCP",
+          "ipAddressType": "ipv6",
+          "healthCheckConfig": {
+            "port": "traffic-port",
+            "protocol": "TCP",
+            "intervalSeconds": 10,
+			"timeoutSeconds": 10,
+            "healthyThresholdCount": 3,
+            "unhealthyThresholdCount": 3
+          },
+          "targetGroupAttributes": [
+            {
+              "key": "proxy_protocol_v2.enabled",
+              "value": "false"
+            }
+          ]
+        }
+      }
+    },
+    "K8S::ElasticLoadBalancingV2::TargetGroupBinding": {
+      "default/traffic-local:80": {
+        "spec": {
+          "template": {
+            "metadata": {
+              "name": "k8s-default-trafficl-060a48475d",
+              "namespace": "default",
+              "creationTimestamp": null
+            },
+            "spec": {
+              "targetGroupARN": {
+                "$ref": "#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/default/traffic-local:80/status/targetGroupARN"
+              },
+              "targetType": "instance",
+              "serviceRef": {
+                "name": "traffic-local",
+                "port": 80
+              },
+              "networking": {
+                "ingress": [
+                  {
+                    "from": [
+                      {
+                        "securityGroup": {
+                          "groupID": {
+                            "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+                          }
+                        }
+                      }
+                    ],
+                    "ports": [
+                      {
+                        "protocol": "TCP",
+                        "port": 32332
+                      }
+                    ]
+                  }
+                ]
+              },
+              "ipAddressType": "ipv6"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`,
+		},
+		{
+			testName: "ipv6 for NLB internet-facing scheme with SG",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "traffic-local",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/aws-load-balancer-type":            "external",
+						"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "instance",
+						"service.beta.kubernetes.io/aws-load-balancer-ip-address-type": "dualstack",
+						"service.beta.kubernetes.io/aws-load-balancer-scheme":          "internet-facing",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Type:       corev1.ServiceTypeLoadBalancer,
+					Selector:   map[string]string{"app": "hello"},
+					IPFamilies: []corev1.IPFamily{corev1.IPv6Protocol},
+					Ports: []corev1.ServicePort{
+						{
+							Port:       80,
+							TargetPort: intstr.FromInt(80),
+							Protocol:   corev1.ProtocolTCP,
+							NodePort:   32332,
+						},
+					},
+				},
+			},
+			resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForOneSubnet},
+			listLoadBalancerCalls:    []listLoadBalancerCall{listLoadBalancerCallForEmptyLB},
+			wantNumResources:         5,
+			wantValue: `
+{
+  "id": "default/traffic-local",
+  "resources": {
+    "AWS::EC2::SecurityGroup": {
+      "ManagedLBSecurityGroup": {
+        "spec": {
+          "groupName": "k8s-default-trafficl-27d98646ec",
+          "description": "[k8s] Managed SecurityGroup for LoadBalancer",
+          "ingress": [
+            {
+              "ipProtocol": "tcp",
+              "fromPort": 80,
+              "toPort": 80,
+              "ipRanges": [
+                {
+                  "cidrIP": "0.0.0.0/0"
+                }
+              ]
+            },
+            {
+              "ipProtocol": "tcp",
+              "fromPort": 80,
+              "toPort": 80,
+              "ipv6Ranges": [
+                {
+                  "cidrIPv6": "::/0"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "AWS::ElasticLoadBalancingV2::Listener": {
+      "80": {
+        "spec": {
+          "loadBalancerARN": {
+            "$ref": "#/resources/AWS::ElasticLoadBalancingV2::LoadBalancer/LoadBalancer/status/loadBalancerARN"
+          },
+          "port": 80,
+          "protocol": "TCP",
+          "defaultActions": [
+            {
+              "type": "forward",
+              "forwardConfig": {
+                "targetGroups": [
+                  {
+                    "targetGroupARN": {
+                      "$ref": "#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/default/traffic-local:80/status/targetGroupARN"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "AWS::ElasticLoadBalancingV2::LoadBalancer": {
+      "LoadBalancer": {
+        "spec": {
+          "name": "k8s-default-trafficl-579592c587",
+          "type": "network",
+          "scheme": "internet-facing",
+          "ipAddressType": "dualstack",
+          "subnetMapping": [
+            {
+              "subnetID": "subnet-1"
+            }
+          ],
+          "securityGroups": [
+            {
+              "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+            }
+          ]
+        }
+      }
+    },
+    "AWS::ElasticLoadBalancingV2::TargetGroup": {
+      "default/traffic-local:80": {
+        "spec": {
+          "name": "k8s-default-trafficl-060a48475d",
+          "targetType": "instance",
+          "port": 32332,
+          "protocol": "TCP",
+          "ipAddressType": "ipv6",
+          "healthCheckConfig": {
+            "port": "traffic-port",
+            "protocol": "TCP",
+            "intervalSeconds": 10,
+			"timeoutSeconds": 10,
+            "healthyThresholdCount": 3,
+            "unhealthyThresholdCount": 3
+          },
+          "targetGroupAttributes": [
+            {
+              "key": "proxy_protocol_v2.enabled",
+              "value": "false"
+            }
+          ]
+        }
+      }
+    },
+    "K8S::ElasticLoadBalancingV2::TargetGroupBinding": {
+      "default/traffic-local:80": {
+        "spec": {
+          "template": {
+            "metadata": {
+              "name": "k8s-default-trafficl-060a48475d",
+              "namespace": "default",
+              "creationTimestamp": null
+            },
+            "spec": {
+              "targetGroupARN": {
+                "$ref": "#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/default/traffic-local:80/status/targetGroupARN"
+              },
+              "targetType": "instance",
+              "serviceRef": {
+                "name": "traffic-local",
+                "port": 80
+              },
+              "networking": {
+                "ingress": [
+                  {
+                    "from": [
+                      {
+                        "securityGroup": {
+                          "groupID": {
+                            "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+                          }
+                        }
+                      }
+                    ],
+                    "ports": [
+                      {
+                        "protocol": "TCP",
+                        "port": 32332
+                      }
+                    ]
+                  }
+                ]
+              },
+              "ipAddressType": "ipv6"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`,
+		},
+		{
+			testName: "spec.loadBalancerClass specified with SG",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "lb-with-class",
+					Namespace: "awesome",
+				},
+				Spec: corev1.ServiceSpec{
+					Type:              corev1.ServiceTypeLoadBalancer,
+					LoadBalancerClass: aws.String("service.k8s.aws/nlb"),
+					Selector:          map[string]string{"app": "class"},
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "http",
+							Port:       80,
+							TargetPort: intstr.FromInt(8080),
+							Protocol:   corev1.ProtocolTCP,
+							NodePort:   32110,
+						},
+					},
+				},
+			},
+			resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForOneSubnet},
+			listLoadBalancerCalls:    []listLoadBalancerCall{listLoadBalancerCallForEmptyLB},
+			fetchVPCInfoCalls: []fetchVPCInfoCall{
+				{
+					wantVPCInfo: networking.VPCInfo{
+						CidrBlockAssociationSet: []*ec2.VpcCidrBlockAssociation{
+							{
+								CidrBlock: aws.String("192.168.0.0/16"),
+								CidrBlockState: &ec2.VpcCidrBlockState{
+									State: &cidrBlockStateAssociated,
+								},
+							},
+						},
+					},
+				},
+			},
+			wantNumResources: 5,
+			wantValue: `
+{
+  "id": "awesome/lb-with-class",
+  "resources": {
+    "AWS::EC2::SecurityGroup": {
+       "ManagedLBSecurityGroup": {
+          "spec": {
+             "groupName": "k8s-awesome-lbwithcl-1054401dd7",
+             "description": "[k8s] Managed SecurityGroup for LoadBalancer",
+             "ingress": [
+                {
+                   "ipProtocol": "tcp",
+                   "fromPort": 80,
+                   "toPort": 80,
+                   "ipRanges": [
+                      {
+                         "cidrIP": "0.0.0.0/0"
+                      }
+                   ]
+                }
+             ]
+          }
+       }
+    },
+    "AWS::ElasticLoadBalancingV2::Listener": {
+      "80": {
+        "spec": {
+          "loadBalancerARN": {
+            "$ref": "#/resources/AWS::ElasticLoadBalancingV2::LoadBalancer/LoadBalancer/status/loadBalancerARN"
+          },
+          "port": 80,
+          "protocol": "TCP",
+          "defaultActions": [
+            {
+              "type": "forward",
+              "forwardConfig": {
+                "targetGroups": [
+                  {
+                    "targetGroupARN": {
+                      "$ref": "#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/awesome/lb-with-class:80/status/targetGroupARN"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "AWS::ElasticLoadBalancingV2::LoadBalancer": {
+      "LoadBalancer": {
+        "spec": {
+          "name": "k8s-awesome-lbwithcl-6652458428",
+          "type": "network",
+          "scheme": "internal",
+          "ipAddressType": "ipv4",
+          "subnetMapping": [
+            {
+              "subnetID": "subnet-1"
+            }
+          ],
+          "securityGroups": [
+            {
+		       "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+            }
+          ]
+        }
+      }
+    },
+    "AWS::ElasticLoadBalancingV2::TargetGroup": {
+      "awesome/lb-with-class:80": {
+        "spec": {
+          "name": "k8s-awesome-lbwithcl-081c7df2ca",
+          "targetType": "instance",
+          "port": 32110,
+          "protocol": "TCP",
+          "ipAddressType": "ipv4",
+          "healthCheckConfig": {
+            "port": "traffic-port",
+            "protocol": "TCP",
+            "intervalSeconds": 10,
+			"timeoutSeconds": 10,
+            "healthyThresholdCount": 3,
+            "unhealthyThresholdCount": 3
+          },
+          "targetGroupAttributes": [
+            {
+              "key": "proxy_protocol_v2.enabled",
+              "value": "false"
+            }
+          ]
+        }
+      }
+    },
+    "K8S::ElasticLoadBalancingV2::TargetGroupBinding": {
+      "awesome/lb-with-class:80": {
+        "spec": {
+          "template": {
+            "metadata": {
+              "name": "k8s-awesome-lbwithcl-081c7df2ca",
+              "namespace": "awesome",
+              "creationTimestamp": null
+            },
+            "spec": {
+              "targetGroupARN": {
+                "$ref": "#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/awesome/lb-with-class:80/status/targetGroupARN"
+              },
+              "targetType": "instance",
+              "serviceRef": {
+                "name": "lb-with-class",
+                "port": 80
+              },
+              "networking": {
+                "ingress": [
+                  {
+                    "from": [
+                      {
+                        "securityGroup": {
+                          "groupID": {
+                            "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+                          }
+                        }
+                      }
+                    ],
+                    "ports": [
+                      {
+                        "protocol": "TCP",
+                        "port": 32110
+                      }
+                    ]
+                  }
+                ]
+              },
+              "ipAddressType": "ipv4"
+            }
+          }
+        }
+      }
+    }
+  }
+}`,
+		},
+		{
+			testName: "existing NLB with Security group, NLB SG feature disabled",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "some-svc",
+					Namespace: "some-namespace",
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/aws-load-balancer-type":            "external",
+						"service.beta.kubernetes.io/aws-load-balancer-internal":        "true",
+						"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "ip",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeLoadBalancer,
+				},
+			},
+			resolveViaNameOrIDSliceCalls: []resolveViaNameOrIDSliceCall{resolveViaNameOrIDSliceCallForThreeSubnet},
+			listLoadBalancerCalls: []listLoadBalancerCall{
+				{
+					sdkLBs: []elbv2.LoadBalancerWithTags{
+						{
+							LoadBalancer: &elbv2sdk.LoadBalancer{
+								Scheme: aws.String("internal"),
+								AvailabilityZones: []*elbv2sdk.AvailabilityZone{
+									{
+										SubnetId: aws.String("subnet-1"),
+									},
+								},
+								SecurityGroups: []*string{aws.String("sg-lb")},
+							},
+						},
+					},
+				},
+			},
+			featureGates: map[config.Feature]bool{
+				config.NLBSecurityGroup: false,
+			},
+			wantError: true,
+		},
+		{
+			testName: "With security groups annotation",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "manual-security-groups",
+					Namespace: "default",
+					UID:       "bdca2bd0-bfc6-449a-88a3-03451f05f18c",
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/aws-load-balancer-type":            "external",
+						"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "ip",
+						"service.beta.kubernetes.io/aws-load-balancer-security-groups": "named security group,sg-id2",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Type:     corev1.ServiceTypeLoadBalancer,
+					Selector: map[string]string{"app": "hello"},
+					Ports: []corev1.ServicePort{
+						{
+							Port:       80,
+							TargetPort: intstr.FromInt(80),
+							Protocol:   corev1.ProtocolTCP,
+						},
+					},
+				},
+			},
+			resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForOneSubnet},
+			listLoadBalancerCalls:    []listLoadBalancerCall{listLoadBalancerCallForEmptyLB},
+			resolveSGViaNameOrIDCall: []resolveSGViaNameOrIDCall{
+				{
+					args: []string{"named security group", "sg-id2"},
+					want: []string{"sg-id1", "sg-id2"},
+				},
+			},
+			wantNumResources: 4,
+			wantValue: `
+{
+  "id": "default/manual-security-groups",
+  "resources": {
+    "AWS::ElasticLoadBalancingV2::Listener": {
+      "80": {
+        "spec": {
+          "loadBalancerARN": {
+            "$ref": "#/resources/AWS::ElasticLoadBalancingV2::LoadBalancer/LoadBalancer/status/loadBalancerARN"
+          },
+          "port": 80,
+          "protocol": "TCP",
+          "defaultActions": [
+            {
+              "type": "forward",
+              "forwardConfig": {
+                "targetGroups": [
+                  {
+                    "targetGroupARN": {
+                      "$ref": "#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/default/manual-security-groups:80/status/targetGroupARN"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "AWS::ElasticLoadBalancingV2::LoadBalancer": {
+      "LoadBalancer": {
+        "spec": {
+          "name": "k8s-default-manualse-6b0ba8ff70",
+          "type": "network",
+          "scheme": "internal",
+          "ipAddressType": "ipv4",
+          "subnetMapping": [
+            {
+              "subnetID": "subnet-1"
+            }
+          ],
+          "securityGroups": [
+            "sg-id1",
+            "sg-id2"
+          ]
+        }
+      }
+    },
+    "AWS::ElasticLoadBalancingV2::TargetGroup": {
+      "default/manual-security-groups:80": {
+        "spec": {
+          "name": "k8s-default-manualse-d4818dcd51",
+          "targetType": "ip",
+          "port": 80,
+          "protocol": "TCP",
+          "ipAddressType": "ipv4",
+          "healthCheckConfig": {
+            "port": "traffic-port",
+            "protocol": "TCP",
+            "intervalSeconds": 10,
+			"timeoutSeconds": 10,
+            "healthyThresholdCount": 3,
+            "unhealthyThresholdCount": 3
+          },
+          "targetGroupAttributes": [
+            {
+              "key": "proxy_protocol_v2.enabled",
+              "value": "false"
+            }
+          ]
+        }
+      }
+    },
+    "K8S::ElasticLoadBalancingV2::TargetGroupBinding": {
+      "default/manual-security-groups:80": {
+        "spec": {
+          "template": {
+            "metadata": {
+              "name": "k8s-default-manualse-d4818dcd51",
+              "namespace": "default",
+              "creationTimestamp": null
+            },
+            "spec": {
+              "targetGroupARN": {
+                "$ref": "#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/default/manual-security-groups:80/status/targetGroupARN"
+              },
+              "targetType": "ip",
+              "serviceRef": {
+                "name": "manual-security-groups",
+                "port": 80
+              },
+              "ipAddressType": "ipv4"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`,
+		},
+		{
+			testName: "Manage backend rules with manual security groups",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "manual-security-groups",
+					Namespace: "default",
+					UID:       "bdca2bd0-bfc6-449a-88a3-03451f05f18c",
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/aws-load-balancer-type":                                "external",
+						"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type":                     "ip",
+						"service.beta.kubernetes.io/aws-load-balancer-security-groups":                     "named security group,sg-id2",
+						"service.beta.kubernetes.io/aws-load-balancer-manage-backend-security-group-rules": "true",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Type:     corev1.ServiceTypeLoadBalancer,
+					Selector: map[string]string{"app": "hello"},
+					Ports: []corev1.ServicePort{
+						{
+							Port:       80,
+							TargetPort: intstr.FromInt(80),
+							Protocol:   corev1.ProtocolTCP,
+						},
+					},
+				},
+			},
+			resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForOneSubnet},
+			listLoadBalancerCalls:    []listLoadBalancerCall{listLoadBalancerCallForEmptyLB},
+			resolveSGViaNameOrIDCall: []resolveSGViaNameOrIDCall{
+				{
+					args: []string{"named security group", "sg-id2"},
+					want: []string{"sg-id1", "sg-id2"},
+				},
+			},
+			enableBackendSG:      true,
+			backendSecurityGroup: "sg-backend",
+			wantNumResources:     4,
+			wantValue: `
+{
+  "id": "default/manual-security-groups",
+  "resources": {
+    "AWS::ElasticLoadBalancingV2::Listener": {
+      "80": {
+        "spec": {
+          "loadBalancerARN": {
+            "$ref": "#/resources/AWS::ElasticLoadBalancingV2::LoadBalancer/LoadBalancer/status/loadBalancerARN"
+          },
+          "port": 80,
+          "protocol": "TCP",
+          "defaultActions": [
+            {
+              "type": "forward",
+              "forwardConfig": {
+                "targetGroups": [
+                  {
+                    "targetGroupARN": {
+                      "$ref": "#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/default/manual-security-groups:80/status/targetGroupARN"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "AWS::ElasticLoadBalancingV2::LoadBalancer": {
+      "LoadBalancer": {
+        "spec": {
+          "name": "k8s-default-manualse-6b0ba8ff70",
+          "type": "network",
+          "scheme": "internal",
+          "ipAddressType": "ipv4",
+          "subnetMapping": [
+            {
+              "subnetID": "subnet-1"
+            }
+          ],
+          "securityGroups": [
+            "sg-id1",
+            "sg-id2",
+            "sg-backend"
+          ]
+        }
+      }
+    },
+    "AWS::ElasticLoadBalancingV2::TargetGroup": {
+      "default/manual-security-groups:80": {
+        "spec": {
+          "name": "k8s-default-manualse-d4818dcd51",
+          "targetType": "ip",
+          "port": 80,
+          "protocol": "TCP",
+          "ipAddressType": "ipv4",
+          "healthCheckConfig": {
+            "port": "traffic-port",
+            "protocol": "TCP",
+            "intervalSeconds": 10,
+			"timeoutSeconds": 10,
+            "healthyThresholdCount": 3,
+            "unhealthyThresholdCount": 3
+          },
+          "targetGroupAttributes": [
+            {
+              "key": "proxy_protocol_v2.enabled",
+              "value": "false"
+            }
+          ]
+        }
+      }
+    },
+    "K8S::ElasticLoadBalancingV2::TargetGroupBinding": {
+      "default/manual-security-groups:80": {
+        "spec": {
+          "template": {
+            "metadata": {
+              "name": "k8s-default-manualse-d4818dcd51",
+              "namespace": "default",
+              "creationTimestamp": null
+            },
+            "spec": {
+              "targetGroupARN": {
+                "$ref": "#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/default/manual-security-groups:80/status/targetGroupARN"
+              },
+              "targetType": "ip",
+              "serviceRef": {
+                "name": "manual-security-groups",
+                "port": 80
+              },
+              "networking": {
+                "ingress": [
+                  {
+                    "from": [
+                      {
+                        "securityGroup": {
+                          "groupID": "sg-backend"
+                        }
+                      }
+                    ],
+                    "ports": [
+                      {
+                        "protocol": "TCP",
+                        "port": 80
+                      }
+                    ]
+                  }
+                ]
+              },
+              "ipAddressType": "ipv4"
+            }
+          }
+        }
+      }
+    } 
+  }
+}
+`,
+		},
+		{
+			testName: "Manage backend rules with manual security groups, backend sg not enabled",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "manual-security-groups",
+					Namespace: "default",
+					UID:       "bdca2bd0-bfc6-449a-88a3-03451f05f18c",
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/aws-load-balancer-type":                                "external",
+						"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type":                     "ip",
+						"service.beta.kubernetes.io/aws-load-balancer-security-groups":                     "named security group,sg-id2",
+						"service.beta.kubernetes.io/aws-load-balancer-manage-backend-security-group-rules": "true",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Type:     corev1.ServiceTypeLoadBalancer,
+					Selector: map[string]string{"app": "hello"},
+					Ports: []corev1.ServicePort{
+						{
+							Port:       80,
+							TargetPort: intstr.FromInt(80),
+							Protocol:   corev1.ProtocolTCP,
+						},
+					},
+				},
+			},
+			resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForOneSubnet},
+			listLoadBalancerCalls:    []listLoadBalancerCall{listLoadBalancerCallForEmptyLB},
+			resolveSGViaNameOrIDCall: []resolveSGViaNameOrIDCall{
+				{
+					args: []string{"named security group", "sg-id2"},
+					want: []string{"sg-id1", "sg-id2"},
+				},
+			},
+			wantError: true,
+		},
+		{
+			testName: "Manage backend rules with manual security groups, resolve SG error",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "manual-security-groups",
+					Namespace: "default",
+					UID:       "bdca2bd0-bfc6-449a-88a3-03451f05f18c",
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/aws-load-balancer-type":                                "external",
+						"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type":                     "ip",
+						"service.beta.kubernetes.io/aws-load-balancer-security-groups":                     "named security group,sg-id2",
+						"service.beta.kubernetes.io/aws-load-balancer-manage-backend-security-group-rules": "true",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Type:     corev1.ServiceTypeLoadBalancer,
+					Selector: map[string]string{"app": "hello"},
+					Ports: []corev1.ServicePort{
+						{
+							Port:       80,
+							TargetPort: intstr.FromInt(80),
+							Protocol:   corev1.ProtocolTCP,
+						},
+					},
+				},
+			},
+			resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForOneSubnet},
+			listLoadBalancerCalls:    []listLoadBalancerCall{listLoadBalancerCallForEmptyLB},
+			resolveSGViaNameOrIDCall: []resolveSGViaNameOrIDCall{
+				{
+					args: []string{"named security group", "sg-id2"},
+					err:  errors.New("unable to resolve security group"),
+				},
+			},
+			wantError: true,
+		},
+		{
+			testName: "ipv6 source ranges, but lb not dual stack",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "traffic-local",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/aws-load-balancer-type":            "external",
+						"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "instance",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Type:     corev1.ServiceTypeLoadBalancer,
+					Selector: map[string]string{"app": "hello"},
+					LoadBalancerSourceRanges: []string{
+						"2002::1234:abcd:ffff:c0a8:101/64",
+					},
+					Ports: []corev1.ServicePort{
+						{
+							Port:       80,
+							TargetPort: intstr.FromInt(80),
+							Protocol:   corev1.ProtocolTCP,
+							NodePort:   32332,
+						},
+					},
+				},
+			},
+			resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForOneSubnet},
+			listLoadBalancerCalls:    []listLoadBalancerCall{listLoadBalancerCallForEmptyLB},
+			wantError:                true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
+
+			ec2Client := services.NewMockEC2(ctrl)
 
 			subnetsResolver := networking.NewMockSubnetsResolver(ctrl)
 			for _, call := range tt.resolveViaDiscoveryCalls {
@@ -2945,8 +6382,12 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 				subnetsResolver.EXPECT().ResolveViaNameOrIDSlice(gomock.Any(), gomock.Any(), gomock.Any()).Return(call.subnets, call.err)
 			}
 			featureGates := config.NewFeatureGates()
-			if tt.restrictToTypeLoadBalancer {
-				featureGates.Enable(config.ServiceTypeLoadBalancerOnly)
+			for key, value := range tt.featureGates {
+				if value {
+					featureGates.Enable(key)
+				} else {
+					featureGates.Disable(key)
+				}
 			}
 			annotationParser := annotations.NewSuffixAnnotationParser("service.beta.kubernetes.io")
 			trackingProvider := tracking.NewDefaultProvider("service.k8s.aws", "my-cluster")
@@ -2964,19 +6405,30 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 			if defaultTargetType == "" {
 				defaultTargetType = "instance"
 			}
+			backendSGProvider := networking.NewMockBackendSGProvider(ctrl)
+			if tt.enableBackendSG {
+				backendSGProvider.EXPECT().Get(gomock.Any(), networking.ResourceType(networking.ResourceTypeService), gomock.Any()).Return(tt.backendSecurityGroup, nil).AnyTimes()
+				backendSGProvider.EXPECT().Release(gomock.Any(), networking.ResourceType(networking.ResourceTypeService), gomock.Any()).Return(nil).AnyTimes()
+			}
+			sgResolver := networking.NewMockSecurityGroupResolver(ctrl)
+			for _, call := range tt.resolveSGViaNameOrIDCall {
+				sgResolver.EXPECT().ResolveViaNameOrID(gomock.Any(), call.args).Return(call.want, call.err)
+			}
 			var enableIPTargetType bool
 			if tt.enableIPTargetType == nil {
 				enableIPTargetType = true
 			} else {
 				enableIPTargetType = *tt.enableIPTargetType
 			}
-			builder := NewDefaultModelBuilder(annotationParser, subnetsResolver, vpcInfoProvider, "vpc-xxx", trackingProvider, elbv2TaggingManager, featureGates,
-				"my-cluster", nil, nil, "ELBSecurityPolicy-2016-08", defaultTargetType, enableIPTargetType, serviceUtils)
+			builder := NewDefaultModelBuilder(annotationParser, subnetsResolver, vpcInfoProvider, "vpc-xxx", trackingProvider, elbv2TaggingManager, ec2Client, featureGates,
+				"my-cluster", nil, nil, "ELBSecurityPolicy-2016-08", defaultTargetType, enableIPTargetType, serviceUtils,
+				backendSGProvider, sgResolver, tt.enableBackendSG, tt.disableRestrictedSGRules)
 			ctx := context.Background()
-			stack, _, err := builder.Build(ctx, tt.svc)
+			stack, _, _, err := builder.Build(ctx, tt.svc)
 			if tt.wantError {
 				assert.Error(t, err)
 			} else {
+				assert.NoError(t, err)
 				d := deploy.NewDefaultStackMarshaller()
 				jsonString, err := d.Marshal(stack)
 				assert.Equal(t, nil, err)


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description

<!--
Please explain the changes you made here.

Help your reviewers by guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->
Added support of Security Groups for NLB. With the security group support, it is feasible to forward the NLB traffic to the EC2 instances without having to open up the instances for global access. For backwards compatibility, NLBs created without the security groups or the existing NLBs will continue to provide the legacy behavior. Similar to ALB, there are two sets of SGs for NLB - frontend and backend SGs:

- The controller will automatically create and attach the frontend SG to the NLB provisioned, and add rules for `inbound-cidrs` and `listen-ports`. If the users want to attach existing frontend SG to the NLB, they can explicitly specify via annotation `service.beta.kubernetes.io/aws-load-balancer-security-groups`
- The Backend SG controls the traffic between the NLB and the EC2 instances/ENIs, and it gets attached to the NLB similar to the frontend SG. In case of auto-generated frontend SG, the controller automatically adds Node/ENI SG rules to allow egress traffic from the NLB. The rule management is disabled by default if the frontend SG is specified via annotation. We provide an annotation to configure controller’s management on backend SG rules regardless of the frontend SG type `service.beta.kubernetes.io/aws-load-balancer-manage-backend-security-group-rules: true/false`



### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
