### PR TITLE
FEAT: LBC metric collector

### DIFF
--- a/pkg/metrics/aws/collector_test.go
+++ b/pkg/metrics/aws/collector_test.go
@@ -1,4 +1,4 @@
-package metrics
+package aws
 
 import (
 	"errors"

--- a/pkg/metrics/lbc/collector.go
+++ b/pkg/metrics/lbc/collector.go
@@ -1,0 +1,39 @@
+package lbc
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"time"
+)
+
+type MetricCollector interface {
+	// ObservePodReadinessGateReady this metric is useful to determine how fast pods are becoming ready in the load balancer.
+	// Due to some architectural constraints, we can only emit this metric for pods that are using readiness gates.
+	ObservePodReadinessGateReady(namespace string, tgbName string, duration time.Duration)
+}
+
+type collector struct {
+	instruments *instruments
+}
+
+type noOpCollector struct{}
+
+func (n *noOpCollector) ObservePodReadinessGateReady(_ string, _ string, _ time.Duration) {
+}
+
+func NewCollector(registerer prometheus.Registerer) MetricCollector {
+	if registerer == nil {
+		return &noOpCollector{}
+	}
+
+	instruments := newInstruments(registerer)
+	return &collector{
+		instruments: instruments,
+	}
+}
+
+func (c *collector) ObservePodReadinessGateReady(namespace string, tgbName string, duration time.Duration) {
+	c.instruments.podReadinessFlipSeconds.With(prometheus.Labels{
+		labelNamespace: namespace,
+		labelName:      tgbName,
+	}).Observe(duration.Seconds())
+}

--- a/pkg/metrics/lbc/instruments.go
+++ b/pkg/metrics/lbc/instruments.go
@@ -1,0 +1,38 @@
+package lbc
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	metricSubsystem = "awslbc"
+)
+
+// These metrics are exported to be used in unit test validation.
+const (
+	// MetricPodReadinessGateReady tracks the time to flip a readiness gate to true
+	MetricPodReadinessGateReady = "readiness_gate_ready_seconds"
+)
+
+const (
+	labelNamespace = "namespace"
+	labelName      = "name"
+)
+
+type instruments struct {
+	podReadinessFlipSeconds *prometheus.HistogramVec
+}
+
+// newInstruments allocates and register new metrics to registerer
+func newInstruments(registerer prometheus.Registerer) *instruments {
+	podReadinessFlipSeconds := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Subsystem: metricSubsystem,
+		Name:      MetricPodReadinessGateReady,
+		Help:      "Latency from pod getting added to the load balancer until the readiness gate is flipped to healthy.",
+	}, []string{labelNamespace, labelName})
+
+	registerer.MustRegister(podReadinessFlipSeconds)
+	return &instruments{
+		podReadinessFlipSeconds: podReadinessFlipSeconds,
+	}
+}

--- a/pkg/metrics/lbc/mockcollector.go
+++ b/pkg/metrics/lbc/mockcollector.go
@@ -1,0 +1,37 @@
+package lbc
+
+import (
+	"time"
+)
+
+type MockCollector struct {
+	Invocations map[string][]interface{}
+}
+
+type MockHistogramMetric struct {
+	namespace string
+	name      string
+	duration  time.Duration
+}
+
+func (m *MockCollector) ObservePodReadinessGateReady(namespace string, tgbName string, d time.Duration) {
+	m.recordHistogram(MetricPodReadinessGateReady, namespace, tgbName, d)
+}
+
+func (m *MockCollector) recordHistogram(metricName string, namespace string, name string, d time.Duration) {
+	m.Invocations[metricName] = append(m.Invocations[MetricPodReadinessGateReady], MockHistogramMetric{
+		namespace: namespace,
+		name:      name,
+		duration:  d,
+	})
+}
+
+func NewMockCollector() MetricCollector {
+
+	mockInvocations := make(map[string][]interface{})
+	mockInvocations[MetricPodReadinessGateReady] = make([]interface{}, 0)
+
+	return &MockCollector{
+		Invocations: mockInvocations,
+	}
+}

--- a/pkg/targetgroupbinding/resource_manager_test.go
+++ b/pkg/targetgroupbinding/resource_manager_test.go
@@ -3,6 +3,8 @@ package targetgroupbinding
 import (
 	"context"
 	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
+	lbcmetrics "sigs.k8s.io/aws-load-balancer-controller/pkg/metrics/lbc"
 	"testing"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
@@ -26,6 +28,9 @@ func Test_defaultResourceManager_updateTargetHealthPodConditionForPod(t *testing
 		pods []*corev1.Pod
 	}
 
+	tgbName := "tgb"
+	tgbNamespace := "tgbNamespace"
+
 	type args struct {
 		pod                  k8s.PodInfo
 		targetHealth         *elbv2types.TargetHealth
@@ -33,12 +38,13 @@ func Test_defaultResourceManager_updateTargetHealthPodConditionForPod(t *testing
 	}
 
 	tests := []struct {
-		name    string
-		env     env
-		args    args
-		want    bool
-		wantPod *corev1.Pod
-		wantErr error
+		name       string
+		env        env
+		args       args
+		want       bool
+		wantPod    *corev1.Pod
+		wantMetric bool
+		wantErr    error
 	}{
 		{
 			name: "pod contains readinessGate and targetHealth is healthy - add pod condition",
@@ -137,10 +143,11 @@ func Test_defaultResourceManager_updateTargetHealthPodConditionForPod(t *testing
 						Status: corev1.PodStatus{
 							Conditions: []corev1.PodCondition{
 								{
-									Type:    "target-health.elbv2.k8s.aws/my-tgb",
-									Message: string(elbv2types.TargetHealthReasonEnumRegistrationInProgress),
-									Reason:  "Elb.RegistrationInProgress",
-									Status:  corev1.ConditionFalse,
+									Type:               "target-health.elbv2.k8s.aws/my-tgb",
+									Message:            string(elbv2types.TargetHealthReasonEnumRegistrationInProgress),
+									Reason:             "Elb.RegistrationInProgress",
+									Status:             corev1.ConditionFalse,
+									LastTransitionTime: metav1.Now(),
 								},
 								{
 									Type:   corev1.ContainersReady,
@@ -162,10 +169,11 @@ func Test_defaultResourceManager_updateTargetHealthPodConditionForPod(t *testing
 					},
 					Conditions: []corev1.PodCondition{
 						{
-							Type:    "target-health.elbv2.k8s.aws/my-tgb",
-							Message: string(elbv2types.TargetHealthReasonEnumRegistrationInProgress),
-							Reason:  "Elb.RegistrationInProgress",
-							Status:  corev1.ConditionFalse,
+							Type:               "target-health.elbv2.k8s.aws/my-tgb",
+							Message:            string(elbv2types.TargetHealthReasonEnumRegistrationInProgress),
+							Reason:             "Elb.RegistrationInProgress",
+							Status:             corev1.ConditionFalse,
+							LastTransitionTime: metav1.Now(),
 						},
 						{
 							Type:   corev1.ContainersReady,
@@ -178,7 +186,8 @@ func Test_defaultResourceManager_updateTargetHealthPodConditionForPod(t *testing
 				},
 				targetHealthCondType: "target-health.elbv2.k8s.aws/my-tgb",
 			},
-			want: false,
+			want:       false,
+			wantMetric: true,
 			wantPod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
@@ -226,10 +235,11 @@ func Test_defaultResourceManager_updateTargetHealthPodConditionForPod(t *testing
 						Status: corev1.PodStatus{
 							Conditions: []corev1.PodCondition{
 								{
-									Type:    "target-health.elbv2.k8s.aws/my-tgb",
-									Status:  corev1.ConditionFalse,
-									Reason:  string(elbv2types.TargetHealthReasonEnumRegistrationInProgress),
-									Message: "Target registration is in progress",
+									Type:               "target-health.elbv2.k8s.aws/my-tgb",
+									Status:             corev1.ConditionFalse,
+									Reason:             string(elbv2types.TargetHealthReasonEnumRegistrationInProgress),
+									Message:            "Target registration is in progress",
+									LastTransitionTime: metav1.Now(),
 								},
 								{
 									Type:   corev1.ContainersReady,
@@ -382,9 +392,14 @@ func Test_defaultResourceManager_updateTargetHealthPodConditionForPod(t *testing
 			k8sClient := testclient.NewClientBuilder().WithScheme(k8sSchema).Build()
 
 			m := &defaultResourceManager{
-				k8sClient: k8sClient,
-				logger:    logr.New(&log.NullLogSink{}),
+				k8sClient:        k8sClient,
+				logger:           logr.New(&log.NullLogSink{}),
+				metricsCollector: lbcmetrics.NewMockCollector(),
 			}
+
+			tgb := &elbv2api.TargetGroupBinding{}
+			tgb.Name = tgbName
+			tgb.Namespace = tgbNamespace
 
 			ctx := context.Background()
 			for _, pod := range tt.env.pods {
@@ -393,7 +408,7 @@ func Test_defaultResourceManager_updateTargetHealthPodConditionForPod(t *testing
 			}
 
 			got, err := m.updateTargetHealthPodConditionForPod(context.Background(),
-				tt.args.pod, tt.args.targetHealth, tt.args.targetHealthCondType)
+				tt.args.pod, tt.args.targetHealth, tt.args.targetHealthCondType, tgb)
 			if tt.wantErr != nil {
 				assert.EqualError(t, err, tt.wantErr.Error())
 			} else {
@@ -410,6 +425,9 @@ func Test_defaultResourceManager_updateTargetHealthPodConditionForPod(t *testing
 				}
 				assert.True(t, cmp.Equal(tt.wantPod, updatedPod, opts), "diff", cmp.Diff(tt.wantPod, updatedPod, opts))
 			}
+
+			mockCollector := m.metricsCollector.(*lbcmetrics.MockCollector)
+			assert.Equal(t, tt.wantMetric, len(mockCollector.Invocations[lbcmetrics.MetricPodReadinessGateReady]) == 1)
 		})
 	}
 }


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->


This metric is helpful to identify slowness between registering pods and them going active within the load balancer. Recently, NLB has released faster target registration times and using this prom metric will help validate how fast targets are going active now.

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/1834

### Description

<!--
Please explain the changes you made here.

Help your reviewers by guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

Refactored the metrics code into it's own package. Introduce an LBC specific Prometheus metric collector that we can expand to collect other interesting metrics.

### Checklist
- [X] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [X] Manually tested
- [ X Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [X] Refactored something and made the world a better place :star2:
