### PR TITLE
[helm chart] add default issuerRef.group for selfsigned cert

### DIFF
--- a/helm/aws-load-balancer-controller/templates/webhook.yaml
+++ b/helm/aws-load-balancer-controller/templates/webhook.yaml
@@ -235,6 +235,7 @@ spec:
   - {{ template "aws-load-balancer-controller.webhookService" . }}.{{ .Release.Namespace }}.svc.{{ .Values.cluster.dnsDomain }}
   issuerRef:
     kind: Issuer
+    group: cert-manager.io
     name: {{ template "aws-load-balancer-controller.namePrefix" . }}-selfsigned-issuer
   secretName: {{ template "aws-load-balancer-controller.webhookCertSecret" . }}
 ---


### PR DESCRIPTION
### Issue

[3867](https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/3867)

### Description

Certificates will fail to automatically renew when newer versions of cert-manager (tested on 1.15.2 and 1.15.3) don't have a default Issuer defined in the cluster and the certificate does not specify `issuerRef.group`. It Fails with `Unknown issuer kind: Issuer`

Since cert-manager is considered a pre-req to use the self-signed issuer/cert config in this chart, the chart should define this value by default when `enableCertManager` is set to true so that no further config is required for cert-manager to function as expected. 

This PR adds this field and sets it to `cert-manager.io`

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
