### PR TITLE
Feat(performance): Accept protobuf responses from kube-apiserver

### DIFF
--- a/docs/deploy/configurations.md
+++ b/docs/deploy/configurations.md
@@ -111,6 +111,7 @@ Currently, you can set only 1 namespace to watch in this flag. See [this Kuberne
 | webhook-cert-dir                                                                | string                          | /tmp/k8s-webhook-server/serving-certs      | The directory that contains the server key and certificate                                                                                     |
 | webhook-cert-file                                                               | string                          | tls.crt                                    | The server certificate name                                                                                                                    |
 | webhook-key-file                                                                | string                          | tls.key                                    | The server key name                                                                                                                            |
+| accept-protobuf-content-type-enabled                                            | boolean                         | false                                      | Allows the controller to receive kubernetes api responses in protobuf instead of json, if possible.                                                                                                                            |
 
 
 ### disable-ingress-class-annotation

--- a/helm/aws-load-balancer-controller/templates/deployment.yaml
+++ b/helm/aws-load-balancer-controller/templates/deployment.yaml
@@ -149,6 +149,9 @@ spec:
         {{- if kindIs "bool" .Values.enableBackendSecurityGroup }}
         - --enable-backend-security-group={{ .Values.enableBackendSecurityGroup }}
         {{- end }}
+        {{- if kindIs "bool" .Values.enableAcceptProtobufContentType }}
+        - --accept-protobuf-content-type-enabled={{ .Values.enableAcceptProtobufContentType }}
+        {{- end }}
         {{- if .Values.backendSecurityGroup }}
         - --backend-security-group={{ .Values.backendSecurityGroup }}
         {{- end }}

--- a/helm/aws-load-balancer-controller/values.yaml
+++ b/helm/aws-load-balancer-controller/values.yaml
@@ -336,6 +336,9 @@ enableEndpointSlices:
 # enableBackendSecurityGroup enables shared security group for backend traffic (default true)
 enableBackendSecurityGroup:
 
+# enableAcceptProtobufContentType allows the controller to receive kubernetes api responses in protobuf instead of json, if possible (default false)
+enableAcceptProtobufContentType:
+
 # backendSecurityGroup specifies backend security group id (default controller auto create backend security group)
 backendSecurityGroup:
 

--- a/pkg/config/runtime_config.go
+++ b/pkg/config/runtime_config.go
@@ -18,18 +18,20 @@ import (
 )
 
 const (
-	flagMetricsBindAddr         = "metrics-bind-addr"
-	flagHealthProbeBindAddr     = "health-probe-bind-addr"
-	flagWebhookBindPort         = "webhook-bind-port"
-	flagEnableLeaderElection    = "enable-leader-election"
-	flagLeaderElectionID        = "leader-election-id"
-	flagLeaderElectionNamespace = "leader-election-namespace"
-	flagWatchNamespace          = "watch-namespace"
-	flagSyncPeriod              = "sync-period"
-	flagKubeconfig              = "kubeconfig"
-	flagWebhookCertDir          = "webhook-cert-dir"
-	flagWebhookCertName         = "webhook-cert-file"
-	flagWebhookKeyName          = "webhook-key-file"
+	flagMetricsBindAddr           = "metrics-bind-addr"
+	flagHealthProbeBindAddr       = "health-probe-bind-addr"
+	flagWebhookBindPort           = "webhook-bind-port"
+	flagEnableLeaderElection      = "enable-leader-election"
+	flagLeaderElectionID          = "leader-election-id"
+	flagLeaderElectionNamespace   = "leader-election-namespace"
+	flagWatchNamespace            = "watch-namespace"
+	flagSyncPeriod                = "sync-period"
+	flagKubeconfig                = "kubeconfig"
+	flagWebhookCertDir            = "webhook-cert-dir"
+	flagWebhookCertName           = "webhook-cert-file"
+	flagWebhookKeyName            = "webhook-key-file"
+	flagApiServerClientTimeout    = "kubernetes-apiserver-client-timeout"
+	flagAcceptProtobufContentType = "accept-protobuf-content-type-enabled"
 
 	defaultKubeconfig              = ""
 	defaultLeaderElectionID        = "aws-load-balancer-controller-leader"
@@ -52,19 +54,20 @@ const (
 
 // RuntimeConfig stores the configuration for the controller-runtime
 type RuntimeConfig struct {
-	APIServer               string
-	KubeConfig              string
-	WebhookBindPort         int
-	MetricsBindAddress      string
-	HealthProbeBindAddress  string
-	EnableLeaderElection    bool
-	LeaderElectionID        string
-	LeaderElectionNamespace string
-	WatchNamespace          string
-	SyncPeriod              time.Duration
-	WebhookCertDir          string
-	WebhookCertName         string
-	WebhookKeyName          string
+	APIServer                 string
+	KubeConfig                string
+	WebhookBindPort           int
+	MetricsBindAddress        string
+	HealthProbeBindAddress    string
+	EnableLeaderElection      bool
+	LeaderElectionID          string
+	LeaderElectionNamespace   string
+	WatchNamespace            string
+	SyncPeriod                time.Duration
+	WebhookCertDir            string
+	WebhookCertName           string
+	WebhookKeyName            string
+	AcceptProtobufContentType bool
 }
 
 // BindFlags binds the command line flags to the fields in the config object
@@ -91,6 +94,8 @@ func (c *RuntimeConfig) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.WebhookCertDir, flagWebhookCertDir, defaultWebhookCertDir, "WebhookCertDir is the directory that contains the webhook server key and certificate.")
 	fs.StringVar(&c.WebhookCertName, flagWebhookCertName, defaultWebhookCertName, "WebhookCertName is the webhook server certificate name.")
 	fs.StringVar(&c.WebhookKeyName, flagWebhookKeyName, defaultWebhookKeyName, "WebhookKeyName is the webhook server key name.")
+	fs.BoolVar(&c.AcceptProtobufContentType, flagAcceptProtobufContentType, false,
+		"Allows the controller to receive kubernetes api responses in protobuf instead of json, if possible. This may improve performance in serialization but is experimental.")
 
 }
 
@@ -110,6 +115,9 @@ func BuildRestConfig(rtCfg RuntimeConfig) (*rest.Config, error) {
 
 	restCFG.QPS = defaultQPS
 	restCFG.Burst = defaultBurst
+	if rtCfg.AcceptProtobufContentType {
+		restCFG.AcceptContentTypes = runtime.ContentTypeProtobuf + "," + runtime.ContentTypeJSON
+	}
 	return restCFG, nil
 }
 


### PR DESCRIPTION
### Issue

Currently the controller only accepts the JSON responses from kube-apiserver. Accepting the more efficient Protobuf representation responses will improve performance at scale. This affects majorly the Pod cache ListWatch that is set [here](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/pkg/k8s/pod_info_repo.go#L37) and can act as a bottleneck in clusters with large amount of pods.

> By default, Kubernetes returns objects serialized to JSON with content type `application/json`. This is the default serialization format for the API. However, clients may request the more efficient [Protobuf representation](https://kubernetes.io/docs/reference/using-api/api-concepts/#protobuf-encoding) of these objects for better performance at scale.

More details in k8s doc [page](https://kubernetes.io/docs/reference/using-api/api-concepts/#alternate-representations-of-resources). 

### Description

1. Added a new flag `accept-protobuf-content-type-enabled` - default to false for compatibility with current behavior
2. Added documentation for the new flag
3. Added helm support for the new flag

### Checklist
- [ ] Added tests that cover your change (if possible)
- [X] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [X] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
