### PR TITLE
Add IPAddressTypeDualStackWithoutPublicIPV4

### DIFF
--- a/apis/elbv2/v1beta1/ingressclassparams_types.go
+++ b/apis/elbv2/v1beta1/ingressclassparams_types.go
@@ -20,13 +20,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// +kubebuilder:validation:Enum=ipv4;dualstack
+// +kubebuilder:validation:Enum=ipv4;dualstack;dualstack-without-public-ipv4
 // IPAddressType is the ip address type of load balancer.
 type IPAddressType string
 
 const (
-	IPAddressTypeIPV4      IPAddressType = "ipv4"
-	IPAddressTypeDualStack IPAddressType = "dualstack"
+	IPAddressTypeIPV4                       IPAddressType = "ipv4"
+	IPAddressTypeDualStack                  IPAddressType = "dualstack"
+	IPAddressTypeDualStackWithoutPublicIPV4 IPAddressType = "dualstack-without-public-ipv4"
 )
 
 // +kubebuilder:validation:Enum=internal;internet-facing


### PR DESCRIPTION
### Description

Add IPAddressTypeDualStackWithoutPublicIPV4 to elbv2 v1beta1, this will fix `make crds` failure issue. 

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
