### PR TITLE
docs: ingress subnets annotation - clarify locale differences

### DIFF
--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -226,7 +226,10 @@ Traffic Routing can be controlled with following annotations:
 - <a name="subnets">`alb.ingress.kubernetes.io/subnets`</a> specifies the [Availability Zone](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html)s that the ALB will route traffic to. See [Load Balancer subnets](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-subnets.html) for more details.
 
     !!!note ""
-        You must specify at least two subnets in different AZs. Either subnetID or subnetName(Name tag on subnets) can be used.
+        You must specify at least two subnets in different AZs unless utilizing the outpost locale, in which case a single subnet suffices. Either subnetID or subnetName(Name tag on subnets) can be used.
+
+    !!!note ""
+        You must not mix subnets from different locales: availability-zone, local-zone, wavelength-zone, outpost.
 
     !!!tip
         You can enable subnet auto discovery to avoid specifying this annotation on every Ingress. See [Subnet Discovery](../../deploy/subnet_discovery.md) for instructions.


### PR DESCRIPTION
### Issue

N/A

### Description

I noticed the special behavior of the controller when subnets from different locales are used. For instance:
- it's enough to specify a single subnet if it's from the outposts locale
- subnets from different locales cannot be mixed, the following error gets logged:
```
{"level":"error","ts":1707915980.0865242,"logger":"controller-runtime.manager.controller.ingress","msg":"Reconciler error","name":"echoserver","namespace":"echoserver","error":"subnets in multiple locales: [availability-zone outpost]"}
```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
