### PR TITLE
Add dualstack without public IPv4 IP Address type

### DIFF
--- a/config/crd/bases/elbv2.k8s.aws_ingressclassparams.yaml
+++ b/config/crd/bases/elbv2.k8s.aws_ingressclassparams.yaml
@@ -83,6 +83,7 @@ spec:
                 enum:
                 - ipv4
                 - dualstack
+                - dualstack-without-public-ipv4
                 type: string
               loadBalancerAttributes:
                 description: LoadBalancerAttributes define the custom attributes to

--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -20,7 +20,7 @@ You can add annotations to kubernetes Ingress and Service objects to customize t
 | [alb.ingress.kubernetes.io/group.name](#group.name)                                                   | string                      |N/A|Ingress|N/A|
 | [alb.ingress.kubernetes.io/group.order](#group.order)                                                 | integer                     |0|Ingress|N/A|
 | [alb.ingress.kubernetes.io/tags](#tags)                                                               | stringMap                   |N/A|Ingress,Service|Merge|
-| [alb.ingress.kubernetes.io/ip-address-type](#ip-address-type)                                         | ipv4 \| dualstack           |ipv4|Ingress|Exclusive|
+| [alb.ingress.kubernetes.io/ip-address-type](#ip-address-type)                                         | ipv4 \| dualstack \|  dualstack-without-public-ipv4           |ipv4|Ingress|Exclusive|
 | [alb.ingress.kubernetes.io/scheme](#scheme)                                                           | internal \| internet-facing |internal|Ingress|Exclusive|
 | [alb.ingress.kubernetes.io/subnets](#subnets)                                                         | stringList                  |N/A|Ingress|Exclusive|
 | [alb.ingress.kubernetes.io/security-groups](#security-groups)                                         | stringList                  |N/A|Ingress|Exclusive|

--- a/docs/guide/ingress/ingress_class.md
+++ b/docs/guide/ingress/ingress_class.md
@@ -206,7 +206,7 @@ Within any given availability zone, subnets with a cluster tag will be chosen ov
 
 #### spec.ipAddressType
 
-`ipAddressType` is an optional setting. The available options are `ipv4` or `dualstack`.
+`ipAddressType` is an optional setting. The available options are `ipv4`, `dualstack`, or `dualstack-without-public-ipv4`.
 
 Cluster administrators can use `ipAddressType` field to restrict the ipAddressType for all Ingresses that belong to this IngressClass.
 

--- a/helm/aws-load-balancer-controller/crds/crds.yaml
+++ b/helm/aws-load-balancer-controller/crds/crds.yaml
@@ -82,6 +82,7 @@ spec:
                 enum:
                 - ipv4
                 - dualstack
+                - dualstack-without-public-ipv4
                 type: string
               loadBalancerAttributes:
                 description: LoadBalancerAttributes define the custom attributes to

--- a/pkg/ingress/model_build_load_balancer.go
+++ b/pkg/ingress/model_build_load_balancer.go
@@ -181,6 +181,8 @@ func (t *defaultModelBuildTask) buildLoadBalancerIPAddressType(_ context.Context
 		return elbv2model.IPAddressTypeIPV4, nil
 	case string(elbv2model.IPAddressTypeDualStack):
 		return elbv2model.IPAddressTypeDualStack, nil
+	case string(elbv2model.IPAddressTypeDualStackWithoutPublicIPV4):
+		return elbv2model.IPAddressTypeDualStackWithoutPublicIPV4, nil
 	default:
 		return "", errors.Errorf("unknown IPAddressType: %v", rawIPAddressType)
 	}
@@ -411,4 +413,13 @@ func buildLoadBalancerSubnetMappingsWithSubnetIDs(subnetIDs []string) []elbv2mod
 		})
 	}
 	return subnetMappings
+}
+
+func isIPv6Supported(ipAddressType elbv2model.IPAddressType) bool {
+	switch ipAddressType {
+	case elbv2model.IPAddressTypeDualStack, elbv2model.IPAddressTypeDualStackWithoutPublicIPV4:
+		return true
+	default:
+		return false
+	}
 }

--- a/pkg/ingress/model_build_managed_sg.go
+++ b/pkg/ingress/model_build_managed_sg.go
@@ -83,7 +83,7 @@ func (t *defaultModelBuildTask) buildManagedSecurityGroupIngressPermissions(_ co
 				},
 			})
 		}
-		if ipAddressType == elbv2model.IPAddressTypeDualStack {
+		if isIPv6Supported(ipAddressType) {
 			for _, cidr := range cfg.inboundCIDRv6s {
 				permissions = append(permissions, ec2model.IPPermission{
 					IPProtocol: "tcp",

--- a/pkg/ingress/model_build_target_group.go
+++ b/pkg/ingress/model_build_target_group.go
@@ -233,7 +233,7 @@ func (t *defaultModelBuildTask) buildTargetGroupIPAddressType(_ context.Context,
 		}
 	}
 	if ipv6Configured {
-		if *t.loadBalancer.Spec.IPAddressType != elbv2model.IPAddressTypeDualStack {
+		if !isIPv6Supported(*t.loadBalancer.Spec.IPAddressType) {
 			return "", errors.New("unsupported IPv6 configuration, lb not dual-stack")
 		}
 		return elbv2model.TargetGroupIPAddressTypeIPv6, nil

--- a/pkg/model/elbv2/load_balancer.go
+++ b/pkg/model/elbv2/load_balancer.go
@@ -83,8 +83,9 @@ const (
 type IPAddressType string
 
 const (
-	IPAddressTypeIPV4      IPAddressType = "ipv4"
-	IPAddressTypeDualStack IPAddressType = "dualstack"
+	IPAddressTypeIPV4                       IPAddressType = "ipv4"
+	IPAddressTypeDualStack                  IPAddressType = "dualstack"
+	IPAddressTypeDualStackWithoutPublicIPV4 IPAddressType = "dualstack-without-public-ipv4"
 )
 
 type SecurityGroupsInboundRulesOnPrivateLinkStatus string


### PR DESCRIPTION
### Description
Application Load Balancer now allows customers to disable public IPv4 on their internet facing dualstack ALB.  To support this on controller, adding a new IpAddressType enum, `dualstack-without-public-ipv4`, to allow controller users to choose a dualstack ALB without public IPv4 when setting up a new ALB,  or switch to dual-stack without public IPv4 for an existing ALB. 

### Checklist
- [X] Added tests that cover your change (if possible)
- [X] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [X] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
