### PR TITLE
Adding support for Availability Zone Affinity

### DIFF
--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -254,6 +254,10 @@ for proxy protocol v2 configuration.
         ```
         service.beta.kubernetes.io/aws-load-balancer-attributes: load_balancing.cross_zone.enabled=true
         ```
+        - enable client availability zone affinity
+        ```
+        service.beta.kubernetes.io/aws-load-balancer-attributes: dns_record.client_routing_policy=availability_zone_affinity
+        ```
 
 - <a name="deprecated-attributes"></a>the following annotations are deprecated in v2.3.0 release in favor of [service.beta.kubernetes.io/aws-load-balancer-attributes](#load-balancer-attributes)
 

--- a/pkg/service/model_build_load_balancer.go
+++ b/pkg/service/model_build_load_balancer.go
@@ -26,12 +26,16 @@ import (
 )
 
 const (
-	lbAttrsAccessLogsS3Enabled           = "access_logs.s3.enabled"
-	lbAttrsAccessLogsS3Bucket            = "access_logs.s3.bucket"
-	lbAttrsAccessLogsS3Prefix            = "access_logs.s3.prefix"
-	lbAttrsLoadBalancingCrossZoneEnabled = "load_balancing.cross_zone.enabled"
-	resourceIDLoadBalancer               = "LoadBalancer"
-	minimalAvailableIPAddressCount       = int64(8)
+	lbAttrsAccessLogsS3Enabled                 = "access_logs.s3.enabled"
+	lbAttrsAccessLogsS3Bucket                  = "access_logs.s3.bucket"
+	lbAttrsAccessLogsS3Prefix                  = "access_logs.s3.prefix"
+	lbAttrsLoadBalancingCrossZoneEnabled       = "load_balancing.cross_zone.enabled"
+	lbAttrsLoadBalancingDnsClientRoutingPolicy = "dns_record.client_routing_policy"
+	availabilityZoneAffinity                   = "availability_zone_affinity"
+	partialAvailabilityZoneAffinity            = "partial_availability_zone_affinity"
+	anyAvailabilityZone                        = "any_availability_zone"
+	resourceIDLoadBalancer                     = "LoadBalancer"
+	minimalAvailableIPAddressCount             = int64(8)
 )
 
 func (t *defaultModelBuildTask) buildLoadBalancer(ctx context.Context, scheme elbv2model.LoadBalancerScheme) error {
@@ -436,6 +440,18 @@ func (t *defaultModelBuildTask) getLoadBalancerAttributes() (map[string]string, 
 	var attributes map[string]string
 	if _, err := t.annotationParser.ParseStringMapAnnotation(annotations.SvcLBSuffixLoadBalancerAttributes, &attributes, t.service.Annotations); err != nil {
 		return nil, err
+	}
+	dnsRecordClientRoutingPolicy, exists := attributes[lbAttrsLoadBalancingDnsClientRoutingPolicy]
+	if exists {
+		switch dnsRecordClientRoutingPolicy {
+		case availabilityZoneAffinity:
+		case partialAvailabilityZoneAffinity:
+		case anyAvailabilityZone:
+		default:
+			return nil, errors.Errorf("invalid dns_record.client_routing_policy set in annotation %s: got '%s' expected one of ['%s', '%s', '%s']",
+				annotations.SvcLBSuffixLoadBalancerAttributes, dnsRecordClientRoutingPolicy,
+				anyAvailabilityZone, partialAvailabilityZoneAffinity, availabilityZoneAffinity)
+		}
 	}
 	return attributes, nil
 }

--- a/pkg/service/model_build_load_balancer_test.go
+++ b/pkg/service/model_build_load_balancer_test.go
@@ -88,7 +88,7 @@ func Test_defaultModelBuilderTask_buildLBAttributes(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						"service.beta.kubernetes.io/aws-load-balancer-attributes": "access_logs.s3.enabled=true,access_logs.s3.bucket=nlb-bucket," +
-							"access_logs.s3.prefix=bkt-pfx,load_balancing.cross_zone.enabled=true,deletion_protection.enabled=true",
+							"access_logs.s3.prefix=bkt-pfx,load_balancing.cross_zone.enabled=true,deletion_protection.enabled=true,dns_record.client_routing_policy=availability_zone_affinity",
 					},
 				},
 			},
@@ -113,6 +113,10 @@ func Test_defaultModelBuilderTask_buildLBAttributes(t *testing.T) {
 				{
 					Key:   lbAttrsDeletionProtectionEnabled,
 					Value: "true",
+				},
+				{
+					Key:   lbAttrsLoadBalancingDnsClientRoutingPolicy,
+					Value: availabilityZoneAffinity,
 				},
 			},
 		},

--- a/test/e2e/ingress/vanilla_ingress_test.go
+++ b/test/e2e/ingress/vanilla_ingress_test.go
@@ -91,7 +91,7 @@ var _ = Describe("vanilla ingress tests", func() {
 				},
 			}
 			annotation := map[string]string{
-				"alb.ingress.kubernetes.io/scheme": "internet-facing",
+				"alb.ingress.kubernetes.io/scheme":      "internet-facing",
 				"alb.ingress.kubernetes.io/target-type": "ip",
 			}
 			if tf.Options.IPFamily == "IPv6" {
@@ -173,8 +173,8 @@ var _ = Describe("vanilla ingress tests", func() {
 				},
 			}
 			annotation := map[string]string{
-				"kubernetes.io/ingress.class":      "alb",
-				"alb.ingress.kubernetes.io/scheme": "internet-facing",
+				"kubernetes.io/ingress.class":           "alb",
+				"alb.ingress.kubernetes.io/scheme":      "internet-facing",
 				"alb.ingress.kubernetes.io/target-type": "ip",
 			}
 			if tf.Options.IPFamily == "IPv6" {


### PR DESCRIPTION


### Issue

Fixes https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/3431

### Description

Added support to set [NLB attribute](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#zonal-dns-affinity) `dns_record.client_routing_policy` to configure [Availability Zone DNS Affinity](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#zonal-dns-affinity).
 
<!--
Please explain the changes you made here.

Help your reviewers by guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [x] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:
