### PR TITLE
fix: Set klog logger to harmonize logging format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	k8s.io/apimachinery v0.30.0
 	k8s.io/cli-runtime v0.30.0
 	k8s.io/client-go v0.30.0
+	k8s.io/klog/v2 v2.120.1
 	k8s.io/utils v0.0.0-20240502163921-fe8a2dddb1d0
 	sigs.k8s.io/controller-runtime v0.18.2
 	sigs.k8s.io/yaml v1.4.0
@@ -166,7 +167,6 @@ require (
 	k8s.io/apiextensions-apiserver v0.30.0 // indirect
 	k8s.io/apiserver v0.30.0 // indirect
 	k8s.io/component-base v0.30.0 // indirect
-	k8s.io/klog/v2 v2.120.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
 	k8s.io/kubectl v0.30.0 // indirect
 	moul.io/http2curl/v2 v2.3.0 // indirect

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"k8s.io/klog/v2"
 	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
 	elbv2controller "sigs.k8s.io/aws-load-balancer-controller/controllers/elbv2"
 	"sigs.k8s.io/aws-load-balancer-controller/controllers/ingress"
@@ -75,7 +76,9 @@ func main() {
 		infoLogger.Error(err, "unable to load controller config")
 		os.Exit(1)
 	}
-	ctrl.SetLogger(getLoggerWithLogLevel(controllerCFG.LogLevel))
+	appLogger := getLoggerWithLogLevel(controllerCFG.LogLevel)
+	ctrl.SetLogger(appLogger)
+	klog.SetLoggerWithOptions(appLogger, klog.ContextualLogger(true))
 
 	cloud, err := aws.NewCloud(controllerCFG.AWSConfig, metrics.Registry, ctrl.Log)
 	if err != nil {


### PR DESCRIPTION
### Issue

#3112

### Description

Some k8s libraries use klog and therefore do not adhere to the logging format & levels of the application logger.
This change ensures that the leader election will also use the configured logger (last two log lines):

```json
{"level":"info","ts":"2024-09-03T09:40:55Z","msg":"version","GitVersion":"v2.7.0-67-g11fee909a-dirty","GitCommit":"11fee909afe00e6f497d592ae43ace4fcf7bd411","BuildDate":"2024-09-03T11:38:13+0200"}
{"level":"info","ts":"2024-09-03T09:40:55Z","logger":"setup","msg":"adding health check for controller"}
{"level":"info","ts":"2024-09-03T09:40:55Z","logger":"setup","msg":"adding readiness check for webhook"}
{"level":"info","ts":"2024-09-03T09:40:55Z","logger":"controller-runtime.webhook","msg":"Registering webhook","path":"/mutate-v1-pod"}
{"level":"info","ts":"2024-09-03T09:40:55Z","logger":"controller-runtime.webhook","msg":"Registering webhook","path":"/mutate-v1-service"}
{"level":"info","ts":"2024-09-03T09:40:55Z","logger":"controller-runtime.webhook","msg":"Registering webhook","path":"/validate-elbv2-k8s-aws-v1beta1-ingressclassparams"}
{"level":"info","ts":"2024-09-03T09:40:55Z","logger":"controller-runtime.webhook","msg":"Registering webhook","path":"/mutate-elbv2-k8s-aws-v1beta1-targetgroupbinding"}
{"level":"info","ts":"2024-09-03T09:40:55Z","logger":"controller-runtime.webhook","msg":"Registering webhook","path":"/validate-elbv2-k8s-aws-v1beta1-targetgroupbinding"}
{"level":"info","ts":"2024-09-03T09:40:55Z","logger":"controller-runtime.webhook","msg":"Registering webhook","path":"/validate-networking-v1-ingress"}
{"level":"info","ts":"2024-09-03T09:40:55Z","logger":"setup","msg":"starting podInfo repo"}
{"level":"info","ts":"2024-09-03T09:40:57Z","logger":"controller-runtime.metrics","msg":"Starting metrics server"}
{"level":"info","ts":"2024-09-03T09:40:57Z","logger":"controller-runtime.webhook","msg":"Starting webhook server"}
{"level":"info","ts":"2024-09-03T09:40:57Z","logger":"controller-runtime.metrics","msg":"Serving metrics server","bindAddress":":8080","secure":false}
{"level":"info","ts":"2024-09-03T09:40:57Z","logger":"controller-runtime.certwatcher","msg":"Updated current TLS certificate"}
{"level":"info","ts":"2024-09-03T09:40:57Z","msg":"starting server","name":"health probe","addr":":61779"}
{"level":"info","ts":"2024-09-03T09:40:57Z","logger":"controller-runtime.certwatcher","msg":"Starting certificate watcher"}
{"level":"info","ts":"2024-09-03T09:40:57Z","logger":"controller-runtime.webhook","msg":"Serving webhook server","host":"","port":9443}
{"level":"info","ts":"2024-09-03T09:40:57Z","msg":"attempting to acquire leader lease kube-system/aws-load-balancer-controller-leader..."}
{"level":"info","ts":"2024-09-03T09:41:13Z","msg":"successfully acquired lease kube-system/aws-load-balancer-controller-leader"}
```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
