### PR TITLE
update the region of shield api

### DIFF
--- a/pkg/aws/provider/default_aws_clients_provider.go
+++ b/pkg/aws/provider/default_aws_clients_provider.go
@@ -57,7 +57,7 @@ func NewDefaultAWSClientsProvider(cfg aws.Config, endpointsResolver *endpoints.R
 		o.BaseEndpoint = wafregionalCustomEndpoint
 	})
 	sheildClient := shield.NewFromConfig(cfg, func(o *shield.Options) {
-		o.Region = "us-east-1"
+		o.Region = cfg.Region
 		o.BaseEndpoint = shieldCustomEndpoint
 	})
 	rgtClient := resourcegroupstaggingapi.NewFromConfig(cfg, func(o *resourcegroupstaggingapi.Options) {


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description

Change the shield api region to `cfg.Region` from the hard coded "us-east-1", as this api is globally available now.
https://docs.aws.amazon.com/general/latest/gr/shield.html
```
 % aws shield get-subscription-state --region us-west-2
{
    "SubscriptionState": "ACTIVE"
}

 % aws shield get-subscription-state --region us-east-2
{
    "SubscriptionState": "ACTIVE"
}
% aws shield get-subscription-state --region ap-southeast-5
{
    "SubscriptionState": "ACTIVE"
}
```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
