### PR TITLE
enable ingress instance e2e test for ipv6

### DIFF
--- a/scripts/run-e2e-test.sh
+++ b/scripts/run-e2e-test.sh
@@ -198,12 +198,9 @@ function run_ginkgo_test() {
   TEST_RESULT=success
   local focus=$1
   echo "Starting the ginkgo tests from generated ginkgo test binaries with focus: $focus"
-  if [ "$IP_FAMILY" == "IPv4" ]; then 
+  if [ "$IP_FAMILY" == "IPv4" ] || [ "$IP_FAMILY" == "IPv6" ]; then
     (CGO_ENABLED=0 GOOS=$OS_OVERRIDE ginkgo --no-color $EXTRA_GINKGO_FLAGS --focus="$focus" -v --timeout 2h --fail-on-pending $GINKGO_TEST_BUILD/ingress.test -- --kubeconfig=$KUBE_CONFIG_PATH --cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id=$VPC_ID --test-image-registry=$TEST_IMAGE_REGISTRY --ip-family=$IP_FAMILY || TEST_RESULT=fail)
     (CGO_ENABLED=0 GOOS=$OS_OVERRIDE ginkgo --no-color $EXTRA_GINKGO_FLAGS --focus="$focus" -v --timeout 2h --fail-on-pending $GINKGO_TEST_BUILD/service.test -- --kubeconfig=$KUBE_CONFIG_PATH --cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id=$VPC_ID --test-image-registry=$TEST_IMAGE_REGISTRY --ip-family=$IP_FAMILY || TEST_RESULT=fail)
-  elif [ "$IP_FAMILY" == "IPv6" ]; then
-    (CGO_ENABLED=0 GOOS=$OS_OVERRIDE ginkgo --no-color $EXTRA_GINKGO_FLAGS --focus="$focus" --skip="instance" -v --timeout 2h --fail-on-pending $GINKGO_TEST_BUILD/ingress.test -- --kubeconfig=$KUBE_CONFIG_PATH --cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id=$VPC_ID --test-image-registry=$TEST_IMAGE_REGISTRY --ip-family=$IP_FAMILY || TEST_RESULT=fail)
-    (CGO_ENABLED=0 GOOS=$OS_OVERRIDE ginkgo --no-color $EXTRA_GINKGO_FLAGS --focus="$focus" --skip="instance" -v --timeout 2h --fail-on-pending $GINKGO_TEST_BUILD/service.test -- --kubeconfig=$KUBE_CONFIG_PATH --cluster-name=$CLUSTER_NAME --aws-region=$REGION --aws-vpc-id=$VPC_ID --test-image-registry=$TEST_IMAGE_REGISTRY --ip-family=$IP_FAMILY || TEST_RESULT=fail)
   else
     echo "Invalid IP_FAMILY input, choose from IPv4 or IPv6 only"
   fi

--- a/test/e2e/ingress/multi_path_backend_test.go
+++ b/test/e2e/ingress/multi_path_backend_test.go
@@ -38,18 +38,10 @@ var _ = Describe("test ingresses with multiple path and backends", func() {
 
 	Context("with podReadinessGate enabled", func() {
 		It("standalone Ingress should behaves correctly", func() {
-			// TODO: Once instance mode is supported in IPv6, the backendConfigA can be removed and reverted
 			backendConfigA := BackendConfig{
 				Replicas:   3,
 				TargetType: elbv2model.TargetTypeInstance,
 				HTTPBody:   "backend-a",
-			}
-			if tf.Options.IPFamily == "IPv6" {
-				backendConfigA = BackendConfig{
-					Replicas:   3,
-					TargetType: elbv2model.TargetTypeIP,
-					HTTPBody:   "backend-a",
-				}
 			}
 			stack := NewMultiPathBackendStack(map[string]NamespacedResourcesConfig{
 				"ns-1": {
@@ -108,7 +100,6 @@ var _ = Describe("test ingresses with multiple path and backends", func() {
 		})
 
 		It("IngressGroup across namespaces should behaves correctly", func() {
-			// TODO: Once instance mode is supported in IPv6, the backendConfigA and backendConfigD can be removed and reverted
 			backendConfigA := BackendConfig{
 				Replicas:   3,
 				TargetType: elbv2model.TargetTypeInstance,
@@ -118,18 +109,6 @@ var _ = Describe("test ingresses with multiple path and backends", func() {
 				Replicas:   3,
 				TargetType: elbv2model.TargetTypeInstance,
 				HTTPBody:   "backend-d",
-			}
-			if tf.Options.IPFamily == "IPv6" {
-				backendConfigA = BackendConfig{
-					Replicas:   3,
-					TargetType: elbv2model.TargetTypeIP,
-					HTTPBody:   "backend-a",
-				}
-				backendConfigD = BackendConfig{
-					Replicas:   3,
-					TargetType: elbv2model.TargetTypeIP,
-					HTTPBody:   "backend-d",
-				}
 			}
 			groupName := fmt.Sprintf("e2e-group.%v", utils.RandomDNS1123Label(8))
 			stack := NewMultiPathBackendStack(map[string]NamespacedResourcesConfig{

--- a/test/e2e/ingress/multi_path_backend_test.go
+++ b/test/e2e/ingress/multi_path_backend_test.go
@@ -98,7 +98,6 @@ var _ = Describe("test ingresses with multiple path and backends", func() {
 			err = stack.Cleanup(ctx, tf)
 			Expect(err).NotTo(HaveOccurred())
 		})
-
 		It("IngressGroup across namespaces should behaves correctly", func() {
 			backendConfigA := BackendConfig{
 				Replicas:   3,


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description

<!--
Please explain the changes you made here.

Help your reviewers by guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->
1. Enable ingress e2e test suites for instance ipv6 target type
2. Update prow script to run ingress and service instance test suites for ipv6 clusters
### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
