### PR TITLE
Creating an ALB requires IAM policy to contain elasticloadbalancing:AddTags

### DIFF
--- a/docs/install/iam_policy.json
+++ b/docs/install/iam_policy.json
@@ -29,6 +29,7 @@
                 "ec2:DescribeTags",
                 "ec2:GetCoipPoolUsage",
                 "ec2:DescribeCoipPools",
+                "elasticloadbalancing:AddTags",
                 "elasticloadbalancing:DescribeLoadBalancers",
                 "elasticloadbalancing:DescribeLoadBalancerAttributes",
                 "elasticloadbalancing:DescribeListeners",

--- a/docs/install/iam_policy_cn.json
+++ b/docs/install/iam_policy_cn.json
@@ -29,6 +29,7 @@
                 "ec2:DescribeTags",
                 "ec2:GetCoipPoolUsage",
                 "ec2:DescribeCoipPools",
+                "elasticloadbalancing:AddTags",
                 "elasticloadbalancing:DescribeLoadBalancers",
                 "elasticloadbalancing:DescribeLoadBalancerAttributes",
                 "elasticloadbalancing:DescribeListeners",

--- a/docs/install/iam_policy_iso.json
+++ b/docs/install/iam_policy_iso.json
@@ -29,6 +29,7 @@
                 "ec2:DescribeTags",
                 "ec2:GetCoipPoolUsage",
                 "ec2:DescribeCoipPools",
+                "elasticloadbalancing:AddTags",
                 "elasticloadbalancing:DescribeLoadBalancers",
                 "elasticloadbalancing:DescribeLoadBalancerAttributes",
                 "elasticloadbalancing:DescribeListeners",

--- a/docs/install/iam_policy_isob.json
+++ b/docs/install/iam_policy_isob.json
@@ -29,6 +29,7 @@
                 "ec2:DescribeTags",
                 "ec2:GetCoipPoolUsage",
                 "ec2:DescribeCoipPools",
+                "elasticloadbalancing:AddTags",
                 "elasticloadbalancing:DescribeLoadBalancers",
                 "elasticloadbalancing:DescribeLoadBalancerAttributes",
                 "elasticloadbalancing:DescribeListeners",

--- a/docs/install/iam_policy_us-gov.json
+++ b/docs/install/iam_policy_us-gov.json
@@ -29,6 +29,7 @@
                 "ec2:DescribeTags",
                 "ec2:GetCoipPoolUsage",
                 "ec2:DescribeCoipPools",
+                "elasticloadbalancing:AddTags",
                 "elasticloadbalancing:DescribeLoadBalancers",
                 "elasticloadbalancing:DescribeLoadBalancerAttributes",
                 "elasticloadbalancing:DescribeListeners",


### PR DESCRIPTION
### Issue

n/a

### Description

When following the [documentation](https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html) to install the AWS load balancer controller, it states to create the IAM policy by downloading and applying an iam_policy.json file from this repo (filename could change based on region).  Using this file prevents an ALB from being created with the following error:

`{"level":"error","ts":"2023-09-01T10:25:01Z","msg":"Reconciler error","controller":"ingress","object":{"name":"example-ing","namespace":"example"},"namespace":"example","name":"example-ing","reconcileID":"cc23bb86-cd1a-45a7-a9f7-c6bffa178781","error":"AccessDenied: User: arn:aws:sts::xxxxxxxxxxxxx:assumed-role/AmazonEKSLoadBalancerControllerRole/1234567890 is not authorized to perform: elasticloadbalancing:AddTags on resource: arn:aws:elasticloadbalancing:us-east-1:xxxxxxxxxxxxx:targetgroup/examplea-bffda1232b/* because no identity-based policy allows the elasticloadbalancing:AddTags action\n\tstatus code: 403, request id: 47362509-42de-9550"}` 

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ X ] Manually tested
- [ X ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
