### PR TITLE
[helm chart] Allow passing template values for clusterName, region and vpcId

### DIFF
--- a/helm/aws-load-balancer-controller/Chart.yaml
+++ b/helm/aws-load-balancer-controller/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.7.1
-appVersion: v2.7.0
+version: 1.7.3
+appVersion: v2.7.2
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/helm/aws-load-balancer-controller/Chart.yaml
+++ b/helm/aws-load-balancer-controller/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 1.7.3
-appVersion: v2.7.2
+version: 1.7.1
+appVersion: v2.7.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/helm/aws-load-balancer-controller/templates/deployment.yaml
+++ b/helm/aws-load-balancer-controller/templates/deployment.yaml
@@ -59,15 +59,17 @@ spec:
       containers:
       - name: {{ .Chart.Name }}
         args:
-        - --cluster-name={{ required "Chart cannot be installed without a valid clusterName!" .Values.clusterName }}
+        - --cluster-name={{ required "Chart cannot be installed without a valid clusterName!" (tpl (default "" .Values.clusterName) .) }}
         {{- if .Values.ingressClass }}
         - --ingress-class={{ .Values.ingressClass }}
         {{- end }}
-        {{- if .Values.region }}
+        {{- $region := tpl (default "" .Values.region) . }}
+        {{- if $region }}
         - --aws-region={{ .Values.region }}
         {{- end }}
-        {{- if .Values.vpcId }}
-        - --aws-vpc-id={{ .Values.vpcId }}
+        {{- $vpcID := tpl (default "" .Values.vpcId) . }}
+        {{- if $vpcID }}
+        - --aws-vpc-id={{ $vpcID }}
         {{- end }}
         {{- if .Values.awsApiEndpoints }}
         - --aws-api-endpoints={{ .Values.awsApiEndpoints }}


### PR DESCRIPTION
### Issue

Helm doesn't support currently passing user parameters of the parent chart to the subchart (without using global)
See https://github.com/helm/helm/issues/6699 and https://github.com/helm/helm/pull/6876 for more context
### Description of changes

While using the `aws-load-balancer-controller` as a dependency for another chart , I found it difficult to pass a global or a dynamic value for the `clusterName`, `vpcId`, `region` and other fields.

This PR adds support for passing a template as value for the `clusterName`, `vpcId` and `region` field.

Initial PR was raised in https://github.com/aws/eks-charts/pull/911

### Checklist
- [x] Added/modified documentation as required (such as the `README.md` for modified charts)
- [x] Incremented the chart `version` in `Chart.yaml` for the modified chart(s)
- [x] Manually tested. Describe what testing was done in the testing section below
- [x] Make sure the title of the PR is a good description that can go into the release notes

### Testing

I've tested it by passing both static value and dynamic ones as follow:
- for static values, nothing has changed, e.g.
  - `values.yaml` :
  ```
  clusterName: "aa"
  ```
  - `helm template --debug  .`
  ```
  ..............
   containers:
        - name: aws-load-balancer-controller
          args:
          - --cluster-name=aa
          - --ingress-class=alb
          command:
          - /controller
  ..............
  ```

- for template value:
  - `values.yaml`:
  ```
  ........
  clusterName: "{{- .Values.global.clusterName }}"
  ........
  ```
    - `helm template --debug --set global.clusterName=ethos000-sbx-va6 .`
    ```
  ..............
  containers:
        - name: aws-load-balancer-controller
          args:
          - --cluster-name=ethos000-sbx-va6
          - --ingress-class=alb
          command:
          - /controller
  ..............
  ```

- for empty/unset `clusterName` value:
  - `helm template --debug .`
```
install.go:194: [debug] Original chart version: ""
install.go:211: [debug] CHART PATH: /test-chart

Error: execution error at (test-chart/charts/aws-load-balancer-controller/templates/deployment.yaml:61:28): Chart cannot be installed without a valid clusterName!
helm.go:84: [debug] execution error at (/test-chart/charts/aws-load-balancer-controller/templates/deployment.yaml:61:28): Chart cannot be installed without a valid clusterName!
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
