### PR TITLE
Add a note to recommend to use compatible chart and image versions

### DIFF
--- a/helm/aws-load-balancer-controller/README.md
+++ b/helm/aws-load-balancer-controller/README.md
@@ -96,7 +96,10 @@ If you are setting `serviceMonitor.enabled: true` you need to have installed the
 
 ## Installing the Chart
 **Note**: You need to uninstall aws-alb-ingress-controller. Please refer to the [upgrade](#Upgrade) section below before you proceed.
+
 **Note**: Starting chart version 1.4.1, you need to explicitly set `clusterSecretsPermissions.allowAllSecrets` to true to grant the controller permission to access all secrets for OIDC feature. We recommend configuring access to individual secrets resource separately [[link](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/examples/secrets_access/)].
+
+**Note**: To ensure compatibility, we recommend installing the AWS Load Balancer controller image version with its compatible Helm chart version. Use the ```helm search repo eks/aws-load-balancer-controller --versions``` command to find the compatible versions.
 
 Add the EKS repository to Helm:
 ```shell script


### PR DESCRIPTION
### Issue


### Description

We introduced a readiness health check condition in image v2.7.0 and added a default readiness probe configuration. This can be found [here](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3375). 
If the customer ends up using a older version of image with new helm chart version, the readiness probe would fail as the health check is missing. The controller pods will fail because the older images do not support readiness checks that the latest helm chart is using. Added a note on Helm Readme to recommend to use the compatible versions for installations. 

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
