### PR TITLE
Add DescribeTrustStores to IAM policy for China partition

### DIFF
--- a/docs/install/iam_policy_cn.json
+++ b/docs/install/iam_policy_cn.json
@@ -38,7 +38,8 @@
                 "elasticloadbalancing:DescribeTargetGroups",
                 "elasticloadbalancing:DescribeTargetGroupAttributes",
                 "elasticloadbalancing:DescribeTargetHealth",
-                "elasticloadbalancing:DescribeTags"
+                "elasticloadbalancing:DescribeTags",
+                "elasticloadbalancing:DescribeTrustStores"
             ],
             "Resource": "*"
         },


### PR DESCRIPTION
### Issue

N/A

### Description

ALB mTLS is now available in the China partition. [This previous PR](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3532) added support for ALB mTLS to the AWS LBC, and updated the IAM policy for the commercial and GovCloud partitions where ALB mTLS was initially launched. This PR updates the IAM policy for the China partition to support ALB mTLS.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes

My understanding is that IAM policy updates do not need to be tested. Additionally, the documentation does not describe any regional differences for ALB mTLS.

Please let me know if you have feedback :)

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
