### PR TITLE
Add support for extra security groups annotation (NLB)

### DIFF
--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -49,7 +49,8 @@
 | [service.beta.kubernetes.io/aws-load-balancer-alpn-policy](#alpn-policy)                         | string                  |                           |                                                        |
 | [service.beta.kubernetes.io/aws-load-balancer-target-node-labels](#target-node-labels)           | stringMap               |                           |                                                        |
 | [service.beta.kubernetes.io/aws-load-balancer-attributes](#load-balancer-attributes)             | stringMap               |                           |                                                        |
-| [service.beta.kubernetes.io/aws-load-balancer-security-groups](#security-groups)                 | stringList              |                           |                                                        | 
+| [service.beta.kubernetes.io/aws-load-balancer-security-groups](#security-groups)                 | stringList              |                           |                                                        |
+| [service.beta.kubernetes.io/aws-load-balancer-extra-security-groups](##security-groups)          | stringList              |                           |                                                        |
 | [service.beta.kubernetes.io/aws-load-balancer-manage-backend-security-group-rules](#manage-backend-sg-rules)  | boolean    | true                      | If `service.beta.kubernetes.io/aws-load-balancer-security-groups` is specified, this must also be explicitly specified otherwise it defaults to `false`. |
 | [service.beta.kubernetes.io/aws-load-balancer-inbound-sg-rules-on-private-link-traffic](#update-security-settings)         | string                  |                           |                                                                                   
 
@@ -494,6 +495,16 @@ Load balancer access can be controlled via following annotations:
     !!!example
         ```
         service.beta.kubernetes.io/aws-load-balancer-security-groups: sg-xxxx, nameOfSg1, nameOfSg2
+        ```
+
+- <a name="security-groups">`service.beta.kubernetes.io/aws-load-balancer-extra-security-groups`</a>  Specifies the additional frontend security groups you want to attach to an NLB 
+
+    !!!tip ""
+        Both name and ID of securityGroups are supported. Name matches a `Name` tag, not the `groupName` attribute.
+
+    !!!example
+        ```
+        service.beta.kubernetes.io/aws-load-balancer-extra-security-groups: sg-xxxx, nameOfSg1, nameOfSg2
         ```
  
 - <a name="manage-backend-sg-rules">`service.beta.kubernetes.io/aws-load-balancer-manage-backend-security-group-rules`</a> specifies whether the controller should automatically add the ingress rules to the instance/ENI security group.

--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -50,7 +50,7 @@
 | [service.beta.kubernetes.io/aws-load-balancer-target-node-labels](#target-node-labels)           | stringMap               |                           |                                                        |
 | [service.beta.kubernetes.io/aws-load-balancer-attributes](#load-balancer-attributes)             | stringMap               |                           |                                                        |
 | [service.beta.kubernetes.io/aws-load-balancer-security-groups](#security-groups)                 | stringList              |                           |                                                        |
-| [service.beta.kubernetes.io/aws-load-balancer-extra-security-groups](##security-groups)          | stringList              |                           |                                                        |
+| [service.beta.kubernetes.io/aws-load-balancer-extra-security-groups](#extra-security-groups)          | stringList              |                           |                                                        |
 | [service.beta.kubernetes.io/aws-load-balancer-manage-backend-security-group-rules](#manage-backend-sg-rules)  | boolean    | true                      | If `service.beta.kubernetes.io/aws-load-balancer-security-groups` is specified, this must also be explicitly specified otherwise it defaults to `false`. |
 | [service.beta.kubernetes.io/aws-load-balancer-inbound-sg-rules-on-private-link-traffic](#update-security-settings)         | string                  |                           |                                                                                   
 
@@ -497,7 +497,7 @@ Load balancer access can be controlled via following annotations:
         service.beta.kubernetes.io/aws-load-balancer-security-groups: sg-xxxx, nameOfSg1, nameOfSg2
         ```
 
-- <a name="security-groups">`service.beta.kubernetes.io/aws-load-balancer-extra-security-groups`</a>  Specifies the additional frontend security groups you want to attach to an NLB 
+- <a name="extra-security-groups">`service.beta.kubernetes.io/aws-load-balancer-extra-security-groups`</a>  Specifies the additional frontend security groups you want to attach to an NLB 
 
     !!!tip ""
         Both name and ID of securityGroups are supported. Name matches a `Name` tag, not the `groupName` attribute.

--- a/pkg/annotations/constants.go
+++ b/pkg/annotations/constants.go
@@ -85,6 +85,7 @@ const (
 	SvcLBSuffixTargetNodeLabels                          = "aws-load-balancer-target-node-labels"
 	SvcLBSuffixLoadBalancerAttributes                    = "aws-load-balancer-attributes"
 	SvcLBSuffixLoadBalancerSecurityGroups                = "aws-load-balancer-security-groups"
+	SvcLBSuffixLoadBalancerExtraSecurityGroups           = "aws-load-balancer-extra-security-groups"
 	SvcLBSuffixManageSGRules                             = "aws-load-balancer-manage-backend-security-group-rules"
 	SvcLBSuffixEnforceSGInboundRulesOnPrivateLinkTraffic = "aws-load-balancer-inbound-sg-rules-on-private-link-traffic"
 	SvcLBSuffixSecurityGroupPrefixLists                  = "aws-load-balancer-security-group-prefix-lists"

--- a/pkg/service/model_build_load_balancer.go
+++ b/pkg/service/model_build_load_balancer.go
@@ -156,6 +156,18 @@ func (t *defaultModelBuildTask) buildLoadBalancerSecurityGroups(ctx context.Cont
 			lbSGTokens = append(lbSGTokens, t.backendSGIDToken)
 		}
 	}
+
+	var extraSgNameOrIDs []string
+	t.annotationParser.ParseStringSliceAnnotation(annotations.SvcLBSuffixLoadBalancerExtraSecurityGroups, &extraSgNameOrIDs, t.service.Annotations)
+	if len(extraSgNameOrIDs) != 0 {
+		extraSigIDs, err := t.sgResolver.ResolveViaNameOrID(ctx, extraSgNameOrIDs)
+		if err != nil {
+			return nil, err
+		}
+		for _, sgID := range extraSigIDs {
+			lbSGTokens = append(lbSGTokens, core.LiteralStringToken(sgID))
+		}
+	}
 	return lbSGTokens, nil
 }
 


### PR DESCRIPTION
### Issue
#3679
<!-- Please link the GitHub issues related to this PR, if available -->

### Description
Add the annotation `service.beta.kubernetes.io/aws-load-balancer-extra-security-groups` to attach an existing security group to the NLB.

<!--
Please explain the changes you made here.

Help your reviewers by guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->
Add a loop in pkg/service/model_build_load_balancer.go to retrieve all security groups from the annotation `service.beta.kubernetes.io/aws-load-balancer-extra-security-groups` and append them to the existing security groups list.

Made local testing, for the following yaml fille:
```bash
apiVersion: v1
kind: Service
metadata:
  name: nlb-sample-service
  namespace: default
  annotations:
    service.beta.kubernetes.io/aws-load-balancer-name: "test-new-annotation"
    service.beta.kubernetes.io/aws-load-balancer-extra-security-groups: sg-0b036fd0124715a4c
    service.beta.kubernetes.io/aws-load-balancer-security-groups: sg-0c721856c63fba26b
spec:
  ports:
    - port: 80
      targetPort: 80
      protocol: TCP
  type: LoadBalancer
  selector:
    app: nginx
```
And this:
```bash
apiVersion: v1
kind: Service
metadata:
  name: nlb-sample-service
  namespace: default
  annotations:
    service.beta.kubernetes.io/aws-load-balancer-name: "test-new-annotation"
    service.beta.kubernetes.io/aws-load-balancer-extra-security-groups: test-for-alb-2
    service.beta.kubernetes.io/aws-load-balancer-security-groups: sg-0c721856c63fba26b
spec:
  ports:
    - port: 80
      targetPort: 80
      protocol: TCP
  type: LoadBalancer
  selector:
    app: nginx
```

The following nlb was created:
![image](https://github.com/kubernetes-sigs/aws-load-balancer-controller/assets/61663422/1822a7d1-a792-497c-8134-db6fa529d234)

As you can see, the extra sg was added to the security groups list.
### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
