### PR TITLE
[BUG FIX] trim control characters from secret to prevent newlines in client secret

### DIFF
--- a/pkg/ingress/model_build_actions.go
+++ b/pkg/ingress/model_build_actions.go
@@ -187,7 +187,7 @@ func (t *defaultModelBuildTask) buildAuthenticateOIDCAction(ctx context.Context,
 
 	t.secretKeys = append(t.secretKeys, secretKey)
 	clientID := strings.TrimRightFunc(string(rawClientID), unicode.IsSpace)
-	clientSecret := string(rawClientSecret)
+	clientSecret := strings.TrimRightFunc(string(rawClientSecret), unicode.IsControl)
 	return elbv2model.Action{
 		Type: elbv2model.ActionTypeAuthenticateOIDC,
 		AuthenticateOIDCConfig: &elbv2model.AuthenticateOIDCActionConfig{

--- a/pkg/ingress/model_build_actions_test.go
+++ b/pkg/ingress/model_build_actions_test.go
@@ -86,6 +86,61 @@ func Test_defaultModelBuildTask_buildAuthenticateOIDCAction(t *testing.T) {
 			},
 		},
 		{
+			name: "clientSecret has control characters at end",
+			env: env{
+				secrets: []*corev1.Secret{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "my-ns",
+							Name:      "my-k8s-secret",
+						},
+						Data: map[string][]byte{
+							"clientID":     []byte("my-client-id"),
+							"clientSecret": []byte("my-client-secret\n"),
+						},
+					},
+				},
+			},
+			args: args{
+				authCfg: AuthConfig{
+					Type: AuthTypeCognito,
+					IDPConfigOIDC: &AuthIDPConfigOIDC{
+						Issuer:                "https://example.com",
+						AuthorizationEndpoint: "https://authorization.example.com",
+						TokenEndpoint:         "https://token.example.com",
+						UserInfoEndpoint:      "https://userinfo.example.co",
+						SecretName:            "my-k8s-secret",
+						AuthenticationRequestExtraParams: map[string]string{
+							"key1": "value1",
+						},
+					},
+					OnUnauthenticatedRequest: "authenticate",
+					Scope:                    "email",
+					SessionCookieName:        "my-session-cookie",
+					SessionTimeout:           65536,
+				},
+				namespace: "my-ns",
+			},
+			want: elbv2model.Action{
+				Type: elbv2model.ActionTypeAuthenticateOIDC,
+				AuthenticateOIDCConfig: &elbv2model.AuthenticateOIDCActionConfig{
+					Issuer:                "https://example.com",
+					AuthorizationEndpoint: "https://authorization.example.com",
+					TokenEndpoint:         "https://token.example.com",
+					UserInfoEndpoint:      "https://userinfo.example.co",
+					ClientID:              "my-client-id",
+					ClientSecret:          "my-client-secret",
+					AuthenticationRequestExtraParams: map[string]string{
+						"key1": "value1",
+					},
+					OnUnauthenticatedRequest: authBehaviorAuthenticate,
+					Scope:                    awssdk.String("email"),
+					SessionCookieName:        awssdk.String("my-session-cookie"),
+					SessionTimeout:           awssdk.Int64(65536),
+				},
+			},
+		},
+		{
 			name: "clientID & clientSecret configured - legacy clientId",
 			env: env{
 				secrets: []*corev1.Secret{


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/3865

### Description

Users commonly base64 encode their secret values by doing `echo some-secret | base64`, which adds an '\n' at the end of the value. The correct way to do the echo is by using the `-n` flag to prevent the newline. However, for ease of use, we can trim control characters at the end of the client secret to make this a bit easier for users.

The client_secret specification only allows `%x20-7E` ascii characters, so it's invalid to have a '\n' in a client secret.
https://datatracker.ietf.org/doc/html/rfc6749#appendix-A.2

### Checklist
- [X] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [X] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
