### PR TITLE
Feature: Deferred queue for no-op TGB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ all: controller
 
 # Run tests
 test: generate fmt vet manifests helm-lint
-	go test -race ./pkg/... ./webhooks/... -coverprofile cover.out
+	go test -race ./pkg/... ./webhooks/... ./controllers/... -coverprofile cover.out
 
 # Build controller binary
 controller: generate fmt vet

--- a/controllers/elbv2/targetgroupbinding_deferred_reconciler.go
+++ b/controllers/elbv2/targetgroupbinding_deferred_reconciler.go
@@ -1,0 +1,130 @@
+package controllers
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"math/rand"
+	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/targetgroupbinding"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
+)
+
+const (
+	// The time to delay the reconcile. Generally, this number should be large enough so we can perform all reconciles
+	// that have changes before processing reconciles that have no detected changes.
+	defaultDelayedReconcileTime = 30 * time.Minute
+	// The max amount of jitter to add to delayedReconcileTime. This is used to ensure that all deferred TGBs are not
+	// reconciled together.
+	defaultMaxJitter = 15 * time.Minute
+
+	// The hash to set that is guaranteed to trigger a new reconcile loop (the hash calculation always has an '/')
+	resetHash = ""
+)
+
+type DeferredTargetGroupBindingReconciler interface {
+	Enqueue(tgb *elbv2api.TargetGroupBinding)
+	Run()
+}
+
+type deferredTargetGroupBindingReconcilerImpl struct {
+	delayQueue workqueue.DelayingInterface
+	syncPeriod time.Duration
+	k8sClient  client.Client
+	logger     logr.Logger
+
+	delayedReconcileTime time.Duration
+	maxJitter            time.Duration
+}
+
+func NewDeferredTargetGroupBindingReconciler(delayQueue workqueue.DelayingInterface, syncPeriod time.Duration, k8sClient client.Client, logger logr.Logger) DeferredTargetGroupBindingReconciler {
+	return &deferredTargetGroupBindingReconcilerImpl{
+		syncPeriod: syncPeriod,
+		logger:     logger,
+		delayQueue: delayQueue,
+		k8sClient:  k8sClient,
+
+		delayedReconcileTime: defaultDelayedReconcileTime,
+		maxJitter:            defaultMaxJitter,
+	}
+}
+
+func (d *deferredTargetGroupBindingReconcilerImpl) Enqueue(tgb *elbv2api.TargetGroupBinding) {
+	nsn := k8s.NamespacedName(tgb)
+	if d.isEligibleForDefer(tgb) {
+		d.enqueue(nsn)
+		d.logger.Info("enqueued new deferred TGB", "TGB", nsn.Name)
+	}
+}
+
+func (d *deferredTargetGroupBindingReconcilerImpl) Run() {
+	var item interface{}
+	shutDown := false
+	for !shutDown {
+		item, shutDown = d.delayQueue.Get()
+		if item != nil {
+			deferredNamespacedName := item.(types.NamespacedName)
+			d.logger.Info("Processing deferred TGB", "item", deferredNamespacedName)
+			d.handleDeferredItem(deferredNamespacedName)
+			d.delayQueue.Done(deferredNamespacedName)
+		}
+	}
+
+	d.logger.Info("Shutting down deferred TGB queue")
+}
+
+func (d *deferredTargetGroupBindingReconcilerImpl) handleDeferredItem(nsn types.NamespacedName) {
+	tgb := &elbv2api.TargetGroupBinding{}
+
+	err := d.k8sClient.Get(context.Background(), nsn, tgb)
+
+	if err != nil {
+		d.handleDeferredItemError(nsn, err, "Failed to get TGB in deferred queue")
+		return
+	}
+
+	// Re-check that this tgb hasn't been updated since it was enqueued
+	if !d.isEligibleForDefer(tgb) {
+		d.logger.Info("TGB not eligible for deferral", "TGB", nsn)
+		return
+	}
+
+	tgbOld := tgb.DeepCopy()
+	targetgroupbinding.SaveTGBReconcileCheckpoint(tgb, resetHash)
+
+	if err := d.k8sClient.Patch(context.Background(), tgb, client.MergeFrom(tgbOld)); err != nil {
+		d.handleDeferredItemError(nsn, err, "Failed to reset TGB checkpoint")
+		return
+	}
+	d.logger.Info("TGB checkpoint reset", "TGB", nsn)
+}
+
+func (d *deferredTargetGroupBindingReconcilerImpl) handleDeferredItemError(nsn types.NamespacedName, err error, msg string) {
+	err = client.IgnoreNotFound(err)
+	if err != nil {
+		d.logger.Error(err, msg, "TGB", nsn)
+		d.enqueue(nsn)
+	}
+}
+
+func (d *deferredTargetGroupBindingReconcilerImpl) isEligibleForDefer(tgb *elbv2api.TargetGroupBinding) bool {
+	then := time.Unix(targetgroupbinding.GetTGBReconcileCheckpointTimestamp(tgb), 0)
+	return time.Now().Sub(then) > d.syncPeriod
+}
+
+func (d *deferredTargetGroupBindingReconcilerImpl) enqueue(nsn types.NamespacedName) {
+	delayedTime := d.jitterReconcileTime()
+	d.delayQueue.AddAfter(nsn, delayedTime)
+}
+
+func (d *deferredTargetGroupBindingReconcilerImpl) jitterReconcileTime() time.Duration {
+
+	if d.maxJitter == 0 {
+		return d.delayedReconcileTime
+	}
+
+	return d.delayedReconcileTime + time.Duration(rand.Int63n(int64(d.maxJitter)))
+}

--- a/controllers/elbv2/targetgroupbinding_deferred_reconciler_test.go
+++ b/controllers/elbv2/targetgroupbinding_deferred_reconciler_test.go
@@ -1,0 +1,386 @@
+package controllers
+
+import (
+	"context"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/util/workqueue"
+	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
+	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestDeferredReconcilerConstructor(t *testing.T) {
+	dq := workqueue.NewDelayingQueue()
+	defer dq.ShutDown()
+	syncPeriod := 5 * time.Minute
+	k8sClient := testclient.NewClientBuilder().Build()
+	logger := logr.New(&log.NullLogSink{})
+
+	d := NewDeferredTargetGroupBindingReconciler(dq, syncPeriod, k8sClient, logger)
+
+	deferredReconciler := d.(*deferredTargetGroupBindingReconcilerImpl)
+	assert.Equal(t, dq, deferredReconciler.delayQueue)
+	assert.Equal(t, syncPeriod, deferredReconciler.syncPeriod)
+	assert.Equal(t, k8sClient, deferredReconciler.k8sClient)
+	assert.Equal(t, logger, deferredReconciler.logger)
+}
+
+func TestDeferredReconcilerEnqueue(t *testing.T) {
+	syncPeriod := 5 * time.Minute
+	testCases := []struct {
+		name                 string
+		tgbToEnqueue         []*elbv2api.TargetGroupBinding
+		expectedQueueEntries sets.Set[types.NamespacedName]
+	}{
+		{
+			name: "one tgb to enqueue",
+			tgbToEnqueue: []*elbv2api.TargetGroupBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tgb1",
+						Namespace: "ns",
+					},
+				},
+			},
+			expectedQueueEntries: sets.New(types.NamespacedName{
+				Name:      "tgb1",
+				Namespace: "ns",
+			}),
+		},
+		{
+			name: "sync period too short, do not enqueue",
+			tgbToEnqueue: []*elbv2api.TargetGroupBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tgb1",
+						Namespace: "ns",
+						Annotations: map[string]string{
+							annotations.AnnotationCheckPointTimestamp: strconv.FormatInt(time.Now().Unix(), 10),
+						},
+					},
+				},
+			},
+			expectedQueueEntries: make(sets.Set[types.NamespacedName]),
+		},
+		{
+			name: "sync period too long, do enqueue",
+			tgbToEnqueue: []*elbv2api.TargetGroupBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tgb1",
+						Namespace: "ns",
+						Annotations: map[string]string{
+							annotations.AnnotationCheckPointTimestamp: strconv.FormatInt(time.Now().Add(-2*syncPeriod).Unix(), 10),
+						},
+					},
+				},
+			},
+			expectedQueueEntries: sets.New(types.NamespacedName{
+				Name:      "tgb1",
+				Namespace: "ns",
+			}),
+		},
+		{
+			name: "multiple tgb",
+			tgbToEnqueue: []*elbv2api.TargetGroupBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tgb1",
+						Namespace: "ns",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tgb1",
+						Namespace: "ns1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tgb2",
+						Namespace: "ns",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tgb2",
+						Namespace: "ns1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tgb3",
+						Namespace: "ns3",
+					},
+				},
+			},
+			expectedQueueEntries: sets.New(types.NamespacedName{
+				Name:      "tgb1",
+				Namespace: "ns",
+			}, types.NamespacedName{
+				Name:      "tgb1",
+				Namespace: "ns1",
+			}, types.NamespacedName{
+				Name:      "tgb2",
+				Namespace: "ns",
+			}, types.NamespacedName{
+				Name:      "tgb2",
+				Namespace: "ns1",
+			}, types.NamespacedName{
+				Name:      "tgb3",
+				Namespace: "ns3",
+			}),
+		},
+		{
+			name: "de-dupe same tgb",
+			tgbToEnqueue: []*elbv2api.TargetGroupBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tgb1",
+						Namespace: "ns",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tgb1",
+						Namespace: "ns",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tgb1",
+						Namespace: "ns",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tgb1",
+						Namespace: "ns",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tgb1",
+						Namespace: "ns",
+					},
+				},
+			},
+			expectedQueueEntries: sets.New(types.NamespacedName{
+				Name:      "tgb1",
+				Namespace: "ns",
+			}),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dq := workqueue.NewDelayingQueue()
+			defer dq.ShutDown()
+
+			k8sSchema := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sSchema)
+			elbv2api.AddToScheme(k8sSchema)
+			k8sClient := testclient.NewClientBuilder().
+				WithScheme(k8sSchema).
+				Build()
+
+			impl := deferredTargetGroupBindingReconcilerImpl{
+				delayQueue: dq,
+				syncPeriod: syncPeriod,
+				k8sClient:  k8sClient,
+				logger:     logr.New(&log.NullLogSink{}),
+
+				delayedReconcileTime: 0 * time.Millisecond,
+				maxJitter:            0 * time.Millisecond,
+			}
+
+			for _, tgb := range tc.tgbToEnqueue {
+				impl.Enqueue(tgb)
+			}
+
+			assert.Equal(t, tc.expectedQueueEntries.Len(), dq.Len())
+
+			for dq.Len() > 0 {
+				v, _ := dq.Get()
+				assert.True(t, tc.expectedQueueEntries.Has(v.(types.NamespacedName)), "Expected queue entry not found %+v", v)
+			}
+
+		})
+	}
+}
+
+func TestDeferredReconcilerRun(t *testing.T) {
+	testCases := []struct {
+		name string
+		nsns []types.NamespacedName
+	}{
+		{
+			name: "nothing enqueued",
+		},
+		{
+			name: "something enqueued",
+			nsns: []types.NamespacedName{
+				{
+					Name:      "name",
+					Namespace: "ns",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dq := workqueue.NewDelayingQueue()
+			go func() {
+				time.Sleep(2 * time.Second)
+				assert.Equal(t, 0, dq.Len())
+				dq.ShutDown()
+			}()
+
+			for _, nsn := range tc.nsns {
+				dq.Add(nsn)
+			}
+
+			k8sSchema := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sSchema)
+			elbv2api.AddToScheme(k8sSchema)
+			k8sClient := testclient.NewClientBuilder().
+				WithScheme(k8sSchema).
+				Build()
+
+			impl := deferredTargetGroupBindingReconcilerImpl{
+				delayQueue: dq,
+				syncPeriod: 5 * time.Minute,
+				k8sClient:  k8sClient,
+				logger:     logr.New(&log.NullLogSink{}),
+
+				delayedReconcileTime: 0 * time.Millisecond,
+				maxJitter:            0 * time.Millisecond,
+			}
+
+			impl.Run()
+
+			time.Sleep(5 * time.Second)
+		})
+	}
+}
+
+func TestHandleDeferredItem(t *testing.T) {
+	syncPeriod := 5 * time.Minute
+	testCases := []struct {
+		name               string
+		nsn                types.NamespacedName
+		storedTGB          *elbv2api.TargetGroupBinding
+		requeue            bool
+		expectedCheckPoint *string
+	}{
+		{
+			name: "not found",
+			nsn: types.NamespacedName{
+				Name:      "name",
+				Namespace: "ns",
+			},
+		},
+		{
+			name: "not eligible",
+			nsn: types.NamespacedName{
+				Name:      "name",
+				Namespace: "ns",
+			},
+			storedTGB: &elbv2api.TargetGroupBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "ns",
+					Annotations: map[string]string{
+						annotations.AnnotationCheckPoint:          "foo",
+						annotations.AnnotationCheckPointTimestamp: strconv.FormatInt(time.Now().Unix(), 10),
+					},
+				},
+			},
+			expectedCheckPoint: aws.String("foo"),
+		},
+		{
+			name: "eligible",
+			nsn: types.NamespacedName{
+				Name:      "name",
+				Namespace: "ns",
+			},
+			storedTGB: &elbv2api.TargetGroupBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "ns",
+					Annotations: map[string]string{
+						annotations.AnnotationCheckPoint:          "foo",
+						annotations.AnnotationCheckPointTimestamp: strconv.FormatInt(time.Now().Add(-2*syncPeriod).Unix(), 10),
+					},
+				},
+			},
+			expectedCheckPoint: aws.String(""),
+		},
+		{
+			name: "failure causes requeue",
+			nsn: types.NamespacedName{
+				Name:      "name",
+				Namespace: "ns",
+			},
+			requeue: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dq := workqueue.NewDelayingQueue()
+			defer dq.ShutDown()
+
+			k8sSchema := runtime.NewScheme()
+			// quick hack to inject a fault into the k8s client.
+			if !tc.requeue {
+				clientgoscheme.AddToScheme(k8sSchema)
+				elbv2api.AddToScheme(k8sSchema)
+			}
+			k8sClient := testclient.NewClientBuilder().
+				WithScheme(k8sSchema).
+				Build()
+
+			impl := deferredTargetGroupBindingReconcilerImpl{
+				delayQueue: dq,
+				syncPeriod: syncPeriod,
+				k8sClient:  k8sClient,
+				logger:     logr.New(&log.NullLogSink{}),
+
+				delayedReconcileTime: 0 * time.Millisecond,
+				maxJitter:            0 * time.Millisecond,
+			}
+
+			if tc.storedTGB != nil {
+				k8sClient.Create(context.Background(), tc.storedTGB)
+			}
+
+			impl.handleDeferredItem(tc.nsn)
+
+			if tc.requeue {
+				assert.Equal(t, 1, dq.Len())
+			} else {
+				assert.Equal(t, 0, dq.Len())
+			}
+
+			if tc.expectedCheckPoint != nil {
+				storedTGB := &elbv2api.TargetGroupBinding{}
+				k8sClient.Get(context.Background(), tc.nsn, storedTGB)
+				assert.Equal(t, *tc.expectedCheckPoint, storedTGB.Annotations[annotations.AnnotationCheckPoint])
+			}
+
+		})
+	}
+}

--- a/pkg/algorithm/hash.go
+++ b/pkg/algorithm/hash.go
@@ -1,0 +1,12 @@
+package algorithm
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+)
+
+func ComputeSha256(s string) string {
+	checkpointHash := sha256.New()
+	_, _ = checkpointHash.Write([]byte(s))
+	return base64.RawURLEncoding.EncodeToString(checkpointHash.Sum(nil))
+}

--- a/pkg/annotations/constants.go
+++ b/pkg/annotations/constants.go
@@ -1,6 +1,13 @@
 package annotations
 
 const (
+	// AnnotationCheckPoint is the annotation used to store a checkpoint for resources.
+	// It contains an opaque value that represents the last known reconciled state.
+	AnnotationCheckPoint = "elbv2.k8s.aws/checkpoint"
+
+	// AnnotationCheckPointTimestamp is the annotation used to store the last checkpointed time. The value is stored in seconds.
+	AnnotationCheckPointTimestamp = AnnotationCheckPoint + "-timestamp"
+
 	// IngressClass
 	IngressClass = "kubernetes.io/ingress.class"
 

--- a/pkg/backend/endpoint_resolver.go
+++ b/pkg/backend/endpoint_resolver.go
@@ -170,8 +170,10 @@ func (r *defaultEndpointResolver) resolvePodEndpointsWithEndpointsData(ctx conte
 					containsPotentialReadyEndpoints = true
 					continue
 				}
+
 				podEndpoint := buildPodEndpoint(pod, epAddr, epPort)
-				if ep.Conditions.Ready != nil && *ep.Conditions.Ready {
+				// Recommendation from Kubernetes is to consider unknown ready status as ready (ready == nil)
+				if ep.Conditions.Ready == nil || *ep.Conditions.Ready {
 					readyPodEndpoints = append(readyPodEndpoints, podEndpoint)
 					continue
 				}

--- a/pkg/backend/endpoint_types.go
+++ b/pkg/backend/endpoint_types.go
@@ -1,11 +1,16 @@
 package backend
 
 import (
+	"fmt"
 	corev1 "k8s.io/api/core/v1"
 	discv1 "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 )
+
+type Endpoint interface {
+	GetIdentifier() string
+}
 
 // An endpoint provided by pod directly.
 type PodEndpoint struct {
@@ -17,6 +22,10 @@ type PodEndpoint struct {
 	Pod k8s.PodInfo
 }
 
+func (e PodEndpoint) GetIdentifier() string {
+	return fmt.Sprintf("%s:%d:%d", e.IP, e.Port, e.Pod.CreationTime.UnixMilli())
+}
+
 // An endpoint provided by nodePort as traffic proxy.
 type NodePortEndpoint struct {
 	// Node's instanceID.
@@ -25,6 +34,10 @@ type NodePortEndpoint struct {
 	Port int32
 	// Node that provides this endpoint.
 	Node *corev1.Node
+}
+
+func (e NodePortEndpoint) GetIdentifier() string {
+	return fmt.Sprintf("%s:%d:%d", e.InstanceID, e.Port, e.Node.CreationTimestamp.UnixMilli())
 }
 
 type EndpointsData struct {

--- a/pkg/k8s/pod_info.go
+++ b/pkg/k8s/pod_info.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -23,6 +24,7 @@ type PodInfo struct {
 	Conditions     []corev1.PodCondition
 	NodeName       string
 	PodIP          string
+	CreationTime   v1.Time
 
 	ENIInfos []PodENIInfo
 }
@@ -104,6 +106,7 @@ func buildPodInfo(pod *corev1.Pod) PodInfo {
 		Conditions:     pod.Status.Conditions,
 		NodeName:       pod.Spec.NodeName,
 		PodIP:          pod.Status.PodIP,
+		CreationTime:   pod.CreationTimestamp,
 
 		ENIInfos: podENIInfos,
 	}

--- a/pkg/k8s/pod_info_repo_test.go
+++ b/pkg/k8s/pod_info_repo_test.go
@@ -7,6 +7,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"testing"
+	"time"
 )
 
 func Test_podInfoKeyFunc(t *testing.T) {
@@ -55,6 +56,8 @@ func Test_podInfoConversionFunc(t *testing.T) {
 	type args struct {
 		obj interface{}
 	}
+
+	timeNow := time.Now()
 	tests := []struct {
 		name    string
 		args    args
@@ -69,12 +72,16 @@ func Test_podInfoConversionFunc(t *testing.T) {
 						Namespace: "ns-1",
 						Name:      "pod-a",
 						UID:       "pod-uuid",
+						CreationTimestamp: metav1.Time{
+							Time: timeNow,
+						},
 					},
 				},
 			},
 			want: &PodInfo{
-				Key: types.NamespacedName{Namespace: "ns-1", Name: "pod-a"},
-				UID: "pod-uuid",
+				Key:          types.NamespacedName{Namespace: "ns-1", Name: "pod-a"},
+				UID:          "pod-uuid",
+				CreationTime: metav1.Time{Time: timeNow},
 			},
 		},
 		{

--- a/pkg/k8s/pod_info_test.go
+++ b/pkg/k8s/pod_info_test.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"testing"
+	"time"
 )
 
 func TestPodInfo_HasAnyOfReadinessGates(t *testing.T) {
@@ -149,6 +150,7 @@ func TestPodInfo_GetPodCondition(t *testing.T) {
 	type args struct {
 		conditionType corev1.PodConditionType
 	}
+
 	tests := []struct {
 		name       string
 		pod        PodInfo
@@ -312,6 +314,9 @@ func Test_buildPodInfo(t *testing.T) {
 	type args struct {
 		pod *corev1.Pod
 	}
+
+	timeNow := time.Now()
+
 	tests := []struct {
 		name string
 		args args
@@ -325,6 +330,9 @@ func Test_buildPodInfo(t *testing.T) {
 						Namespace: "my-ns",
 						Name:      "pod-1",
 						UID:       "pod-uuid",
+						CreationTimestamp: metav1.Time{
+							Time: timeNow,
+						},
 					},
 					Spec: corev1.PodSpec{
 						NodeName: "ip-192-168-13-198.us-west-2.compute.internal",
@@ -409,8 +417,9 @@ func Test_buildPodInfo(t *testing.T) {
 						Status: corev1.ConditionTrue,
 					},
 				},
-				NodeName: "ip-192-168-13-198.us-west-2.compute.internal",
-				PodIP:    "192.168.1.1",
+				NodeName:     "ip-192-168-13-198.us-west-2.compute.internal",
+				PodIP:        "192.168.1.1",
+				CreationTime: metav1.Time{Time: timeNow},
 			},
 		},
 		{
@@ -424,6 +433,9 @@ func Test_buildPodInfo(t *testing.T) {
 						Annotations: map[string]string{
 							"vpc.amazonaws.com/pod-eni": `[{"eniId":"eni-06a712e1622fda4a0","ifAddress":"02:34:a5:25:0b:63","privateIp":"192.168.219.103","vlanId":3,"subnetCidr":"192.168.192.0/19"}]`,
 						},
+						CreationTimestamp: metav1.Time{
+							Time: timeNow,
+						},
 					},
 					Spec: corev1.PodSpec{
 						NodeName: "ip-192-168-13-198.us-west-2.compute.internal",
@@ -508,8 +520,9 @@ func Test_buildPodInfo(t *testing.T) {
 						Status: corev1.ConditionTrue,
 					},
 				},
-				NodeName: "ip-192-168-13-198.us-west-2.compute.internal",
-				PodIP:    "192.168.1.1",
+				NodeName:     "ip-192-168-13-198.us-west-2.compute.internal",
+				PodIP:        "192.168.1.1",
+				CreationTime: metav1.Time{Time: timeNow},
 				ENIInfos: []PodENIInfo{
 					{
 						ENIID:     "eni-06a712e1622fda4a0",

--- a/pkg/k8s/secrets_manager.go
+++ b/pkg/k8s/secrets_manager.go
@@ -7,7 +7,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	"github.com/go-logr/logr"
@@ -44,7 +43,6 @@ type defaultSecretsManager struct {
 	secretMap        map[types.NamespacedName]*secretItem
 	secretsEventChan chan<- event.TypedGenericEvent[*corev1.Secret]
 	clientSet        kubernetes.Interface
-	queue            workqueue.RateLimitingInterface
 	logger           logr.Logger
 }
 

--- a/pkg/targetgroupbinding/utils.go
+++ b/pkg/targetgroupbinding/utils.go
@@ -1,11 +1,19 @@
 package targetgroupbinding
 
 import (
+	"encoding/json"
 	"fmt"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/algorithm"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/backend"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
 )
 
 const (
@@ -27,6 +35,59 @@ func BuildTargetHealthPodConditionType(tgb *elbv2api.TargetGroupBinding) corev1.
 func IndexFuncServiceRefName(obj client.Object) []string {
 	tgb := obj.(*elbv2api.TargetGroupBinding)
 	return []string{tgb.Spec.ServiceRef.Name}
+}
+
+// calculateTGBReconcileCheckpoint calculates the checkpoint for a tgb using the endpoints and tgb spec
+func calculateTGBReconcileCheckpoint[V backend.Endpoint](endpoints []V, tgb *elbv2api.TargetGroupBinding) (string, error) {
+
+	endpointStrings := make([]string, 0, len(endpoints))
+
+	for _, ep := range endpoints {
+		endpointStrings = append(endpointStrings, ep.GetIdentifier())
+	}
+
+	slices.Sort(endpointStrings)
+	csv := strings.Join(endpointStrings, ",")
+
+	specJSON, err := json.Marshal(tgb.Spec)
+	if err != nil {
+		return "", err
+	}
+
+	endpointSha := algorithm.ComputeSha256(csv)
+	specSha := algorithm.ComputeSha256(string(specJSON))
+
+	return fmt.Sprintf("%s/%s", endpointSha, specSha), nil
+}
+
+// GetTGBReconcileCheckpoint gets the sha256 hash saved in the annotations
+func GetTGBReconcileCheckpoint(tgb *elbv2api.TargetGroupBinding) string {
+	if checkPoint, ok := tgb.Annotations[annotations.AnnotationCheckPoint]; ok {
+		return checkPoint
+	}
+	return ""
+}
+
+// GetTGBReconcileCheckpointTimestamp gets the latest updated timestamp (in seconds) for the TGB checkpoint
+func GetTGBReconcileCheckpointTimestamp(tgb *elbv2api.TargetGroupBinding) int64 {
+	if ts, ok := tgb.Annotations[annotations.AnnotationCheckPointTimestamp]; ok {
+		ts64, err := strconv.ParseInt(ts, 10, 64)
+		if err != nil {
+			return 0
+		}
+		return ts64
+	}
+	return 0
+}
+
+// SaveTGBReconcileCheckpoint updates the TGB object with a new checkpoint string.
+func SaveTGBReconcileCheckpoint(tgb *elbv2api.TargetGroupBinding, checkpoint string) {
+	if tgb.Annotations == nil {
+		tgb.Annotations = map[string]string{}
+	}
+
+	tgb.Annotations[annotations.AnnotationCheckPoint] = checkpoint
+	tgb.Annotations[annotations.AnnotationCheckPointTimestamp] = strconv.FormatInt(time.Now().Unix(), 10)
 }
 
 func buildServiceReferenceKey(tgb *elbv2api.TargetGroupBinding, svcRef elbv2api.ServiceReference) types.NamespacedName {


### PR DESCRIPTION
### Issue

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/3326

Continuation of https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3821, I removed ingress / svc hashing due to some complexities with ensuring the ingress / svc hash is stable.

### Description

As outlined in #3326, during controller restarts it might take a long time for the new controller to start processing meaningful changes. This is because the controller has no state of what is fresh and stale. This PR improves start time for customers with lots of TargetGroupBindings by caching the last state of the endpoints / tgb spec in a SHA256 hash which is stored within the TGB annotations. When the controller detects that the reconcile is a no-op, by recomputing the SHA256 on, it can short circuit the reconciliation logic to quickly get the no-op TGB out of the queue.

For any TGBs that are deemed no-ops they are put into a different queue that sideline the TGB for a "safe" amount of time to let all reconciliations happen. After the safe amount of time, these TGBs have their annotations reset which will trigger the main reconcile loop to reconcile completely. This safe time is jittered as to not reconcile all TGBs together, I noticed the standard reconcile loop will reconcile all TGB together which might drain AWS API throttle limits temporarily. By adding jitter to the reconcile this should help general throttling issues. 

logs:

```
{"level":"info","ts":"2024-09-23T19:30:56Z","msg":"Skipping targetgroupbinding reconcile","TGB":{"name":"echoserver-mc","namespace":"echoserver"},"calculated hash":"ymUzgdqlKVVW0ZY2YGTF7OTKMiqHT002RcJLRXWDols/1iL7S-XTGHlK2M1d0-P0eu-rdNyvq0X9fwxUyz9mWa4"}
{"level":"info","ts":"2024-09-23T19:30:56Z","logger":"deferredTGBQueue","msg":"enqueued new deferred TGB","TGB":"echoserver-mc"}
{"level":"info","ts":"2024-09-23T19:30:56Z","msg":"Skipping targetgroupbinding reconcile","TGB":{"name":"k8s-esing-echoserv-3c797ed157","namespace":"es-ing"},"calculated hash":"IxSgm9GyLMW40ZYIQvig7HMFICZYqIaEuXkzi2O3deg/8VJ5SF6mKRO_9WTA0uPGEReYMZT1d2Piq0STqZxR7ls"}
{"level":"info","ts":"2024-09-23T19:30:56Z","logger":"deferredTGBQueue","msg":"enqueued new deferred TGB","TGB":"k8s-esing-echoserv-3c797ed157"}
{"level":"info","ts":"2024-09-23T19:30:56Z","msg":"Skipping targetgroupbinding reconcile","TGB":{"name":"echoserver-instance","namespace":"echoserver"},"calculated hash":"5SXxZawWspjdLtEOu46ZTAkDxWYc4LxAC2P_GFE7skw/9Ja0pzCp6YecOAJjY2TqwYoPEwZEb04tn3BiBHneLe8"}
{"level":"info","ts":"2024-09-23T19:30:56Z","logger":"deferredTGBQueue","msg":"enqueued new deferred TGB","TGB":"echoserver-instance"}
{"level":"info","ts":"2024-09-23T19:30:56Z","msg":"Skipping targetgroupbinding reconcile","TGB":{"name":"echoserver-instance","namespace":"echoserver"},"calculated hash":"5SXxZawWspjdLtEOu46ZTAkDxWYc4LxAC2P_GFE7skw/9Ja0pzCp6YecOAJjY2TqwYoPEwZEb04tn3BiBHneLe8"}
{"level":"info","ts":"2024-09-23T19:30:56Z","logger":"deferredTGBQueue","msg":"enqueued new deferred TGB","TGB":"echoserver-instance"}
{"level":"info","ts":"2024-09-23T19:30:56Z","msg":"Skipping targetgroupbinding reconcile","TGB":{"name":"k8s-esing-echoserv-3c797ed157","namespace":"es-ing"},"calculated hash":"IxSgm9GyLMW40ZYIQvig7HMFICZYqIaEuXkzi2O3deg/8VJ5SF6mKRO_9WTA0uPGEReYMZT1d2Piq0STqZxR7ls"}
{"level":"info","ts":"2024-09-23T19:30:56Z","logger":"deferredTGBQueue","msg":"enqueued new deferred TGB","TGB":"k8s-esing-echoserv-3c797ed157"}
{"level":"info","ts":"2024-09-23T19:30:56Z","msg":"Skipping targetgroupbinding reconcile","TGB":{"name":"echoserver-mc","namespace":"echoserver"},"calculated hash":"ymUzgdqlKVVW0ZY2YGTF7OTKMiqHT002RcJLRXWDols/1iL7S-XTGHlK2M1d0-P0eu-rdNyvq0X9fwxUyz9mWa4"}
{"level":"info","ts":"2024-09-23T19:30:56Z","logger":"deferredTGBQueue","msg":"enqueued new deferred TGB","TGB":"echoserver-mc"}
....
{"level":"info","ts":"2024-09-23T19:31:56Z","logger":"deferredTGBQueue","msg":"Processing deferred TGB","item":{"name":"echoserver-mc","namespace":"echoserver"}}
{"level":"info","ts":"2024-09-23T19:31:56Z","logger":"deferredTGBQueue","msg":"TGB checkpoint reset","TGB":{"name":"echoserver-mc","namespace":"echoserver"}}
{"level":"info","ts":"2024-09-23T19:31:56Z","logger":"deferredTGBQueue","msg":"Processing deferred TGB","item":{"name":"echoserver-instance","namespace":"echoserver"}}
{"level":"info","ts":"2024-09-23T19:31:56Z","logger":"deferredTGBQueue","msg":"TGB checkpoint reset","TGB":{"name":"echoserver-instance","namespace":"echoserver"}}
{"level":"info","ts":"2024-09-23T19:31:56Z","logger":"deferredTGBQueue","msg":"Processing deferred TGB","item":{"name":"k8s-esing-echoserv-3c797ed157","namespace":"es-ing"}}
{"level":"info","ts":"2024-09-23T19:31:56Z","msg":"authorizing securityGroup ingress","securityGroupID":"sg-086f1ccc63c13108a","permission":[{"FromPort":8081,"IpProtocol":"tcp","IpRanges":null,"Ipv6Ranges":null,"PrefixListIds":null,"ToPort":8081,"UserIdGroupPairs":[{"Description":"elbv2.k8s.aws/targetGroupBinding=shared","GroupId":"sg-0016497699787096a","GroupName":null,"PeeringStatus":null,"UserId":null,"VpcId":null,"VpcPeeringConnectionId":null}]}]}
{"level":"info","ts":"2024-09-23T19:31:56Z","logger":"deferredTGBQueue","msg":"TGB checkpoint reset","TGB":{"name":"k8s-esing-echoserv-3c797ed157","namespace":"es-ing"}}
{"level":"info","ts":"2024-09-23T19:31:56Z","msg":"authorized securityGroup ingress","securityGroupID":"sg-086f1ccc63c13108a"}
{"level":"info","ts":"2024-09-23T19:31:57Z","msg":"Skipping targetgroupbinding reconcile","TGB":{"name":"echoserver-mc","namespace":"echoserver"},"calculated hash":"ymUzgdqlKVVW0ZY2YGTF7OTKMiqHT002RcJLRXWDols/1iL7S-XTGHlK2M1d0-P0eu-rdNyvq0X9fwxUyz9mWa4"}
{"level":"info","ts":"2024-09-23T19:31:57Z","msg":"revoking securityGroup ingress","securityGroupID":"sg-086f1ccc63c13108a","permission":[{"FromPort":8081,"IpProtocol":"tcp","IpRanges":null,"Ipv6Ranges":null,"PrefixListIds":null,"ToPort":8081,"UserIdGroupPairs":[{"Description":"elbv2.k8s.aws/targetGroupBinding=shared","GroupId":"sg-0016497699787096a","GroupName":null,"PeeringStatus":null,"UserId":"565768096483","VpcId":null,"VpcPeeringConnectionId":null}]}]}
```


Commit 2

TL;DR
The approach did not consider the case of containers restarting, while keeping the same pod object. The reconcile logic is to deregister the pod on container stop, then when the container starts up again re-register it. This part worked fine. The issue is that the solution would not re-run the reconcile loop again to flip the readiness gate from false to true.
I've added logic that will clear out any checkpoints during register / deregister calls to ensure that we will run the reconcile loop until all readiness gates are flipped to true. For controllers WITHOUT readiness gates, no extra reconciles are ran.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:
