### PR TITLE
feat: support for enabling proxy protocol on specified ports only

### DIFF
--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -203,6 +203,7 @@ NLB resource attributes can be controlled via the following annotations:
 
 - <a name="proxy-protocol-v2">service.beta.kubernetes.io/aws-load-balancer-proxy-protocol</a> specifies whether to enable proxy protocol v2 on the target group.
 This annotation takes precedence over the annotation `service.beta.kubernetes.io/aws-load-balancer-target-group-attributes` for proxy protocol v2 configuration.
+If you specify `*`, proxy protocol v2 is enabled for all ports. If you specify a list of one or more ports, proxy protocol v2 is enabled only for those ports.
 
     !!!example
         - enable proxy protocol for all ports

--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -22,7 +22,7 @@
 | [service.beta.kubernetes.io/aws-load-balancer-name](#load-balancer-name)                         | string                  |                           |                                                        |
 | [service.beta.kubernetes.io/aws-load-balancer-internal](#lb-internal)                            | boolean                 | false                     | deprecated, in favor of [aws-load-balancer-scheme](#lb-scheme)|
 | [service.beta.kubernetes.io/aws-load-balancer-scheme](#lb-scheme)                                | string                  | internal                  |                                                        |
-| [service.beta.kubernetes.io/aws-load-balancer-proxy-protocol](#proxy-protocol-v2)                | string                  |                           | Set to `"*"` to enable                                 |
+| [service.beta.kubernetes.io/aws-load-balancer-proxy-protocol](#proxy-protocol-v2)                | string                  |                           | Set to `"*"` to enable for all service ports           |
 | [service.beta.kubernetes.io/aws-load-balancer-ip-address-type](#ip-address-type)                 | string                  | ipv4                      | ipv4 \| dualstack                                      |
 | [service.beta.kubernetes.io/aws-load-balancer-access-log-enabled](#deprecated-attributes)        | boolean                 | false                     | deprecated, in favor of [aws-load-balancer-attributes](#load-balancer-attributes)|
 | [service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-name](#deprecated-attributes) | string                  |                           | deprecated, in favor of [aws-load-balancer-attributes](#load-balancer-attributes)|
@@ -202,11 +202,17 @@ Traffic Listening can be controlled with following annotations:
 NLB resource attributes can be controlled via the following annotations:
 
 - <a name="proxy-protocol-v2">service.beta.kubernetes.io/aws-load-balancer-proxy-protocol</a> specifies whether to enable proxy protocol v2 on the target group.
-Set to '*' to enable proxy protocol v2. This annotation takes precedence over the annotation `service.beta.kubernetes.io/aws-load-balancer-target-group-attributes`
-for proxy protocol v2 configuration.
+This annotation takes precedence over the annotation `service.beta.kubernetes.io/aws-load-balancer-target-group-attributes` for proxy protocol v2 configuration.
 
-    !!!note ""
-        The only valid value for this annotation is `*`.
+    !!!example
+        - enable proxy protocol for all ports
+        ```
+        service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: *
+        ```
+        - enable proxy protocol for ports 80 and 443
+        ```
+        service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: 80, 443
+        ```
 
 - <a name="target-group-attributes">`service.beta.kubernetes.io/aws-load-balancer-target-group-attributes`</a> specifies the
 [Target Group Attributes](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html#target-group-attributes) to be configured.

--- a/pkg/service/model_build_target_group_test.go
+++ b/pkg/service/model_build_target_group_test.go
@@ -3,15 +3,16 @@ package service
 import (
 	"context"
 	"errors"
-	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	"github.com/golang/mock/gomock"
-	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/core"
-	"sigs.k8s.io/aws-load-balancer-controller/pkg/networking"
 	"sort"
 	"strconv"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/core"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/networking"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,6 +27,7 @@ func Test_defaultModelBuilderTask_targetGroupAttrs(t *testing.T) {
 	tests := []struct {
 		testName  string
 		svc       *corev1.Service
+		svcPort   corev1.ServicePort
 		wantError bool
 		wantValue []elbv2.TargetGroupAttribute
 	}{
@@ -35,6 +37,12 @@ func Test_defaultModelBuilderTask_targetGroupAttrs(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{},
 				},
+			},
+			svcPort: corev1.ServicePort{
+				Name:       "http",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+				NodePort:   32768,
 			},
 			wantError: false,
 			wantValue: []elbv2.TargetGroupAttribute{
@@ -53,6 +61,12 @@ func Test_defaultModelBuilderTask_targetGroupAttrs(t *testing.T) {
 					},
 				},
 			},
+			svcPort: corev1.ServicePort{
+				Name:       "http",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+				NodePort:   32768,
+			},
 			wantError: false,
 			wantValue: []elbv2.TargetGroupAttribute{
 				{
@@ -62,7 +76,7 @@ func Test_defaultModelBuilderTask_targetGroupAttrs(t *testing.T) {
 			},
 		},
 		{
-			testName: "Invalid value",
+			testName: "no matching value",
 			svc: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
@@ -70,7 +84,65 @@ func Test_defaultModelBuilderTask_targetGroupAttrs(t *testing.T) {
 					},
 				},
 			},
-			wantError: true,
+			svcPort: corev1.ServicePort{
+				Name:       "http",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+				NodePort:   32768,
+			},
+			wantValue: []elbv2.TargetGroupAttribute{
+				{
+					Key:   tgAttrsProxyProtocolV2Enabled,
+					Value: "false",
+				},
+			},
+			wantError: false,
+		},
+		{
+			testName: "matching value",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/aws-load-balancer-proxy-protocol": "80",
+					},
+				},
+			},
+			svcPort: corev1.ServicePort{
+				Name:       "http",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+				NodePort:   32768,
+			},
+			wantValue: []elbv2.TargetGroupAttribute{
+				{
+					Key:   tgAttrsProxyProtocolV2Enabled,
+					Value: "true",
+				},
+			},
+			wantError: false,
+		},
+		{
+			testName: "multiple values",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/aws-load-balancer-proxy-protocol": "443, 80, 9090",
+					},
+				},
+			},
+			svcPort: corev1.ServicePort{
+				Name:       "http",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+				NodePort:   32768,
+			},
+			wantValue: []elbv2.TargetGroupAttribute{
+				{
+					Key:   tgAttrsProxyProtocolV2Enabled,
+					Value: "true",
+				},
+			},
+			wantError: false,
 		},
 		{
 			testName: "target group attributes",
@@ -80,6 +152,12 @@ func Test_defaultModelBuilderTask_targetGroupAttrs(t *testing.T) {
 						"service.beta.kubernetes.io/aws-load-balancer-target-group-attributes": "target.group-attr-1=80, t2.enabled=false, preserve_client_ip.enabled=true",
 					},
 				},
+			},
+			svcPort: corev1.ServicePort{
+				Name:       "http",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+				NodePort:   32768,
 			},
 			wantValue: []elbv2.TargetGroupAttribute{
 				{
@@ -111,6 +189,12 @@ func Test_defaultModelBuilderTask_targetGroupAttrs(t *testing.T) {
 					},
 				},
 			},
+			svcPort: corev1.ServicePort{
+				Name:       "http",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+				NodePort:   32768,
+			},
 			wantValue: []elbv2.TargetGroupAttribute{
 				{
 					Key:   tgAttrsProxyProtocolV2Enabled,
@@ -127,6 +211,12 @@ func Test_defaultModelBuilderTask_targetGroupAttrs(t *testing.T) {
 					},
 				},
 			},
+			svcPort: corev1.ServicePort{
+				Name:       "http",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+				NodePort:   32768,
+			},
 			wantError: true,
 		},
 		{
@@ -138,6 +228,12 @@ func Test_defaultModelBuilderTask_targetGroupAttrs(t *testing.T) {
 					},
 				},
 			},
+			svcPort: corev1.ServicePort{
+				Name:       "http",
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+				NodePort:   32768,
+			},
 			wantError: true,
 		},
 	}
@@ -148,7 +244,7 @@ func Test_defaultModelBuilderTask_targetGroupAttrs(t *testing.T) {
 				service:          tt.svc,
 				annotationParser: parser,
 			}
-			tgAttrs, err := builder.buildTargetGroupAttributes(context.Background())
+			tgAttrs, err := builder.buildTargetGroupAttributes(context.Background(), tt.svcPort)
 			if tt.wantError {
 				assert.Error(t, err)
 			} else {


### PR DESCRIPTION
### Issue

Hi! I am using the LBC with Istio gateway ingress and the proxy protocol activated on the k8s service, but the health check port 15021 on the Istio side does not support this protocol.

### Description

Keeping the default behavior with a `*` value for the `service.beta.kubernetes.io/aws-load-balancer-proxy-protocol`, this change allows you to specify a list of ports (i.e., target groups) on which the proxy protocol will be activated.

Example for Istio:
```
service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: 80, 443
```

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
