### PR TITLE
feat: support automountServiceAccountToken parameter in deployment

### DIFF
--- a/helm/aws-load-balancer-controller/templates/deployment.yaml
+++ b/helm/aws-load-balancer-controller/templates/deployment.yaml
@@ -43,6 +43,7 @@ spec:
       runtimeClassName: {{ .Values.runtimeClassName }}
     {{- end }}
       serviceAccountName: {{ include "aws-load-balancer-controller.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       volumes:
       - name: cert
         secret:


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description

Added possibility to customize `automountServiceAccountToken` for aws-loadbalancer-controller deployment to satisfy gatekeeper validation 

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
