### PR TITLE
[helm chart] add resource-policy annotations to crds

### DIFF
--- a/helm/aws-load-balancer-controller/crds/crds.yaml
+++ b/helm/aws-load-balancer-controller/crds/crds.yaml
@@ -1,8 +1,15 @@
+{{- if .Values.crds.install }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
+    {{- if .Values.crds.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    {{- with .Values.crds.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: ingressclassparams.elbv2.k8s.aws
 spec:
   group: elbv2.k8s.aws
@@ -244,6 +251,12 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
+    {{- if .Values.crds.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
+    {{- with .Values.crds.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: targetgroupbindings.elbv2.k8s.aws
 spec:
   group: elbv2.k8s.aws
@@ -657,3 +670,4 @@ spec:
     storage: true
     subresources:
       status: {}
+{{- end }}

--- a/helm/aws-load-balancer-controller/values.yaml
+++ b/helm/aws-load-balancer-controller/values.yaml
@@ -430,3 +430,12 @@ loadBalancerClass:
 
 # creator will disable helm default labels, so you can only add yours
 # creator: "me"
+
+# custom resource definitions configuration
+crds:
+  # retain CRDs upon chart uninstall
+  keep: true
+  # install CRDs 
+  install: true
+  # pass in annotations to CRDs
+  annotations: {}


### PR DESCRIPTION
### Issue
Guidance on upgrades for AWS LB controller includes references to uninstalling the old version before moving to the new version of the controller. In those cases it would be ideal if we could retain the CRDs during that uninstall so as to prevent downtime associated with a fresh install.

### Description
CRDs are deleted by default when the helm chart is uninstalled. Offering an option to retain those resources would be great. Addittionally it would be ideal to pass in annotations to the CRDs.

In this PR I've added the following section which allow for configuring whether or not the helm "helm.sh/resource-policy": keep annotation is added to the CRDs, whether or not the CRDs are installed, and additional annotations that could be passed into the CRDs.


```yaml
crds:
  keep: false
  install: true
  annotations: {}
```

<!-- Please link the GitHub issues related to this PR, if available -->


<!--
Please explain the changes you made here.

Help your reviewers by guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
