### PR TITLE
Allow Services in multiple namespaces within a ForwardConfig/TargetGroup

### DIFF
--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -248,6 +248,8 @@ Traffic Routing can be controlled with following annotations:
         ARN can be used in forward action(both simplified schema and advanced schema), it must be an targetGroup created outside of k8s, typically an targetGroup for legacy application.
     !!!note "use ServiceName/ServicePort in forward Action"
         ServiceName/ServicePort can be used in forward action(advanced schema only).
+    !!!note "use ServiceNamespace in forward Action"
+        ServiceNamespace can be used in combination with ServiceName/ServicePort in forward action to reference a Service in a different namespace than the Ingress resource (advanced schema only).
 
     !!!warning ""
         [Auth related annotations](#authentication) on Service object will only be respected if a single TargetGroup in is used.
@@ -257,6 +259,7 @@ Traffic Routing can be controlled with following annotations:
         - redirect-to-eks: redirect to an external url
         - forward-single-tg: forward to a single targetGroup [**simplified schema**]
         - forward-multiple-tg: forward to multiple targetGroups with different weights and stickiness config [**advanced schema**]
+        - forward-multiple-tg-multiple-ns: forward to multiple targetGroups with services in different namespaces
 
         ```yaml
         apiVersion: networking.k8s.io/v1
@@ -274,6 +277,8 @@ Traffic Routing can be controlled with following annotations:
               {"type":"forward","targetGroupARN": "arn-of-your-target-group"}
             alb.ingress.kubernetes.io/actions.forward-multiple-tg: >
               {"type":"forward","forwardConfig":{"targetGroups":[{"serviceName":"service-1","servicePort":"http","weight":20},{"serviceName":"service-2","servicePort":80,"weight":20},{"targetGroupARN":"arn-of-your-non-k8s-target-group","weight":60}],"targetGroupStickinessConfig":{"enabled":true,"durationSeconds":200}}}
+            alb.ingress.kubernetes.io/actions.forward-multiple-tg-multiple-ns: >
+              {"type":"forward","forwardConfig":{"targetGroups":[{"serviceName":"service-1","servicePort":"http","weight":20},{"serviceName":"service-2","servicePort":80,"serviceNamespace": "other-namespace", "weight":20}]}}
         spec:
           ingressClassName: alb
           rules:
@@ -305,6 +310,13 @@ Traffic Routing can be controlled with following annotations:
                     backend:
                       service:
                         name: forward-multiple-tg
+                        port:
+                          name: use-annotation
+                  - path: /path3
+                    pathType: Exact
+                    backend:
+                      service:
+                        name: forward-multiple-tg-multiple-ns
                         port:
                           name: use-annotation
         ```

--- a/pkg/ingress/config_types.go
+++ b/pkg/ingress/config_types.go
@@ -74,6 +74,10 @@ type TargetGroupTuple struct {
 	// the K8s service port
 	ServicePort *intstr.IntOrString `json:"servicePort"`
 
+	// the K8s service Namespace
+	// +optional
+	ServiceNamespace *string `json:"serviceNamespace,omitempty"`
+
 	// The weight.
 	// +optional
 	Weight *int32 `json:"weight,omitempty"`

--- a/pkg/ingress/model_build_actions_test.go
+++ b/pkg/ingress/model_build_actions_test.go
@@ -2,17 +2,314 @@ package ingress
 
 import (
 	"context"
+	"sort"
+	"testing"
+
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	networking "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/core"
 	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
 	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
 )
+
+func Test_defaultModelBuildTask_buildForwardAction(t *testing.T) {
+	ing := ClassifiedIngress{
+		Ing: &networking.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "awesome-ns",
+				Name:      "ing-1",
+				Annotations: map[string]string{
+					"alb.ingress.kubernetes.io/target-type": "ip",
+				},
+			},
+		},
+	}
+	portHTTP := intstr.FromString("http")
+	svcSpec := corev1.ServiceSpec{
+		Ports: []corev1.ServicePort{
+			{
+				Name: "http",
+				Port: 80,
+			},
+		},
+	}
+	svc1 := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   "awesome-ns",
+			Name:        "svc-1",
+			Annotations: map[string]string{},
+		},
+		Spec: svcSpec,
+	}
+	svc2 := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   "awesome-ns",
+			Name:        "svc-2",
+			Annotations: map[string]string{},
+		},
+		Spec: svcSpec,
+	}
+	svc3 := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   "awesome-ns-2",
+			Name:        "svc-3",
+			Annotations: map[string]string{},
+		},
+		Spec: svcSpec,
+	}
+
+	type args struct {
+		ing       ClassifiedIngress
+		actionCfg Action
+	}
+	type env struct {
+		services []*corev1.Service
+	}
+	type want struct {
+		targetGroupARN core.StringToken
+		service        *corev1.Service
+		weight         *int32
+	}
+
+	tests := []struct {
+		name    string
+		env     env
+		args    args
+		wants   []want
+		wantErr error
+	}{
+		{
+			name: "missing ForwardConfig",
+			args: args{
+				actionCfg: Action{},
+			},
+			wantErr: errors.New("missing ForwardConfig"),
+		},
+		{
+			name: "single TargetGroup with TargetGroupARN",
+			args: args{
+				actionCfg: Action{
+					ForwardConfig: &ForwardActionConfig{
+						TargetGroups: []TargetGroupTuple{
+							{
+								TargetGroupARN: awssdk.String("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-target-group"),
+							},
+						},
+					},
+				},
+			},
+			wants: []want{
+				{targetGroupARN: core.LiteralStringToken("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-target-group")},
+			},
+		},
+		{
+			name: "single TargetGroup with service",
+			env: env{
+				services: []*corev1.Service{svc1},
+			},
+			args: args{
+				ing: ing,
+				actionCfg: Action{
+					ForwardConfig: &ForwardActionConfig{
+						TargetGroups: []TargetGroupTuple{
+							{
+								ServiceName: awssdk.String("svc-1"),
+								ServicePort: &portHTTP,
+							},
+						},
+					},
+				},
+			},
+			wants: []want{
+				{service: svc1},
+			},
+		},
+		{
+			name: "multiple TargetGroups with services",
+			env: env{
+				services: []*corev1.Service{svc1, svc2},
+			},
+			args: args{
+				ing: ing,
+				actionCfg: Action{
+					ForwardConfig: &ForwardActionConfig{
+						TargetGroups: []TargetGroupTuple{
+							{
+								ServiceName: awssdk.String("svc-1"),
+								ServicePort: &portHTTP,
+								Weight:      awssdk.Int32(80),
+							},
+							{
+								ServiceName: awssdk.String("svc-2"),
+								ServicePort: &portHTTP,
+								Weight:      awssdk.Int32(20),
+							},
+						},
+					},
+				},
+			},
+			wants: []want{
+				{service: svc1, weight: awssdk.Int32(80)},
+				{service: svc2, weight: awssdk.Int32(20)},
+			},
+		},
+		{
+			name: "multiple TargetGroups with mix of TargetGroupARN and service",
+			env: env{
+				services: []*corev1.Service{svc1},
+			},
+			args: args{
+				ing: ing,
+				actionCfg: Action{
+					ForwardConfig: &ForwardActionConfig{
+						TargetGroups: []TargetGroupTuple{
+							{
+								TargetGroupARN: awssdk.String("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-target-group"),
+								Weight:         awssdk.Int32(80),
+							},
+							{
+								ServiceName: awssdk.String("svc-1"),
+								ServicePort: &portHTTP,
+								Weight:      awssdk.Int32(20),
+							},
+						},
+					},
+				},
+			},
+			wants: []want{
+				{
+					targetGroupARN: core.LiteralStringToken("arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-target-group"),
+					weight:         awssdk.Int32((80)),
+				},
+				{
+					service: svc1,
+					weight:  awssdk.Int32(20),
+				},
+			},
+		},
+		{
+			name: "multiple TargetGroups without weight",
+			env: env{
+				services: []*corev1.Service{svc1, svc2},
+			},
+			args: args{
+				ing: ing,
+				actionCfg: Action{
+					ForwardConfig: &ForwardActionConfig{
+						TargetGroups: []TargetGroupTuple{
+							{
+								ServiceName: awssdk.String("svc-1"),
+								ServicePort: &portHTTP,
+							},
+							{
+								ServiceName: awssdk.String("svc-2"),
+								ServicePort: &portHTTP,
+							},
+						},
+					},
+				},
+			},
+			wants: []want{
+				{service: svc1},
+				{service: svc2},
+			},
+		},
+		{
+			name: "multiple TargetGroups with services in separate namespaces",
+			env: env{
+				services: []*corev1.Service{svc1, svc3},
+			},
+			args: args{
+				ing: ing,
+				actionCfg: Action{
+					ForwardConfig: &ForwardActionConfig{
+						TargetGroups: []TargetGroupTuple{
+							{
+								ServiceName: awssdk.String("svc-1"),
+								ServicePort: &portHTTP,
+								Weight:      awssdk.Int32(80),
+							},
+							{
+								ServiceNamespace: awssdk.String("awesome-ns-2"),
+								ServiceName:      awssdk.String("svc-3"),
+								ServicePort:      &portHTTP,
+								Weight:           awssdk.Int32(20),
+							},
+						},
+					},
+				},
+			},
+			wants: []want{
+				{service: svc1, weight: awssdk.Int32(80)},
+				{service: svc3, weight: awssdk.Int32(20)},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k8sSchema := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sSchema)
+			k8sClient := testclient.NewClientBuilder().WithScheme(k8sSchema).Build()
+			backendServices := map[types.NamespacedName]*corev1.Service{}
+			for _, service := range tt.env.services {
+				err := k8sClient.Create(context.Background(), service.DeepCopy())
+				assert.NoError(t, err)
+				key := types.NamespacedName{Namespace: service.ObjectMeta.Namespace, Name: service.ObjectMeta.Name}
+				backendServices[key] = service
+			}
+			stack := core.NewDefaultStack(core.StackID(types.NamespacedName{Namespace: "awesome-ns", Name: "ing-1"}))
+			task := &defaultModelBuildTask{
+				k8sClient:                     k8sClient,
+				annotationParser:              annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io"),
+				backendServices:               backendServices,
+				enableIPTargetType:            true,
+				defaultBackendProtocol:        elbv2model.ProtocolHTTP,
+				defaultBackendProtocolVersion: elbv2model.ProtocolVersionHTTP1,
+				stack:                         stack,
+				tgByResID:                     make(map[string]*elbv2model.TargetGroup),
+			}
+			got, err := task.buildForwardAction(context.Background(), tt.args.ing, tt.args.actionCfg)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, elbv2model.ActionTypeForward, got.Type)
+				assert.NotNil(t, got.ForwardConfig)
+
+				var gotTargetGroupBindings []*elbv2model.TargetGroupBindingResource
+				err = stack.ListResources(&gotTargetGroupBindings)
+				assert.NoError(t, err)
+				sort.Slice(gotTargetGroupBindings, func(i, j int) bool {
+					return gotTargetGroupBindings[i].ID() < gotTargetGroupBindings[j].ID()
+				})
+
+				tgbIndex := 0
+				for i, want := range tt.wants {
+					if want.targetGroupARN != nil {
+						assert.Equal(t, want.targetGroupARN, got.ForwardConfig.TargetGroups[i].TargetGroupARN)
+					}
+					if want.service != nil {
+						tgb := gotTargetGroupBindings[tgbIndex]
+						assert.Equal(t, want.service.ObjectMeta.Namespace, tgb.Spec.Template.ObjectMeta.Namespace)
+						assert.Equal(t, want.service.ObjectMeta.Name, tgb.Spec.Template.Spec.ServiceRef.Name)
+						assert.Equal(t, intstr.FromString(want.service.Spec.Ports[0].Name), tgb.Spec.Template.Spec.ServiceRef.Port)
+						assert.Equal(t, want.weight, got.ForwardConfig.TargetGroups[i].Weight)
+						tgbIndex += 1
+					}
+				}
+			}
+		})
+	}
+}
 
 func Test_defaultModelBuildTask_buildAuthenticateOIDCAction(t *testing.T) {
 	type env struct {


### PR DESCRIPTION
### Description

<!--
Please explain the changes you made here.

Help your reviewers by guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

Add the ability to target Services in different namespaces within a `FowardActionConfig.TargetGroupTuple` by providing an optional `ServiceNamespace` field. When this field is not provided, the namespace will default to the namespace of the Ingress object as it did before.

### Checklist
- [X] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [x] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
