### PR TITLE
fixup(sg-resolver): Allow multiple SGs with the same Name tag

### DIFF
--- a/pkg/algorithm/slices.go
+++ b/pkg/algorithm/slices.go
@@ -1,0 +1,18 @@
+package algorithm
+
+import "cmp"
+
+// RemoveSliceDuplicates returns a copy of the slice without duplicate entries.
+func RemoveSliceDuplicates[S ~[]E, E cmp.Ordered](s S) []E {
+	result := make([]E, 0, len(s))
+	found := make(map[E]struct{}, len(s))
+
+	for _, x := range s {
+		if _, ok := found[x]; !ok {
+			found[x] = struct{}{}
+			result = append(result, x)
+		}
+	}
+
+	return result
+}

--- a/pkg/algorithm/slices_test.go
+++ b/pkg/algorithm/slices_test.go
@@ -1,0 +1,46 @@
+package algorithm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_RemoveSliceDuplicates(t *testing.T) {
+	type args struct {
+		data []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "empty",
+			args: args{
+				data: []string{},
+			},
+			want: []string{},
+		},
+		{
+			name: "no duplicate entries",
+			args: args{
+				data: []string{"a", "b", "c", "d"},
+			},
+			want: []string{"a", "b", "c", "d"},
+		},
+		{
+			name: "with duplicates",
+			args: args{
+				data: []string{"a", "b", "a", "c", "b"},
+			},
+			want: []string{"a", "b", "c"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RemoveSliceDuplicates(tt.args.data)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/networking/security_group_resolver.go
+++ b/pkg/networking/security_group_resolver.go
@@ -7,6 +7,7 @@ import (
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	ec2sdk "github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/pkg/errors"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/algorithm"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/services"
 )
 
@@ -35,6 +36,7 @@ type defaultSecurityGroupResolver struct {
 func (r *defaultSecurityGroupResolver) ResolveViaNameOrID(ctx context.Context, sgNameOrIDs []string) ([]string, error) {
 	sgIDs, sgNames := r.splitIntoSgNameAndIDs(sgNameOrIDs)
 	var resolvedSGs []*ec2sdk.SecurityGroup
+
 	if len(sgIDs) > 0 {
 		sgs, err := r.resolveViaGroupID(ctx, sgIDs)
 		if err != nil {
@@ -42,6 +44,7 @@ func (r *defaultSecurityGroupResolver) ResolveViaNameOrID(ctx context.Context, s
 		}
 		resolvedSGs = append(resolvedSGs, sgs...)
 	}
+
 	if len(sgNames) > 0 {
 		sgs, err := r.resolveViaGroupName(ctx, sgNames)
 		if err != nil {
@@ -49,13 +52,12 @@ func (r *defaultSecurityGroupResolver) ResolveViaNameOrID(ctx context.Context, s
 		}
 		resolvedSGs = append(resolvedSGs, sgs...)
 	}
+
 	resolvedSGIDs := make([]string, 0, len(resolvedSGs))
 	for _, sg := range resolvedSGs {
 		resolvedSGIDs = append(resolvedSGIDs, awssdk.StringValue(sg.GroupId))
 	}
-	if len(resolvedSGIDs) != len(sgNameOrIDs) {
-		return nil, errors.Errorf("couldn't find all securityGroups, nameOrIDs: %v, found: %v", sgNameOrIDs, resolvedSGIDs)
-	}
+
 	return resolvedSGIDs, nil
 }
 
@@ -63,14 +65,31 @@ func (r *defaultSecurityGroupResolver) resolveViaGroupID(ctx context.Context, sg
 	req := &ec2sdk.DescribeSecurityGroupsInput{
 		GroupIds: awssdk.StringSlice(sgIDs),
 	}
+
 	sgs, err := r.ec2Client.DescribeSecurityGroupsAsList(ctx, req)
 	if err != nil {
 		return nil, err
 	}
+
+	resolvedSGIDs := make([]string, 0, len(sgs))
+	for _, sg := range sgs {
+		resolvedSGIDs = append(resolvedSGIDs, awssdk.StringValue(sg.GroupId))
+	}
+
+	if len(sgIDs) != len(resolvedSGIDs) {
+		return nil, errors.Errorf(
+			"couldn't find all securityGroups, requested ids: [%s], found: [%s]",
+			strings.Join(sgIDs, ", "),
+			strings.Join(resolvedSGIDs, ", "),
+		)
+	}
+
 	return sgs, nil
 }
 
 func (r *defaultSecurityGroupResolver) resolveViaGroupName(ctx context.Context, sgNames []string) ([]*ec2sdk.SecurityGroup, error) {
+	sgNames = algorithm.RemoveSliceDuplicates(sgNames)
+
 	req := &ec2sdk.DescribeSecurityGroupsInput{
 		Filters: []*ec2sdk.Filter{
 			{
@@ -83,10 +102,31 @@ func (r *defaultSecurityGroupResolver) resolveViaGroupName(ctx context.Context, 
 			},
 		},
 	}
+
 	sgs, err := r.ec2Client.DescribeSecurityGroupsAsList(ctx, req)
 	if err != nil {
 		return nil, err
 	}
+
+	resolvedSGNames := make([]string, 0, len(sgs))
+	for _, sg := range sgs {
+		for _, tag := range sg.Tags {
+			if awssdk.StringValue(tag.Key) == "Name" {
+				resolvedSGNames = append(resolvedSGNames, awssdk.StringValue(tag.Value))
+			}
+		}
+	}
+
+	resolvedSGNames = algorithm.RemoveSliceDuplicates(resolvedSGNames)
+
+	if len(sgNames) != len(resolvedSGNames) {
+		return nil, errors.Errorf(
+			"couldn't find all securityGroups, requested names: [%s], found: [%s]",
+			strings.Join(sgNames, ", "),
+			strings.Join(resolvedSGNames, ", "),
+		)
+	}
+
 	return sgs, nil
 }
 


### PR DESCRIPTION
### Issue

I looked but couldn't find any open issues about the problem this pull request intends to solve.

### Description

The current implementation of [`ResolveViaNameOrID`](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/pkg/networking/security_group_resolver.go#L35) incorrectly [assumes that searching security groups by the `Name` tag will always yield a single resource per searched name](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/pkg/networking/security_group_resolver.go#L56-L58). This is incorrect because AWS allows multiple security groups in the same VPC to share the same `Name` tag.

In practice, this issue manifests in the form of a rather cryptic runtime error:

```
Events:
  Type     Reason             Age                    From       Message
  ----     ------             ----                   ----       -------
  Warning  FailedBuildModel   9m (x207 over 2d2h)    ingress    Failed build model due to couldn't find all securityGroups, nameOrIDs: [some-sg-name], found: [sg-xxxxx sg-yyyyy sg-zzzzz]"
```

Our particular use case is the following:

We have a large set of IP ranges that we need to allow ingress from in our ALBs. Unfortunately, the number of CIDR ranges we need to allow lists is bigger than the [default maximum quota of 60 ingress rules per security group](https://docs.aws.amazon.com/vpc/latest/userguide/amazon-vpc-limits.html#vpc-limits-security-groups). To remediate that, we created multiple security groups all with different IDs but with the same `tag:Name=allow-ingress-from-xyz`, and spread the CIDR ranges across them. 

We have some automation in place to create/delete these security group resources when the number of allowed CIDR ranges changes. Hence, we cannot hard-code the security group IDs in the `alb.ingress.kubernetes.io/security-groups` annotation. Instead, we would like the controller to dynamically resolve the security group IDs to attach to the ALB from the specified security group names in the annotation.

In the current implementation, the approach described above works if and only if all the security group names specified in the annotation resolve to a **single** security group ID (1-to-1 mapping). Otherwise, the controller errors out with the error message shown above.

The approach I've taken to solve this problem is the following:

- For ID-based lookups, it is correct to assume that the number of security group IDs requested needs to match with the number of security group IDs found. That is because, within a VPC, security group IDs are unique.

- For name-based lookups, each given name needs to match one or more security groups.

To implement that, I moved the "response correctness" logic from the `ResolveViaNameOrID` to the respective `resolveViaGroupID` and `resolveViaGroupName` so that it can be slightly different on each search strategy.

### Checklist
- [X] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
