### PR TITLE
feat: add support for templated clusterName

### DIFF
--- a/helm/aws-load-balancer-controller/templates/deployment.yaml
+++ b/helm/aws-load-balancer-controller/templates/deployment.yaml
@@ -59,7 +59,7 @@ spec:
       containers:
       - name: {{ .Chart.Name }}
         args:
-        - --cluster-name={{ required "Chart cannot be installed without a valid clusterName!" .Values.clusterName }}
+        - --cluster-name={{ required "Chart cannot be installed without a valid clusterName!" (tpl .Values.clusterName .) }}
         {{- if .Values.ingressClass }}
         - --ingress-class={{ .Values.ingressClass }}
         {{- end }}


### PR DESCRIPTION
### Issue

Allows templating of clusterName. This is similar to https://github.com/DataDog/helm-charts/pull/1324 and solves the same purpose.

### Description

We're deploying the chart using ArgoCD and ApplicationSets with a cluster generator. To avoid having to bake alb-specific logic into our wider ArgoCD Application generator, we need support for rendering `clusterName` as a template variable in order to generate an appropriate value from generic values.


### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
