### PR TITLE
Add referencing existing security groups for inbound traffic

### DIFF
--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -530,6 +530,24 @@ Access control for LoadBalancer can be controlled with following annotations:
         ```
         alb.ingress.kubernetes.io/inbound-cidrs: 10.0.0.0/24
         ```
+- <a name="inbound-security-groups">`alb.ingress.kubernetes.io/inbound-security-groups`</a> specifies the SecurtityGroups that are allowed to access LoadBalancer.
+
+    !!!note "Merge Behavior"
+        `inbound-security-groups` is merged across all Ingresses in IngressGroup, but is exclusive per listen-port.
+
+        - the `inbound-security-groups` will only impact the ports defined for that Ingress.
+        - if same listen-port is defined by multiple Ingress within IngressGroup, `inbound-security-groups` should only be defined on one of the Ingress.
+
+    !!!warning ""
+        this annotation will be ignored if `alb.ingress.kubernetes.io/security-groups` is specified.
+
+    !!!tip ""
+        Both name or ID of securityGroups are supported. Name matches a `Name` tag, not the `groupName` attribute.
+
+    !!!example
+        ```
+        alb.ingress.kubernetes.io/inbound-security-groups: sg-xxxx, nameOfSg1, nameOfSg2
+        ```
 
 - <a name="security-group-prefix-lists">`alb.ingress.kubernetes.io/security-group-prefix-lists`</a> specifies the managed prefix lists that are allowed to access LoadBalancer.
 

--- a/pkg/annotations/constants.go
+++ b/pkg/annotations/constants.go
@@ -23,6 +23,7 @@ const (
 	IngressSuffixListenPorts                  = "listen-ports"
 	IngressSuffixSSLRedirect                  = "ssl-redirect"
 	IngressSuffixInboundCIDRs                 = "inbound-cidrs"
+	IngressSuffixInboundSecurityGroups        = "inbound-security-groups"
 	IngressSuffixCertificateARN               = "certificate-arn"
 	IngressSuffixSSLPolicy                    = "ssl-policy"
 	IngressSuffixTargetType                   = "target-type"

--- a/pkg/ingress/model_build_listener.go
+++ b/pkg/ingress/model_build_listener.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"strings"
 
+	
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/pkg/errors"
 	networking "k8s.io/api/networking/v1"
@@ -107,6 +108,7 @@ type listenPortConfig struct {
 	sslPolicy            *string
 	tlsCerts             []string
 	mutualAuthentication *elbv2model.MutualAuthenticationAttributes
+	securityGroupIDs     []string
 }
 
 func (t *defaultModelBuildTask) computeIngressListenPortConfigByPort(ctx context.Context, ing *ClassifiedIngress) (map[int64]listenPortConfig, error) {
@@ -114,10 +116,17 @@ func (t *defaultModelBuildTask) computeIngressListenPortConfigByPort(ctx context
 	explicitSSLPolicy := t.computeIngressExplicitSSLPolicy(ctx, ing)
 	var prefixListIDs []string
 	t.annotationParser.ParseStringSliceAnnotation(annotations.IngressSuffixSecurityGroupPrefixLists, &prefixListIDs, ing.Ing.Annotations)
+
+	securityGroupIDs, err := t.computeIngressExplicitSecurityGroupIDs(ctx, ing)
+	if err != nil {
+		return nil, err
+	}
+
 	inboundCIDRv4s, inboundCIDRV6s, err := t.computeIngressExplicitInboundCIDRs(ctx, ing)
 	if err != nil {
 		return nil, err
 	}
+
 	mutualAuthenticationAttributes, err := t.computeIngressMutualAuthentication(ctx, ing)
 	if err != nil {
 		return nil, err
@@ -146,10 +155,11 @@ func (t *defaultModelBuildTask) computeIngressListenPortConfigByPort(ctx context
 	listenPortConfigByPort := make(map[int64]listenPortConfig, len(listenPorts))
 	for port, protocol := range listenPorts {
 		cfg := listenPortConfig{
-			protocol:       protocol,
-			inboundCIDRv4s: inboundCIDRv4s,
-			inboundCIDRv6s: inboundCIDRV6s,
-			prefixLists:    prefixListIDs,
+			protocol:         protocol,
+			inboundCIDRv4s:   inboundCIDRv4s,
+			inboundCIDRv6s:   inboundCIDRV6s,
+			prefixLists:      prefixListIDs,
+			securityGroupIDs: securityGroupIDs,
 		}
 		if protocol == elbv2model.ProtocolHTTPS {
 			if len(explicitTLSCertARNs) == 0 {
@@ -223,6 +233,20 @@ func (t *defaultModelBuildTask) computeIngressListenPorts(_ context.Context, ing
 		}
 	}
 	return portAndProtocols, nil
+}
+
+func (t *defaultModelBuildTask) computeIngressExplicitSecurityGroupIDs(ctx context.Context, ing *ClassifiedIngress) ([]string, error) {
+	var rawSecurityGroups []string
+	if exists := t.annotationParser.ParseStringSliceAnnotation(annotations.IngressSuffixInboundSecurityGroups, &rawSecurityGroups, ing.Ing.Annotations); !exists {
+		return nil, nil
+	}
+
+	securityGroupIDs, err := t.sgResolver.ResolveViaNameOrID(ctx, rawSecurityGroups)
+	if err != nil {
+		return nil, fmt.Errorf("invalid %v settings on Ingress: %v: %w", annotations.IngressSuffixInboundSecurityGroups, k8s.NamespacedName(ing.Ing), err)
+	}
+
+	return securityGroupIDs, nil
 }
 
 func (t *defaultModelBuildTask) computeIngressExplicitInboundCIDRs(_ context.Context, ing *ClassifiedIngress) ([]string, []string, error) {

--- a/pkg/ingress/model_build_listener_test.go
+++ b/pkg/ingress/model_build_listener_test.go
@@ -2,6 +2,7 @@ package ingress
 
 import (
 	"context"
+
 	"github.com/stretchr/testify/assert"
 	networking "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/ingress/model_build_managed_sg.go
+++ b/pkg/ingress/model_build_managed_sg.go
@@ -109,6 +109,18 @@ func (t *defaultModelBuildTask) buildManagedSecurityGroupIngressPermissions(_ co
 				},
 			})
 		}
+		for _, sgID := range cfg.securityGroupIDs {
+			permissions = append(permissions, ec2model.IPPermission{
+				IPProtocol: "tcp",
+				FromPort:   awssdk.Int64(port),
+				ToPort:     awssdk.Int64(port),
+				UserIDGroupPairs: []ec2model.UserIDGroupPair{
+					{
+						GroupID: sgID,
+					},
+				},
+			})
+		}
 	}
 	return permissions
 }


### PR DESCRIPTION
### Issue

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2688

### Description
To enhance security and enable more flexible management of security groups, we are adding a security group source chaining feature to inbound security groups. This is great for allowing traffic from public IP spaces, but for internal ALBs, it would be ideal to allow inbound traffic from specific security groups. For instance, allowing API Gateway traffic (via VPC Link) to an ALB without exposing the ALB to the entire subnet or VPC. It would be preferable to reference the security group of the VPC Link. Similarly, you might want to allow a specific EC2 instance (not part of the EKS cluster) to connect to an ALB while restricting access for another EC2 instance.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
