### PR TITLE
cache ELB resource tags to reduce API calls

### DIFF
--- a/controllers/ingress/group_controller.go
+++ b/controllers/ingress/group_controller.go
@@ -46,7 +46,7 @@ const (
 func NewGroupReconciler(cloud aws.Cloud, k8sClient client.Client, eventRecorder record.EventRecorder,
 	finalizerManager k8s.FinalizerManager, networkingSGManager networkingpkg.SecurityGroupManager,
 	networkingSGReconciler networkingpkg.SecurityGroupReconciler, subnetsResolver networkingpkg.SubnetsResolver,
-	controllerConfig config.ControllerConfig, backendSGProvider networkingpkg.BackendSGProvider,
+	elbv2TaggingManager elbv2deploy.TaggingManager, controllerConfig config.ControllerConfig, backendSGProvider networkingpkg.BackendSGProvider,
 	sgResolver networkingpkg.SecurityGroupResolver, logger logr.Logger) *groupReconciler {
 
 	annotationParser := annotations.NewSuffixAnnotationParser(annotations.AnnotationPrefixIngress)
@@ -54,7 +54,6 @@ func NewGroupReconciler(cloud aws.Cloud, k8sClient client.Client, eventRecorder 
 	enhancedBackendBuilder := ingress.NewDefaultEnhancedBackendBuilder(k8sClient, annotationParser, authConfigBuilder, controllerConfig.IngressConfig.TolerateNonExistentBackendService, controllerConfig.IngressConfig.TolerateNonExistentBackendAction)
 	referenceIndexer := ingress.NewDefaultReferenceIndexer(enhancedBackendBuilder, authConfigBuilder, logger)
 	trackingProvider := tracking.NewDefaultProvider(ingressTagPrefix, controllerConfig.ClusterName)
-	elbv2TaggingManager := elbv2deploy.NewDefaultTaggingManager(cloud.ELBV2(), cloud.VpcID(), controllerConfig.FeatureGates, cloud.RGT(), logger)
 	modelBuilder := ingress.NewDefaultModelBuilder(k8sClient, eventRecorder,
 		cloud.EC2(), cloud.ELBV2(), cloud.ACM(),
 		annotationParser, subnetsResolver,
@@ -63,7 +62,7 @@ func NewGroupReconciler(cloud aws.Cloud, k8sClient client.Client, eventRecorder 
 		controllerConfig.DefaultSSLPolicy, controllerConfig.DefaultTargetType, backendSGProvider, sgResolver,
 		controllerConfig.EnableBackendSecurityGroup, controllerConfig.DisableRestrictedSGRules, controllerConfig.FeatureGates.Enabled(config.EnableIPTargetType), logger)
 	stackMarshaller := deploy.NewDefaultStackMarshaller()
-	stackDeployer := deploy.NewDefaultStackDeployer(cloud, k8sClient, networkingSGManager, networkingSGReconciler,
+	stackDeployer := deploy.NewDefaultStackDeployer(cloud, k8sClient, networkingSGManager, networkingSGReconciler, elbv2TaggingManager,
 		controllerConfig, ingressTagPrefix, logger)
 	classLoader := ingress.NewDefaultClassLoader(k8sClient, true)
 	classAnnotationMatcher := ingress.NewDefaultClassAnnotationMatcher(controllerConfig.IngressConfig.IngressClass)

--- a/controllers/service/service_controller.go
+++ b/controllers/service/service_controller.go
@@ -14,7 +14,7 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/config"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy"
-	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/elbv2"
+	elbv2deploy "sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/elbv2"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/tracking"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/core"
@@ -38,19 +38,18 @@ const (
 func NewServiceReconciler(cloud aws.Cloud, k8sClient client.Client, eventRecorder record.EventRecorder,
 	finalizerManager k8s.FinalizerManager, networkingSGManager networking.SecurityGroupManager,
 	networkingSGReconciler networking.SecurityGroupReconciler, subnetsResolver networking.SubnetsResolver,
-	vpcInfoProvider networking.VPCInfoProvider, controllerConfig config.ControllerConfig,
+	vpcInfoProvider networking.VPCInfoProvider, elbv2TaggingManager elbv2deploy.TaggingManager, controllerConfig config.ControllerConfig,
 	backendSGProvider networking.BackendSGProvider, sgResolver networking.SecurityGroupResolver, logger logr.Logger) *serviceReconciler {
 
 	annotationParser := annotations.NewSuffixAnnotationParser(serviceAnnotationPrefix)
 	trackingProvider := tracking.NewDefaultProvider(serviceTagPrefix, controllerConfig.ClusterName)
-	elbv2TaggingManager := elbv2.NewDefaultTaggingManager(cloud.ELBV2(), cloud.VpcID(), controllerConfig.FeatureGates, cloud.RGT(), logger)
 	serviceUtils := service.NewServiceUtils(annotationParser, serviceFinalizer, controllerConfig.ServiceConfig.LoadBalancerClass, controllerConfig.FeatureGates)
 	modelBuilder := service.NewDefaultModelBuilder(annotationParser, subnetsResolver, vpcInfoProvider, cloud.VpcID(), trackingProvider,
 		elbv2TaggingManager, cloud.EC2(), controllerConfig.FeatureGates, controllerConfig.ClusterName, controllerConfig.DefaultTags, controllerConfig.ExternalManagedTags,
 		controllerConfig.DefaultSSLPolicy, controllerConfig.DefaultTargetType, controllerConfig.FeatureGates.Enabled(config.EnableIPTargetType), serviceUtils,
 		backendSGProvider, sgResolver, controllerConfig.EnableBackendSecurityGroup, controllerConfig.DisableRestrictedSGRules)
 	stackMarshaller := deploy.NewDefaultStackMarshaller()
-	stackDeployer := deploy.NewDefaultStackDeployer(cloud, k8sClient, networkingSGManager, networkingSGReconciler, controllerConfig, serviceTagPrefix, logger)
+	stackDeployer := deploy.NewDefaultStackDeployer(cloud, k8sClient, networkingSGManager, networkingSGReconciler, elbv2TaggingManager, controllerConfig, serviceTagPrefix, logger)
 	return &serviceReconciler{
 		k8sClient:         k8sClient,
 		eventRecorder:     eventRecorder,

--- a/pkg/deploy/elbv2/tagging_manager.go
+++ b/pkg/deploy/elbv2/tagging_manager.go
@@ -2,6 +2,10 @@ package elbv2
 
 import (
 	"context"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/cache"
 
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	elbv2sdk "github.com/aws/aws-sdk-go/service/elbv2"
@@ -18,6 +22,8 @@ import (
 const (
 	// ELBV2 API supports up to 20 resource per DescribeTags API call.
 	defaultDescribeTagsChunkSize = 20
+	// cache ttl for tags on ELB resources.
+	defaultResourceTagsCacheTTL = 20 * time.Minute
 )
 
 // LoadBalancer with it's tags.
@@ -103,6 +109,8 @@ func NewDefaultTaggingManager(elbv2Client services.ELBV2, vpcID string, featureG
 		featureGates:          featureGates,
 		logger:                logger,
 		describeTagsChunkSize: defaultDescribeTagsChunkSize,
+		resourceTagsCache:     cache.NewExpiring(),
+		resourceTagsCacheTTL:  defaultResourceTagsCacheTTL,
 		rgt:                   rgt,
 	}
 }
@@ -117,7 +125,11 @@ type defaultTaggingManager struct {
 	featureGates          config.FeatureGates
 	logger                logr.Logger
 	describeTagsChunkSize int
-	rgt                   services.RGT
+	// cache for tags on ELB resources.
+	resourceTagsCache      *cache.Expiring
+	resourceTagsCacheTTL   time.Duration
+	resourceTagsCacheMutex sync.RWMutex
+	rgt                    services.RGT
 }
 
 func (m *defaultTaggingManager) ReconcileTags(ctx context.Context, arn string, desiredTags map[string]string, opts ...ReconcileTagsOption) error {
@@ -128,7 +140,7 @@ func (m *defaultTaggingManager) ReconcileTags(ctx context.Context, arn string, d
 	reconcileOpts.ApplyOptions(opts)
 	currentTags := reconcileOpts.CurrentTags
 	if currentTags == nil {
-		tagsByARN, err := m.describeResourceTagsNative(ctx, []string{arn})
+		tagsByARN, err := m.describeResourceTags(ctx, []string{arn})
 		if err != nil {
 			return err
 		}
@@ -153,6 +165,7 @@ func (m *defaultTaggingManager) ReconcileTags(ctx context.Context, arn string, d
 		if _, err := m.elbv2Client.AddTagsWithContext(ctx, req); err != nil {
 			return err
 		}
+		m.invalidateResourceTagsCache(arn)
 		m.logger.Info("added resource tags",
 			"arn", arn)
 	}
@@ -170,6 +183,7 @@ func (m *defaultTaggingManager) ReconcileTags(ctx context.Context, arn string, d
 		if _, err := m.elbv2Client.RemoveTagsWithContext(ctx, req); err != nil {
 			return err
 		}
+		m.invalidateResourceTagsCache(arn)
 		m.logger.Info("removed resource tags",
 			"arn", arn)
 	}
@@ -193,7 +207,7 @@ func (m *defaultTaggingManager) ListListeners(ctx context.Context, lbARN string)
 	}
 	var tagsByARN map[string]map[string]string
 	if m.featureGates.Enabled(config.ListenerRulesTagging) {
-		tagsByARN, err = m.describeResourceTagsNative(ctx, lsARNs)
+		tagsByARN, err = m.describeResourceTags(ctx, lsARNs)
 		if err != nil {
 			return nil, err
 		}
@@ -226,7 +240,7 @@ func (m *defaultTaggingManager) ListListenerRules(ctx context.Context, lsARN str
 	}
 	var tagsByARN map[string]map[string]string
 	if m.featureGates.Enabled(config.ListenerRulesTagging) {
-		tagsByARN, err = m.describeResourceTagsNative(ctx, lrARNs)
+		tagsByARN, err = m.describeResourceTags(ctx, lrARNs)
 		if err != nil {
 			return nil, err
 		}
@@ -242,6 +256,7 @@ func (m *defaultTaggingManager) ListListenerRules(ctx context.Context, lsARN str
 	return sdkLRs, err
 }
 
+// TODO: we can refactor this by store provisioned LB's ARN as annotations on Ingress/Service, thus avoid this heavy lookup calls when RGT is not available.
 func (m *defaultTaggingManager) ListLoadBalancers(ctx context.Context, tagFilters ...tracking.TagFilter) ([]LoadBalancerWithTags, error) {
 	if m.featureGates.Enabled(config.EnableRGTAPI) {
 		return m.listLoadBalancersRGT(ctx, tagFilters)
@@ -254,7 +269,6 @@ func (m *defaultTaggingManager) ListTargetGroups(ctx context.Context, tagFilters
 		return m.listTargetGroupsRGT(ctx, tagFilters)
 	}
 	return m.listTargetGroupsNative(ctx, tagFilters)
-
 }
 
 func (m *defaultTaggingManager) listLoadBalancersRGT(ctx context.Context, tagFilters []tracking.TagFilter) ([]LoadBalancerWithTags, error) {
@@ -311,7 +325,7 @@ func (m *defaultTaggingManager) listLoadBalancersNative(ctx context.Context, tag
 		lbARNsWithinVPC = append(lbARNsWithinVPC, lbARN)
 		lbByARNWithinVPC[lbARN] = lb
 	}
-	tagsByARN, err := m.describeResourceTagsNative(ctx, lbARNsWithinVPC)
+	tagsByARN, err := m.describeResourceTags(ctx, lbARNsWithinVPC)
 	if err != nil {
 		return nil, err
 	}
@@ -391,7 +405,7 @@ func (m *defaultTaggingManager) listTargetGroupsNative(ctx context.Context, tagF
 		tgARNsWithinVPC = append(tgARNsWithinVPC, tgARN)
 		tgByARNWithinVPC[tgARN] = tg
 	}
-	tagsByARN, err := m.describeResourceTagsNative(ctx, tgARNsWithinVPC)
+	tagsByARN, err := m.describeResourceTags(ctx, tgARNsWithinVPC)
 	if err != nil {
 		return nil, err
 	}
@@ -416,9 +430,34 @@ func (m *defaultTaggingManager) listTargetGroupsNative(ctx context.Context, tagF
 	return matchedTGs, nil
 }
 
-// describeResourceTagsNative describes tags for elbv2 resources.
+func (m *defaultTaggingManager) describeResourceTags(ctx context.Context, arns []string) (map[string]map[string]string, error) {
+	m.resourceTagsCacheMutex.Lock()
+	defer m.resourceTagsCacheMutex.Unlock()
+
+	tagsByARN := make(map[string]map[string]string, len(arns))
+	var arnsWithoutTagsCache []string
+	for _, arn := range arns {
+		if rawTagsCacheItem, exists := m.resourceTagsCache.Get(arn); exists {
+			tagsCacheItem := rawTagsCacheItem.(map[string]string)
+			tagsByARN[arn] = tagsCacheItem
+		} else {
+			arnsWithoutTagsCache = append(arnsWithoutTagsCache, arn)
+		}
+	}
+	tagsByARNFromAWS, err := m.describeResourceTagsFromAWS(ctx, arnsWithoutTagsCache)
+	if err != nil {
+		return nil, err
+	}
+	for arn, tags := range tagsByARNFromAWS {
+		m.resourceTagsCache.Set(arn, tags, m.resourceTagsCacheTTL)
+		tagsByARN[arn] = tags
+	}
+	return tagsByARN, nil
+}
+
+// describeResourceTagsFromAWS describes tags for elbv2 resources.
 // returns tags indexed by resource ARN.
-func (m *defaultTaggingManager) describeResourceTagsNative(ctx context.Context, arns []string) (map[string]map[string]string, error) {
+func (m *defaultTaggingManager) describeResourceTagsFromAWS(ctx context.Context, arns []string) (map[string]map[string]string, error) {
 	tagsByARN := make(map[string]map[string]string, len(arns))
 	arnsChunks := algorithm.ChunkStrings(arns, m.describeTagsChunkSize)
 	for _, arnsChunk := range arnsChunks {
@@ -434,6 +473,13 @@ func (m *defaultTaggingManager) describeResourceTagsNative(ctx context.Context, 
 		}
 	}
 	return tagsByARN, nil
+}
+
+func (m *defaultTaggingManager) invalidateResourceTagsCache(arn string) {
+	m.resourceTagsCacheMutex.Lock()
+	defer m.resourceTagsCacheMutex.Unlock()
+
+	m.resourceTagsCache.Delete(arn)
 }
 
 // convert tags into AWS SDK tag presentation.

--- a/pkg/deploy/elbv2/tagging_manager_test.go
+++ b/pkg/deploy/elbv2/tagging_manager_test.go
@@ -2,6 +2,7 @@ package elbv2
 
 import (
 	"context"
+	"k8s.io/apimachinery/pkg/util/cache"
 	"testing"
 
 	awssdk "github.com/aws/aws-sdk-go/aws"
@@ -233,6 +234,8 @@ func Test_defaultTaggingManager_ReconcileTags(t *testing.T) {
 				vpcID:                 "vpc-xxxxxxx",
 				logger:                logr.New(&log.NullLogSink{}),
 				describeTagsChunkSize: defaultDescribeTagsChunkSize,
+				resourceTagsCache:     cache.NewExpiring(),
+				resourceTagsCacheTTL:  defaultResourceTagsCacheTTL,
 				featureGates:          featureGates,
 			}
 			err := m.ReconcileTags(context.Background(), tt.args.arn, tt.args.desiredTags, tt.args.opts...)
@@ -608,6 +611,8 @@ func Test_defaultTaggingManager_ListLoadBalancers(t *testing.T) {
 				elbv2Client:           elbv2Client,
 				vpcID:                 "vpc-xxxxxxx",
 				describeTagsChunkSize: defaultDescribeTagsChunkSize,
+				resourceTagsCache:     cache.NewExpiring(),
+				resourceTagsCacheTTL:  defaultResourceTagsCacheTTL,
 				featureGates:          featureGates,
 			}
 			got, err := m.ListLoadBalancers(context.Background(), tt.args.tagFilters...)
@@ -1108,6 +1113,8 @@ func Test_defaultTaggingManager_ListTargetGroups(t *testing.T) {
 				elbv2Client:           elbv2Client,
 				vpcID:                 "vpc-xxxxxxx",
 				describeTagsChunkSize: defaultDescribeTagsChunkSize,
+				resourceTagsCache:     cache.NewExpiring(),
+				resourceTagsCacheTTL:  defaultResourceTagsCacheTTL,
 				featureGates:          featureGates,
 			}
 			got, err := m.ListTargetGroups(context.Background(), tt.args.tagFilters...)
@@ -1121,7 +1128,224 @@ func Test_defaultTaggingManager_ListTargetGroups(t *testing.T) {
 	}
 }
 
-func Test_defaultTaggingManager_describeResourceTagsNative(t *testing.T) {
+func Test_defaultTaggingManager_describeResourceTags(t *testing.T) {
+	type describeTagsWithContextCall struct {
+		req  *elbv2sdk.DescribeTagsInput
+		resp *elbv2sdk.DescribeTagsOutput
+		err  error
+	}
+	type fields struct {
+		resourceTagsCacheItems       map[string]map[string]string
+		describeTagsWithContextCalls []describeTagsWithContextCall
+	}
+	type args struct {
+		arns []string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    map[string]map[string]string
+		wantErr error
+	}{
+		{
+			name: "cache miss for all items",
+			fields: fields{
+				describeTagsWithContextCalls: []describeTagsWithContextCall{
+					{
+						req: &elbv2sdk.DescribeTagsInput{
+							ResourceArns: awssdk.StringSlice([]string{"arn-1", "arn-2", "arn-3"}),
+						},
+						resp: &elbv2sdk.DescribeTagsOutput{
+							TagDescriptions: []*elbv2sdk.TagDescription{
+								{
+									ResourceArn: awssdk.String("arn-1"),
+									Tags: []*elbv2sdk.Tag{
+										{
+											Key:   awssdk.String("keyA"),
+											Value: awssdk.String("valueA1"),
+										},
+										{
+											Key:   awssdk.String("keyB"),
+											Value: awssdk.String("valueB1"),
+										},
+									},
+								},
+								{
+									ResourceArn: awssdk.String("arn-2"),
+									Tags: []*elbv2sdk.Tag{
+										{
+											Key:   awssdk.String("keyA"),
+											Value: awssdk.String("valueA2"),
+										},
+										{
+											Key:   awssdk.String("keyB"),
+											Value: awssdk.String("valueB2"),
+										},
+									},
+								},
+								{
+									ResourceArn: awssdk.String("arn-3"),
+									Tags: []*elbv2sdk.Tag{
+										{
+											Key:   awssdk.String("keyA"),
+											Value: awssdk.String("valueA3"),
+										},
+										{
+											Key:   awssdk.String("keyB"),
+											Value: awssdk.String("valueB3"),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				arns: []string{"arn-1", "arn-2", "arn-3"},
+			},
+			want: map[string]map[string]string{
+				"arn-1": {
+					"keyA": "valueA1",
+					"keyB": "valueB1",
+				},
+				"arn-2": {
+					"keyA": "valueA2",
+					"keyB": "valueB2",
+				},
+				"arn-3": {
+					"keyA": "valueA3",
+					"keyB": "valueB3",
+				},
+			},
+		},
+		{
+			name: "cache hit for all items",
+			fields: fields{
+				resourceTagsCacheItems: map[string]map[string]string{
+					"arn-1": {
+						"keyA": "valueA1",
+						"keyB": "valueB1",
+					},
+					"arn-2": {
+						"keyA": "valueA2",
+						"keyB": "valueB2",
+					},
+					"arn-3": {
+						"keyA": "valueA3",
+						"keyB": "valueB3",
+					},
+				},
+				describeTagsWithContextCalls: []describeTagsWithContextCall{},
+			},
+			args: args{
+				arns: []string{"arn-1", "arn-2", "arn-3"},
+			},
+			want: map[string]map[string]string{
+				"arn-1": {
+					"keyA": "valueA1",
+					"keyB": "valueB1",
+				},
+				"arn-2": {
+					"keyA": "valueA2",
+					"keyB": "valueB2",
+				},
+				"arn-3": {
+					"keyA": "valueA3",
+					"keyB": "valueB3",
+				},
+			},
+		},
+		{
+			name: "cache hit for 2/3 items",
+			fields: fields{
+				resourceTagsCacheItems: map[string]map[string]string{
+					"arn-1": {
+						"keyA": "valueA1",
+						"keyB": "valueB1",
+					},
+					"arn-3": {
+						"keyA": "valueA3",
+						"keyB": "valueB3",
+					},
+				},
+				describeTagsWithContextCalls: []describeTagsWithContextCall{
+					{
+						req: &elbv2sdk.DescribeTagsInput{
+							ResourceArns: awssdk.StringSlice([]string{"arn-2"}),
+						},
+						resp: &elbv2sdk.DescribeTagsOutput{
+							TagDescriptions: []*elbv2sdk.TagDescription{
+								{
+									ResourceArn: awssdk.String("arn-2"),
+									Tags: []*elbv2sdk.Tag{
+										{
+											Key:   awssdk.String("keyA"),
+											Value: awssdk.String("valueA2"),
+										},
+										{
+											Key:   awssdk.String("keyB"),
+											Value: awssdk.String("valueB2"),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				arns: []string{"arn-1", "arn-2", "arn-3"},
+			},
+			want: map[string]map[string]string{
+				"arn-1": {
+					"keyA": "valueA1",
+					"keyB": "valueB1",
+				},
+				"arn-2": {
+					"keyA": "valueA2",
+					"keyB": "valueB2",
+				},
+				"arn-3": {
+					"keyA": "valueA3",
+					"keyB": "valueB3",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			elbv2Client := services.NewMockELBV2(ctrl)
+			for _, call := range tt.fields.describeTagsWithContextCalls {
+				elbv2Client.EXPECT().DescribeTagsWithContext(gomock.Any(), call.req).Return(call.resp, call.err)
+			}
+
+			m := &defaultTaggingManager{
+				elbv2Client:           elbv2Client,
+				vpcID:                 "vpc-xxxxxxx",
+				describeTagsChunkSize: 20,
+				resourceTagsCache:     cache.NewExpiring(),
+				resourceTagsCacheTTL:  defaultResourceTagsCacheTTL,
+			}
+			for arn, tags := range tt.fields.resourceTagsCacheItems {
+				m.resourceTagsCache.Set(arn, tags, m.resourceTagsCacheTTL)
+			}
+
+			got, err := m.describeResourceTags(context.Background(), tt.args.arns)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func Test_defaultTaggingManager_describeResourceTagsFromAWS(t *testing.T) {
 	type describeTagsWithContextCall struct {
 		req  *elbv2sdk.DescribeTagsInput
 		resp *elbv2sdk.DescribeTagsOutput
@@ -1273,8 +1497,10 @@ func Test_defaultTaggingManager_describeResourceTagsNative(t *testing.T) {
 				elbv2Client:           elbv2Client,
 				vpcID:                 "vpc-xxxxxxx",
 				describeTagsChunkSize: 2,
+				resourceTagsCache:     cache.NewExpiring(),
+				resourceTagsCacheTTL:  defaultResourceTagsCacheTTL,
 			}
-			got, err := m.describeResourceTagsNative(context.Background(), tt.args.arns)
+			got, err := m.describeResourceTagsFromAWS(context.Background(), tt.args.arns)
 			if tt.wantErr != nil {
 				assert.EqualError(t, err, tt.wantErr.Error())
 			} else {

--- a/pkg/deploy/stack_deployer.go
+++ b/pkg/deploy/stack_deployer.go
@@ -25,11 +25,11 @@ type StackDeployer interface {
 // NewDefaultStackDeployer constructs new defaultStackDeployer.
 func NewDefaultStackDeployer(cloud aws.Cloud, k8sClient client.Client,
 	networkingSGManager networking.SecurityGroupManager, networkingSGReconciler networking.SecurityGroupReconciler,
+	elbv2TaggingManager elbv2.TaggingManager,
 	config config.ControllerConfig, tagPrefix string, logger logr.Logger) *defaultStackDeployer {
 
 	trackingProvider := tracking.NewDefaultProvider(tagPrefix, config.ClusterName)
 	ec2TaggingManager := ec2.NewDefaultTaggingManager(cloud.EC2(), networkingSGManager, cloud.VpcID(), logger)
-	elbv2TaggingManager := elbv2.NewDefaultTaggingManager(cloud.ELBV2(), cloud.VpcID(), config.FeatureGates, cloud.RGT(), logger)
 
 	return &defaultStackDeployer{
 		cloud:                               cloud,


### PR DESCRIPTION
### Issue

[<!-- Please link the GitHub issues related to this PR, if available -->](https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/3540)

### Description

<!--
Please explain the changes you made here.

Help your reviewers by guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

Backgroud:
By default, during reconcile for a Ingress/Service, the controller will need to find the ALB/NLB created for Ingress/Service. It achieves it by looking for ALB/NLB tagged with certain tags. However, the ELBv2 API don't support filter ALB/NLB with certain tags, thus we have to list all ALB/NLB in VPC and then list the tags on each of them. This is inefficient when there is large number of ALB/NLBs in vpc. 
Note, there is a optional feature that uses RGT API, which supports directly filter ALB/NLB with certain tags, however that API requires internet access and not suitable for private clusters.

Changes done:
This PR will 
1. cache the ELB resource tags to reduce API calls.  The cache for certain resource will expire after 20 mins and will be invalidated when the tags were mutated by controller.
2. share the same ELBv2TaggingManager for Ingress/Service's modelBuilder & modelDeployer to reuse cache.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:
