### PR TITLE
enable nlb-instance e2e tests for ipv6

### DIFF
--- a/test/e2e/service/nlb_instance_target_test.go
+++ b/test/e2e/service/nlb_instance_target_test.go
@@ -29,9 +29,16 @@ var _ = Describe("test k8s service reconciled by the aws load balancer controlle
 		Expect(err).NotTo(HaveOccurred())
 	})
 	Context("with NLB instance target configuration", func() {
+		annotation := make(map[string]string)
+		BeforeEach(func() {
+			if tf.Options.IPFamily == "IPv6" {
+				annotation["service.beta.kubernetes.io/aws-load-balancer-ip-address-type"] = "dualstack"
+			}
+		})
 		It("should provision internet-facing load balancer resources", func() {
+			annotation["service.beta.kubernetes.io/aws-load-balancer-scheme"] = "internet-facing"
 			By("deploying stack", func() {
-				err := stack.Deploy(ctx, tf, nil)
+				err := stack.Deploy(ctx, tf, annotation)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -156,9 +163,8 @@ var _ = Describe("test k8s service reconciled by the aws load balancer controlle
 		})
 		It("should provision internal load-balancer resources", func() {
 			By("deploying stack", func() {
-				err := stack.Deploy(ctx, tf, map[string]string{
-					"service.beta.kubernetes.io/aws-load-balancer-scheme": "internal",
-				})
+				annotation["service.beta.kubernetes.io/aws-load-balancer-scheme"] = "internal"
+				err := stack.Deploy(ctx, tf, annotation)
 				Expect(err).NotTo(HaveOccurred())
 			})
 			By("checking service status for lb dns name", func() {
@@ -217,9 +223,8 @@ var _ = Describe("test k8s service reconciled by the aws load balancer controlle
 				Skip("Skipping tests, certificates not specified")
 			}
 			By("deploying stack", func() {
-				err := stack.Deploy(ctx, tf, map[string]string{
-					"service.beta.kubernetes.io/aws-load-balancer-ssl-cert": tf.Options.CertificateARNs,
-				})
+				annotation["service.beta.kubernetes.io/aws-load-balancer-ssl-cert"] = tf.Options.CertificateARNs
+				err := stack.Deploy(ctx, tf, annotation)
 				Expect(err).NotTo(HaveOccurred())
 			})
 			By("checking service status for lb dns name", func() {
@@ -280,9 +285,8 @@ var _ = Describe("test k8s service reconciled by the aws load balancer controlle
 		})
 		It("should enable proxy protocol v2", func() {
 			By("deploying stack", func() {
-				err := stack.Deploy(ctx, tf, map[string]string{
-					"service.beta.kubernetes.io/aws-load-balancer-proxy-protocol": "*",
-				})
+				annotation["service.beta.kubernetes.io/aws-load-balancer-proxy-protocol"] = "*"
+				err := stack.Deploy(ctx, tf, annotation)
 				Expect(err).ToNot(HaveOccurred())
 				dnsName = stack.GetLoadBalancerIngressHostName()
 				Expect(dnsName).ToNot(BeEmpty())
@@ -316,11 +320,16 @@ var _ = Describe("test k8s service reconciled by the aws load balancer controlle
 	})
 
 	Context("with NLB instance target configuration with target node labels", func() {
+		annotation := make(map[string]string)
+		BeforeEach(func() {
+			if tf.Options.IPFamily == "IPv6" {
+				annotation["service.beta.kubernetes.io/aws-load-balancer-ip-address-type"] = "dualstack"
+			}
+		})
 		It("should add only the labelled nodes to the target group", func() {
 			By("deploying stack", func() {
-				err := stack.Deploy(ctx, tf, map[string]string{
-					"service.beta.kubernetes.io/aws-load-balancer-target-node-labels": "service.node.label/key1=value1",
-				})
+				annotation["service.beta.kubernetes.io/aws-load-balancer-target-node-labels"] = "service.node.label/key1=value1"
+				err := stack.Deploy(ctx, tf, annotation)
 				Expect(err).ToNot(HaveOccurred())
 				dnsName = stack.GetLoadBalancerIngressHostName()
 				Expect(dnsName).ToNot(BeEmpty())


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description

<!--
Please explain the changes you made here.

Help your reviewers by guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->
Enable nlb-instance e2e test for ipv6.
Tested locally with `ginkgo -v -r test/e2e/service --  --kubeconfig=${KUBECONFIG} --cluster-name=ipv6-125 --aws-region=us-west-2 --aws-vpc-id=vpc-01292d33f19f444ce --ip-family IPv6 --certificate-arns xxx`

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
