### PR TITLE
subnet discovery: new flag to enable prioritization by availability-zone locale

### DIFF
--- a/docs/deploy/configurations.md
+++ b/docs/deploy/configurations.md
@@ -97,6 +97,7 @@ Currently, you can set only 1 namespace to watch in this flag. See [this Kuberne
 |load-balancer-class                    | string                          | service.k8s.aws/nlb| Name of the load balancer class specified in service `spec.loadBalancerClass` reconciled by this controller |
 |log-level                              | string                          | info            | Set the controller log level - info, debug |
 |metrics-bind-addr                      | string                          | :8080           | The address the metric endpoint binds to |
+|subnet-discovery-sorting-algorithm     | string                          | id              | Set the algoritm by which subnets should be sorted if multiple are found in the same availability zone |
 |service-max-concurrent-reconciles      | int                             | 3               | Maximum number of concurrently running reconcile loops for service |
 |[sync-period](#sync-period)                            | duration                        | 10h0m0s         | Period at which the controller forces the repopulation of its local object stores|
 |targetgroupbinding-max-concurrent-reconciles | int                       | 3               | Maximum number of concurrently running reconcile loops for targetGroupBinding |

--- a/docs/deploy/subnet_discovery.md
+++ b/docs/deploy/subnet_discovery.md
@@ -2,8 +2,8 @@
 By default, the AWS Load Balancer Controller (LBC) auto-discovers network subnets that it can create AWS Network Load Balancers (NLB) and AWS Application Load Balancers (ALB) in. ALBs require at least two subnets across Availability Zones by default, 
 set [Feature Gate ALBSingleSubnet](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/deploy/configurations/#feature-gates) to "true" allows using only 1 subnet for provisioning ALB. NLBs require one subnet.
 The subnets must be tagged appropriately for auto-discovery to work. The controller chooses one subnet from each Availability Zone. During auto-discovery, the controller
-considers subnets with at least eight available IP addresses. In the case of multiple qualified tagged subnets in an Availability Zone, the controller chooses the first one in lexicographical 
-order by the subnet IDs.
+considers subnets with at least eight available IP addresses. In the case of multiple qualified tagged subnets in an Availability Zone, the controller defaults to selecting the first subnet based on lexicographical order of subnet IDs 
+Other available algorithm for selection include `azfirst` to prioritize subnets from availability-zone locale. 
 For more information about the subnets for the LBC, see [Application Load Balancers](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html) 
 and [Network Load Balancers](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html).
 If you used `eksctl` or an Amazon EKS AWS CloudFormation template to create your VPC after March 26, 2020, then the subnets are tagged appropriately when they're created. For 

--- a/main.go
+++ b/main.go
@@ -105,7 +105,7 @@ func main() {
 	sgReconciler := networking.NewDefaultSecurityGroupReconciler(sgManager, ctrl.Log)
 	azInfoProvider := networking.NewDefaultAZInfoProvider(cloud.EC2(), ctrl.Log.WithName("az-info-provider"))
 	vpcInfoProvider := networking.NewDefaultVPCInfoProvider(cloud.EC2(), ctrl.Log.WithName("vpc-info-provider"))
-	subnetResolver := networking.NewDefaultSubnetsResolver(azInfoProvider, cloud.EC2(), cloud.VpcID(), controllerCFG.ClusterName, ctrl.Log.WithName("subnets-resolver"))
+	subnetResolver := networking.NewDefaultSubnetsResolver(azInfoProvider, cloud.EC2(), cloud.VpcID(), controllerCFG.ClusterName, controllerCFG.SubnetDiscoverySortingAlgorithm, ctrl.Log.WithName("subnets-resolver"))
 	tgbResManager := targetgroupbinding.NewDefaultResourceManager(mgr.GetClient(), cloud.ELBV2(), cloud.EC2(),
 		podInfoRepo, sgManager, sgReconciler, vpcInfoProvider,
 		cloud.VpcID(), controllerCFG.ClusterName, controllerCFG.FeatureGates.Enabled(config.EndpointsFailOpen), controllerCFG.EnableEndpointSlices, controllerCFG.DisableRestrictedSGRules,

--- a/pkg/ingress/model_build_load_balancer_test.go
+++ b/pkg/ingress/model_build_load_balancer_test.go
@@ -1270,6 +1270,7 @@ func Test_defaultModelBuildTask_buildLoadBalancerSubnets(t *testing.T) {
 				mockEC2,
 				"vpc-1",
 				"test-cluster",
+				"id",
 				logr.New(&log.NullLogSink{}),
 			)
 


### PR DESCRIPTION
### Issue

N/A

### Description
Draft PR to gather opinions about adding a flag to enable different algorithms for the subnet selection from multiple qualified ones when they all come from the same availability zone. The sorting by subnet IDs remains the default. A new sorting alogrithm `azfirst` is added to prioritize `availability-zone` locale over other locales. This change may help to reduce the random aspect of the subnet selection when multiple locales are used in a cluster.

Example of where this can be helpful:
- AZ1: has availability-zone an outpost subnets, all tagged with cluster and role tags, so all eligible for the discovery
- AZ2: has only availability-zone subnets also tagged for the subnet discovery
- The discovery may fail with "subnets in multiple locales" error if outposts subnets from AZ1 have lower subnet IDs
 
### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
