### PR TITLE
feat: allow to set automountServiceAccountToken at Pod level

### DIFF
--- a/helm/aws-load-balancer-controller/templates/deployment.yaml
+++ b/helm/aws-load-balancer-controller/templates/deployment.yaml
@@ -43,6 +43,9 @@ spec:
       runtimeClassName: {{ .Values.runtimeClassName }}
     {{- end }}
       serviceAccountName: {{ include "aws-load-balancer-controller.serviceAccountName" . }}
+    {{- if ne .Values.automountServiceAccountToken nil }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+    {{- end }}
       volumes:
       - name: cert
         secret:

--- a/helm/aws-load-balancer-controller/templates/serviceaccount.yaml
+++ b/helm/aws-load-balancer-controller/templates/serviceaccount.yaml
@@ -10,7 +10,9 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- if ne .Values.automountServiceAccountToken nil }}
+automountServiceAccountToken: false
+{{- end }}
 {{- with .Values.serviceAccount.imagePullSecrets }}
 imagePullSecrets:
 {{ toYaml . }}

--- a/helm/aws-load-balancer-controller/values.yaml
+++ b/helm/aws-load-balancer-controller/values.yaml
@@ -428,5 +428,9 @@ serviceTargetENISGTags:
 # Specifies the class of load balancer to use for services. This affects how services are provisioned if type LoadBalancer is used (default service.k8s.aws/nlb)
 loadBalancerClass:
 
+# When set, it will disable automountServiceAccountToken on service account
+# and set the true or false value on pod template
+automountServiceAccountToken:
+
 # creator will disable helm default labels, so you can only add yours
 # creator: "me"


### PR DESCRIPTION
### Description

This PR is based on https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3575 
It tries to follow @oliviassss [suggestion](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3575#discussion_r1612099488)

By default, it changes nothing.
When it is set, it will disable it at `ServiceAccount` level and set the true / false value on the pod template level. 


### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
