### PR TITLE
GO2 SDK Migration bug fix on comparators

### DIFF
--- a/pkg/equality/elbv2/compare_option_for_actions.go
+++ b/pkg/equality/elbv2/compare_option_for_actions.go
@@ -30,6 +30,7 @@ func CompareOptionForForwardActionConfig() cmp.Option {
 	return cmp.Options{
 		equality.IgnoreLeftHandUnset(elbv2types.ForwardActionConfig{}, "TargetGroupStickinessConfig"),
 		cmpopts.IgnoreUnexported(elbv2types.ForwardActionConfig{}),
+		cmpopts.IgnoreUnexported(elbv2types.TargetGroupStickinessConfig{}),
 		CompareOptionForTargetGroupTuples(),
 	}
 }

--- a/pkg/equality/elbv2/compare_option_for_rule_conditions.go
+++ b/pkg/equality/elbv2/compare_option_for_rule_conditions.go
@@ -11,9 +11,11 @@ func CompareOptionForRuleCondition() cmp.Option {
 	return cmp.Options{
 		cmpopts.IgnoreUnexported(elbv2types.RuleCondition{}),
 		cmpopts.IgnoreUnexported(elbv2types.HostHeaderConditionConfig{}),
+		cmpopts.IgnoreUnexported(elbv2types.HttpHeaderConditionConfig{}),
 		cmpopts.IgnoreUnexported(elbv2types.HttpRequestMethodConditionConfig{}),
 		cmpopts.IgnoreUnexported(elbv2types.PathPatternConditionConfig{}),
 		cmpopts.IgnoreUnexported(elbv2types.QueryStringConditionConfig{}),
+		cmpopts.IgnoreUnexported(elbv2types.QueryStringKeyValuePair{}),
 		cmpopts.IgnoreUnexported(elbv2types.SourceIpConditionConfig{}),
 		cmpopts.IgnoreFields(elbv2types.RuleCondition{}, "Values"),
 	}


### PR DESCRIPTION


### Description

The controller crashes due to the `noSmithyDocumentSerde` on `TargetGroupStickinessConfig` type This fixes the controller crashing while comparing the actions having "TargetGroupStickinessConfig". 

### Checklist
- [] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
