### PR TITLE
Disable WAF to run tests against YYC.

### DIFF
--- a/scripts/run-e2e-test.sh
+++ b/scripts/run-e2e-test.sh
@@ -169,7 +169,12 @@ else
   helm repo add eks https://aws.github.io/eks-charts
   helm repo update
   echo "Install aws-load-balancer-controller"
-  helm upgrade -i aws-load-balancer-controller eks/aws-load-balancer-controller -n kube-system --set clusterName=$CLUSTER_NAME --set serviceAccount.create=false --set serviceAccount.name=aws-load-balancer-controller --set region=$REGION --set vpcId=$VPC_ID --set image.repository=$IMAGE
+  if [[ "$REGION" == "ca-west-1" ]]; then
+    # Disable Shield and WAF temporarily for ca-west-1
+    helm upgrade -i aws-load-balancer-controller eks/aws-load-balancer-controller -n kube-system --set clusterName=$CLUSTER_NAME --set serviceAccount.create=false --set serviceAccount.name=aws-load-balancer-controller --set region=$REGION --set vpcId=$VPC_ID --set image.repository=$IMAGE --set enableShield=false --set enableWaf=false --set enableWafv2=false
+  else
+    helm upgrade -i aws-load-balancer-controller eks/aws-load-balancer-controller -n kube-system --set clusterName=$CLUSTER_NAME --set serviceAccount.create=false --set serviceAccount.name=aws-load-balancer-controller --set region=$REGION --set vpcId=$VPC_ID --set image.repository=$IMAGE
+  fi
 fi
 
 echo_time() {
@@ -190,7 +195,7 @@ wait_until_deployment_ready() {
 		fi
 		echo -n "."
 		sleep 2
-	done 
+	done
 	echo_time "Deployment $1 $NS replicas desired=$desiredReplicas available=$availableReplicas"
 }
 


### PR DESCRIPTION
### Issue

The tests in YYC Region were failing due to WAF not being enabled.

### Description

This will temporarily disable using waf service in alb test for yyc region only.

Tests were successful in Prow after these changes.

```
{
  "level": "info",
  "timestamp": "2023-12-15T22:14:13.869Z",
  "caller": "tester/test.go:255",
  "msg": "finished running each component's test suite"
}
```


### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
