### PR TITLE
fix: targetGroupBinding now works if the LBs is in a different VPCs than the POD

### DIFF
--- a/docs/deploy/installation.md
+++ b/docs/deploy/installation.md
@@ -7,10 +7,10 @@ The LBC is supported by AWS. Some clusters may be using the legacy "in-tree" fun
 !!!question "Existing AWS ALB Ingress Controller users"
     The AWS ALB Ingress controller must be uninstalled before installing the AWS Load Balancer Controller.
     Please follow our [migration guide](upgrade/migrate_v1_v2.md) to do a migration.
-    
+
 !!!warning "When using AWS Load Balancer Controller v2.5+"
-    The AWS LBC provides a mutating webhook for service resources to set the `spec.loadBalancerClass` field for service of type LoadBalancer on create. 
-    This makes the AWS LBC the **default controller for service** of type LoadBalancer. You can disable this feature and revert to set Cloud Controller Manager (in-tree controller) as the default by setting the helm chart value **enableServiceMutatorWebhook to false** with `--set enableServiceMutatorWebhook=false` . 
+    The AWS LBC provides a mutating webhook for service resources to set the `spec.loadBalancerClass` field for service of type LoadBalancer on create.
+    This makes the AWS LBC the **default controller for service** of type LoadBalancer. You can disable this feature and revert to set Cloud Controller Manager (in-tree controller) as the default by setting the helm chart value **enableServiceMutatorWebhook to false** with `--set enableServiceMutatorWebhook=false` .
     You will no longer be able to provision new Classic Load Balancer (CLB) from your kubernetes service unless you disable this feature. Existing CLB will continue to work fine.
 
 ## Supported Kubernetes versions
@@ -30,7 +30,7 @@ The LBC is supported by AWS. Some clusters may be using the legacy "in-tree" fun
 Isolated clusters are clusters without internet access, and instead reply on VPC endpoints for all required connects.
 When installing the AWS LBC in isolated clusters, you need to disable shield, waf and wafv2 via controller flags `--enable-shield=false, --enable-waf=false, --enable-wafv2=false`
 ### Using the Amazon EC2 instance metadata server version 2 (IMDSv2)
-We recommend blocking the access to instance metadata by requiring the instance to use [IMDSv2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html) only. For more information, please refer to the AWS guidance [here](https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node). If you are using the IMDSv2, set the hop limit to 2 or higher in order to allow the LBC to perform the metadata introspection. 
+We recommend blocking the access to instance metadata by requiring the instance to use [IMDSv2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html) only. For more information, please refer to the AWS guidance [here](https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node). If you are using the IMDSv2, set the hop limit to 2 or higher in order to allow the LBC to perform the metadata introspection.
 
 You can set the IMDSv2 as follows:
 ```
@@ -137,6 +137,7 @@ The following IAM permissions subset is for those using `TargetGroupBinding` onl
                 "ec2:DescribeVpcs",
                 "ec2:DescribeSecurityGroups",
                 "ec2:DescribeInstances",
+                "elasticloadbalancing:DescribeLoadBalancers",
                 "elasticloadbalancing:DescribeTargetGroups",
                 "elasticloadbalancing:DescribeTargetHealth",
                 "elasticloadbalancing:ModifyTargetGroup",


### PR DESCRIPTION
closes #3462

Details on the solution is here: https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/3462#issuecomment-1935877452

*** VERY IMPORTANT NOTE ***

for this to work, one need to add one extra IAM permission to the ALB controller: `elasticloadbalancing:DescribeLoadBalancers`


One can test the implementation using the following docker container: `marcosdiez/aws-load-balancer-controller:v2.7.1-m1` 