### PR TITLE
chore(doc): update service healthcheck timeout documentation

### DIFF
--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -429,9 +429,6 @@ Health check on target groups can be configured with following annotations:
 
 - <a name="healthcheck-timeout">`service.beta.kubernetes.io/aws-load-balancer-healthcheck-timeout`</a> specifies the target group health check timeout. The target has to respond within the timeout for a successful health check.
 
-    !!!note
-        The controller currently ignores the timeout configuration due to the limitations on the AWS NLB. The default timeout for TCP is 10s and HTTP is 6s.
-
     !!!example
         ```
         service.beta.kubernetes.io/aws-load-balancer-healthcheck-timeout: "10"


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->
Closes #3838 

### Description

<!--
Please explain the changes you made here.

Help your reviewers by guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->
- Doc: remove outdated note that `service.beta.kubernetes.io/aws-load-balancer-healthcheck-timeout` is ignored

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- Confirm LBC able to modify Target Group healthcheck timeout when service annotation updated
- Local doc preview
<img width="839" alt="Screenshot 2024-11-20 182044" src="https://github.com/user-attachments/assets/d7b4549d-b2b9-405c-9421-c29daa0dcc6b">

- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
