### PR TITLE
fix log level in listener manager and tagging manager

### DIFF
--- a/pkg/deploy/elbv2/listener_manager.go
+++ b/pkg/deploy/elbv2/listener_manager.go
@@ -161,7 +161,7 @@ func (m *defaultListenerManager) updateSDKListenerWithExtraCertificates(ctx cont
 	sdkLS ListenerWithTags, isNewSDKListener bool) error {
 	// if TLS is not supported, we shouldn't update
 	if resLS.Spec.SSLPolicy == nil && sdkLS.Listener.SslPolicy == nil {
-		m.logger.V(2).Info("Res and Sdk Listener don't have SSL Policy set, we skip updating extra certs for non-TLS listener.")
+		m.logger.V(1).Info("Res and Sdk Listener don't have SSL Policy set, skip updating extra certs for non-TLS listener.")
 		return nil
 	}
 

--- a/pkg/deploy/elbv2/tagging_manager.go
+++ b/pkg/deploy/elbv2/tagging_manager.go
@@ -259,7 +259,7 @@ func (m *defaultTaggingManager) ListListenerRules(ctx context.Context, lsARN str
 // TODO: we can refactor this by store provisioned LB's ARN as annotations on Ingress/Service, thus avoid this heavy lookup calls when RGT is not available.
 func (m *defaultTaggingManager) ListLoadBalancers(ctx context.Context, tagFilters ...tracking.TagFilter) ([]LoadBalancerWithTags, error) {
 	if m.featureGates.Enabled(config.EnableRGTAPI) {
-		m.logger.V(2).Info("ResourceGroupTagging enabled, list the load balancers via RGT API")
+		m.logger.V(1).Info("ResourceGroupTagging enabled, list the load balancers via RGT API")
 		return m.listLoadBalancersRGT(ctx, tagFilters)
 	}
 	return m.listLoadBalancersNative(ctx, tagFilters)
@@ -267,7 +267,7 @@ func (m *defaultTaggingManager) ListLoadBalancers(ctx context.Context, tagFilter
 
 func (m *defaultTaggingManager) ListTargetGroups(ctx context.Context, tagFilters ...tracking.TagFilter) ([]TargetGroupWithTags, error) {
 	if m.featureGates.Enabled(config.EnableRGTAPI) {
-		m.logger.V(2).Info("ResourceGroupTagging enabled, list the target groups via RGT API")
+		m.logger.V(1).Info("ResourceGroupTagging enabled, list the target groups via RGT API")
 		return m.listTargetGroupsRGT(ctx, tagFilters)
 	}
 	return m.listTargetGroupsNative(ctx, tagFilters)


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->
Fix the log level from v(2) to v(1) introduced in previous PR: https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3564

### Description

<!--
Please explain the changes you made here.

Help your reviewers by guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->
The `logger.V(1).Info()` should be the correct log level for debug log,
### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
