### PR TITLE
feat: support for setting timeout for kubernetes api client requests

### DIFF
--- a/docs/deploy/configurations.md
+++ b/docs/deploy/configurations.md
@@ -111,6 +111,7 @@ Currently, you can set only 1 namespace to watch in this flag. See [this Kuberne
 | webhook-cert-dir                                                                | string                          | /tmp/k8s-webhook-server/serving-certs      | The directory that contains the server key and certificate                                                                                     |
 | webhook-cert-file                                                               | string                          | tls.crt                                    | The server certificate name                                                                                                                    |
 | webhook-key-file                                                                | string                          | tls.key                                    | The server key name                                                                                                                            |
+| kubernetes-apiserver-client-timeout                                             | duration                        | 10s                                    | "The timeout for the client when connecting to the Kubernetes API server.                                                                             |
 
 
 ### disable-ingress-class-annotation

--- a/pkg/config/runtime_config.go
+++ b/pkg/config/runtime_config.go
@@ -30,6 +30,7 @@ const (
 	flagWebhookCertDir          = "webhook-cert-dir"
 	flagWebhookCertName         = "webhook-cert-file"
 	flagWebhookKeyName          = "webhook-key-file"
+	flagApiServerClientTimeout  = "kubernetes-apiserver-client-timeout"
 
 	defaultKubeconfig              = ""
 	defaultLeaderElectionID        = "aws-load-balancer-controller-leader"
@@ -44,10 +45,11 @@ const (
 	defaultQPS = 1e6
 	// High enough Burst to fit all expected use cases. Burst=0 is not set here, because
 	// client code is overriding it.
-	defaultBurst           = 1e6
-	defaultWebhookCertDir  = ""
-	defaultWebhookCertName = ""
-	defaultWebhookKeyName  = ""
+	defaultBurst                  = 1e6
+	defaultWebhookCertDir         = ""
+	defaultWebhookCertName        = ""
+	defaultWebhookKeyName         = ""
+	defaultApiServerClientTimeout = 10 * time.Second
 )
 
 // RuntimeConfig stores the configuration for the controller-runtime
@@ -65,6 +67,7 @@ type RuntimeConfig struct {
 	WebhookCertDir          string
 	WebhookCertName         string
 	WebhookKeyName          string
+	ApiServerClientTimeout  time.Duration
 }
 
 // BindFlags binds the command line flags to the fields in the config object
@@ -91,6 +94,8 @@ func (c *RuntimeConfig) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.WebhookCertDir, flagWebhookCertDir, defaultWebhookCertDir, "WebhookCertDir is the directory that contains the webhook server key and certificate.")
 	fs.StringVar(&c.WebhookCertName, flagWebhookCertName, defaultWebhookCertName, "WebhookCertName is the webhook server certificate name.")
 	fs.StringVar(&c.WebhookKeyName, flagWebhookKeyName, defaultWebhookKeyName, "WebhookKeyName is the webhook server key name.")
+	fs.DurationVar(&c.ApiServerClientTimeout, flagApiServerClientTimeout, defaultApiServerClientTimeout,
+		"The timeout for the client when connecting to the Kubernetes API server.")
 
 }
 
@@ -110,6 +115,7 @@ func BuildRestConfig(rtCfg RuntimeConfig) (*rest.Config, error) {
 
 	restCFG.QPS = defaultQPS
 	restCFG.Burst = defaultBurst
+	restCFG.Timeout = rtCfg.ApiServerClientTimeout
 	return restCFG, nil
 }
 


### PR DESCRIPTION
### Issue

aws-load-balancer-controller is failing to establish watches to kube-apiserver due to 'timed out waiting for the condition'. Currently the  kubernetes api client timeout parameter isn't configurable.

### Description

Created a new command line flag `kubernetes-apiserver-client-timeout` set by default to 10 seconds.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [X] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
