### PR TITLE
chore: add readiness probe to webhook endpoint

### DIFF
--- a/helm/aws-load-balancer-controller/templates/deployment.yaml
+++ b/helm/aws-load-balancer-controller/templates/deployment.yaml
@@ -180,6 +180,10 @@ spec:
         livenessProbe:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- with .Values.readinessProbe }}
+        readinessProbe:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/helm/aws-load-balancer-controller/values.yaml
+++ b/helm/aws-load-balancer-controller/values.yaml
@@ -240,6 +240,17 @@ livenessProbe:
   initialDelaySeconds: 30
   timeoutSeconds: 10
 
+# readiness probe configuration for the controller
+readinessProbe:
+  failureThreshold: 2
+  httpGet:
+    path: /readyz
+    port: 61779
+    scheme: HTTP
+  successThreshold: 1
+  initialDelaySeconds: 10
+  timeoutSeconds: 10
+
 # Environment variables to set for aws-load-balancer-controller pod.
 # We strongly discourage programming access credentials in the controller environment. You should setup IRSA or
 # comparable solutions like kube2iam, kiam etc instead.

--- a/main.go
+++ b/main.go
@@ -149,6 +149,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Add readiness probe
+	err = mgr.AddReadyzCheck("ready-webhook", mgr.GetWebhookServer().StartedChecker())
+	setupLog.Info("adding readiness check for webhook")
+	if err != nil {
+		setupLog.Error(err, "unable add a readiness check")
+		os.Exit(1)
+	}
+
 	podReadinessGateInjector := inject.NewPodReadinessGate(controllerCFG.PodWebhookConfig,
 		mgr.GetClient(), ctrl.Log.WithName("pod-readiness-gate-injector"))
 	corewebhook.NewPodMutator(podReadinessGateInjector).SetupWithManager(mgr)


### PR DESCRIPTION
### Issue
Closes #2768

During installation of the controller, its starts recieving addmissions requests before the webhook is ready. This happens due to slight seconds of delay in which the webhook is starts to serve requests.

<!-- Please link the GitHub issues related to this PR, if available -->

### Description
The PR addes readiness probe which registers `Checker` fuction which is mapped to the webhook [StartedChecker](https://github.com/kubernetes-sigs/controller-runtime/blob/v0.14.6/pkg/webhook/server.go#L301) from controller-runtime framework.

<!--
Please explain the changes you made here.

Help your reviewers by guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
