### PR TITLE
Add support for TCP_UDP to NLB TargetGroups and Listeners (rebase)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ site
 *~
 *.bak
 scripts/aws_sdk_model_override/*
+/gomock_reflect*

--- a/apis/elbv2/v1beta1/targetgroupbinding_types.go
+++ b/apis/elbv2/v1beta1/targetgroupbinding_types.go
@@ -87,6 +87,9 @@ const (
 
 	// NetworkingProtocolUDP is the UDP protocol.
 	NetworkingProtocolUDP NetworkingProtocol = "UDP"
+
+	// NetworkingProtocolTCP_UDP is the TCP_UDP protocol.
+	NetworkingProtocolTCP_UDP NetworkingProtocol = "TCP_UDP"
 )
 
 // NetworkingPort defines the port and protocol for networking rules.

--- a/apis/elbv2/v1beta1/targetgroupbinding_types.go
+++ b/apis/elbv2/v1beta1/targetgroupbinding_types.go
@@ -77,7 +77,7 @@ type NetworkingPeer struct {
 	SecurityGroup *SecurityGroup `json:"securityGroup,omitempty"`
 }
 
-// +kubebuilder:validation:Enum=TCP;UDP
+// +kubebuilder:validation:Enum=TCP;UDP;TCP_UDP
 // NetworkingProtocol defines the protocol for networking rules.
 type NetworkingProtocol string
 

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -2,130 +2,130 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: webhook
+  name: mutating-webhook-configuration
 webhooks:
-  - admissionReviewVersions:
-      - v1beta1
-    clientConfig:
-      service:
-        name: webhook-service
-        namespace: system
-        path: /mutate-v1-pod
-    failurePolicy: Fail
-    name: mpod.elbv2.k8s.aws
-    rules:
-      - apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-        resources:
-          - pods
-    sideEffects: None
-  - admissionReviewVersions:
-      - v1beta1
-    clientConfig:
-      service:
-        name: webhook-service
-        namespace: system
-        path: /mutate-v1-service
-    failurePolicy: Fail
-    name: mservice.elbv2.k8s.aws
-    rules:
-      - apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-        resources:
-          - services
-    sideEffects: None
-  - admissionReviewVersions:
-      - v1beta1
-    clientConfig:
-      service:
-        name: webhook-service
-        namespace: system
-        path: /mutate-elbv2-k8s-aws-v1beta1-targetgroupbinding
-    failurePolicy: Fail
-    name: mtargetgroupbinding.elbv2.k8s.aws
-    rules:
-      - apiGroups:
-          - elbv2.k8s.aws
-        apiVersions:
-          - v1beta1
-        operations:
-          - CREATE
-          - UPDATE
-        resources:
-          - targetgroupbindings
-    sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-v1-pod
+  failurePolicy: Fail
+  name: mpod.elbv2.k8s.aws
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-v1-service
+  failurePolicy: Fail
+  name: mservice.elbv2.k8s.aws
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - services
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-elbv2-k8s-aws-v1beta1-targetgroupbinding
+  failurePolicy: Fail
+  name: mtargetgroupbinding.elbv2.k8s.aws
+  rules:
+  - apiGroups:
+    - elbv2.k8s.aws
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - targetgroupbindings
+  sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: webhook
+  name: validating-webhook-configuration
 webhooks:
-  - admissionReviewVersions:
-      - v1beta1
-    clientConfig:
-      service:
-        name: webhook-service
-        namespace: system
-        path: /validate-elbv2-k8s-aws-v1beta1-ingressclassparams
-    failurePolicy: Fail
-    name: vingressclassparams.elbv2.k8s.aws
-    rules:
-      - apiGroups:
-          - elbv2.k8s.aws
-        apiVersions:
-          - v1beta1
-        operations:
-          - CREATE
-          - UPDATE
-        resources:
-          - ingressclassparams
-    sideEffects: None
-  - admissionReviewVersions:
-      - v1beta1
-    clientConfig:
-      service:
-        name: webhook-service
-        namespace: system
-        path: /validate-elbv2-k8s-aws-v1beta1-targetgroupbinding
-    failurePolicy: Fail
-    name: vtargetgroupbinding.elbv2.k8s.aws
-    rules:
-      - apiGroups:
-          - elbv2.k8s.aws
-        apiVersions:
-          - v1beta1
-        operations:
-          - CREATE
-          - UPDATE
-        resources:
-          - targetgroupbindings
-    sideEffects: None
-  - admissionReviewVersions:
-      - v1beta1
-    clientConfig:
-      service:
-        name: webhook-service
-        namespace: system
-        path: /validate-networking-v1-ingress
-    failurePolicy: Fail
-    matchPolicy: Equivalent
-    name: vingress.elbv2.k8s.aws
-    rules:
-      - apiGroups:
-          - networking.k8s.io
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-          - UPDATE
-        resources:
-          - ingresses
-    sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-elbv2-k8s-aws-v1beta1-ingressclassparams
+  failurePolicy: Fail
+  name: vingressclassparams.elbv2.k8s.aws
+  rules:
+  - apiGroups:
+    - elbv2.k8s.aws
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ingressclassparams
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-elbv2-k8s-aws-v1beta1-targetgroupbinding
+  failurePolicy: Fail
+  name: vtargetgroupbinding.elbv2.k8s.aws
+  rules:
+  - apiGroups:
+    - elbv2.k8s.aws
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - targetgroupbindings
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-networking-v1-ingress
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: vingress.elbv2.k8s.aws
+  rules:
+  - apiGroups:
+    - networking.k8s.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ingresses
+  sideEffects: None

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -2,7 +2,7 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: mutating-webhook-configuration
+  name: webhook
 webhooks:
 - admissionReviewVersions:
   - v1beta1

--- a/pkg/ingress/model_build_target_group.go
+++ b/pkg/ingress/model_build_target_group.go
@@ -5,9 +5,10 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"regexp"
 	"strconv"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -95,7 +96,7 @@ func (t *defaultModelBuildTask) buildTargetGroupBindingSpec(ctx context.Context,
 	}, nil
 }
 
-func (t *defaultModelBuildTask) buildTargetGroupBindingNetworking(ctx context.Context, targetPort intstr.IntOrString, healthCheckPort intstr.IntOrString) *elbv2model.TargetGroupBindingNetworking {
+func (t *defaultModelBuildTask) buildTargetGroupBindingNetworking(_ context.Context, targetPort intstr.IntOrString, healthCheckPort intstr.IntOrString) *elbv2model.TargetGroupBindingNetworking {
 	if t.backendSGIDToken == nil {
 		return nil
 	}

--- a/pkg/service/model_build_listener.go
+++ b/pkg/service/model_build_listener.go
@@ -19,16 +19,38 @@ func (t *defaultModelBuildTask) buildListeners(ctx context.Context, scheme elbv2
 		return err
 	}
 
+	// group by listener port number
+	portMap := make(map[int32][]corev1.ServicePort)
 	for _, port := range t.service.Spec.Ports {
-		_, err := t.buildListener(ctx, port, *cfg, scheme)
-		if err != nil {
-			return err
+		key := port.Port
+		if vals, exists := portMap[key]; exists {
+			portMap[key] = append(vals, port)
+		} else {
+			portMap[key] = []corev1.ServicePort{port}
 		}
 	}
+
+	// execute build listener
+	for _, port := range t.service.Spec.Ports {
+		key := port.Port
+		if vals, exists := portMap[key]; exists {
+			if len(vals) > 1 {
+				port = mergeServicePortsForListener(vals)
+			} else {
+				port = vals[0]
+			}
+			_, err := t.buildListener(ctx, port, cfg, scheme)
+			if err != nil {
+				return err
+			}
+			delete(portMap, key)
+		}
+	}
+
 	return nil
 }
 
-func (t *defaultModelBuildTask) buildListener(ctx context.Context, port corev1.ServicePort, cfg listenerConfig,
+func (t *defaultModelBuildTask) buildListener(ctx context.Context, port corev1.ServicePort, cfg *listenerConfig,
 	scheme elbv2model.LoadBalancerScheme) (*elbv2model.Listener, error) {
 	lsSpec, err := t.buildListenerSpec(ctx, port, cfg, scheme)
 	if err != nil {
@@ -39,7 +61,7 @@ func (t *defaultModelBuildTask) buildListener(ctx context.Context, port corev1.S
 	return ls, nil
 }
 
-func (t *defaultModelBuildTask) buildListenerSpec(ctx context.Context, port corev1.ServicePort, cfg listenerConfig,
+func (t *defaultModelBuildTask) buildListenerSpec(ctx context.Context, port corev1.ServicePort, cfg *listenerConfig,
 	scheme elbv2model.LoadBalancerScheme) (elbv2model.ListenerSpec, error) {
 	tgProtocol := elbv2model.Protocol(port.Protocol)
 	listenerProtocol := elbv2model.Protocol(port.Protocol)
@@ -149,7 +171,7 @@ func validateTLSPortsSet(rawTLSPorts []string, ports []corev1.ServicePort) error
 	return nil
 }
 
-func (t *defaultModelBuildTask) buildTLSPortsSet(_ context.Context) (sets.String, error) {
+func (t *defaultModelBuildTask) buildTLSPortsSet(_ context.Context) (sets.Set[string], error) {
 	var rawTLSPorts []string
 
 	_ = t.annotationParser.ParseStringSliceAnnotation(annotations.SvcLBSuffixSSLPorts, &rawTLSPorts, t.service.Annotations)
@@ -160,7 +182,7 @@ func (t *defaultModelBuildTask) buildTLSPortsSet(_ context.Context) (sets.String
 		return nil, err
 	}
 
-	return sets.NewString(rawTLSPorts...), nil
+	return sets.New[string](rawTLSPorts...), nil
 }
 
 func (t *defaultModelBuildTask) buildBackendProtocol(_ context.Context) string {
@@ -191,7 +213,7 @@ func (t *defaultModelBuildTask) buildListenerALPNPolicy(ctx context.Context, lis
 
 type listenerConfig struct {
 	certificates    []elbv2model.Certificate
-	tlsPortsSet     sets.String
+	tlsPortsSet     sets.Set[string]
 	sslPolicy       *string
 	backendProtocol string
 }
@@ -233,4 +255,25 @@ func (t *defaultModelBuildTask) buildListenerAttributes(ctx context.Context, svc
 		})
 	}
 	return attributes, nil
+}
+
+func mergeServicePortsForListener(ports []corev1.ServicePort) corev1.ServicePort {
+	port0 := ports[0]
+	mergeableProtocols := map[corev1.Protocol]bool{
+		corev1.ProtocolTCP: true,
+		corev1.ProtocolUDP: true,
+	}
+	if _, ok := mergeableProtocols[port0.Protocol]; !ok {
+		return port0
+	}
+	for _, port := range ports[1:] {
+		if _, ok := mergeableProtocols[port.Protocol]; !ok {
+			continue
+		}
+		if port.NodePort == port0.NodePort && port.Protocol != port0.Protocol {
+			port0.Protocol = corev1.Protocol("TCP_UDP")
+			break
+		}
+	}
+	return port0
 }

--- a/pkg/service/model_build_listener_test.go
+++ b/pkg/service/model_build_listener_test.go
@@ -159,7 +159,7 @@ func Test_defaultModelBuilderTask_buildListenerConfig(t *testing.T) {
 			},
 			want: &listenerConfig{
 				certificates:    ([]elbv2model.Certificate)(nil),
-				tlsPortsSet:     sets.NewString("83"),
+				tlsPortsSet:     sets.New[string]("83"),
 				sslPolicy:       new(string),
 				backendProtocol: "",
 			},
@@ -300,4 +300,221 @@ func Test_defaultModelBuilderTask_buildListenerAttributes(t *testing.T) {
 
 		})
 	}
+}
+
+func Test_mergeServicePortsForListener(t *testing.T) {
+	tests := []struct {
+		name  string
+		ports []corev1.ServicePort
+		want  corev1.ServicePort
+	}{
+		{
+			name: "one port",
+			ports: []corev1.ServicePort{
+				{
+					Name:       "p1",
+					Port:       80,
+					TargetPort: intstr.FromInt(80),
+					Protocol:   corev1.ProtocolTCP,
+					NodePort:   31223,
+				},
+			},
+			want: corev1.ServicePort{
+				Name:       "p1",
+				Port:       80,
+				TargetPort: intstr.FromInt(80),
+				Protocol:   corev1.ProtocolTCP,
+				NodePort:   31223,
+			},
+		},
+		{
+			name: "two tcp ports, different target and node ports",
+			ports: []corev1.ServicePort{
+				{
+					Name:       "p1",
+					Port:       80,
+					TargetPort: intstr.FromInt(80),
+					Protocol:   corev1.ProtocolTCP,
+					NodePort:   31223,
+				},
+				{
+					Name:       "p2",
+					Port:       80,
+					TargetPort: intstr.FromInt(8888),
+					Protocol:   corev1.ProtocolTCP,
+					NodePort:   31224,
+				},
+			},
+			want: corev1.ServicePort{
+				Name:       "p1",
+				Port:       80,
+				TargetPort: intstr.FromInt(80),
+				Protocol:   corev1.ProtocolTCP,
+				NodePort:   31223,
+			},
+		},
+		{
+			name: "two udp ports, different target and node ports",
+			ports: []corev1.ServicePort{
+				{
+					Name:       "p1",
+					Port:       80,
+					TargetPort: intstr.FromInt(80),
+					Protocol:   corev1.ProtocolUDP,
+					NodePort:   31223,
+				},
+				{
+					Name:       "p2",
+					Port:       80,
+					TargetPort: intstr.FromInt(8888),
+					Protocol:   corev1.ProtocolUDP,
+					NodePort:   31224,
+				},
+			},
+			want: corev1.ServicePort{
+				Name:       "p1",
+				Port:       80,
+				TargetPort: intstr.FromInt(80),
+				Protocol:   corev1.ProtocolUDP,
+				NodePort:   31223,
+			},
+		},
+		{
+			name: "one tcp and one udp, different target and node ports",
+			ports: []corev1.ServicePort{
+				{
+					Name:       "p1",
+					Port:       80,
+					TargetPort: intstr.FromInt(80),
+					Protocol:   corev1.ProtocolTCP,
+					NodePort:   31223,
+				},
+				{
+					Name:       "p2",
+					Port:       80,
+					TargetPort: intstr.FromInt(8888),
+					Protocol:   corev1.ProtocolUDP,
+					NodePort:   31224,
+				},
+			},
+			want: corev1.ServicePort{
+				Name:       "p1",
+				Port:       80,
+				TargetPort: intstr.FromInt(80),
+				Protocol:   corev1.ProtocolTCP,
+				NodePort:   31223,
+			},
+		},
+		{
+			name: "one tcp and one udp, same target and node ports",
+			ports: []corev1.ServicePort{
+				{
+					Name:       "p1",
+					Port:       80,
+					TargetPort: intstr.FromInt(80),
+					Protocol:   corev1.ProtocolTCP,
+					NodePort:   31223,
+				},
+				{
+					Name:       "p2",
+					Port:       80,
+					TargetPort: intstr.FromInt(80),
+					Protocol:   corev1.ProtocolUDP,
+					NodePort:   31223,
+				},
+			},
+			want: corev1.ServicePort{
+				Name:       "p1",
+				Port:       80,
+				TargetPort: intstr.FromInt(80),
+				Protocol:   corev1.Protocol("TCP_UDP"),
+				NodePort:   31223,
+			},
+		},
+		{
+			name: "one udp and one tcp, same target and node ports",
+			ports: []corev1.ServicePort{
+				{
+					Name:       "p1",
+					Port:       80,
+					TargetPort: intstr.FromInt(80),
+					Protocol:   corev1.ProtocolUDP,
+					NodePort:   31223,
+				},
+				{
+					Name:       "p2",
+					Port:       80,
+					TargetPort: intstr.FromInt(80),
+					Protocol:   corev1.ProtocolTCP,
+					NodePort:   31223,
+				},
+			},
+			want: corev1.ServicePort{
+				Name:       "p1",
+				Port:       80,
+				TargetPort: intstr.FromInt(80),
+				Protocol:   corev1.Protocol("TCP_UDP"),
+				NodePort:   31223,
+			},
+		},
+		{
+			name: "one tcp and one udp, same node port, different target port",
+			ports: []corev1.ServicePort{
+				{
+					Name:       "p1",
+					Port:       80,
+					TargetPort: intstr.FromInt(80),
+					Protocol:   corev1.ProtocolTCP,
+					NodePort:   31223,
+				},
+				{
+					Name:       "p2",
+					Port:       80,
+					TargetPort: intstr.FromInt(8888),
+					Protocol:   corev1.ProtocolUDP,
+					NodePort:   31223,
+				},
+			},
+			want: corev1.ServicePort{
+				Name:       "p1",
+				Port:       80,
+				TargetPort: intstr.FromInt(80),
+				Protocol:   corev1.Protocol("TCP_UDP"),
+				NodePort:   31223,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			port := mergeServicePortsForListener(tt.ports)
+			assert.Equal(t, port.Name, tt.want.Name)
+			assert.Equal(t, port.Port, tt.want.Port)
+			assert.Equal(t, port.TargetPort.IntVal, tt.want.TargetPort.IntVal)
+			assert.Equal(t, port.Protocol, tt.want.Protocol)
+			assert.Equal(t, port.NodePort, tt.want.NodePort)
+		})
+	}
+
+	// test that function returns new ServicePort instance
+	p1 := corev1.ServicePort{
+		Name:       "p1",
+		Port:       80,
+		TargetPort: intstr.FromInt(80),
+		Protocol:   corev1.ProtocolTCP,
+		NodePort:   31223,
+	}
+	p2 := corev1.ServicePort{
+		Name:       "p2",
+		Port:       80,
+		TargetPort: intstr.FromInt(80),
+		Protocol:   corev1.ProtocolUDP,
+		NodePort:   31223,
+	}
+	ports := []corev1.ServicePort{p1, p2}
+	mergedPort := mergeServicePortsForListener(ports)
+
+	assert.Equal(t, corev1.ProtocolTCP, p1.Protocol)
+	assert.Equal(t, corev1.Protocol("TCP_UDP"), mergedPort.Protocol)
+	assert.NotEqual(t, &p1, &mergedPort)
 }

--- a/pkg/service/model_build_listener_test.go
+++ b/pkg/service/model_build_listener_test.go
@@ -304,9 +304,10 @@ func Test_defaultModelBuilderTask_buildListenerAttributes(t *testing.T) {
 
 func Test_mergeServicePortsForListener(t *testing.T) {
 	tests := []struct {
-		name  string
-		ports []corev1.ServicePort
-		want  corev1.ServicePort
+		name    string
+		ports   []corev1.ServicePort
+		want    corev1.ServicePort
+		success bool
 	}{
 		{
 			name: "one port",
@@ -326,6 +327,7 @@ func Test_mergeServicePortsForListener(t *testing.T) {
 				Protocol:   corev1.ProtocolTCP,
 				NodePort:   31223,
 			},
+			success: true,
 		},
 		{
 			name: "two tcp ports, different target and node ports",
@@ -352,6 +354,7 @@ func Test_mergeServicePortsForListener(t *testing.T) {
 				Protocol:   corev1.ProtocolTCP,
 				NodePort:   31223,
 			},
+			success: true,
 		},
 		{
 			name: "two udp ports, different target and node ports",
@@ -378,6 +381,7 @@ func Test_mergeServicePortsForListener(t *testing.T) {
 				Protocol:   corev1.ProtocolUDP,
 				NodePort:   31223,
 			},
+			success: true,
 		},
 		{
 			name: "one tcp and one udp, different target and node ports",
@@ -404,6 +408,7 @@ func Test_mergeServicePortsForListener(t *testing.T) {
 				Protocol:   corev1.ProtocolTCP,
 				NodePort:   31223,
 			},
+			success: true,
 		},
 		{
 			name: "one tcp and one udp, same target and node ports",
@@ -430,6 +435,7 @@ func Test_mergeServicePortsForListener(t *testing.T) {
 				Protocol:   corev1.Protocol("TCP_UDP"),
 				NodePort:   31223,
 			},
+			success: true,
 		},
 		{
 			name: "one udp and one tcp, same target and node ports",
@@ -456,6 +462,7 @@ func Test_mergeServicePortsForListener(t *testing.T) {
 				Protocol:   corev1.Protocol("TCP_UDP"),
 				NodePort:   31223,
 			},
+			success: true,
 		},
 		{
 			name: "one tcp and one udp, same node port, different target port",
@@ -470,7 +477,7 @@ func Test_mergeServicePortsForListener(t *testing.T) {
 				{
 					Name:       "p2",
 					Port:       80,
-					TargetPort: intstr.FromInt(8888),
+					TargetPort: intstr.FromInt(80),
 					Protocol:   corev1.ProtocolUDP,
 					NodePort:   31223,
 				},
@@ -482,12 +489,45 @@ func Test_mergeServicePortsForListener(t *testing.T) {
 				Protocol:   corev1.Protocol("TCP_UDP"),
 				NodePort:   31223,
 			},
+			success: true,
+		},
+		{
+			name: "one tcp and one udp, same node port, different target port",
+			ports: []corev1.ServicePort{
+				{
+					Name:       "p1",
+					Port:       80,
+					TargetPort: intstr.FromInt(80),
+					Protocol:   corev1.ProtocolTCP,
+					NodePort:   31223,
+				},
+				{
+					Name:       "p2",
+					Port:       80,
+					TargetPort: intstr.FromInt(80),
+					Protocol:   corev1.ProtocolUDP,
+					NodePort:   31223,
+				},
+				{
+					Name:       "p2",
+					Port:       80,
+					TargetPort: intstr.FromInt(80),
+					Protocol:   corev1.ProtocolSCTP,
+					NodePort:   31223,
+				},
+			},
+			want:    corev1.ServicePort{},
+			success: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			port := mergeServicePortsForListener(tt.ports)
+			port, err := mergeServicePortsForListener(tt.ports)
+			if !tt.success {
+				assert.NotNil(t, err)
+				return
+			}
 			assert.Equal(t, port.Name, tt.want.Name)
 			assert.Equal(t, port.Port, tt.want.Port)
 			assert.Equal(t, port.TargetPort.IntVal, tt.want.TargetPort.IntVal)
@@ -495,26 +535,4 @@ func Test_mergeServicePortsForListener(t *testing.T) {
 			assert.Equal(t, port.NodePort, tt.want.NodePort)
 		})
 	}
-
-	// test that function returns new ServicePort instance
-	p1 := corev1.ServicePort{
-		Name:       "p1",
-		Port:       80,
-		TargetPort: intstr.FromInt(80),
-		Protocol:   corev1.ProtocolTCP,
-		NodePort:   31223,
-	}
-	p2 := corev1.ServicePort{
-		Name:       "p2",
-		Port:       80,
-		TargetPort: intstr.FromInt(80),
-		Protocol:   corev1.ProtocolUDP,
-		NodePort:   31223,
-	}
-	ports := []corev1.ServicePort{p1, p2}
-	mergedPort := mergeServicePortsForListener(ports)
-
-	assert.Equal(t, corev1.ProtocolTCP, p1.Protocol)
-	assert.Equal(t, corev1.Protocol("TCP_UDP"), mergedPort.Protocol)
-	assert.NotEqual(t, &p1, &mergedPort)
 }

--- a/pkg/service/model_builder_test.go
+++ b/pkg/service/model_builder_test.go
@@ -2251,6 +2251,264 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 			wantError:                true,
 		},
 		{
+			testName: "Instance mode, TCP/UDP same port test",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tcpudp-protocol",
+					Namespace: "app",
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/aws-load-balancer-type":            "external",
+						"service.beta.kubernetes.io/aws-load-balancer-scheme":          "internet-facing",
+						"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "instance",
+					},
+					UID: "2dc098f0-ae33-4378-af7b-83e2a0424495",
+				},
+				Spec: corev1.ServiceSpec{
+					ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeCluster,
+					Type:                  corev1.ServiceTypeLoadBalancer,
+					Selector:              map[string]string{"app": "hello"},
+					HealthCheckNodePort:   29123,
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "p1",
+							Port:       80,
+							TargetPort: intstr.FromInt(80),
+							Protocol:   corev1.ProtocolTCP,
+							NodePort:   31223,
+						},
+						{
+							Name:       "p2",
+							Port:       80,
+							TargetPort: intstr.FromInt(80),
+							Protocol:   corev1.ProtocolUDP,
+							NodePort:   31223,
+						},
+						{
+							Name:       "alt2",
+							Port:       83,
+							TargetPort: intstr.FromInt(8883),
+							Protocol:   corev1.ProtocolTCP,
+							NodePort:   32323,
+						},
+					},
+				},
+			},
+			resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForThreeSubnet},
+			listLoadBalancerCalls:    []listLoadBalancerCall{listLoadBalancerCallForEmptyLB},
+			wantError:                false,
+			wantValue: `
+{
+ "id":"app/tcpudp-protocol",
+ "resources":{
+    "AWS::ElasticLoadBalancingV2::Listener":{
+       "80":{
+          "spec":{
+             "loadBalancerARN":{
+                "$ref":"#/resources/AWS::ElasticLoadBalancingV2::LoadBalancer/LoadBalancer/status/loadBalancerARN"
+             },
+             "port":80,
+             "protocol":"TCP_UDP",
+             "defaultActions":[
+                {
+                   "type":"forward",
+                   "forwardConfig":{
+                      "targetGroups":[
+                         {
+                            "targetGroupARN":{
+                               "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/app/tcpudp-protocol:80/status/targetGroupARN"
+                            }
+                         }
+                      ]
+                   }
+                }
+             ]
+          }
+       },
+       "83":{
+          "spec":{
+             "loadBalancerARN":{
+                "$ref":"#/resources/AWS::ElasticLoadBalancingV2::LoadBalancer/LoadBalancer/status/loadBalancerARN"
+             },
+             "port":83,
+             "protocol":"TCP",
+             "defaultActions":[
+                {
+                   "type":"forward",
+                   "forwardConfig":{
+                      "targetGroups":[
+                         {
+                            "targetGroupARN":{
+                               "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/app/tcpudp-protocol:83/status/targetGroupARN"
+                            }
+                         }
+                      ]
+                   }
+                }
+             ]
+          }
+       }
+    },
+    "AWS::ElasticLoadBalancingV2::LoadBalancer":{
+       "LoadBalancer":{
+          "spec":{
+             "name":"k8s-app-tcpudppr-2af705447d",
+             "type":"network",
+             "scheme":"internet-facing",
+             "ipAddressType":"ipv4",
+             "subnetMapping":[
+                {
+                   "subnetID":"subnet-1"
+                },
+                {
+                   "subnetID":"subnet-2"
+                },
+                {
+                   "subnetID":"subnet-3"
+                }
+             ]
+          }
+       }
+    },
+    "AWS::ElasticLoadBalancingV2::TargetGroup":{
+       "app/tcpudp-protocol:80":{
+          "spec":{
+             "ipAddressType":"ipv4",
+             "name":"k8s-app-tcpudppr-2213a0d759",
+             "targetType":"instance",
+             "port":31223,
+             "protocol":"TCP_UDP",
+             "healthCheckConfig":{
+                "port":"traffic-port",
+                "protocol":"TCP",
+                "unhealthyThresholdCount":3,
+                "healthyThresholdCount":3,
+                "intervalSeconds":10
+             },
+             "targetGroupAttributes":[
+                {
+                   "key":"proxy_protocol_v2.enabled",
+                   "value":"false"
+                }
+             ]
+          }
+       },
+       "app/tcpudp-protocol:83":{
+          "spec":{
+             "ipAddressType":"ipv4",
+             "name":"k8s-app-tcpudppr-c200165858",
+             "targetType":"instance",
+             "port":32323,
+             "protocol":"TCP",
+             "healthCheckConfig":{
+                "port":"traffic-port",
+                "protocol":"TCP",
+                "unhealthyThresholdCount":3,
+                "healthyThresholdCount":3,
+                "intervalSeconds":10
+             },
+             "targetGroupAttributes":[
+                {
+                   "key":"proxy_protocol_v2.enabled",
+                   "value":"false"
+                }
+             ]
+          }
+       }
+    },
+    "K8S::ElasticLoadBalancingV2::TargetGroupBinding":{
+       "app/tcpudp-protocol:80":{
+          "spec":{
+             "template":{
+                "metadata":{
+                   "creationTimestamp":null,
+                   "name":"k8s-app-tcpudppr-2213a0d759",
+                   "namespace":"app"
+                },
+                "spec":{
+                   "targetGroupARN":{
+                      "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/app/tcpudp-protocol:80/status/targetGroupARN"
+                   },
+                   "targetType":"instance",
+                   "serviceRef":{
+                      "name":"tcpudp-protocol",
+                      "port":80
+                   },
+                   "ipAddressType": "ipv4",
+                   "networking":{
+                      "ingress":[
+                         {
+                            "from":[
+                               {
+                                  "ipBlock":{
+                                     "cidr":"0.0.0.0/0"
+                                  }
+                               }
+                            ],
+                            "ports":[
+                               {
+                                  "protocol":"TCP",
+                                  "port":31223
+                               },
+                               {
+                                  "protocol":"UDP",
+                                  "port":31223
+                               }
+                            ]
+                         }
+                      ]
+                   }
+                }
+             }
+          }
+       },
+       "app/tcpudp-protocol:83":{
+          "spec":{
+             "template":{
+                "metadata":{
+                   "name":"k8s-app-tcpudppr-c200165858",
+                   "namespace":"app",
+                   "creationTimestamp":null
+                },
+                "spec":{
+                   "targetGroupARN":{
+                      "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/app/tcpudp-protocol:83/status/targetGroupARN"
+                   },
+                   "targetType":"instance",
+                   "serviceRef":{
+                      "name":"tcpudp-protocol",
+                      "port":83
+                   },
+                   "ipAddressType": "ipv4",
+                   "networking":{
+                      "ingress":[
+                         {
+                            "from":[
+                               {
+                                  "ipBlock":{
+                                     "cidr":"0.0.0.0/0"
+                                  }
+                               }
+                            ],
+                            "ports":[
+                               {
+                                  "protocol":"TCP",
+                                  "port":32323
+                               }
+                            ]
+                         }
+                      ]
+                   }
+                }
+             }
+          }
+       }
+    }
+ }
+}
+`,
+			wantNumResources: 7,
+		},
+		{
 			testName: "list load balancers error",
 			svc: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/service/model_builder_test.go
+++ b/pkg/service/model_builder_test.go
@@ -560,8 +560,8 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                 "healthyThresholdCount":2,
                 "unhealthyThresholdCount":2,
                 "matcher":{
-					"httpCode": "200-399"
-				}
+                   "httpCode": "200-399"
+                }
              },
              "targetGroupAttributes":[
                 {
@@ -587,8 +587,8 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                 "healthyThresholdCount":2,
                 "unhealthyThresholdCount":2,
                 "matcher":{
-					"httpCode": "200-399"
-				}
+                   "httpCode": "200-399"
+                }
              },
              "targetGroupAttributes":[
                 {
@@ -908,8 +908,8 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                 "healthyThresholdCount":2,
                 "unhealthyThresholdCount":2,
                 "matcher":{
-					"httpCode": "200-399"
-				}
+                   "httpCode": "200-399"
+                }
              },
              "targetGroupAttributes":[
                 {
@@ -935,8 +935,8 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                 "healthyThresholdCount":2,
                 "unhealthyThresholdCount":2,
                 "matcher":{
-					"httpCode": "200-399"
-				}
+                   "httpCode": "200-399"
+                }
              },
              "targetGroupAttributes":[
                 {
@@ -1526,8 +1526,8 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                 "healthyThresholdCount":2,
                 "unhealthyThresholdCount":2,
                 "matcher":{
-					"httpCode": "200-399"
-				}
+                   "httpCode": "200-399"
+                }
              },
              "targetGroupAttributes":[
                 {
@@ -1553,8 +1553,8 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                 "healthyThresholdCount":2,
                 "unhealthyThresholdCount":2,
                 "matcher":{
-					"httpCode": "200-399"
-				}
+                   "httpCode": "200-399"
+                }
              },
              "targetGroupAttributes":[
                 {
@@ -2145,21 +2145,21 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
               },
               "networking": {
                 "ingress": [
-				 {
-					"from":[
-					   {
-						  "ipBlock":{
-							 "cidr":"192.168.0.0/19"
-						  }
-					   }
-					],
-					"ports":[
-					   {
-						  "protocol":"TCP",
-						  "port":80
-					   }
-					]
-				 }
+                 {
+                    "from":[
+                       {
+                          "ipBlock":{
+                             "cidr":"192.168.0.0/19"
+                          }
+                       }
+                    ],
+                    "ports":[
+                       {
+                          "protocol":"TCP",
+                          "port":80
+                       }
+                    ]
+                 }
                 ]
               },
               "serviceRef": {
@@ -2301,46 +2301,46 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 {
  "id":"app/tcpudp-protocol",
  "resources":{
-		"AWS::EC2::SecurityGroup":{
-			 "ManagedLBSecurityGroup":{
-					"spec":{
-						 "description":"[k8s] Managed SecurityGroup for LoadBalancer",
-						 "groupName":"k8s-app-tcpudppr-06a9156bf8",
-						 "ingress":[
-						    {
-								   "fromPort":80,
-									 "ipProtocol":"tcp",
-									 "ipRanges":[
-									    {
-											   "cidrIP":"0.0.0.0/0"
-											}
-									 ],
-									 "toPort":80
-								},
-						    {
-								   "fromPort":80,
-									 "ipProtocol":"udp",
-									 "ipRanges":[
-									    {
-											   "cidrIP":"0.0.0.0/0"
-											}
-									 ],
-									 "toPort":80
-								},
-						    {
-								   "fromPort":83,
-									 "ipProtocol":"tcp",
-									 "ipRanges":[
-									    {
-											   "cidrIP":"0.0.0.0/0"
-											}
-									 ],
-									 "toPort":83
-								}
-						 ]
-					}
-			 }
-		},
+    "AWS::EC2::SecurityGroup":{
+       "ManagedLBSecurityGroup":{
+          "spec":{
+             "description":"[k8s] Managed SecurityGroup for LoadBalancer",
+             "groupName":"k8s-app-tcpudppr-06a9156bf8",
+             "ingress":[
+                {
+                   "fromPort":80,
+                   "ipProtocol":"tcp",
+                   "ipRanges":[
+                      {
+                         "cidrIP":"0.0.0.0/0"
+                      }
+                   ],
+                   "toPort":80
+                },
+                {
+                   "fromPort":80,
+                   "ipProtocol":"udp",
+                   "ipRanges":[
+                      {
+                         "cidrIP":"0.0.0.0/0"
+                      }
+                   ],
+                   "toPort":80
+                },
+                {
+                   "fromPort":83,
+                   "ipProtocol":"tcp",
+                   "ipRanges":[
+                      {
+                         "cidrIP":"0.0.0.0/0"
+                      }
+                   ],
+                   "toPort":83
+                }
+             ]
+          }
+       }
+    },
     "AWS::ElasticLoadBalancingV2::Listener":{
        "80":{
           "spec":{
@@ -2395,11 +2395,11 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
              "name":"k8s-app-tcpudppr-2af705447d",
              "type":"network",
              "scheme":"internet-facing",
-						 "securityGroups":[
-								{
-									"$ref":"#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
-								}
-						 ],
+             "securityGroups":[
+                {
+                  "$ref":"#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+                }
+             ],
              "ipAddressType":"ipv4",
              "subnetMapping":[
                 {
@@ -2426,7 +2426,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
              "healthCheckConfig":{
                 "port":"traffic-port",
                 "protocol":"TCP",
-								"timeoutSeconds":10,
+                "timeoutSeconds":10,
                 "unhealthyThresholdCount":3,
                 "healthyThresholdCount":3,
                 "intervalSeconds":10
@@ -2449,7 +2449,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
              "healthCheckConfig":{
                 "port":"traffic-port",
                 "protocol":"TCP",
-								"timeoutSeconds":10,
+                "timeoutSeconds":10,
                 "unhealthyThresholdCount":3,
                 "healthyThresholdCount":3,
                 "intervalSeconds":10
@@ -2477,7 +2477,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                       "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/app/tcpudp-protocol:80/status/targetGroupARN"
                    },
                    "targetType":"instance",
-									 "vpcID":"vpc-xxx",
+                   "vpcID":"vpc-xxx",
                    "serviceRef":{
                       "name":"tcpudp-protocol",
                       "port":80
@@ -2488,10 +2488,10 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                          {
                             "from":[
                                {
-																	"securityGroup": {
-																		"groupID": {
-																			"$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
-																		}
+                                  "securityGroup": {
+                                    "groupID": {
+                                      "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+                                    }
                                   }
                                }
                             ],
@@ -2525,7 +2525,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                       "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/app/tcpudp-protocol:83/status/targetGroupARN"
                    },
                    "targetType":"instance",
-									 "vpcID":"vpc-xxx",
+                   "vpcID":"vpc-xxx",
                    "serviceRef":{
                       "name":"tcpudp-protocol",
                       "port":83
@@ -2536,10 +2536,10 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                          {
                             "from":[
                                {
-																	"securityGroup": {
-																		"groupID": {
-																			"$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
-																		}
+                                  "securityGroup": {
+                                    "groupID": {
+                                      "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+                                    }
                                   }
                                }
                             ],
@@ -3451,10 +3451,10 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
              ],
            "securityGroups": [
             {
-			   "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+               "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
             },
             "sg-backend"
-		 ]
+         ]
           }
        }
     },
@@ -3635,10 +3635,10 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
              ],
            "securityGroups": [
             {
-			   "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+               "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
             },
             "sg-backend"
-		 ]
+           ]
           }
        }
     },
@@ -3699,7 +3699,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                             ],
                             "ports":[
                                {
-																	"port": 80,
+                                  "port": 80,
                                   "protocol":"TCP"
                                }
                             ]
@@ -3859,10 +3859,10 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
              ],
              "securityGroups": [
                {
-			     "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+                 "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
                },
                "sg-backend"
-		     ]
+             ]
           }
        }
     },
@@ -3883,8 +3883,8 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                 "healthyThresholdCount":2,
                 "unhealthyThresholdCount":2,
                 "matcher":{
-					"httpCode": "200-399"
-				}
+                   "httpCode": "200-399"
+                }
              },
              "targetGroupAttributes":[
                 {
@@ -3910,8 +3910,8 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                 "healthyThresholdCount":2,
                 "unhealthyThresholdCount":2,
                 "matcher":{
-					"httpCode": "200-399"
-				}
+                   "httpCode": "200-399"
+                }
              },
              "targetGroupAttributes":[
                 {
@@ -3953,12 +3953,12 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                                }
                             ],
                             "ports":[
-															 {
-																	"port": 80,
+                               {
+                                  "port": 80,
                                   "protocol":"TCP"
                                },
-															 {
-																	"port": 8888,
+                               {
+                                  "port": 8888,
                                   "protocol":"TCP"
                                }
                             ]
@@ -4000,11 +4000,11 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                             ],
                             "ports":[
                                {
-							      "port": 80,
+                                  "port": 80,
                                   "protocol":"TCP"
                                },
-							   {
-							      "port": 8888,
+                               {
+                                  "port": 8888,
                                   "protocol":"TCP"
                                }
                             ]
@@ -4200,10 +4200,10 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
              ],
            "securityGroups": [
             {
-			   "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+               "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
             },
             "sg-backend"
-		 ]
+           ]
           }
        }
     },
@@ -4224,8 +4224,8 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                 "healthyThresholdCount":2,
                 "unhealthyThresholdCount":2,
                 "matcher":{
-					"httpCode": "200-399"
-				}
+                   "httpCode": "200-399"
+                }
              },
              "targetGroupAttributes":[
                 {
@@ -4251,8 +4251,8 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                 "healthyThresholdCount":2,
                 "unhealthyThresholdCount":2,
                 "matcher":{
-					"httpCode": "200-399"
-				}
+                   "httpCode": "200-399"
+                }
              },
              "targetGroupAttributes":[
                 {
@@ -4295,7 +4295,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                             ],
                             "ports":[
                                {
-								  "port": 80,
+                                  "port": 80,
                                   "protocol":"TCP"
                                }
                             ]
@@ -4337,11 +4337,11 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                             ],
                             "ports":[
                                {
-								  "port": 8883,
+                                  "port": 8883,
                                   "protocol":"TCP"
                                },
-							   {
-								  "port": 80,
+                               {
+                                  "port": 80,
                                   "protocol":"TCP"
                                }
                             ]
@@ -4514,9 +4514,9 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
              ],
            "securityGroups": [
             {
-			   "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+               "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
             }
-		 ]
+           ]
           }
        }
     },
@@ -4594,9 +4594,9 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                             "from":[
                                {
                                   "securityGroup":{
-																		 "groupID": {
-																						 "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
-																		}
+                                    "groupID": {
+                                        "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+                                    }
                                   }
                                }
                             ],
@@ -4638,8 +4638,8 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                                {
                                   "securityGroup":{
                                      "groupID": {
-                                       "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
-																		 }
+                                        "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+                                     }
                                   }
                                }
                             ],
@@ -4847,9 +4847,9 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
              ],
            "securityGroups": [
             {
-			   "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+               "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
             }
-		 ]
+           ]
           }
        }
     },
@@ -4864,14 +4864,14 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
              "healthCheckConfig":{
                 "port": 29123,
                 "protocol":"HTTP",
-			    "path":"/healthz",
+                "path":"/healthz",
                 "intervalSeconds":10,
                 "timeoutSeconds":6,
                 "healthyThresholdCount":2,
                 "unhealthyThresholdCount":2,
                 "matcher":{
-					"httpCode": "200-399"
-				}
+                   "httpCode": "200-399"
+                }
              },
              "targetGroupAttributes":[
                 {
@@ -4891,14 +4891,14 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
              "healthCheckConfig":{
                 "port": 29123,
                 "protocol":"HTTP",
-			    "path":"/healthz",
+                "path":"/healthz",
                 "intervalSeconds":10,
                 "timeoutSeconds":6,
                 "healthyThresholdCount":2,
                 "unhealthyThresholdCount":2,
                 "matcher":{
-					"httpCode": "200-399"
-				}
+                   "httpCode": "200-399"
+                }
              },
              "targetGroupAttributes":[
                 {
@@ -4936,18 +4936,18 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                                {
                                   "securityGroup":{
                                      "groupID": {
-									"$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
-								 }
+                                        "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+                                     }
                                   }
                                }
                             ],
                             "ports":[
                                {
-								  "port": 31223,
+                                  "port": 31223,
                                   "protocol":"TCP"
                                },
-							   {
-							      "port": 29123,
+                               {
+                                  "port": 29123,
                                   "protocol":"TCP"
                                }
                             ]
@@ -4983,19 +4983,19 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                             "from":[
                                {
                                   "securityGroup":{
-									"groupID": {
-										"$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
-								 	}
+                                    "groupID": {
+                                        "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+                                     }
                                   }
                                }
                             ],
                             "ports":[
                                {
-								  "port": 32323,
+                                  "port": 32323,
                                   "protocol":"TCP"
                                },
-							   {
-								  "port": 29123,
+                               {
+                                  "port": 29123,
                                   "protocol":"TCP"
                                }
                             ]
@@ -5198,9 +5198,9 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
              ],
            "securityGroups": [
             {
-			   "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+               "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
             }
-		 ]
+           ]
           }
        }
     },
@@ -5215,14 +5215,14 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
              "healthCheckConfig":{
                 "port": 29123,
                 "protocol":"HTTP",
-				"path":"/healthz",
+                "path":"/healthz",
                 "intervalSeconds":10,
                 "timeoutSeconds":6,
                 "healthyThresholdCount":2,
                 "unhealthyThresholdCount":2,
                 "matcher":{
-					"httpCode": "200-399"
-				}
+                   "httpCode": "200-399"
+                }
              },
              "targetGroupAttributes":[
                 {
@@ -5242,14 +5242,14 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
              "healthCheckConfig":{
                 "port": 29123,
                 "protocol":"HTTP",
-				"path":"/healthz",
+                "path":"/healthz",
                 "intervalSeconds":10,
                 "timeoutSeconds":6,
                 "healthyThresholdCount":2,
                 "unhealthyThresholdCount":2,
                 "matcher":{
-					"httpCode": "200-399"
-				}
+                   "httpCode": "200-399"
+                }
              },
              "targetGroupAttributes":[
                 {
@@ -5287,18 +5287,18 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                                {
                                   "securityGroup":{
                                      "groupID": {
-									    "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
-								     }
+                                        "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+                                     }
                                   }
                                }
                             ],
                             "ports":[
-							   {
-								  "port": 31223,
+                               {
+                                  "port": 31223,
                                   "protocol":"UDP"
                                },
-							   {
-							      "port": 29123,
+                               {
+                                  "port": 29123,
                                   "protocol":"TCP"
                                }
                             ]
@@ -5334,19 +5334,19 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                             "from":[
                                {
                                   "securityGroup":{
-									"groupID": {
-										"$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
-								 	}
+                                    "groupID": {
+                                        "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+                                     }
                                   }
                                }
                             ],
                             "ports":[
-							   {
-								  "port": 32323,
+                               {
+                                  "port": 32323,
                                   "protocol":"UDP"
                                },
-							   {
-								  "port": 29123,
+                               {
+                                  "port": 29123,
                                   "protocol":"TCP"
                                }
                             ]
@@ -5480,7 +5480,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                 "port":"traffic-port",
                 "protocol":"TCP",
                 "intervalSeconds":10,
-				"timeoutSeconds": 10,
+                "timeoutSeconds": 10,
                 "healthyThresholdCount":3,
                 "unhealthyThresholdCount":3
              },
@@ -5660,7 +5660,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                         "securityGroup":{
                           "groupID":"sg-backend"
                         }
-					  }
+                      }
                     ],
                     "ports": [
                       {
@@ -5698,10 +5698,10 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
           ],
           "securityGroups": [
             {
-		     "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+             "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
             },
             "sg-backend"
-		  ],
+          ],
           "scheme": "internal",
           "type": "network"
         }
@@ -5719,7 +5719,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
             "unhealthyThresholdCount": 3,
             "protocol": "TCP",
             "port": "traffic-port",
-			"timeoutSeconds": 10,
+            "timeoutSeconds": 10,
             "intervalSeconds": 10
           },
           "targetGroupAttributes": [
@@ -5875,7 +5875,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
             "port": "traffic-port",
             "protocol": "TCP",
             "intervalSeconds": 10,
-			"timeoutSeconds": 10,
+            "timeoutSeconds": 10,
             "healthyThresholdCount": 3,
             "unhealthyThresholdCount": 3
           },
@@ -6060,7 +6060,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
             "port": "traffic-port",
             "protocol": "TCP",
             "intervalSeconds": 10,
-			"timeoutSeconds": 10,
+            "timeoutSeconds": 10,
             "healthyThresholdCount": 3,
             "unhealthyThresholdCount": 3
           },
@@ -6226,7 +6226,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
           ],
           "securityGroups": [
             {
-		       "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+               "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
             }
           ]
         }
@@ -6244,7 +6244,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
             "port": "traffic-port",
             "protocol": "TCP",
             "intervalSeconds": 10,
-			"timeoutSeconds": 10,
+            "timeoutSeconds": 10,
             "healthyThresholdCount": 3,
             "unhealthyThresholdCount": 3
           },
@@ -6440,7 +6440,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
             "port": "traffic-port",
             "protocol": "TCP",
             "intervalSeconds": 10,
-			"timeoutSeconds": 10,
+            "timeoutSeconds": 10,
             "healthyThresholdCount": 3,
             "unhealthyThresholdCount": 3
           },
@@ -6581,7 +6581,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
             "port": "traffic-port",
             "protocol": "TCP",
             "intervalSeconds": 10,
-			"timeoutSeconds": 10,
+            "timeoutSeconds": 10,
             "healthyThresholdCount": 3,
             "unhealthyThresholdCount": 3
           },

--- a/pkg/service/model_builder_test.go
+++ b/pkg/service/model_builder_test.go
@@ -2,10 +2,11 @@ package service
 
 import (
 	"context"
-	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 	"testing"
 	"time"
+
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/go-logr/logr"
@@ -2300,6 +2301,46 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 {
  "id":"app/tcpudp-protocol",
  "resources":{
+		"AWS::EC2::SecurityGroup":{
+			 "ManagedLBSecurityGroup":{
+					"spec":{
+						 "description":"[k8s] Managed SecurityGroup for LoadBalancer",
+						 "groupName":"k8s-app-tcpudppr-06a9156bf8",
+						 "ingress":[
+						    {
+								   "fromPort":80,
+									 "ipProtocol":"tcp",
+									 "ipRanges":[
+									    {
+											   "cidrIP":"0.0.0.0/0"
+											}
+									 ],
+									 "toPort":80
+								},
+						    {
+								   "fromPort":80,
+									 "ipProtocol":"udp",
+									 "ipRanges":[
+									    {
+											   "cidrIP":"0.0.0.0/0"
+											}
+									 ],
+									 "toPort":80
+								},
+						    {
+								   "fromPort":83,
+									 "ipProtocol":"tcp",
+									 "ipRanges":[
+									    {
+											   "cidrIP":"0.0.0.0/0"
+											}
+									 ],
+									 "toPort":83
+								}
+						 ]
+					}
+			 }
+		},
     "AWS::ElasticLoadBalancingV2::Listener":{
        "80":{
           "spec":{
@@ -2354,6 +2395,11 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
              "name":"k8s-app-tcpudppr-2af705447d",
              "type":"network",
              "scheme":"internet-facing",
+						 "securityGroups":[
+								{
+									"$ref":"#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+								}
+						 ],
              "ipAddressType":"ipv4",
              "subnetMapping":[
                 {
@@ -2380,6 +2426,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
              "healthCheckConfig":{
                 "port":"traffic-port",
                 "protocol":"TCP",
+								"timeoutSeconds":10,
                 "unhealthyThresholdCount":3,
                 "healthyThresholdCount":3,
                 "intervalSeconds":10
@@ -2402,6 +2449,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
              "healthCheckConfig":{
                 "port":"traffic-port",
                 "protocol":"TCP",
+								"timeoutSeconds":10,
                 "unhealthyThresholdCount":3,
                 "healthyThresholdCount":3,
                 "intervalSeconds":10
@@ -2429,6 +2477,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                       "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/app/tcpudp-protocol:80/status/targetGroupARN"
                    },
                    "targetType":"instance",
+									 "vpcID":"vpc-xxx",
                    "serviceRef":{
                       "name":"tcpudp-protocol",
                       "port":80
@@ -2439,18 +2488,20 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                          {
                             "from":[
                                {
-                                  "ipBlock":{
-                                     "cidr":"0.0.0.0/0"
+																	"securityGroup": {
+																		"groupID": {
+																			"$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+																		}
                                   }
                                }
                             ],
                             "ports":[
                                {
-                                  "protocol":"TCP",
+                                  "protocol":"UDP",
                                   "port":31223
                                },
                                {
-                                  "protocol":"UDP",
+                                  "protocol":"TCP",
                                   "port":31223
                                }
                             ]
@@ -2474,6 +2525,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                       "$ref":"#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/app/tcpudp-protocol:83/status/targetGroupARN"
                    },
                    "targetType":"instance",
+									 "vpcID":"vpc-xxx",
                    "serviceRef":{
                       "name":"tcpudp-protocol",
                       "port":83
@@ -2484,8 +2536,10 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                          {
                             "from":[
                                {
-                                  "ipBlock":{
-                                     "cidr":"0.0.0.0/0"
+																	"securityGroup": {
+																		"groupID": {
+																			"$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+																		}
                                   }
                                }
                             ],
@@ -2506,7 +2560,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
  }
 }
 `,
-			wantNumResources: 7,
+			wantNumResources: 8,
 		},
 		{
 			testName: "list load balancers error",
@@ -3645,7 +3699,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                             ],
                             "ports":[
                                {
-								  "port": 80,
+																	"port": 80,
                                   "protocol":"TCP"
                                }
                             ]
@@ -3899,12 +3953,12 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                                }
                             ],
                             "ports":[
-							   {
-							      "port": 80,
+															 {
+																	"port": 80,
                                   "protocol":"TCP"
                                },
-							   {
-							      "port": 8888,
+															 {
+																	"port": 8888,
                                   "protocol":"TCP"
                                }
                             ]
@@ -4540,9 +4594,9 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                             "from":[
                                {
                                   "securityGroup":{
-									"groupID": {
-										"$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
-									}
+																		 "groupID": {
+																						 "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+																		}
                                   }
                                }
                             ],
@@ -4584,8 +4638,8 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
                                {
                                   "securityGroup":{
                                      "groupID": {
-									"$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
-								 }
+                                       "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
+																		 }
                                   }
                                }
                             ],


### PR DESCRIPTION
This is a work in progress - I need to test it.

### Issue

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/1608#issuecomment-937346660

And based on this PR: https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2275

### Description

Previously, aws-load-balancer-controller ignored extra overlapping
ServicePorts defined in the Kubernetes Service spec if the external port
numbers were the same even if the protocols were different (e.g. TCP:53,
UDP:53).

This behavior prevented users from exposing services that support TCP
and UDP on the same external load balancer port number.

This patch solves the problem by detecting when a user defines multiple
ServicePorts for the same external load balancer port number but using
TCP and UDP protocols separately. In such situations, a TCP_UDP
TargetGroup and Listener are created and SecurityGroup rules are
updated accordingly. If more than two ServicePorts are defined, only the
first two mergeable ServicePorts are used. Otherwise, the first
ServicePort is used.

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [x] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:
