### PR TITLE
Preserve loadBalancerClass on Service updates

### DIFF
--- a/webhooks/core/service_mutator.go
+++ b/webhooks/core/service_mutator.go
@@ -52,7 +52,41 @@ func (m *serviceMutator) MutateCreate(ctx context.Context, obj runtime.Object) (
 }
 
 func (m *serviceMutator) MutateUpdate(ctx context.Context, obj runtime.Object, oldObj runtime.Object) (runtime.Object, error) {
-	return obj, nil
+	// this mutator only cares about Service objects
+	newSvc, ok := obj.(*corev1.Service)
+	if !ok {
+		return obj, nil
+	}
+
+	oldSvc, ok := oldObj.(*corev1.Service)
+	if !ok {
+		return obj, nil
+	}
+
+	if newSvc.Spec.Type != corev1.ServiceTypeLoadBalancer {
+		return obj, nil
+	}
+
+	// does the old Service object have spec.loadBalancerClass?
+	if oldSvc.Spec.LoadBalancerClass != nil && *oldSvc.Spec.LoadBalancerClass != "" {
+		// if so, let's inspect the incoming object for the same field
+
+		// does the new Service object lack spec.loadBalancerClass?
+		// if so, set it to the old value
+		// if yes, then leave it be because someone wanted it that way, let the user deal with the error
+		if newSvc.Spec.LoadBalancerClass == nil || *newSvc.Spec.LoadBalancerClass == "" {
+			newSvc.Spec.LoadBalancerClass = oldSvc.Spec.LoadBalancerClass
+
+			m.logger.Info("preserved loadBalancerClass", "service", newSvc.Name, "loadBalancerClass", *newSvc.Spec.LoadBalancerClass)
+			return newSvc, nil
+		}
+
+		m.logger.Info("service already has loadBalancerClass, skipping", "service", newSvc.Name, "loadBalancerClass", *newSvc.Spec.LoadBalancerClass)
+		return newSvc, nil
+	}
+
+	m.logger.Info("service did not originally have a loadBalancerClass, skipping", "service", newSvc.Name)
+	return newSvc, nil
 }
 
 // +kubebuilder:webhook:path=/mutate-v1-service,mutating=true,failurePolicy=fail,groups="",resources=services,verbs=create,versions=v1,name=mservice.elbv2.k8s.aws,sideEffects=None,webhookVersions=v1,admissionReviewVersions=v1beta1

--- a/webhooks/core/service_mutator_test.go
+++ b/webhooks/core/service_mutator_test.go
@@ -1,0 +1,50 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestMutateUpdate_WhenServiceIsNotLoadBalancer(t *testing.T) {
+	m := &serviceMutator{}
+	svc := &corev1.Service{Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeClusterIP}}
+	_, err := m.MutateUpdate(context.Background(), svc, svc)
+	assert.NoError(t, err)
+
+	assert.Nil(t, svc.Spec.LoadBalancerClass)
+}
+
+func TestMutateUpdate_WhenOldServiceHasLoadBalancerClassAndNewServiceDoesNot(t *testing.T) {
+	m := &serviceMutator{}
+	oldSvc := &corev1.Service{Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer, LoadBalancerClass: stringPtr("old-class")}}
+	newSvc := &corev1.Service{Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer}}
+	_, err := m.MutateUpdate(context.Background(), newSvc, oldSvc)
+	assert.NoError(t, err)
+	assert.Equal(t, "old-class", *newSvc.Spec.LoadBalancerClass)
+}
+
+func TestMutateUpdate_WhenOldServiceHasLoadBalancerClassAndNewServiceHasDifferent(t *testing.T) {
+	m := &serviceMutator{}
+	oldSvc := &corev1.Service{Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer, LoadBalancerClass: stringPtr("old-class")}}
+	newSvc := &corev1.Service{Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer, LoadBalancerClass: stringPtr("new-class")}}
+	_, err := m.MutateUpdate(context.Background(), newSvc, oldSvc)
+	assert.NoError(t, err)
+	assert.Equal(t, "new-class", *newSvc.Spec.LoadBalancerClass)
+}
+
+func TestMutateUpdate_WhenOldServiceDoesNotHaveLoadBalancerClass(t *testing.T) {
+	m := &serviceMutator{}
+	oldSvc := &corev1.Service{Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer}}
+	newSvc := &corev1.Service{Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer}}
+	_, err := m.MutateUpdate(context.Background(), newSvc, oldSvc)
+	assert.NoError(t, err)
+
+	assert.Nil(t, newSvc.Spec.LoadBalancerClass)
+}
+
+func stringPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION
### Issue

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/3617

### Description

See the linked issue for the observed problem.

This PR enables service mutator to run on updates to service objects (the `UPDATE` operation needs to be added to the webhook configuration for this to work).

Update mutator will only act on service objects that have `spec.loadBalancerClass` set to a non-empty value. When this is true, the incoming (updated) Service object will be updated to have the same `spec.loadBalancerClass` as the existing Service object.

Considering that `spec.loadBalancerClass`, once set, cannot be unset or modified, this change prevents unexpected validation errors in cases of `UPDATE` operation with Service object that omits the `spec.loadBalancerClass` field. This is the case for `helm rollback --force`, described in the linked issue, as well as for `kubectl replace` command.

Documentation may need to be updated depending on the outcome of https://github.com/aws/eks-charts/issues/1063 - that PR changes some chart values that are being referenced in the docs.

### Testing
This change was tested using the helm chart built from https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3653.

For testing, I had MWC with no UPDATE operation first (as it is currently configured), then I enabled it in the chart.

Tested by creating a Service via `kubectl apply`, updating it via `kubectl apply`, and then replacing it via `kubectl replace`. `kubectl replace` previously would fail with validation error due to attempt to modify spec.loadBalancerClass. No longer fails.

I submitted Service manifests with and without the `spec.loadBalancerClass` field.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
