### PR TITLE
[Doc] Update cert-manager GitHub URL

### DIFF
--- a/docs/deploy/installation.md
+++ b/docs/deploy/installation.md
@@ -203,7 +203,7 @@ We recommend using the Helm chart to install the controller. The chart supports 
     ### Install `cert-manager`
 
     ```
-    kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.12.3/cert-manager.yaml
+    kubectl apply --validate=false -f https://github.com/cert-manager/cert-manager/releases/download/v1.12.3/cert-manager.yaml
     ```
 
     ### Apply YAML

--- a/test/prow/cert_manager.yaml
+++ b/test/prow/cert_manager.yaml
@@ -958,7 +958,7 @@ spec:
                   description: SecretName is the name of the secret resource that will be automatically created and managed by this Certificate resource. It will be populated with a private key and certificate, signed by the denoted issuer.
                   type: string
                 secretTemplate:
-                  description: SecretTemplate defines annotations and labels to be propagated to the Kubernetes Secret when it is created or updated. Once created, labels and annotations are not yet removed from the Secret when they are removed from the template. See https://github.com/jetstack/cert-manager/issues/4292
+                  description: SecretTemplate defines annotations and labels to be propagated to the Kubernetes Secret when it is created or updated. Once created, labels and annotations are not yet removed from the Secret when they are removed from the template. See https://github.com/cert-manager/cert-manager/issues/4292
                   type: object
                   properties:
                     annotations:
@@ -1270,7 +1270,7 @@ spec:
                   description: SecretName is the name of the secret resource that will be automatically created and managed by this Certificate resource. It will be populated with a private key and certificate, signed by the denoted issuer.
                   type: string
                 secretTemplate:
-                  description: SecretTemplate defines annotations and labels to be propagated to the Kubernetes Secret when it is created or updated. Once created, labels and annotations are not yet removed from the Secret when they are removed from the template. See https://github.com/jetstack/cert-manager/issues/4292
+                  description: SecretTemplate defines annotations and labels to be propagated to the Kubernetes Secret when it is created or updated. Once created, labels and annotations are not yet removed from the Secret when they are removed from the template. See https://github.com/cert-manager/cert-manager/issues/4292
                   type: object
                   properties:
                     annotations:
@@ -1589,7 +1589,7 @@ spec:
                   description: SecretName is the name of the secret resource that will be automatically created and managed by this Certificate resource. It will be populated with a private key and certificate, signed by the denoted issuer.
                   type: string
                 secretTemplate:
-                  description: SecretTemplate defines annotations and labels to be propagated to the Kubernetes Secret when it is created or updated. Once created, labels and annotations are not yet removed from the Secret when they are removed from the template. See https://github.com/jetstack/cert-manager/issues/4292
+                  description: SecretTemplate defines annotations and labels to be propagated to the Kubernetes Secret when it is created or updated. Once created, labels and annotations are not yet removed from the Secret when they are removed from the template. See https://github.com/cert-manager/cert-manager/issues/4292
                   type: object
                   properties:
                     annotations:
@@ -1909,7 +1909,7 @@ spec:
                   description: SecretName is the name of the secret resource that will be automatically created and managed by this Certificate resource. It will be populated with a private key and certificate, signed by the denoted issuer.
                   type: string
                 secretTemplate:
-                  description: SecretTemplate defines annotations and labels to be propagated to the Kubernetes Secret when it is created or updated. Once created, labels and annotations are not yet removed from the Secret when they are removed from the template. See https://github.com/jetstack/cert-manager/issues/4292
+                  description: SecretTemplate defines annotations and labels to be propagated to the Kubernetes Secret when it is created or updated. Once created, labels and annotations are not yet removed from the Secret when they are removed from the template. See https://github.com/cert-manager/cert-manager/issues/4292
                   type: object
                   properties:
                     annotations:


### PR DESCRIPTION
### Issue

Related issue: N/A

### Description

The GitHub organization for cert-manager has changed from jetstack to cert-manager. Therefore, I have updated the documentation to reflect this change by replacing https://github.com/jetstack/cert-manager with https://github.com/cert-manager/cert-manager. This ensures that users are directed to the correct repository.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
