### PR TITLE
restrict dual-stack-without-ipv4 e2e test to pdx only

### DIFF
--- a/test/e2e/ingress/vanilla_ingress_test.go
+++ b/test/e2e/ingress/vanilla_ingress_test.go
@@ -745,7 +745,12 @@ var _ = Describe("vanilla ingress tests", func() {
 			}
 
 			if tf.Options.IPFamily == "IPv6" {
-				annotation["alb.ingress.kubernetes.io/ip-address-type"] = "dualstack-without-public-ipv4"
+				// TODO: annotate to "dualstack-without-public-ipv4" for all regions once it's GA
+				if tf.Options.AWSRegion == "us-west-2" {
+					annotation["alb.ingress.kubernetes.io/ip-address-type"] = "dualstack-without-public-ipv4"
+				} else {
+					annotation["alb.ingress.kubernetes.io/ip-address-type"] = "dualstack"
+				}
 			}
 
 			ing := ingBuilder.

--- a/test/framework/utils/poll.go
+++ b/test/framework/utils/poll.go
@@ -13,5 +13,5 @@ const (
 	// IngressReconcileTimeout is the timeout we expected the controller finishes reconcile for Ingresses.
 	IngressReconcileTimeout = 1 * time.Minute
 	// IngressDNSAvailableWaitTimeout is the timeout we expect the DNS records of ALB to be propagated.
-	IngressDNSAvailableWaitTimeout = 5 * time.Minute
+	IngressDNSAvailableWaitTimeout = 10 * time.Minute
 )


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->
the `dual-stack-without-ipv4` is not GA in all prod regions yet, restrict the e2e test suite to pdx only as it's failing our internal CI jobs.

### Description

<!--
Please explain the changes you made here.

Help your reviewers by guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->
1. restrict `dual-stack-without-ipv4` e2e test to pdx only, this can be reverted once the feature is GA in all regions.
2. increase the `IngressDNSAvailableWaitTimeout` to 10 min to migitate timeout issue in internal CI job.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
