### PR TITLE
feat(NLB): Introduce Service annotation to allow ICMP for Path MTU Discovery

### DIFF
--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -57,6 +57,7 @@
 | [service.beta.kubernetes.io/aws-load-balancer-enable-prefix-for-ipv6-source-nat](#enable-prefix-for-ipv6-source-nat)         | string                  | off                       | Optional annotation. dualstack lb only. Allowed values - on and off                                                                                                                                                                 |
 | [service.beta.kubernetes.io/aws-load-balancer-source-nat-ipv6-prefixes](#source-nat-ipv6-prefixes)        | stringList                  |                           | Optional annotation. dualstack lb only. This annotation is only applicable when user has to set the service.beta.kubernetes.io/aws-load-balancer-enable-prefix-for-ipv6-source-nat to "on". Length must match the number of subnets |
 | [service.beta.kubernetes.io/aws-load-balancer-minimum-load-balancer-capacity](#load-balancer-capacity-reservation)                 | stringMap                  |                           |
+| [service.beta.kubernetes.io/aws-load-balancer-enable-icmp-for-path-mtu-discovery](#icmp-path-mtu-discovery)        | string                  |                           | If specified, a security group rule is added to the managed security group to allow explicit ICMP traffic for [Path MTU discovery](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/network_mtu.html#path_mtu_discovery) for IPv4 and dual-stack VPCs. Creates a rule for each source range if `service.beta.kubernetes.io/load-balancer-source-ranges` is present.  |
 
 ## Traffic Routing
 Traffic Routing can be controlled with following annotations:
@@ -190,6 +191,13 @@ on the load balancer.
     !!!example
         ```
         service.beta.kubernetes.io/aws-load-balancer-ipv6-addresses: 2600:1f13:837:8501::1, 2600:1f13:837:8504::1
+        ```
+
+- <a name="icmp-path-mtu-discovery">`service.beta.kubernetes.io/aws-load-balancer-enable-icmp-for-path-mtu-discovery`</a> enables the creation of security group rules to the managed security group to allow explicit ICMP traffic for [Path MTU discovery](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/network_mtu.html#path_mtu_discovery) for IPv4 and dual-stack VPCs. Creates a rule for each source range if `service.beta.kubernetes.io/load-balancer-source-ranges` is present.
+
+    !!!example
+        ```
+        service.beta.kubernetes.io/aws-load-balancer-enable-icmp-for-path-mtu-discovery: "on"
         ```
 
 ## Traffic Listening

--- a/pkg/annotations/constants.go
+++ b/pkg/annotations/constants.go
@@ -100,7 +100,8 @@ const (
 	SvcLBSuffixSecurityGroupPrefixLists                  = "aws-load-balancer-security-group-prefix-lists"
 	SvcLBSuffixlsAttsAnnotationPrefix                    = "aws-load-balancer-listener-attributes"
 	SvcLBSuffixMultiClusterTargetGroup                   = "aws-load-balancer-multi-cluster-target-group"
-	ScvLBSuffixEnablePrefixForIpv6SourceNat              = "aws-load-balancer-enable-prefix-for-ipv6-source-nat"
-	ScvLBSuffixSourceNatIpv6Prefixes                     = "aws-load-balancer-source-nat-ipv6-prefixes"
+	SvcLBSuffixEnablePrefixForIpv6SourceNat              = "aws-load-balancer-enable-prefix-for-ipv6-source-nat"
+	SvcLBSuffixSourceNatIpv6Prefixes                     = "aws-load-balancer-source-nat-ipv6-prefixes"
 	SvcLBSuffixLoadBalancerCapacityReservation           = "aws-load-balancer-minimum-load-balancer-capacity"
+	SvcLBSuffixEnableIcmpForPathMtuDiscovery             = "aws-load-balancer-enable-icmp-for-path-mtu-discovery"
 )

--- a/pkg/service/model_build_load_balancer.go
+++ b/pkg/service/model_build_load_balancer.go
@@ -199,7 +199,7 @@ func (t *defaultModelBuildTask) buildLoadBalancerIPAddressType(_ context.Context
 
 func (t *defaultModelBuildTask) buildLoadBalancerEnablePrefixForIpv6SourceNat(_ context.Context, ipAddressType elbv2model.IPAddressType, ec2Subnets []ec2types.Subnet) (elbv2model.EnablePrefixForIpv6SourceNat, error) {
 	rawEnablePrefixForIpv6SourceNat := ""
-	if exists := t.annotationParser.ParseStringAnnotation(annotations.ScvLBSuffixEnablePrefixForIpv6SourceNat, &rawEnablePrefixForIpv6SourceNat, t.service.Annotations); !exists {
+	if exists := t.annotationParser.ParseStringAnnotation(annotations.SvcLBSuffixEnablePrefixForIpv6SourceNat, &rawEnablePrefixForIpv6SourceNat, t.service.Annotations); !exists {
 		return elbv2model.EnablePrefixForIpv6SourceNatOff, nil
 	}
 
@@ -382,7 +382,7 @@ func (t *defaultModelBuildTask) buildLoadBalancerSubnetMappings(_ context.Contex
 	var isPrefixForIpv6SourceNatEnabled = enablePrefixForIpv6SourceNat == elbv2model.EnablePrefixForIpv6SourceNatOn
 
 	var sourceNatIpv6Prefixes []string
-	sourceNatIpv6PrefixesConfigured := t.annotationParser.ParseStringSliceAnnotation(annotations.ScvLBSuffixSourceNatIpv6Prefixes, &sourceNatIpv6Prefixes, t.service.Annotations)
+	sourceNatIpv6PrefixesConfigured := t.annotationParser.ParseStringSliceAnnotation(annotations.SvcLBSuffixSourceNatIpv6Prefixes, &sourceNatIpv6Prefixes, t.service.Annotations)
 	if sourceNatIpv6PrefixesConfigured {
 		sourceNatIpv6PrefixesError := networking.ValidateSourceNatPrefixes(sourceNatIpv6Prefixes, ipAddressType, isPrefixForIpv6SourceNatEnabled, ec2Subnets)
 		if sourceNatIpv6PrefixesError != nil {

--- a/pkg/service/model_builder_test.go
+++ b/pkg/service/model_builder_test.go
@@ -2,10 +2,11 @@ package service
 
 import (
 	"context"
-	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 	"testing"
 	"time"
+
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/go-logr/logr"
@@ -6502,6 +6503,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
              "scheme":"internet-facing",
              "securityGroupsInboundRulesOnPrivateLink":"on",
              "ipAddressType":"ipv4",
+             "enablePrefixForIpv6SourceNat": "off",
              "subnetMapping":[
                 {
                    "subnetID":"subnet-1"


### PR DESCRIPTION
### Issue

 #3897 

### Description

It might be necessary for some environments to allow Path MTU discovery for negotiation of MTU between two hosts. If a receiving host has a smaller MTU than the sending host, the receiving host sends an ICMP message to instruct the sending host to split the payload into multiple smaller packets and retransmit them:

- `Destination Unreachable: Fragmentation Needed and Don't Fragment was Set` (Type 3, Code 4) for IPv4 networks.
- `ICMPv6 Packet Too Big (PTB)` (Type 2) for IPv6 networks.

This work introduces a Service annotation (below) that when configured, will automatically add a security group rule to the managed security group, depending on the IP address type.

```
service.beta.kubernetes.io/aws-load-balancer-enable-icmp-for-path-mtu-discovery: "on"
```
&nbsp;

For IPv4 VPCs, an explicit rule is added to the managed security group to allow [ICMPv4 Type 3 Code 4](https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml#icmp-parameters-codes-3).

![Screenshot 2024-11-12 at 10 13 27](https://github.com/user-attachments/assets/87781f24-d33d-4d77-8edc-48c73e60a05a)
&nbsp;

For dual stack VPCs, an explicit rule is added to the managed security group to allow both ICMPv4 Type 3 Code 4 and [ICMPv6 Type 2 Code 0](https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml#icmpv6-parameters-codes-2).

<img width="1461" alt="Screenshot 2024-11-12 at 00 40 16" src="https://github.com/user-attachments/assets/33512864-400c-4a6c-b45d-41fd9f9d066f">
&nbsp;

If the `service.beta.kubernetes.io/load-balancer-source-ranges` annotation is also present, it will also create an explicit rule for each source range.

<img width="1461" alt="Screenshot 2024-11-12 at 00 49 22" src="https://github.com/user-attachments/assets/ee2377b7-6c0e-42e4-a3df-59cb44c07bed">


### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [X] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
