### PR TITLE
Add helm chart variable to specify webhook annotations

### DIFF
--- a/helm/aws-load-balancer-controller/templates/webhook.yaml
+++ b/helm/aws-load-balancer-controller/templates/webhook.yaml
@@ -3,9 +3,14 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-{{- if $.Values.enableCertManager }}
+{{- if or $.Values.enableCertManager $.Values.webhookAnnotations }}
   annotations:
+  {{- if $.Values.webhookAnnotations }}
+    {{- toYaml $.Values.webhookAnnotations | nindent 4}}
+  {{- end }}
+  {{- if $.Values.enableCertManager }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ template "aws-load-balancer-controller.namePrefix" . }}-serving-cert
+  {{- end }}
 {{- end }}
   name: {{ include "aws-load-balancer-controller.namePrefix" . }}-webhook
   labels:
@@ -113,9 +118,14 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-{{- if $.Values.enableCertManager }}
+{{- if or $.Values.enableCertManager $.Values.webhookAnnotations }}
   annotations:
+  {{- if $.Values.webhookAnnotations }}
+    {{- toYaml $.Values.webhookAnnotations | nindent 4}}
+  {{- end }}
+  {{- if $.Values.enableCertManager }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ template "aws-load-balancer-controller.namePrefix" . }}-serving-cert
+  {{- end }}
 {{- end }}
   name: {{ include "aws-load-balancer-controller.namePrefix" . }}-webhook
   labels:

--- a/helm/aws-load-balancer-controller/values.yaml
+++ b/helm/aws-load-balancer-controller/values.yaml
@@ -98,6 +98,9 @@ updateStrategy: {}
   #   maxSurge: 1
   #   maxUnavailable: 1
 
+# webhookAnnotations contains annotations to be added to webhooks.
+webhookAnnotations: {}
+
 # serviceAnnotations contains annotations to be added to the provisioned webhook service resource
 serviceAnnotations: {}
 


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description

This PR adds an option in aws-load-balancer-controller helm chart to specify extra annotations to both mutating and validating webhook.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
