### PR TITLE
Feature alb subnets

### DIFF
--- a/docs/deploy/configurations.md
+++ b/docs/deploy/configurations.md
@@ -172,3 +172,4 @@ They are a set of kye=value pairs that describe AWS load balance controller feat
 | EnableRGTAPI                       | string                          | false          | If enabled, the tagging manager will describe resource tags via RGT APIs, otherwise via ELB APIs. In order to enable RGT API, `tag:GetResources` is needed in controller IAM policy. |
 | SubnetsClusterTagCheck                | string                          | true           | Enable or disable the check for `kubernetes.io/cluster/${cluster-name}` during subnet auto-discovery |
 | NLBHealthCheckAdvancedConfiguration   | string                          | true           | Enable or disable advanced health check configuration for NLB, for example health check timeout |
+| ALBSingleSubnet                       | string                          | false          | If enabled, controller will allow using only 1 subnet for provisioning ALB, which need to get whitelisted by ELB in advance |

--- a/docs/deploy/subnet_discovery.md
+++ b/docs/deploy/subnet_discovery.md
@@ -1,5 +1,6 @@
 # Subnet auto-discovery
-By default, the AWS Load Balancer Controller (LBC) auto-discovers network subnets that it can create AWS Network Load Balancers (NLB) and AWS Application Load Balancers (ALB) in. ALBs require at least two subnets across Availability Zones. NLBs require one subnet.
+By default, the AWS Load Balancer Controller (LBC) auto-discovers network subnets that it can create AWS Network Load Balancers (NLB) and AWS Application Load Balancers (ALB) in. ALBs require at least two subnets across Availability Zones by default, 
+set [Feature Gate ALBSingleSubnet](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/deploy/configurations/#feature-gates) to "true" allows using only 1 subnet for provisioning ALB. NLBs require one subnet.
 The subnets must be tagged appropriately for auto-discovery to work. The controller chooses one subnet from each Availability Zone. During auto-discovery, the controller
 considers subnets with at least eight available IP addresses. In the case of multiple qualified tagged subnets in an Availability Zone, the controller chooses the first one in lexicographical 
 order by the subnet IDs.

--- a/helm/aws-load-balancer-controller/values.yaml
+++ b/helm/aws-load-balancer-controller/values.yaml
@@ -321,6 +321,7 @@ controllerConfig:
   # EnableIPTargetType: true
   # SubnetsClusterTagCheck: true
   # NLBHealthCheckAdvancedConfig: true
+  # ALBSingleSubnet: false
 
 # objectSelector for webhook
 objectSelector:

--- a/pkg/config/feature_gates.go
+++ b/pkg/config/feature_gates.go
@@ -21,6 +21,7 @@ const (
 	SubnetsClusterTagCheck       Feature = "SubnetsClusterTagCheck"
 	NLBHealthCheckAdvancedConfig Feature = "NLBHealthCheckAdvancedConfig"
 	NLBSecurityGroup             Feature = "NLBSecurityGroup"
+	ALBSingleSubnet              Feature = "ALBSingleSubnet"
 )
 
 type FeatureGates interface {
@@ -58,6 +59,7 @@ func NewFeatureGates() FeatureGates {
 			SubnetsClusterTagCheck:       true,
 			NLBHealthCheckAdvancedConfig: true,
 			NLBSecurityGroup:             true,
+			ALBSingleSubnet:              false,
 		},
 	}
 }

--- a/pkg/ingress/model_build_load_balancer.go
+++ b/pkg/ingress/model_build_load_balancer.go
@@ -215,6 +215,7 @@ func (t *defaultModelBuildTask) buildLoadBalancerSubnetMappings(ctx context.Cont
 			networking.WithSubnetsResolveLBType(elbv2model.LoadBalancerTypeApplication),
 			networking.WithSubnetsResolveLBScheme(scheme),
 			networking.WithSubnetsClusterTagCheck(t.featureGates.Enabled(config.SubnetsClusterTagCheck)),
+			networking.WithALBSingleSubnet(t.featureGates.Enabled(config.ALBSingleSubnet)),
 		)
 		if err != nil {
 			return nil, err
@@ -233,6 +234,7 @@ func (t *defaultModelBuildTask) buildLoadBalancerSubnetMappings(ctx context.Cont
 		chosenSubnets, err := t.subnetsResolver.ResolveViaNameOrIDSlice(ctx, chosenSubnetNameOrIDs,
 			networking.WithSubnetsResolveLBType(elbv2model.LoadBalancerTypeApplication),
 			networking.WithSubnetsResolveLBScheme(scheme),
+			networking.WithALBSingleSubnet(t.featureGates.Enabled(config.ALBSingleSubnet)),
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/networking/subnet_resolver.go
+++ b/pkg/networking/subnet_resolver.go
@@ -373,10 +373,7 @@ func (r *defaultSubnetsResolver) validateSubnetsMinimalCount(subnets []*ec2sdk.S
 // computeSubnetsMinimalCount returns the minimal count requirement for subnets.
 func (r *defaultSubnetsResolver) computeSubnetsMinimalCount(subnetLocale subnetLocaleType, resolveOpts SubnetsResolveOptions) int {
 	minimalCount := 1
-	if resolveOpts.ALBSingleSubnet && resolveOpts.LBType == elbv2model.LoadBalancerTypeApplication {
-		return minimalCount
-	}
-	if resolveOpts.LBType == elbv2model.LoadBalancerTypeApplication && subnetLocale == subnetLocaleTypeAvailabilityZone {
+	if resolveOpts.LBType == elbv2model.LoadBalancerTypeApplication && subnetLocale == subnetLocaleTypeAvailabilityZone && !resolveOpts.ALBSingleSubnet {
 		minimalCount = 2
 	}
 	return minimalCount

--- a/pkg/networking/subnet_resolver.go
+++ b/pkg/networking/subnet_resolver.go
@@ -48,7 +48,7 @@ type SubnetsResolveOptions struct {
 	AvailableIPAddressCount int64
 	// whether to check the cluster tag
 	SubnetsClusterTagCheck bool
-	// Disable subnet minimal count restriction
+	// whether to allow using only 1 subnet for provisioning ALB, default to false
 	ALBSingleSubnet bool
 }
 
@@ -97,7 +97,7 @@ func WithSubnetsClusterTagCheck(SubnetsClusterTagCheck bool) SubnetsResolveOptio
 	}
 }
 
-// WithALBSingleSubnet generate an option that foncigure ALBSingleSubnet
+// WithALBSingleSubnet generate an option that configures ALBSingleSubnet
 func WithALBSingleSubnet(ALBSingleSubnet bool) SubnetsResolveOption {
 	return func(opts *SubnetsResolveOptions) {
 		opts.ALBSingleSubnet = ALBSingleSubnet

--- a/pkg/networking/subnet_resolver.go
+++ b/pkg/networking/subnet_resolver.go
@@ -48,6 +48,8 @@ type SubnetsResolveOptions struct {
 	AvailableIPAddressCount int64
 	// whether to check the cluster tag
 	SubnetsClusterTagCheck bool
+	// Disable subnet minimal count restriction
+	ALBSingleSubnet bool
 }
 
 // ApplyOptions applies slice of SubnetsResolveOption.
@@ -92,6 +94,13 @@ func WithSubnetsResolveAvailableIPAddressCount(AvailableIPAddressCount int64) Su
 func WithSubnetsClusterTagCheck(SubnetsClusterTagCheck bool) SubnetsResolveOption {
 	return func(opts *SubnetsResolveOptions) {
 		opts.SubnetsClusterTagCheck = SubnetsClusterTagCheck
+	}
+}
+
+// WithALBSingleSubnet generate an option that foncigure ALBSingleSubnet
+func WithALBSingleSubnet(ALBSingleSubnet bool) SubnetsResolveOption {
+	return func(opts *SubnetsResolveOptions) {
+		opts.ALBSingleSubnet = ALBSingleSubnet
 	}
 }
 
@@ -364,6 +373,9 @@ func (r *defaultSubnetsResolver) validateSubnetsMinimalCount(subnets []*ec2sdk.S
 // computeSubnetsMinimalCount returns the minimal count requirement for subnets.
 func (r *defaultSubnetsResolver) computeSubnetsMinimalCount(subnetLocale subnetLocaleType, resolveOpts SubnetsResolveOptions) int {
 	minimalCount := 1
+	if resolveOpts.ALBSingleSubnet {
+		return minimalCount
+	}
 	if resolveOpts.LBType == elbv2model.LoadBalancerTypeApplication && subnetLocale == subnetLocaleTypeAvailabilityZone {
 		minimalCount = 2
 	}

--- a/pkg/networking/subnet_resolver.go
+++ b/pkg/networking/subnet_resolver.go
@@ -373,7 +373,7 @@ func (r *defaultSubnetsResolver) validateSubnetsMinimalCount(subnets []*ec2sdk.S
 // computeSubnetsMinimalCount returns the minimal count requirement for subnets.
 func (r *defaultSubnetsResolver) computeSubnetsMinimalCount(subnetLocale subnetLocaleType, resolveOpts SubnetsResolveOptions) int {
 	minimalCount := 1
-	if resolveOpts.ALBSingleSubnet {
+	if resolveOpts.ALBSingleSubnet && resolveOpts.LBType == elbv2model.LoadBalancerTypeApplication {
 		return minimalCount
 	}
 	if resolveOpts.LBType == elbv2model.LoadBalancerTypeApplication && subnetLocale == subnetLocaleTypeAvailabilityZone {


### PR DESCRIPTION
### Issue

#3082 

### Description

Added a new feature gate named "ALBSingleSubnet" with default value false, once it set to true, the user who get whitelisted by AWS ELB team for using only one subnet for their application load balancer could be processed as expected.

Manual Test Items:

For account which doesn't get whitelisted, creating the ingress resource with only one subnet attached. 
Comes up with LBC error message while ALBSIngleSubnet is set to false.
Comes up with ELB error message while ALBSIngleSubnet is set to true.

For account which get whitelisted, creating the ingress resource with only one subnet attached. 
Comes up with LBC error message while ALBSIngleSubnet is set to false.
ALB is successfully provisioning while ALBSIngleSubnet is set to true.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [X] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
