### PR TITLE
feat: add support for global accelerator endpoint groups

### DIFF
--- a/docs/examples/globalaccelerator.yaml
+++ b/docs/examples/globalaccelerator.yaml
@@ -1,0 +1,19 @@
+kind: Ingress
+metadata:
+    name: echoserver
+    annotations:
+        kubernetes.io/ingress.class: alb
+        alb.ingress.kubernetes.io/scheme: internet-facing
+        alb.ingress.kubernetes.io/ga-epg-arn: arn:aws:globalaccelerator::12345678912:accelerator/d60128f1-4134-4e03-bed9-edd00f77b3e6/listener/a309af4a/endpoint-group/ed7bf648f700
+        alb.ingress.kubernetes.io/ga-ep-create: "true"
+spec:
+    rules:
+    - http:
+        paths:
+          - backend:
+              service:
+                name: my-release-nginx
+                port:
+                  number: 80
+            path: /
+            pathType: Prefix

--- a/docs/guide/globalaccelerator/endpointgroup.md
+++ b/docs/guide/globalaccelerator/endpointgroup.md
@@ -1,0 +1,12 @@
+# Create Endpoint on exisitng Endpointgroup
+
+In order to create an endpoint for the ingress-group, the user
+needs to specify two annotations:
+
+`alb.ingress.kubernetes.io/ga-epg-arn: arn:aws:globalaccelerator::12345678912:accelerator/d60128f1-4134-4e03-bed9-edd00f77b3e6/listener/a309af4a/endpoint-group/ed7bf648f700`
+`alb.ingress.kubernetes.io/ga-ep-create: "true"`
+
+This second annotation exists because of the fact that endpoints don't support tags
+and with the current stateless logic it is not possible to identify the correct
+endpoint for deletion. This means that:
+*Deletion is only supported by setting `ga-ep-create: "false"`*

--- a/pkg/annotations/constants.go
+++ b/pkg/annotations/constants.go
@@ -19,6 +19,8 @@ const (
 	IngressSuffixWAFACLID                     = "waf-acl-id"
 	IngressSuffixWebACLID                     = "web-acl-id" // deprecated, use "waf-acl-id" instead.
 	IngressSuffixShieldAdvancedProtection     = "shield-advanced-protection"
+	IngressSuffixGAEndpointGroup              = "ga-epg-arn"
+	IngressSuffixGAEndpointCreate             = "ga-ep-create"
 	IngressSuffixSecurityGroups               = "security-groups"
 	IngressSuffixListenPorts                  = "listen-ports"
 	IngressSuffixSSLRedirect                  = "ssl-redirect"

--- a/pkg/aws/cloud.go
+++ b/pkg/aws/cloud.go
@@ -41,6 +41,9 @@ type Cloud interface {
 	// RGT provides API to AWS RGT
 	RGT() services.RGT
 
+	// GA provides API to AWS Global Accelerator
+	GA() services.GlobalAccelerator
+
 	// Region for the kubernetes cluster
 	Region() string
 
@@ -125,6 +128,7 @@ func NewCloud(cfg CloudConfig, metricsRegisterer prometheus.Registerer) (Cloud, 
 		ec2:         ec2Service,
 		elbv2:       services.NewELBV2(sess),
 		acm:         services.NewACM(sess),
+		ga:          services.NewGlobalAccelerator(sess),
 		wafv2:       services.NewWAFv2(sess),
 		wafRegional: services.NewWAFRegional(sess, cfg.Region),
 		shield:      services.NewShield(sess),
@@ -177,6 +181,7 @@ type defaultCloud struct {
 	elbv2 services.ELBV2
 
 	acm         services.ACM
+	ga          services.GlobalAccelerator
 	wafv2       services.WAFv2
 	wafRegional services.WAFRegional
 	shield      services.Shield
@@ -209,6 +214,10 @@ func (c *defaultCloud) Shield() services.Shield {
 
 func (c *defaultCloud) RGT() services.RGT {
 	return c.rgt
+}
+
+func (c *defaultCloud) GA() services.GlobalAccelerator {
+	return c.ga
 }
 
 func (c *defaultCloud) Region() string {

--- a/pkg/aws/services/globalaccelerator.go
+++ b/pkg/aws/services/globalaccelerator.go
@@ -1,0 +1,25 @@
+package services
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/globalaccelerator"
+	"github.com/aws/aws-sdk-go/service/globalaccelerator/globalacceleratoriface"
+)
+
+type GlobalAccelerator interface {
+	globalacceleratoriface.GlobalAcceleratorAPI
+}
+
+// NewGlobalAccelerator constructs new GlobalAccelerator implementation.
+func NewGlobalAccelerator(session *session.Session) GlobalAccelerator {
+	return &defaultGlobalAcceleratorAPI{
+		// global accelerator always needs `us-west-2`-region
+		GlobalAcceleratorAPI: globalaccelerator.New(session, aws.NewConfig().WithRegion("us-west-2")),
+	}
+}
+
+// default implementation for Global Accelerator.
+type defaultGlobalAcceleratorAPI struct {
+	globalacceleratoriface.GlobalAcceleratorAPI
+}

--- a/pkg/deploy/globalaccelerator/endpoint_manager.go
+++ b/pkg/deploy/globalaccelerator/endpoint_manager.go
@@ -1,0 +1,85 @@
+package globalaccelerator
+
+import (
+	"context"
+
+	awssdk "github.com/aws/aws-sdk-go/aws"
+	gasdk "github.com/aws/aws-sdk-go/service/globalaccelerator"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/services"
+)
+
+type EndpointManager interface {
+	// AddEndpoint add an endpoint to a globalaccelerator endpoint group
+	AddEndpoint(ctx context.Context, endpointGroupARN string, lbArn string) error
+
+	// GetEndpoint gets the existing endpoint for an endpointgroup and load balancer
+	GetEndpoint(ctx context.Context, endpointGroupARN string, lbArn string) (string, error)
+
+	// DeleteEndpoints deletes an existing endpoint for an endpointgroup and load balancer
+	DeleteEndpoint(ctx context.Context, endpointGroupARN string, lbArn string) error
+}
+
+func NewDefaultEndpointManager(gaClient services.GlobalAccelerator, logger logr.Logger) *defaultEndpointManager {
+	return &defaultEndpointManager{
+		gaClient: gaClient,
+	}
+}
+
+var _ EndpointManager = &defaultEndpointManager{}
+
+type defaultEndpointManager struct {
+	gaClient services.GlobalAccelerator
+}
+
+func (m *defaultEndpointManager) AddEndpoint(ctx context.Context, endpointGroupARN string, lbArn string) error {
+	_, err := m.gaClient.AddEndpoints(&gasdk.AddEndpointsInput{
+		EndpointGroupArn: &endpointGroupARN,
+		EndpointConfigurations: []*gasdk.EndpointConfiguration{
+			{
+				EndpointId: awssdk.String(lbArn),
+			},
+		},
+	})
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *defaultEndpointManager) GetEndpoint(ctx context.Context, endpointGroupARN string, lbArn string) (string, error) {
+	epResponse, err := m.gaClient.DescribeEndpointGroup(&gasdk.DescribeEndpointGroupInput{
+		EndpointGroupArn: &endpointGroupARN,
+	})
+
+	if err != nil {
+		return "", err
+	}
+
+	for _, endpoint := range epResponse.EndpointGroup.EndpointDescriptions {
+		if *endpoint.EndpointId == lbArn {
+			return lbArn, nil
+		}
+	}
+
+	return "", nil
+}
+
+func (m *defaultEndpointManager) DeleteEndpoint(ctx context.Context, endpointGroupARN string, lbArn string) error {
+	_, err := m.gaClient.RemoveEndpoints(&gasdk.RemoveEndpointsInput{
+		EndpointGroupArn: &endpointGroupARN,
+		EndpointIdentifiers: []*gasdk.EndpointIdentifier{
+			{
+				EndpointId: awssdk.String(lbArn),
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/deploy/globalaccelerator/endpoint_synthesizer.go
+++ b/pkg/deploy/globalaccelerator/endpoint_synthesizer.go
@@ -1,0 +1,103 @@
+package globalaccelerator
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/core"
+	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
+	gamodel "sigs.k8s.io/aws-load-balancer-controller/pkg/model/globalaccelerator"
+)
+
+// NewEndpointSynthesizer constructs new endpointSynthesizer
+func NewEndpointSynthesizer(epManager EndpointManager, logger logr.Logger, stack core.Stack) *endpointSynthesizer {
+	return &endpointSynthesizer{
+		endpointManager: epManager,
+		logger:          logger,
+		stack:           stack,
+	}
+}
+
+type endpointSynthesizer struct {
+	endpointManager EndpointManager
+	logger          logr.Logger
+	stack           core.Stack
+}
+
+func (s *endpointSynthesizer) Synthesize(ctx context.Context) error {
+	var resEndpoints []*gamodel.Endpoint
+	s.stack.ListResources(&resEndpoints)
+	resEndpointsByARN, err := mapResEndpointByResourceARN(resEndpoints)
+	if err != nil {
+		return err
+	}
+
+	var resLBs []*elbv2model.LoadBalancer
+	s.stack.ListResources(&resLBs)
+	for _, resLB := range resLBs {
+		// Global Accelerator can only be created for ALB for now.
+		if resLB.Spec.Type != elbv2model.LoadBalancerTypeApplication {
+			continue
+		}
+		lbARN, err := resLB.LoadBalancerARN().Resolve(ctx)
+		if err != nil {
+			return err
+		}
+		resEndpoints := resEndpointsByARN[lbARN]
+
+		if err := s.synthesizeGAEndpoints(ctx, lbARN, resEndpoints); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (*endpointSynthesizer) PostSynthesize(ctx context.Context) error {
+	// nothing to do here.
+	return nil
+}
+
+func (s *endpointSynthesizer) synthesizeGAEndpoints(ctx context.Context, lbARN string, resEndpoints []*gamodel.Endpoint) error {
+	if len(resEndpoints) > 1 {
+		return fmt.Errorf("[should never happen] multiple Global Accelerator Endpoints desired on LoadBalancer: %v", lbARN)
+	}
+
+	var desiredEndpointGroupARN string
+	var desiredEndpointCreate bool
+	if len(resEndpoints) == 1 {
+		desiredEndpointGroupARN = resEndpoints[0].Spec.EndpointGroupARN
+		desiredEndpointCreate = resEndpoints[0].Spec.Create
+	}
+
+	if desiredEndpointGroupARN != "" {
+		// no lbARN means delete
+		if !desiredEndpointCreate {
+			s.endpointManager.DeleteEndpoint(ctx, desiredEndpointGroupARN, lbARN)
+			return nil
+		}
+
+		existingEndpoint, err := s.endpointManager.GetEndpoint(ctx, desiredEndpointGroupARN, lbARN)
+		if err != nil {
+			return err
+		}
+		if existingEndpoint == "" {
+			s.endpointManager.AddEndpoint(ctx, desiredEndpointGroupARN, lbARN)
+		}
+	}
+
+	return nil
+}
+
+func mapResEndpointByResourceARN(resEndpoints []*gamodel.Endpoint) (map[string][]*gamodel.Endpoint, error) {
+	resEndpointsByARN := make(map[string][]*gamodel.Endpoint, len(resEndpoints))
+	ctx := context.Background()
+	for _, resEndpoint := range resEndpoints {
+		resARN, err := resEndpoint.Spec.ResourceARN.Resolve(ctx)
+		if err != nil {
+			return nil, err
+		}
+		resEndpointsByARN[resARN] = append(resEndpointsByARN[resARN], resEndpoint)
+	}
+	return resEndpointsByARN, nil
+}

--- a/pkg/model/globalaccelerator/endpoint.go
+++ b/pkg/model/globalaccelerator/endpoint.go
@@ -1,0 +1,35 @@
+package globalaccelerator
+
+import "sigs.k8s.io/aws-load-balancer-controller/pkg/model/core"
+
+type Endpoint struct {
+	core.ResourceMeta `json:"-"`
+
+	// desired state of Endpoint
+	Spec EndpointSpec `json:"spec"`
+}
+
+// NewEndpoint constructs new Endpoint resource.
+func NewEndpoint(stack core.Stack, id string, spec EndpointSpec) *Endpoint {
+	e := &Endpoint{
+		ResourceMeta: core.NewResourceMeta(stack, "AWS::GlobalAccelerator::Endpoint", id),
+		Spec:         spec,
+	}
+	stack.AddResource(e)
+	e.registerDependencies(stack)
+	return e
+}
+
+// register dependencies for Endpoint.
+func (p *Endpoint) registerDependencies(stack core.Stack) {
+	for _, dep := range p.Spec.ResourceARN.Dependencies() {
+		stack.AddDependency(dep, p)
+	}
+}
+
+// EndpointSpec defines the desired state of Endpoint.
+type EndpointSpec struct {
+	EndpointGroupARN string           `json:"endpointGroupARN"`
+	ResourceARN      core.StringToken `json:"resourceARN"`
+	Create           bool             `json:"create"`
+}


### PR DESCRIPTION
### Issue

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/1572

### Description

It's a first try to get some support to register and deregister endpoints to an existing endpointgroup.
Because users are limited to one endpointgroup per region, i also think it makes the most sense to approach it that way. Later down the line one could work with weights even which would give users a mechanism to switch traffic between clusters.

The approach i chose for now has an ugly limitation of being: You can't delete an endpoint by deleting the listener. It looks to me like this is a design-limitation because as far as i see it:
- logic to destroy stuff is omitting it's output in the generated stack per ingress group
- ususally the external state is pictured with tags 
- endpoints on ga don't support tags
- this means to me that the current logic of deleting resources is not capable of capturing the deletion case :(

What i tried next is to implement a custom cleanup logic, inspired by the way we cleanup security groups but that has the pitfall that we do the cleanup AFTER the stack is deployed (deleted in that case) which leaves us with no way of identifying the endpoint we created earlier on because we can't access the arn of the load-balancer anymore. 

Maybe someone who knows the code better knows how to work around that. I considered adding labels as a workaround but wanted to get feedback first :)

### Checklist
- [x] Added tests that cover your change (if possible)
- [x ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
