### PR TITLE
docs: eip service annotation - mention subnet discovery

### DIFF
--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -152,7 +152,7 @@ on the load balancer.
 
     !!!note
         - This configuration is optional, and you can use it to assign static IP addresses to your NLB
-        - You must specify the same number of eip allocations as load balancer subnets [annotation](#subnets)
+        - You must specify the same number of eip allocations as load balancer subnets ([annotation](#subnets) or [discovery](../../deploy/subnet_discovery.md))
         - NLB must be internet-facing
 
     !!!example

--- a/pkg/service/model_build_load_balancer.go
+++ b/pkg/service/model_build_load_balancer.go
@@ -416,7 +416,7 @@ func (t *defaultModelBuildTask) buildLoadBalancerSubnets(ctx context.Context, sc
 		)
 	}
 
-	// for internet-facing Load Balancers, the subnets mush have at least 8 available IP addresses;
+	// for internet-facing Load Balancers, the subnets must have at least 8 available IP addresses;
 	// for internal Load Balancers, this is only required if private ip address is not assigned
 	var privateIpv4Addresses []string
 	ipv4Configured := t.annotationParser.ParseStringSliceAnnotation(annotations.SvcLBSuffixPrivateIpv4Addresses, &privateIpv4Addresses, t.service.Annotations)


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description

This PR changes a note for `service.beta.kubernetes.io/aws-load-balancer-eip-allocations` annotation doc by mentioning the subnet discovery (additionally to the subnet annotation). This way the user doesn't have to follow the subnet annotation link to find out that the discovery may also be involved. IMO this makes the note clearer. WDYT?

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
