### PR TITLE
Drop the Security disclosures that point to AWS security

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,5 @@ This project was formerly known as "AWS ALB Ingress Controller", we rebranded it
 
   - AWS ALB Ingress Controller was donated to Kubernetes SIG-AWS to allow AWS, CoreOS, Ticketmaster and other SIG-AWS contributors to officially maintain the project. SIG-AWS reached this consensus on June 1, 2018.
 
-
-## Security disclosures
-
-If you think you’ve found a potential security issue, please do not post it in the Issues.  Instead, please follow the instructions [here](https://aws.amazon.com/security/vulnerability-reporting/) or [email AWS security directly](mailto:aws-security@amazon.com).
-
 ## Documentation
 Checkout our [Live Docs](https://kubernetes-sigs.github.io/aws-load-balancer-controller/)!

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,9 +48,5 @@ This project was formerly known as "AWS ALB Ingress Controller", we rebranded it
   - AWS ALB Ingress Controller was donated to Kubernetes SIG-AWS to allow AWS, CoreOS, Ticketmaster and other SIG-AWS contributors to officially maintain the project. SIG-AWS reached this consensus on June 1, 2018.
 
 
-## Security disclosures
-
-If you think you’ve found a potential security issue, please do not post it in the Issues.  Instead, please follow the instructions [here](https://aws.amazon.com/security/vulnerability-reporting/) or [email AWS security directly](mailto:aws-security@amazon.com).
-
 ## Support Policy
 Currently, AWS provides security updates and bug fixes to the latest available minor versions of AWS LBC. For other ad-hoc supports on older versions, please reach out through AWS support ticket.


### PR DESCRIPTION
A community repository SHOULD NOT be pointing to specific vendor's security process