### PR TITLE
Add Annotation Check for Load-Balancer Scheme in SG Source Ranges

### DIFF
--- a/pkg/service/model_build_load_balancer.go
+++ b/pkg/service/model_build_load_balancer.go
@@ -61,7 +61,7 @@ func (t *defaultModelBuildTask) buildLoadBalancerSpec(ctx context.Context, schem
 	if err != nil {
 		return elbv2model.LoadBalancerSpec{}, err
 	}
-	securityGroups, err := t.buildLoadBalancerSecurityGroups(ctx, existingLB, ipAddressType)
+	securityGroups, err := t.buildLoadBalancerSecurityGroups(ctx, existingLB, scheme, ipAddressType)
 	if err != nil {
 		return elbv2model.LoadBalancerSpec{}, err
 	}
@@ -101,7 +101,7 @@ func (t *defaultModelBuildTask) buildLoadBalancerSpec(ctx context.Context, schem
 }
 
 func (t *defaultModelBuildTask) buildLoadBalancerSecurityGroups(ctx context.Context, existingLB *elbv2deploy.LoadBalancerWithTags,
-	ipAddressType elbv2model.IPAddressType) ([]core.StringToken, error) {
+	scheme elbv2model.LoadBalancerScheme, ipAddressType elbv2model.IPAddressType) ([]core.StringToken, error) {
 	if existingLB != nil && len(existingLB.LoadBalancer.SecurityGroups) == 0 {
 		return nil, nil
 	}
@@ -115,7 +115,7 @@ func (t *defaultModelBuildTask) buildLoadBalancerSecurityGroups(ctx context.Cont
 	var lbSGTokens []core.StringToken
 	t.annotationParser.ParseStringSliceAnnotation(annotations.SvcLBSuffixLoadBalancerSecurityGroups, &sgNameOrIDs, t.service.Annotations)
 	if len(sgNameOrIDs) == 0 {
-		managedSG, err := t.buildManagedSecurityGroup(ctx, ipAddressType)
+		managedSG, err := t.buildManagedSecurityGroup(ctx, ipAddressType, scheme)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/service/model_builder_test.go
+++ b/pkg/service/model_builder_test.go
@@ -3427,9 +3427,23 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 			},
 			enableBackendSG:          true,
 			resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForTwoSubnet},
-			listLoadBalancerCalls:    []listLoadBalancerCall{listLoadBalancerCallForEmptyLB},
-			backendSecurityGroup:     "sg-backend",
-			wantError:                false,
+			fetchVPCInfoCalls: []fetchVPCInfoCall{
+				{
+					wantVPCInfo: networking.VPCInfo{
+						CidrBlockAssociationSet: []*ec2.VpcCidrBlockAssociation{
+							{
+								CidrBlock: aws.String("192.168.0.0/16"),
+								CidrBlockState: &ec2.VpcCidrBlockState{
+									State: &cidrBlockStateAssociated,
+								},
+							},
+						},
+					},
+				},
+			},
+			listLoadBalancerCalls: []listLoadBalancerCall{listLoadBalancerCallForEmptyLB},
+			backendSecurityGroup:  "sg-backend",
+			wantError:             false,
 			wantValue: `
 {
  "id":"default/nlb-ip-svc",
@@ -3446,7 +3460,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                    "toPort": 80,
                    "ipRanges": [
                       {
-                         "cidrIP": "0.0.0.0/0"
+                         "cidrIP": "192.168.0.0/16"
                       }
                    ]
                 },
@@ -3456,7 +3470,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                    "toPort": 83,
                    "ipRanges": [
                       {
-                         "cidrIP": "0.0.0.0/0"
+                         "cidrIP": "192.168.0.0/16"
                       }
                    ]
                 }


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->
solves #3706 
### Description
This pull request adds a new check for the Kubernetes service annotation "service.beta.kubernetes.io/aws-load-balancer-scheme": "internal".

Key changes:
1. Implemented a check for the internal load balancer scheme annotation.
2. Modified the default inbound CIDR logic:
   - If source range is not provided:
     a. For internal scheme: Default inbound CIDR will be vpcCIDR
     b. For internet-facing scheme: Default inbound CIDR remains 0.0.0.0/0


A good, clear description == a faster review :)
-->

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
