### PR TITLE
Fix controller crash due enabling shield protection after AWSSDKGoV2 upgrade

### DIFF
--- a/pkg/deploy/shield/protection_manager.go
+++ b/pkg/deploy/shield/protection_manager.go
@@ -125,7 +125,7 @@ func (m *defaultProtectionManager) GetProtection(ctx context.Context, resourceAR
 			return nil, err
 		}
 	}
-	if resp.Protection != nil {
+	if resp != nil && resp.Protection != nil {
 		protectionInfo = &ProtectionInfo{
 			Name: awssdk.ToString(resp.Protection.Name),
 			ID:   awssdk.ToString(resp.Protection.Id),


### PR DESCRIPTION
### Issue

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/3888

### Description

The DescribeProtection API returns nil response if the protection is not found for the resource. We missed the nil check on it which resulted in controller crashing.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
