### PR TITLE
add retry logic in e2e test to wait for ALB to be available

### DIFF
--- a/test/e2e/ingress/vanilla_ingress_test.go
+++ b/test/e2e/ingress/vanilla_ingress_test.go
@@ -753,16 +753,17 @@ func ExpectNoLBProvisionedForIngress(ctx context.Context, tf *framework.Framewor
 }
 
 func ExpectLBDNSBeAvailable(ctx context.Context, tf *framework.Framework, lbARN string, lbDNS string) {
-	ctx, cancel := context.WithTimeout(ctx, utils.IngressDNSAvailableWaitTimeout)
-	defer cancel()
-
 	tf.Logger.Info("wait loadBalancer becomes available", "arn", lbARN)
-	err := tf.LBManager.WaitUntilLoadBalancerAvailable(ctx, lbARN)
-	Expect(err).NotTo(HaveOccurred())
+	Eventually(func() bool {
+		err := tf.LBManager.WaitUntilLoadBalancerAvailable(ctx, lbARN)
+		return Expect(err).NotTo(HaveOccurred()) == true
+	}, utils.IngressDNSAvailableWaitTimeout, utils.IngressDNSAvailableRetryInterval).Should(BeTrue())
 	tf.Logger.Info("loadBalancer becomes available", "arn", lbARN)
 
 	tf.Logger.Info("wait dns becomes available", "dns", lbDNS)
-	err = utils.WaitUntilDNSNameAvailable(ctx, lbDNS)
-	Expect(err).NotTo(HaveOccurred())
+	Eventually(func() bool {
+		err := utils.WaitUntilDNSNameAvailable(ctx, lbDNS)
+		return Expect(err).NotTo(HaveOccurred()) == true
+	}, utils.IngressDNSAvailableWaitTimeout, utils.IngressDNSAvailableRetryInterval).Should(BeTrue())
 	tf.Logger.Info("dns becomes available", "dns", lbDNS)
 }

--- a/test/framework/utils/poll.go
+++ b/test/framework/utils/poll.go
@@ -13,5 +13,7 @@ const (
 	// IngressReconcileTimeout is the timeout we expected the controller finishes reconcile for Ingresses.
 	IngressReconcileTimeout = 1 * time.Minute
 	// IngressDNSAvailableWaitTimeout is the timeout we expect the DNS records of ALB to be propagated.
-	IngressDNSAvailableWaitTimeout = 5 * time.Minute
+	IngressDNSAvailableWaitTimeout = 10 * time.Minute
+	// IngressDNSAvailableRetryInterval is the interval to retry wait
+	IngressDNSAvailableRetryInterval = 3 * time.Minute
 )


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description

<!--
Please explain the changes you made here.

Help your reviewers by guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->
Add retry logic in ALB e2e test to tolerate timeout issue. Will retry every 3min and timeout after 10min.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
