### PR TITLE
improve the enable primary ipv6 address and TEST_ID in prow script

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -22,5 +22,5 @@ jobs:
       - id: govulncheck
         uses: golang/govulncheck-action@v1
         with:
-          go-version-input: 1.21.4
+          go-version-input: 1.21.5
           go-version-file: go.mod

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ MAKEFILE_PATH = $(dir $(realpath -s $(firstword $(MAKEFILE_LIST))))
 # Image URL to use all building/pushing image targets
 IMG ?= public.ecr.aws/eks/aws-load-balancer-controller:v2.6.1
 # Image URL to use for builder stage in Docker build
-BUILD_IMAGE ?= public.ecr.aws/docker/library/golang:1.21.4
+BUILD_IMAGE ?= public.ecr.aws/docker/library/golang:1.21.5
 # Image URL to use for base layer in Docker build
 BASE_IMAGE ?= public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:2023-09-06-1694026927.2
 IMG_PLATFORM ?= linux/amd64,linux/arm64

--- a/scripts/run-e2e-test.sh
+++ b/scripts/run-e2e-test.sh
@@ -28,7 +28,7 @@ function toggle_windows_scheduling(){
   done
 }
 
-TEST_ID=$(date +%s)
+TEST_ID=$(date +%s)-$((RANDOM % 1000))
 echo "TEST_ID: $TEST_ID"
 ROLE_NAME="aws-load-balancer-controller-$TEST_ID"
 POLICY_NAME="AWSLoadBalancerControllerIAMPolicy-$TEST_ID"
@@ -159,9 +159,12 @@ function install_controller_for_adc_regions() {
 
 function enable_primary_ipv6_address() {
   echo "enable primary ipv6 address for the ec2 instance"
-  ENI_IDS=$(aws ec2 describe-instances --filters "Name=tag:aws:eks:cluster-name,Values=$CLUSTER_NAME" --query "Reservations[].Instances[].NetworkInterfaces[].NetworkInterfaceId" --output text)
+  ENI_IDS=$(aws ec2 describe-instances --region $REGION --filters "Name=tag:aws:eks:cluster-name,Values=$CLUSTER_NAME" --query "Reservations[].Instances[].NetworkInterfaces[].NetworkInterfaceId" --output text)
+  ENI_COUNT=$(echo "$ENI_IDS" | wc -w)
+  echo "found $ENI_COUNT ENIs: $ENI_IDS"
   for ENI_ID in $ENI_IDS; do
-    aws ec2 modify-network-interface-attribute --network-interface-id $ENI_ID --enable-primary-ipv6 || true
+    echo "enable primary ipv6 address for ENI $ENI_ID"
+    aws ec2 modify-network-interface-attribute --region $REGION --network-interface-id $ENI_ID --enable-primary-ipv6
   done
 }
 

--- a/test/framework/utils/poll.go
+++ b/test/framework/utils/poll.go
@@ -13,5 +13,5 @@ const (
 	// IngressReconcileTimeout is the timeout we expected the controller finishes reconcile for Ingresses.
 	IngressReconcileTimeout = 1 * time.Minute
 	// IngressDNSAvailableWaitTimeout is the timeout we expect the DNS records of ALB to be propagated.
-	IngressDNSAvailableWaitTimeout = 3 * time.Minute
+	IngressDNSAvailableWaitTimeout = 5 * time.Minute
 )


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description

<!--
Please explain the changes you made here.

Help your reviewers by guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->
This PR bumps up the go version to 1.21.5 and also improves and fixes the prow script by -
1. making the $TEST_ID more random, to avoid duplicate naming for jobs launch at the same time in the same region
2. adding `--region` param, and also log lines in enable_primary_ipv6_address()
3. bumping up the `IngressDNSAvailableWaitTimeout` from 3min to 5min to tolerate the timeout issue in prow

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
