### PR TITLE
feat: replaced go.uber.zap log config with controller runtime logging config, enables more logging options

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/prometheus/client_golang v1.16.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4
-	go.uber.org/zap v1.26.0
 	golang.org/x/time v0.3.0
 	gomodules.xyz/jsonpatch/v2 v2.4.0
 	helm.sh/helm/v3 v3.15.0
@@ -23,6 +22,8 @@ require (
 	k8s.io/apimachinery v0.30.0
 	k8s.io/cli-runtime v0.30.0
 	k8s.io/client-go v0.30.0
+	k8s.io/component-base v0.30.0
+	k8s.io/klog/v2 v2.120.1
 	k8s.io/utils v0.0.0-20240502163921-fe8a2dddb1d0
 	sigs.k8s.io/controller-runtime v0.18.2
 	sigs.k8s.io/yaml v1.4.0
@@ -42,6 +43,7 @@ require (
 	github.com/andybalholm/brotli v1.0.4 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/chai2010/gettext-go v1.0.2 // indirect
 	github.com/containerd/containerd v1.7.12 // indirect
@@ -147,6 +149,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.19.0 // indirect
 	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.26.0 // indirect
 	golang.org/x/crypto v0.21.0 // indirect
 	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect
 	golang.org/x/net v0.23.0 // indirect
@@ -165,8 +168,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.30.0 // indirect
 	k8s.io/apiserver v0.30.0 // indirect
-	k8s.io/component-base v0.30.0 // indirect
-	k8s.io/klog/v2 v2.120.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
 	k8s.io/kubectl v0.30.0 // indirect
 	moul.io/http2curl/v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
+github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bshuster-repo/logrus-logstash-hook v1.0.0 h1:e+C0SB5R1pu//O4MQ3f9cFuPGoOVeF2fE4Og9otCc70=
 github.com/bshuster-repo/logrus-logstash-hook v1.0.0/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd h1:rFt+Y/IK1aEZkEHchZRSq9OQbsSzIT/OrI8YFFmRIng=

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
 	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/throttle"
@@ -55,7 +56,8 @@ func InitFramework() (*Framework, error) {
 		return nil, err
 	}
 
-	logger, loggerReporter := utils.NewGinkgoLogger()
+	logger := klog.Background()
+	ctrl.SetLogger(logger)
 
 	cloud, err := aws.NewCloud(aws.CloudConfig{
 		Region:         globalOptions.AWSRegion,
@@ -84,7 +86,7 @@ func InitFramework() (*Framework, error) {
 		HTTPVerifier: http.NewDefaultVerifier(),
 
 		Logger:         logger,
-		LoggerReporter: loggerReporter,
+		LoggerReporter: &utils.DefaultGinkgoLogger{Logger: logger},
 	}
 
 	return f, nil

--- a/test/framework/utils/log.go
+++ b/test/framework/utils/log.go
@@ -2,45 +2,28 @@ package utils
 
 import (
 	"fmt"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	httpexpectv2 "github.com/gavv/httpexpect/v2"
 	"github.com/go-logr/logr"
 	ginkgov2 "github.com/onsi/ginkgo/v2"
-	zapraw "go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 type GinkgoLogger interface {
 	httpexpectv2.LoggerReporter
 }
 
-var _ GinkgoLogger = &defaultGinkgoLogger{}
+var _ GinkgoLogger = &DefaultGinkgoLogger{}
 
-type defaultGinkgoLogger struct {
-	logger logr.Logger
+type DefaultGinkgoLogger struct {
+	Logger logr.Logger
 }
 
-func (l *defaultGinkgoLogger) Logf(format string, args ...interface{}) {
+func (l *DefaultGinkgoLogger) Logf(format string, args ...interface{}) {
 	message := fmt.Sprintf(format, args...)
-	l.logger.Info(message)
+	l.Logger.Info(message)
 }
 
-func (l *defaultGinkgoLogger) Errorf(format string, args ...interface{}) {
+func (l *DefaultGinkgoLogger) Errorf(format string, args ...interface{}) {
 	message := fmt.Sprintf(format, args...)
 	ginkgov2.Fail(message)
-}
-
-// NewGinkgoLogger returns new logger with ginkgo backend.
-func NewGinkgoLogger() (logr.Logger, httpexpectv2.LoggerReporter) {
-	encoder := zapcore.NewJSONEncoder(zapraw.NewProductionEncoderConfig())
-
-	logger := zap.New(zap.UseDevMode(false),
-		zap.Level(zapraw.InfoLevel),
-		zap.WriteTo(ginkgov2.GinkgoWriter),
-		zap.Encoder(encoder))
-	// this line is to prevent controller runtime complaining about SetupLogger() was never called
-	logf.SetLogger(logger)
-	return logger, &defaultGinkgoLogger{logger: logger}
 }


### PR DESCRIPTION
### Issue

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/3744

### Description

Removed go.uber.org config, replaced with controller-runtime logging configuration. Used the kubernetes-sigs/cluster-api project as a good example to template changes from. 

The previous arg, `--log-level` is still allowed for compatibility, but does nothing. `--v`, like most other k8s controllers, is now used for setting log visibility.

Note: to restore the json log output that the controller previously had, users can set `--logging-format=json` and I verified that worked as expected.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [X] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [X] Refactored something and made the world a better place :star2:
