### PR TITLE
add missing targets field to de/registered targets log messages

### DIFF
--- a/pkg/targetgroupbinding/targets_manager.go
+++ b/pkg/targetgroupbinding/targets_manager.go
@@ -91,7 +91,8 @@ func (m *cachedTargetsManager) RegisterTargets(ctx context.Context, tgARN string
 			return err
 		}
 		m.logger.Info("registered targets",
-			"arn", tgARN)
+			"arn", tgARN,
+			"targets", targetsChunk)
 		m.recordSuccessfulRegisterTargetsOperation(tgARN, targetsChunk)
 	}
 	return nil
@@ -112,7 +113,8 @@ func (m *cachedTargetsManager) DeregisterTargets(ctx context.Context, tgARN stri
 			return err
 		}
 		m.logger.Info("deRegistered targets",
-			"arn", tgARN)
+			"arn", tgARN,
+			"targets", targetsChunk)
 		m.recordSuccessfulDeregisterTargetsOperation(tgARN, targetsChunk)
 	}
 	return nil


### PR DESCRIPTION
### Issue
The logs of the aws-load-balancer-controller do not mention the targets upon registering/deregistering targets in their "success" message.
This makes it harder to search for actions and their success logs.
<!-- Please link the GitHub issues related to this PR, if available -->

### Description
Added targetsChunk to log messages.
<!--
Please explain the changes you made here.

Help your reviewers by guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
