### PR TITLE
[helm chart] Only create ServiceMonitor if CRD/api resource is available

### DIFF
--- a/helm/aws-load-balancer-controller/templates/servicemonitor.yaml
+++ b/helm/aws-load-balancer-controller/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if.Values.serviceMonitor.enabled -}}
+{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:


### PR DESCRIPTION
### Description

It is best practice to make sure a given api resource is defined in the cluster before trying to create it.
Example: https://github.com/fluent/helm-charts/blob/154127f95f40ea53f7955826a937340cf2b48dad/charts/fluent-bit/templates/servicemonitor.yaml#L1C1-L1C106
