### PR TITLE
chore(docs): fix external-dns routing policies link

### DIFF
--- a/docs/guide/integrations/external_dns.md
+++ b/docs/guide/integrations/external_dns.md
@@ -73,4 +73,4 @@ Adequate roles and policies must be configured in AWS and available to the node(
       external-dns.alpha.kubernetes.io/aws-weight: "100"
       external-dns.alpha.kubernetes.io/set-identifier: "3"
    ```
-   You can refer to the External DNS documentation for further details [[link](https://kubernetes-sigs.github.io/external-dns/latest/tutorials/aws/#routing-policies)]. 
+   You can refer to the External DNS documentation for further details [[link](https://kubernetes-sigs.github.io/external-dns/latest/docs/tutorials/aws/#routing-policies)]. 


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description
Old link is not working: https://kubernetes-sigs.github.io/external-dns/latest/tutorials/aws/#routing-policies

Needs an extra `/docs/` in the URL: https://kubernetes-sigs.github.io/external-dns/latest/docs/tutorials/aws/#routing-policies
<!--
Please explain the changes you made here.

Help your reviewers by guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
