### PR TITLE
fix(docs): Update the link to the AWS documentation for the TLS Ingress annotation for Security policy

### DIFF
--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -781,7 +781,7 @@ TLS support can be controlled with the following annotations:
             alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-west-2:xxxxx:certificate/cert1,arn:aws:acm:us-west-2:xxxxx:certificate/cert2,arn:aws:acm:us-west-2:xxxxx:certificate/cert3
             ```
 
-- <a name="ssl-policy">`alb.ingress.kubernetes.io/ssl-policy`</a> specifies the [Security Policy](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies) that should be assigned to the ALB, allowing you to control the protocol and ciphers.
+- <a name="ssl-policy">`alb.ingress.kubernetes.io/ssl-policy`</a> specifies the [Security Policy](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/describe-ssl-policies.html) that should be assigned to the ALB, allowing you to control the protocol and ciphers.
 
     !!!example
         ```


### PR DESCRIPTION
### Issue


### Description

The link to the Security policy AWS documentation page in the `alb.ingress.kubernetes.io/ssl-policy` Ingress annotation section is outdated.

This PR updates that link to the latest page that is dedicated for the security policies available for an ALB.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [X] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [X] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
