### PR TITLE
prevent controller runtime complaining about SetupLogger() was never …

### DIFF
--- a/test/framework/utils/log.go
+++ b/test/framework/utils/log.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	httpexpectv2 "github.com/gavv/httpexpect/v2"
 	"github.com/go-logr/logr"
@@ -39,5 +40,7 @@ func NewGinkgoLogger() (logr.Logger, httpexpectv2.LoggerReporter) {
 		zap.Level(zapraw.InfoLevel),
 		zap.WriteTo(ginkgov2.GinkgoWriter),
 		zap.Encoder(encoder))
+	// this line is to prevent controller runtime complaining about SetupLogger() was never called
+	logf.SetLogger(logger)
 	return logger, &defaultGinkgoLogger{logger: logger}
 }


### PR DESCRIPTION
…called

### Issue

<!-- Please link the GitHub issues related to this PR, if available -->
fix the error message in e2e test logs that the controller runtime complains about SetupLogger() was never called 
```
[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
```
reference: https://github.com/solo-io/gloo/pull/8549
### Description

<!--
Please explain the changes you made here.

Help your reviewers by guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
