### PR TITLE
Add OIDC configuration auto discovery support

### DIFF
--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -622,6 +622,14 @@ ALB supports authentication with Cognito or OIDC. See [Authenticate Users Using 
         ```
         alb.ingress.kubernetes.io/auth-idp-oidc: '{"issuer":"https://example.com","authorizationEndpoint":"https://authorization.example.com","tokenEndpoint":"https://token.example.com","userInfoEndpoint":"https://userinfo.example.com","secretName":"my-k8s-secret"}'
         ```
+        
+    !!!tip ""
+        This annotation allows fetching OIDC configuration dynamically from the specified Discovery Endpoint (`https://example.auth0.com`). The endpoint should provide the necessary details: `issuer`, `authorizationEndpoint`, `tokenEndpoint`, and `userInfoEndpoint` in its JSON response. (Note: `discoveryEndpoint` will override other OIDC configuration fields)
+    
+    !!example
+        ```
+        alb.ingress.kubernetes.io/auth-idp-oidc: '{"discoveryEndpoint":"https://example.auth0.com","secretName":"my-k8s-secret","authenticationRequestExtraParams":{"key":"value"}}'
+        ```
 
 - <a name="auth-on-unauthenticated-request">`alb.ingress.kubernetes.io/auth-on-unauthenticated-request`</a> specifies the behavior if the user is not authenticated.
 

--- a/pkg/ingress/config_types.go
+++ b/pkg/ingress/config_types.go
@@ -413,4 +413,8 @@ type AuthIDPConfigOIDC struct {
 	// The query parameters (up to 10) to include in the redirect request to the authorization endpoint.
 	// +optional
 	AuthenticationRequestExtraParams map[string]string `json:"authenticationRequestExtraParams,omitempty"`
+
+	// For IdP that supports discovery
+	// +optional
+	DiscoveryEndpoint string `json:"discoveryEndpoint,omitempty"`
 }


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->
#2921
### Description
Introduced new functionality to alb.ingress.kubernetes.io/auth-idp-oidc annotation, support for OIDC configuration using discoveryEndpoint to fetch OIDC details dynamically.
Enhanced documentation with instructions and example for using discoveryEndpoint in OIDC configuration.
Created unit tests to validate the implementation and functionality of OIDC Discovery feature.

<!--
Please explain the changes you made here.

Help your reviewers by guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
