### PR TITLE
Use the documented .Capabilities.KubeVersion.Version built-in value in the hpa template

### DIFF
--- a/helm/aws-load-balancer-controller/templates/hpa.yaml
+++ b/helm/aws-load-balancer-controller/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-{{- if (semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion)}}
+{{- if (semverCompare ">=1.23-0" .Capabilities.KubeVersion.Version)}}
 apiVersion: autoscaling/v2
 {{- else }}
 apiVersion: autoscaling/v2beta2


### PR DESCRIPTION
### Issue

`.Capabilities.KubeVersion.GitVersion` is undocumented in Helm v3 - https://helm.sh/docs/chart_template_guide/builtin_objects/

### Description

The value `.Capabilities.KubeVersion.GitVersion` is documented in Helm v2 docs - https://v2.helm.sh/docs/chart_template_guide/#built-in-objects

It seems to also work with Helm v3, but it is not documented in the docs - https://helm.sh/docs/chart_template_guide/builtin_objects/

We should stick to the officially documented values.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
