### PR TITLE
Add indention to forwardConfig

### DIFF
--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -462,22 +462,22 @@ Traffic Routing can be controlled with following annotations:
                 {
                     "type":"forward",
                     "forwardConfig":{
-                    "targetGroups":[
-                        {
-                        "serviceName":"service-1",
-                        "servicePort":"80",
-                        "weight":50
-                        },
-                        {
-                        "serviceName":"service-2",
-                        "servicePort":"80",
-                        "weight":50
+			"targetGroups":[
+			    {
+			    "serviceName":"service-1",
+			    "servicePort":"80",
+			    "weight":50
+			    },
+			    {
+			    "serviceName":"service-2",
+			    "servicePort":"80",
+			    "weight":50
+			    }
+		        ],
+                        "TargetGroupStickinessConfig": {
+                            "Enabled": true,
+                            "DurationSeconds": 120
                         }
-                    ],
-                    "TargetGroupStickinessConfig": {
-                        "Enabled": true,
-                        "DurationSeconds": 120
-                    }
                     }
                 }
             spec:


### PR DESCRIPTION
This clarifies to the reader that `targetGroups` and `TargetGroupStickinessConfig` are both within the `forwardConfig`, which was not clear before due to lack of indentation.

### Issue

General improvement for docs readability, not related to an issue

### Description

When configuring the `forwardConfig`, it was not initially clear to me that these two properties were part of the `forwardConfig` block since they were indented to the same level as it, instead of indented a layer deeper to show nesting.

This change simply provides the extra indention in the example code of the docs which should make it clearer to other readers to prevent them from making the same mistake.
