### PR TITLE
Removed extra slash to fix kubectl apply of crd command

### DIFF
--- a/helm/aws-load-balancer-controller/README.md
+++ b/helm/aws-load-balancer-controller/README.md
@@ -109,7 +109,7 @@ helm repo add eks https://aws.github.io/eks-charts
 Install the TargetGroupBinding CRDs:
 
 ```shell script
-kubectl apply -k "github.com/aws/eks-charts/stable/aws-load-balancer-controller//crds?ref=master"
+kubectl apply -k "github.com/aws/eks-charts/stable/aws-load-balancer-controller/crds?ref=master"
 ```
 
 Install the AWS Load Balancer controller, if using iamserviceaccount


### PR DESCRIPTION
Remove extra / in crds

Without this change, the command results in an error:
```
% kubectl apply -k "github.com/aws/eks-charts/stable/aws-load-balancer-controller//crds?ref=master"
error: failed to run '/usr/bin/git fetch --depth=1 https://github.com/aws/eks-charts/stable/aws-load-balancer-controller master': remote: Not Found
fatal: repository 'https://github.com/aws/eks-charts/stable/aws-load-balancer-controller/' not found
: exit status 128
```

This change fixes this issue.
### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:
