### PR TITLE
enable http and https listener attributes

### DIFF
--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -60,6 +60,7 @@ You can add annotations to kubernetes Ingress and Service objects to customize t
 | [alb.ingress.kubernetes.io/target-node-labels](#target-node-labels)                                   | stringMap                   |N/A| Ingress,Service | N/A           |
 | [alb.ingress.kubernetes.io/mutual-authentication](#mutual-authentication)                             | json                        |N/A| Ingress         | Exclusive     |
 | [alb.ingress.kubernetes.io/multi-cluster-target-group](#multi-cluster-target-group)                   | boolean                     |N/A| Ingress, Service | N/A           |
+| [alb.ingress.kubernetes.io/listener-attributes.${Protocol}-${Port}](#listener-attributes)                           | stringMap                        |N/A| Ingress         |Merge|
 
 ## IngressGroup
 IngressGroup feature enables you to group multiple Ingress resources together.
@@ -902,6 +903,14 @@ Custom attributes to LoadBalancers and TargetGroups can be controlled with follo
     ```
     alb.ingress.kubernetes.io/multi-cluster-target-group: "true"
     ```
+
+- <a name="listener-attributes">`alb.ingress.kubernetes.io/listener-attributes.${Protocol}-${Port}`</a> specifies Listener Attributes which should be applied to listener.
+
+    !!!example
+        - Server header enablement attribute
+            ```
+            alb.ingress.kubernetes.io/listener-attributes.HTTP-80: routing.http.response.server.enabled=true
+            ```
 
 
 ## Resource Tags

--- a/pkg/deploy/elbv2/listener_manager.go
+++ b/pkg/deploy/elbv2/listener_manager.go
@@ -23,8 +23,8 @@ import (
 )
 
 var PROTOCOLS_SUPPORTING_LISTENER_ATTRIBUTES = map[elbv2model.Protocol]bool{
-	elbv2model.ProtocolHTTP:  false,
-	elbv2model.ProtocolHTTPS: false,
+	elbv2model.ProtocolHTTP:  true,
+	elbv2model.ProtocolHTTPS: true,
 	elbv2model.ProtocolTCP:   true,
 	elbv2model.ProtocolUDP:   false,
 	elbv2model.ProtocolTLS:   false,

--- a/pkg/ingress/model_build_load_balancer_attributes_test.go
+++ b/pkg/ingress/model_build_load_balancer_attributes_test.go
@@ -2,13 +2,14 @@ package ingress
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	networking "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
-	"testing"
 )
 
 func Test_defaultModelBuildTask_buildIngressGroupLoadBalancerAttributes(t *testing.T) {
@@ -82,7 +83,7 @@ func Test_defaultModelBuildTask_buildIngressGroupLoadBalancerAttributes(t *testi
 					},
 				},
 			},
-			wantErr: errors.New("conflicting attributes deletion_protection.enabled: true | false"),
+			wantErr: errors.New("conflicting load balancer attributes deletion_protection.enabled: true | false"),
 		},
 		{
 			name: "non-empty annotation attributes from single Ingress, non-empty IngressClass attributes - has overlap attributes",

--- a/test/e2e/ingress/vanilla_ingress_test.go
+++ b/test/e2e/ingress/vanilla_ingress_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gavv/httpexpect/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -777,6 +778,56 @@ var _ = Describe("vanilla ingress tests", func() {
 			}
 		})
 	})
+
+	Context("with `alb.ingress.kubernetes.io/listener-attributes.{Protocol}-{Port}` variant settings", func() {
+		It("with 'alb.ingress.kubernetes.io/listener-attributes.{Protocol}-{Port}' annotation explicitly specified, one ALB shall be created and functional", func() {
+			appBuilder := manifest.NewFixedResponseServiceBuilder()
+			ingBuilder := manifest.NewIngressBuilder()
+			dp, svc := appBuilder.Build(sandboxNS.Name, "app", tf.Options.TestImageRegistry)
+			ingBackend := networking.IngressBackend{
+				Service: &networking.IngressServiceBackend{
+					Name: svc.Name,
+					Port: networking.ServiceBackendPort{
+						Number: 80,
+					},
+				},
+			}
+			annotation := map[string]string{
+				"kubernetes.io/ingress.class":                           "alb",
+				"alb.ingress.kubernetes.io/scheme":                      "internet-facing",
+				"alb.ingress.kubernetes.io/listen-ports":                `[{"HTTP": 80}]`,
+				"alb.ingress.kubernetes.io/listener-attributes.HTTP-80": "routing.http.response.server.enabled=false",
+			}
+			if tf.Options.IPFamily == "IPv6" {
+				annotation["alb.ingress.kubernetes.io/ip-address-type"] = "dualstack"
+				annotation["alb.ingress.kubernetes.io/target-type"] = "ip"
+			}
+			ing := ingBuilder.
+				AddHTTPRoute("", networking.HTTPIngressPath{Path: "/path", PathType: &exact, Backend: ingBackend}).
+				WithAnnotations(annotation).Build(sandboxNS.Name, "ing")
+			resStack := fixture.NewK8SResourceStack(tf, dp, svc, ing)
+			err := resStack.Setup(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			defer resStack.TearDown(ctx)
+
+			lbARN, lbDNS := ExpectOneLBProvisionedForIngress(ctx, tf, ing)
+			sdkListeners, err := tf.LBManager.GetLoadBalancerListeners(ctx, lbARN)
+
+			Eventually(func() bool {
+				return verifyListenerAttributes(ctx, tf, *sdkListeners[0].ListenerArn, map[string]string{
+					"routing.http.response.server.enabled": "false",
+				}) == nil
+			}, utils.PollTimeoutShort, utils.PollIntervalMedium).Should(BeTrue())
+
+			// test traffic
+			ExpectLBDNSBeAvailable(ctx, tf, lbARN, lbDNS)
+			httpExp := httpexpect.New(tf.LoggerReporter, fmt.Sprintf("http://%v", lbDNS))
+			httpExp.GET("/path").Expect().
+				Status(http.StatusOK).
+				Body().Equal("Hello World!")
+		})
+	})
 })
 
 // ExpectOneLBProvisionedForIngress expects one LoadBalancer provisioned for Ingress.
@@ -819,4 +870,15 @@ func ExpectLBDNSBeAvailable(ctx context.Context, tf *framework.Framework, lbARN 
 	err = utils.WaitUntilDNSNameAvailable(ctx, lbDNS)
 	Expect(err).NotTo(HaveOccurred())
 	tf.Logger.Info("dns becomes available", "dns", lbDNS)
+}
+
+func verifyListenerAttributes(ctx context.Context, f *framework.Framework, lsARN string, expectedAttrs map[string]string) error {
+	lsAttrs, err := f.LBManager.GetListenerAttributes(ctx, lsARN)
+	Expect(err).NotTo(HaveOccurred())
+	for _, attr := range lsAttrs {
+		if val, ok := expectedAttrs[awssdk.ToString(attr.Key)]; ok && val != awssdk.ToString(attr.Value) {
+			return errors.Errorf("Attribute %v, expected %v, actual %v", awssdk.ToString(attr.Key), val, awssdk.ToString(attr.Value))
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
### Description
* Improvement:  setting attributes on IngressClassParam should resolve the conflicts in ingress group. 
* Enabled Http and Https listener attributes. `alb.ingress.kubernetes.io/listener-attributes.${Protocol}-{Port}` annotation, which allows dynamically configuration of protocol and port. With the combination of protocol and port, it serves as a unique identifier, enabling us to identify the listener and set attributes to it accordingly. For example, set
`alb.ingress.kubernetes.io/listener-attributes.HTTPS-443 : routing.http.response.server.enabled=true`. 
* Also, new IngressClassParams spec `listeners`, allowing set listener attributes at ingress class level.  For example
```
  listeners:
    - protocol: HTTPS
      port: 443
      listenerAttributes:
        - key: routing.http.response.server.enabled
          value: "true"
```


### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
