### PR TITLE
Document AWS LBC set up with Pod Identity Associations

### DIFF
--- a/docs/deploy/installation.md
+++ b/docs/deploy/installation.md
@@ -272,6 +272,7 @@ Review the [worker nodes security group](https://docs.aws.amazon.com/eks/latest/
 If you use [eksctl](https://eksctl.io/usage/vpc-networking/), this is the default configuration.
 
 If you use custom networking, please refer to the [EKS Best Practices Guides](https://aws.github.io/aws-eks-best-practices/networking/custom-networking/#use-custom-networking-when) for network configuration.
+
 ## Add controller to cluster
 
 We recommend using the Helm chart to install the controller. The chart supports Fargate and facilitates updating the controller.


### PR DESCRIPTION
### Issue

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/3613

### Description

Updated documentation to demonstrate how to set up AWS LBC in EKS with Pod Identity Associations using both AWS CLI and terraform. 

### Checklist
- [ NA] Added tests that cover your change (if possible)
- [X] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [X] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
