### PR TITLE
fix: EnablePrefixForIpv6SourceNat is only applicable to NLB

### DIFF
--- a/pkg/deploy/elbv2/load_balancer_manager.go
+++ b/pkg/deploy/elbv2/load_balancer_manager.go
@@ -3,6 +3,7 @@ package elbv2
 import (
 	"context"
 	"fmt"
+
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	elbv2sdk "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
 	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
@@ -176,14 +177,15 @@ func (m *defaultLoadBalancerManager) updateSDKLoadBalancerWithSubnetMappings(ctx
 
 	resLBEnablePrefixForIpv6SourceNatValue = string(resLB.Spec.EnablePrefixForIpv6SourceNat)
 
-	if desiredSubnets.Equal(currentSubnets) && desiredSubnetsSourceNATPrefixes.Equal(currentSubnetsSourceNATPrefixes) && sdkLBEnablePrefixForIpv6SourceNatValue == resLBEnablePrefixForIpv6SourceNatValue {
+	if desiredSubnets.Equal(currentSubnets) && desiredSubnetsSourceNATPrefixes.Equal(currentSubnetsSourceNATPrefixes) && ((sdkLBEnablePrefixForIpv6SourceNatValue == resLBEnablePrefixForIpv6SourceNatValue) || (resLBEnablePrefixForIpv6SourceNatValue == "")) {
 		return nil
 	}
-
 	req := &elbv2sdk.SetSubnetsInput{
-		LoadBalancerArn:              sdkLB.LoadBalancer.LoadBalancerArn,
-		SubnetMappings:               buildSDKSubnetMappings(resLB.Spec.SubnetMappings),
-		EnablePrefixForIpv6SourceNat: elbv2types.EnablePrefixForIpv6SourceNatEnum(resLBEnablePrefixForIpv6SourceNatValue),
+		LoadBalancerArn: sdkLB.LoadBalancer.LoadBalancerArn,
+		SubnetMappings:  buildSDKSubnetMappings(resLB.Spec.SubnetMappings),
+	}
+	if resLB.Spec.Type == elbv2model.LoadBalancerTypeNetwork {
+		req.EnablePrefixForIpv6SourceNat = elbv2types.EnablePrefixForIpv6SourceNatEnum(resLBEnablePrefixForIpv6SourceNatValue)
 	}
 	changeDesc := fmt.Sprintf("%v => %v", currentSubnets.List(), desiredSubnets.List())
 	m.logger.Info("modifying loadBalancer subnetMappings",

--- a/pkg/deploy/elbv2/load_balancer_manager_test.go
+++ b/pkg/deploy/elbv2/load_balancer_manager_test.go
@@ -2,10 +2,11 @@ package elbv2
 
 import (
 	"context"
+	"testing"
+
 	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/services"
-	"testing"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	elbv2sdk "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
@@ -552,6 +553,7 @@ func Test_defaultLoadBalancerManager_updateSDKLoadBalancerWithSubnetMappings(t *
 				resLB: &elbv2model.LoadBalancer{
 					ResourceMeta: coremodel.NewResourceMeta(stack, "AWS::ElasticLoadBalancingV2::LoadBalancer", "id-1"),
 					Spec: elbv2model.LoadBalancerSpec{
+						Type:                         elbv2model.LoadBalancerTypeNetwork,
 						EnablePrefixForIpv6SourceNat: enablePrefixForIpv6SourceNatOn,
 						SubnetMappings: []elbv2model.SubnetMapping{
 							{
@@ -591,6 +593,7 @@ func Test_defaultLoadBalancerManager_updateSDKLoadBalancerWithSubnetMappings(t *
 				resLB: &elbv2model.LoadBalancer{
 					ResourceMeta: coremodel.NewResourceMeta(stack, "AWS::ElasticLoadBalancingV2::LoadBalancer", "id-1"),
 					Spec: elbv2model.LoadBalancerSpec{
+						Type: elbv2model.LoadBalancerTypeNetwork,
 						SubnetMappings: []elbv2model.SubnetMapping{
 							{
 								SubnetID: "subnet-A",


### PR DESCRIPTION

### Description
* The modify loadBalancer subnetMappings is being called on every update due to because `resLBEnablePrefixForIpv6SourceNatValue` is "" for [ALB](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/8ba34e27224d1f7a56f0e416086c43b6877c7e65/pkg/deploy/elbv2/load_balancer_manager.go#L179) ,  even though it should prevent the call when it is. 


### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
