### PR TITLE
feat: allowed ACM cert discovery to filter on CA ARNs (#3565)

### DIFF
--- a/controllers/ingress/group_controller.go
+++ b/controllers/ingress/group_controller.go
@@ -60,7 +60,7 @@ func NewGroupReconciler(cloud aws.Cloud, k8sClient client.Client, eventRecorder 
 		authConfigBuilder, enhancedBackendBuilder, trackingProvider, elbv2TaggingManager, controllerConfig.FeatureGates,
 		cloud.VpcID(), controllerConfig.ClusterName, controllerConfig.DefaultTags, controllerConfig.ExternalManagedTags,
 		controllerConfig.DefaultSSLPolicy, controllerConfig.DefaultTargetType, backendSGProvider, sgResolver,
-		controllerConfig.EnableBackendSecurityGroup, controllerConfig.DisableRestrictedSGRules, controllerConfig.FeatureGates.Enabled(config.EnableIPTargetType), logger)
+		controllerConfig.EnableBackendSecurityGroup, controllerConfig.DisableRestrictedSGRules, controllerConfig.IngressConfig.AllowedCertificateAuthorityARNs, controllerConfig.FeatureGates.Enabled(config.EnableIPTargetType), logger)
 	stackMarshaller := deploy.NewDefaultStackMarshaller()
 	stackDeployer := deploy.NewDefaultStackDeployer(cloud, k8sClient, networkingSGManager, networkingSGReconciler, elbv2TaggingManager,
 		controllerConfig, ingressTagPrefix, logger)

--- a/docs/deploy/configurations.md
+++ b/docs/deploy/configurations.md
@@ -71,6 +71,7 @@ Currently, you can set only 1 namespace to watch in this flag. See [this Kuberne
 |aws-max-retries                        | int                             | 10              | Maximum retries for AWS APIs |
 |aws-region                             | string                          | [instance metadata](#instance-metadata)   | AWS Region for the kubernetes cluster |
 |aws-vpc-id                             | string                          | [instance metadata](#instance-metadata)   | AWS VPC ID for the Kubernetes cluster |
+|allowed-certificate-authority-arns     | stringList                      | []              | Specify an optional list of CA ARNs to filter on in cert discovery (empty means all CAs are allowed) |
 |backend-security-group                 | string                          |                 | Backend security group id to use for the ingress rules on the worker node SG|
 |cluster-name                           | string                          |                 | Kubernetes cluster name|
 |default-ssl-policy                     | string                          | ELBSecurityPolicy-2016-08 | Default SSL Policy that will be applied to all Ingresses or Services that do not have the SSL Policy annotation |

--- a/helm/aws-load-balancer-controller/templates/deployment.yaml
+++ b/helm/aws-load-balancer-controller/templates/deployment.yaml
@@ -159,6 +159,9 @@ spec:
         {{- if .Values.serviceTargetENISGTags }}
         - --service-target-eni-security-group-tags={{ .Values.serviceTargetENISGTags }}
         {{- end }}
+        {{- if .Values.certDiscovery.allowedCertificateAuthorityARNs }}
+        - --allowed-certificate-authority-arns={{ .Values.certDiscovery.allowedCertificateAuthorityARNs }}
+        {{- end }}
         {{- if or .Values.env .Values.envSecretName }}
         env:
         {{- if .Values.env}}

--- a/helm/aws-load-balancer-controller/values.yaml
+++ b/helm/aws-load-balancer-controller/values.yaml
@@ -350,6 +350,9 @@ controllerConfig:
   # NLBHealthCheckAdvancedConfig: true
   # ALBSingleSubnet: false
 
+certDiscovery: 
+  allowedCertificateAuthorityARNs: "" # empty means all CAs are in scope
+
 # objectSelector for webhook
 objectSelector:
   matchExpressions:

--- a/pkg/config/ingress_config.go
+++ b/pkg/config/ingress_config.go
@@ -9,6 +9,7 @@ const (
 	flagIngressMaxConcurrentReconciles       = "ingress-max-concurrent-reconciles"
 	flagTolerateNonExistentBackendService    = "tolerate-non-existent-backend-service"
 	flagTolerateNonExistentBackendAction     = "tolerate-non-existent-backend-action"
+	flagAllowedCAArns                        = "allowed-certificate-authority-arns"
 	defaultIngressClass                      = "alb"
 	defaultDisableIngressClassAnnotation     = false
 	defaultDisableIngressGroupNameAnnotation = false
@@ -42,6 +43,9 @@ type IngressConfig struct {
 	// TolerateNonExistentBackendAction specifies whether to allow rules that reference a backend action that does not
 	// exist. In this case, requests to that rule will result in a 503 error.
 	TolerateNonExistentBackendAction bool
+
+	// AllowedCertificateAuthoritiyARNs contains a list of all CAs to consider when discovering certificates for ingress resources
+	AllowedCertificateAuthorityARNs []string
 }
 
 // BindFlags binds the command line flags to the fields in the config object
@@ -58,4 +62,5 @@ func (cfg *IngressConfig) BindFlags(fs *pflag.FlagSet) {
 		"Tolerate rules that specify a non-existent backend service")
 	fs.BoolVar(&cfg.TolerateNonExistentBackendAction, flagTolerateNonExistentBackendAction, defaultTolerateNonExistentBackendAction,
 		"Tolerate rules that specify a non-existent backend action")
+	fs.StringSliceVar(&cfg.AllowedCertificateAuthorityARNs, flagAllowedCAArns, []string{}, "Specify an optional list of CA ARNs to filter on in cert discovery")
 }

--- a/pkg/ingress/model_builder.go
+++ b/pkg/ingress/model_builder.go
@@ -44,8 +44,8 @@ func NewDefaultModelBuilder(k8sClient client.Client, eventRecorder record.EventR
 	trackingProvider tracking.Provider, elbv2TaggingManager elbv2deploy.TaggingManager, featureGates config.FeatureGates,
 	vpcID string, clusterName string, defaultTags map[string]string, externalManagedTags []string, defaultSSLPolicy string, defaultTargetType string,
 	backendSGProvider networkingpkg.BackendSGProvider, sgResolver networkingpkg.SecurityGroupResolver,
-	enableBackendSG bool, disableRestrictedSGRules bool, enableIPTargetType bool, logger logr.Logger) *defaultModelBuilder {
-	certDiscovery := NewACMCertDiscovery(acmClient, logger)
+	enableBackendSG bool, disableRestrictedSGRules bool, allowedCAARNs []string, enableIPTargetType bool, logger logr.Logger) *defaultModelBuilder {
+	certDiscovery := NewACMCertDiscovery(acmClient, allowedCAARNs, logger)
 	ruleOptimizer := NewDefaultRuleOptimizer(logger)
 	return &defaultModelBuilder{
 		k8sClient:                k8sClient,


### PR DESCRIPTION
### Issue

Resolves #3565

### Description

This PR adds a new flag that is passed to the ACMCertDiscovery type in order to filter auto-discovered certificates for a list of CA ARNs. This is usefull in situations where one needs to switch PCA while ensuring the aws-load-balancer-controller should explicitly pick the new CA to allow the old one to be removed (which is not possible when certificates are in use).

### Checklist
- [ ] Added tests that cover your change (if possible) -> there's no mock for the AWS ACM api in the code right now
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2: