### PR TITLE
Add `load-balancer-name-prefix` annotation

### DIFF
--- a/docs/controller-devel.md
+++ b/docs/controller-devel.md
@@ -117,3 +117,10 @@ To deploy the CRDs and the container image to a Kubernetes cluster, run the foll
 ```bash
 make deploy
 ```
+
+
+## Running E2E tests
+
+To run the E2E tests, run `make e2e-test`.
+This will spin up an EKS cluster and run the E2E tests against it.
+Resources created during the test run will be cleaned up after the test run.

--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -17,6 +17,7 @@ You can add annotations to kubernetes Ingress and Service objects to customize t
 | Name                                                                                                  | Type                        |Default|Location|MergeBehavior|
 |-------------------------------------------------------------------------------------------------------|-----------------------------|-------|--------|------|
 | [alb.ingress.kubernetes.io/load-balancer-name](#load-balancer-name)                                   | string                      |N/A|Ingress|Exclusive|
+| [alb.ingress.kubernetes.io/load-balancer-name-prefix](#load-balancer-name-prefix)                     | string                      |N/A|Ingress|Exclusive|
 | [alb.ingress.kubernetes.io/group.name](#group.name)                                                   | string                      |N/A|Ingress|N/A|
 | [alb.ingress.kubernetes.io/group.order](#group.order)                                                 | integer                     |0|Ingress|N/A|
 | [alb.ingress.kubernetes.io/tags](#tags)                                                               | stringMap                   |N/A|Ingress,Service|Merge|
@@ -33,7 +34,7 @@ You can add annotations to kubernetes Ingress and Service objects to customize t
 | [alb.ingress.kubernetes.io/listen-ports](#listen-ports)                                               | json                        |'[{"HTTP": 80}]' \| '[{"HTTPS": 443}]'|Ingress|Merge|
 | [alb.ingress.kubernetes.io/ssl-redirect](#ssl-redirect)                                               | integer                     |N/A|Ingress|Exclusive|
 | [alb.ingress.kubernetes.io/inbound-cidrs](#inbound-cidrs)                                             | stringList                  |0.0.0.0/0, ::/0|Ingress|Exclusive|
-| [alb.ingress.kubernetes.io/security-group-prefix-lists](#security-group-prefix-lists)                                               | stringList                        |pl-00000000, pl-1111111|Ingress|Exclusive|
+| [alb.ingress.kubernetes.io/security-group-prefix-lists](#security-group-prefix-lists)                 | stringList                        |pl-00000000, pl-1111111|Ingress|Exclusive|
 | [alb.ingress.kubernetes.io/certificate-arn](#certificate-arn)                                         | stringList                  |N/A|Ingress|Merge|
 | [alb.ingress.kubernetes.io/ssl-policy](#ssl-policy)                                                   | string                      |ELBSecurityPolicy-2016-08|Ingress|Exclusive|
 | [alb.ingress.kubernetes.io/target-type](#target-type)                                                 | instance \| ip              |instance|Ingress,Service|N/A|
@@ -174,6 +175,20 @@ Traffic Routing can be controlled with following annotations:
     !!!example
         ```
         alb.ingress.kubernetes.io/load-balancer-name: custom-name
+        ```
+
+- <a name="load-balancer-name-prefix">`alb.ingress.kubernetes.io/load-balancer-name-prefix`</a> specifies the custom name prefix to use for the load balancer. The provided value will have 11 characters appended to it for uniqueness. Prefixes longer than 21 characters will be treated as an error.
+
+    !!!note "Merge Behavior"
+        `name-prefix` is exclusive across all Ingresses in an IngressGroup.
+
+        - Once defined on a single Ingress, it impacts every Ingress within the IngressGroup.
+
+    !!!example
+        The created load balancer name will be `custom-name-prefix-xxxxxxxxxx`, with the last portion being a unique identifier.
+
+        ```
+        alb.ingress.kubernetes.io/load-balancer-name-prefix: custom-name-prefix
         ```
 
 - <a name="target-type">`alb.ingress.kubernetes.io/target-type`</a> specifies how to route traffic to pods. You can choose between `instance` and `ip`:

--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -177,7 +177,7 @@ Traffic Routing can be controlled with following annotations:
         alb.ingress.kubernetes.io/load-balancer-name: custom-name
         ```
 
-- <a name="load-balancer-name-prefix">`alb.ingress.kubernetes.io/load-balancer-name-prefix`</a> specifies the custom name prefix to use for the load balancer. The provided value will have 11 characters appended to it for uniqueness. Prefixes longer than 21 characters will be treated as an error.
+- <a name="load-balancer-name-prefix">`alb.ingress.kubernetes.io/load-balancer-name-prefix`</a> specifies the custom name prefix to use for the load balancer. The provided value will have 11 characters appended to it for uniqueness. Due to AWS load balancer naming constraints, specifying a prefix longer than 21 characters will be treated as an error.
 
     !!!note "Merge Behavior"
         `name-prefix` is exclusive across all Ingresses in an IngressGroup.

--- a/pkg/annotations/constants.go
+++ b/pkg/annotations/constants.go
@@ -7,6 +7,7 @@ const (
 	AnnotationPrefixIngress = "alb.ingress.kubernetes.io"
 	// Ingress annotation suffixes
 	IngressSuffixLoadBalancerName             = "load-balancer-name"
+	IngressSuffixLoadBalancerNamePrefix       = "load-balancer-name-prefix"
 	IngressSuffixGroupName                    = "group.name"
 	IngressSuffixGroupOrder                   = "group.order"
 	IngressSuffixTags                         = "tags"

--- a/pkg/ingress/model_build_load_balancer.go
+++ b/pkg/ingress/model_build_load_balancer.go
@@ -90,13 +90,13 @@ func (t *defaultModelBuildTask) buildLoadBalancerSpec(ctx context.Context, liste
 var invalidLoadBalancerNamePattern = regexp.MustCompile("[[:^alnum:]]")
 
 func (t *defaultModelBuildTask) buildLoadBalancerName(_ context.Context, scheme elbv2model.LoadBalancerScheme) (string, error) {
-	explicitName, err := t.getNameAnnotation(annotations.IngressSuffixLoadBalancerName, maximumLoadBalancerNameLength)
+	explicitName, err := t.parseNameOrNamePrefixFromAnnotation(annotations.IngressSuffixLoadBalancerName, maximumLoadBalancerNameLength)
 
 	if explicitName != "" || err != nil {
 		return explicitName, err
 	}
 
-	prefixName, err := t.getNameAnnotation(
+	prefixName, err := t.parseNameOrNamePrefixFromAnnotation(
 		annotations.IngressSuffixLoadBalancerNamePrefix,
 		maximumLoadBalancerNameLength-nameRandomLength-1, // including the dash
 	)
@@ -125,7 +125,7 @@ func (t *defaultModelBuildTask) buildLoadBalancerName(_ context.Context, scheme 
 	return fmt.Sprintf("k8s-%.8s-%.8s-%.*s", sanitizedNamespace, sanitizedName, nameRandomLength, uuid), nil
 }
 
-func (t *defaultModelBuildTask) getNameAnnotation(annotationName string, maxLength int) (string, error) {
+func (t *defaultModelBuildTask) parseNameOrNamePrefixFromAnnotation(annotationName string, maxLength int) (string, error) {
 	explicitNames := sets.String{}
 	for _, member := range t.ingGroup.Members {
 		rawName := ""

--- a/test/e2e/ingress/vanilla_ingress_test.go
+++ b/test/e2e/ingress/vanilla_ingress_test.go
@@ -337,7 +337,7 @@ var _ = Describe("vanilla ingress tests", func() {
 		})
 	})
 
-	Context("with `alb.ingress.kubernetes.io/load-balancer-name` variant settings", func() {
+	Context("with `alb.ingress.kubernetes.io/load-balancer-name*` variant settings", func() {
 		It("with 'alb.ingress.kubernetes.io/load-balancer-name' annotation explicitly specified, one ALB shall be created and functional", func() {
 			appBuilder := manifest.NewFixedResponseServiceBuilder()
 			ingBuilder := manifest.NewIngressBuilder()
@@ -375,6 +375,51 @@ var _ = Describe("vanilla ingress tests", func() {
 			sdkLB, err := tf.LBManager.GetLoadBalancerFromARN(ctx, lbARN)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(awssdk.StringValue(sdkLB.LoadBalancerName)).Should(Equal(lbName))
+
+			// test traffic
+			ExpectLBDNSBeAvailable(ctx, tf, lbARN, lbDNS)
+			httpExp := httpexpect.New(tf.LoggerReporter, fmt.Sprintf("http://%v", lbDNS))
+			httpExp.GET("/path").Expect().
+				Status(http.StatusOK).
+				Body().Equal("Hello World!")
+		})
+
+		It("with 'alb.ingress.kubernetes.io/load-balancer-name-prefix' annotation explicitly specified, one ALB shall be created with specified name", func() {
+			appBuilder := manifest.NewFixedResponseServiceBuilder()
+			ingBuilder := manifest.NewIngressBuilder()
+			dp, svc := appBuilder.Build(sandboxNS.Name, "app", tf.Options.TestImageRegistry)
+			ingBackend := networking.IngressBackend{
+				Service: &networking.IngressServiceBackend{
+					Name: svc.Name,
+					Port: networking.ServiceBackendPort{
+						Number: 80,
+					},
+				},
+			}
+			lbNamePrefix := "lb-prefix"
+			annotation := map[string]string{
+				"kubernetes.io/ingress.class":                         "alb",
+				"alb.ingress.kubernetes.io/scheme":                    "internet-facing",
+				"alb.ingress.kubernetes.io/load-balancer-name-prefix": lbNamePrefix,
+			}
+			if tf.Options.IPFamily == "IPv6" {
+				annotation["alb.ingress.kubernetes.io/ip-address-type"] = "dualstack"
+				annotation["alb.ingress.kubernetes.io/target-type"] = "ip"
+			}
+			ing := ingBuilder.
+				AddHTTPRoute("", networking.HTTPIngressPath{Path: "/path", PathType: &exact, Backend: ingBackend}).
+				WithAnnotations(annotation).Build(sandboxNS.Name, "ing")
+			resStack := fixture.NewK8SResourceStack(tf, dp, svc, ing)
+			err := resStack.Setup(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			defer resStack.TearDown(ctx)
+
+			lbARN, lbDNS := ExpectOneLBProvisionedForIngress(ctx, tf, ing)
+
+			sdkLB, err := tf.LBManager.GetLoadBalancerFromARN(ctx, lbARN)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(awssdk.StringValue(sdkLB.LoadBalancerName)).Should(HavePrefix("lb-prefix-"))
 
 			// test traffic
 			ExpectLBDNSBeAvailable(ctx, tf, lbARN, lbDNS)


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description

This adds a `alb.ingress.kubernetes.io/load-balancer-name-prefix` annotation. This is useful for being able to control the name of the created load balancer without needing to specify a fully unique name.

We have several similar clusters in one AWS account, all with similar namespace/resources. This leads to this situation, where it's hard to tell at a glance (without digging into tags) which load balancer goes to which cluster:

![image](https://github.com/kubernetes-sigs/aws-load-balancer-controller/assets/1041838/faa7d0f7-6d9c-48e4-b0e5-847f6a7340b0)

Already the ALBC will provide uniqueness for you if you do not specify a name. This is nice because you can be reasonable certain there will be no name collisions. That means you can copy/paste (and we can vend) a static piece of yaml into different clusters or namespaces IF you do not specify the `load-balancer-name`. 

However, if you want to get more descriptive with the name via `load-balancer-name`, now you need to worry about collision (even potentially with resources in other clusters).

`load-balancer-name-prefix` is a happy middle ground where you can be more specific without having to own avoiding naming collisions. 


### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested - make test and reviewed generated docs so they look right
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:
