### PR TITLE
Add `wafv2AclArn` field to IngressClassParams

### DIFF
--- a/apis/elbv2/v1beta1/ingressclassparams_types.go
+++ b/apis/elbv2/v1beta1/ingressclassparams_types.go
@@ -181,6 +181,10 @@ type IngressClassParamsSpec struct {
 	// PrefixListsIDs defines the security group prefix lists for all Ingresses that belong to IngressClass with this IngressClassParams.
 	// +optional
 	PrefixListsIDs []string `json:"prefixListsIDs,omitempty"`
+
+	// WAFv2ACLArn specifies ARN for the Amazon WAFv2 web ACL.
+	// +optional
+	WAFv2ACLArn string `json:"wafv2AclArn"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/elbv2.k8s.aws_ingressclassparams.yaml
+++ b/config/crd/bases/elbv2.k8s.aws_ingressclassparams.yaml
@@ -275,6 +275,9 @@ spec:
                 - instance
                 - ip
                 type: string
+              wafv2AclArn:
+                description: WAFv2ACLArn specifies ARN for the Amazon WAFv2 web ACL.
+                type: string
             type: object
             x-kubernetes-validations:
             - message: cannot specify both 'prefixListsIDs' and 'PrefixListsIDs' fields

--- a/docs/guide/ingress/ingress_class.md
+++ b/docs/guide/ingress/ingress_class.md
@@ -172,7 +172,7 @@ You can use IngressClassParams to enforce settings for a set of Ingresses.
     metadata:
       name: class2048-config
     spec:
-      ipamConfiguration: 
+      ipamConfiguration:
         ipv4IPAMPoolId: ipam-pool-000000000
     ```
     - with PrefixListsIDs (not recommended, use prefixListsIDs instead)
@@ -248,6 +248,7 @@ Cluster administrators can use the optional `inboundCIDRs` field to specify the 
 If the field is specified, LBC will ignore the `alb.ingress.kubernetes.io/inbound-cidrs` annotation.
 
 #### spec.certificateArn
+
 Cluster administrators can use the optional `certificateARN` field to specify the ARN of the certificates for all Ingresses that belong to IngressClass with this IngressClassParams.
 
 If the field is specified, LBC will ignore the `alb.ingress.kubernetes.io/certificate-arn` annotation.
@@ -332,7 +333,7 @@ Cluster administrators can use `ipamConfiguration` field to specify the IPv4 IPA
 
 #### spec.PrefixListsIDs
 
-We accept either `spec.prefixListsIDs` or `spec.PrefixListsIDs`. Specify both is not allowed. But `spec.PrefixListsIDs` is not recommended, use `spec.prefixListsIDs` instead. 
+We accept either `spec.prefixListsIDs` or `spec.PrefixListsIDs`. Specify both is not allowed. But `spec.PrefixListsIDs` is not recommended, use `spec.prefixListsIDs` instead.
 
 `PrefixListsIDs` is an optional setting.
 
@@ -340,7 +341,6 @@ Cluster administrators can use `PrefixListsIDs` field to specify the managed pre
 
 1. If `PrefixListsIDs` is set, the prefix lists defined will be applied to the load balancer that belong to this IngressClass. If you specify invalid prefix list IDs, the controller will fail to reconcile ingresses belonging to the particular ingress class.
 2. If `PrefixListsIDs` un-specified, Ingresses with this IngressClass can continue to use `alb.ingress.kubernetes.io/security-group-prefix-lists` annotation to specify the load balancer prefix lists.
-
 
 #### spec.prefixListsIDs
 
@@ -355,10 +355,16 @@ Cluster administrators can use `prefixListsIDs` field to specify the managed pre
 
 `listeners` is an optional setting.
 
-!!!note 
+!!!note
     Adding listeners in the classparam specification does not automatically create listeners on your load balancers. To create listeners, you must explicitly define the listen ports in your ingress configurations. The classparam `spec.listeners` are only used to set attributes for the listeners that you define in your ingresses.
 
 Cluster administrators can use `Listeners` field to specify the [Listener Attributes](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-listeners.html#listener-attributes) for multiple load balancer listeners associated with this IngressClass. For each listener entry in the list, the desired attributes and their values are specified in the `listenerAttributes` field. Each listener is uniquely identified by its `port` and `protocol` fields, which determine which listener the attributes should be applied to.
 
 1. If `listeners` is set, the defined attributes will be applied to the corresponding load balancer listeners based on port and protocol matching. Note that using invalid keys or values will cause the controller to fail when reconciling ingresses in this IngressClass.
 2. If `Listeners` un-specified, Ingresses with this IngressClass can continue to use `alb.ingress.kubernetes.io/listener-attributes.${Protocol}-{Port}` annotation to specify the listener attributes.
+
+#### spec.wafv2AclArn
+
+Cluster administrators can use the optional `wafv2AclArn` field to specify ARN for the Amazon WAFv2 web ACL.
+Only Regional WAFv2 is supported.
+When this annotation is absent or empty, the controller will keep LoadBalancer WAFv2 settings unchanged. To disable WAFv2, explicitly set the annotation value to 'none'.

--- a/helm/aws-load-balancer-controller/crds/crds.yaml
+++ b/helm/aws-load-balancer-controller/crds/crds.yaml
@@ -274,6 +274,9 @@ spec:
                 - instance
                 - ip
                 type: string
+              wafv2AclArn:
+                description: WAFv2ACLArn specifies ARN for the Amazon WAFv2 web ACL.
+                type: string
             type: object
             x-kubernetes-validations:
             - message: cannot specify both 'prefixListsIDs' and 'PrefixListsIDs' fields

--- a/pkg/ingress/model_build_load_balancer_addons.go
+++ b/pkg/ingress/model_build_load_balancer_addons.go
@@ -2,6 +2,7 @@ package ingress
 
 import (
 	"context"
+
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
@@ -38,6 +39,10 @@ func (t *defaultModelBuildTask) buildWAFv2WebACLAssociation(_ context.Context, l
 		_ = t.annotationParser.ParseStringAnnotation(annotations.IngressSuffixWAFv2ACLARN, &rawWebACLARN, member.Ing.Annotations)
 		if rawWebACLARN != "" {
 			explicitWebACLARNs.Insert(rawWebACLARN)
+		}
+		params := member.IngClassConfig.IngClassParams
+		if params != nil && params.Spec.WAFv2ACLArn != "" {
+			explicitWebACLARNs.Insert(params.Spec.WAFv2ACLArn)
 		}
 	}
 	if len(explicitWebACLARNs) == 0 {

--- a/pkg/ingress/model_builder_test.go
+++ b/pkg/ingress/model_builder_test.go
@@ -2753,6 +2753,109 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 }`,
 		},
 		{
+			name: "Ingress - wafv2AclArn in IngressClassParams",
+			env: env{
+				svcs: []*corev1.Service{ns_1_svc_1, ns_1_svc_2, ns_1_svc_3},
+			},
+			fields: fields{
+				resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
+				listLoadBalancersCalls:   []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
+				enableBackendSG:          true,
+			},
+			args: args{
+				ingGroup: Group{
+					ID: GroupID{Namespace: "ns-1", Name: "ing-1"},
+					Members: []ClassifiedIngress{
+						{
+							IngClassConfig: ClassConfiguration{
+								IngClassParams: &v1beta1.IngressClassParams{
+									Spec: v1beta1.IngressClassParamsSpec{
+										WAFv2ACLArn: "alb.ingress.kubernetes.io/wafv2-acl-arn: arn:aws:wafv2:us-west-2:xxxxx:regional/webacl/xxxxxxx/3ab78708-85b0-49d3-b4e1-7a9615a6613b",
+									},
+								},
+							},
+							Ing: &networking.Ingress{ObjectMeta: metav1.ObjectMeta{
+								Namespace: "ns-1",
+								Name:      "ing-1",
+							},
+								Spec: networking.IngressSpec{
+									Rules: []networking.IngressRule{
+										{
+											Host: "app-1.example.com",
+											IngressRuleValue: networking.IngressRuleValue{
+												HTTP: &networking.HTTPIngressRuleValue{
+													Paths: []networking.HTTPIngressPath{
+														{
+															Path: "/svc-1",
+															Backend: networking.IngressBackend{
+																Service: &networking.IngressServiceBackend{
+																	Name: ns_1_svc_1.Name,
+																	Port: networking.ServiceBackendPort{
+																		Name: "http",
+																	},
+																},
+															},
+														},
+														{
+															Path: "/svc-2",
+															Backend: networking.IngressBackend{
+																Service: &networking.IngressServiceBackend{
+																	Name: ns_1_svc_2.Name,
+																	Port: networking.ServiceBackendPort{
+																		Name: "http",
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+										{
+											Host: "app-2.example.com",
+											IngressRuleValue: networking.IngressRuleValue{
+												HTTP: &networking.HTTPIngressRuleValue{
+													Paths: []networking.HTTPIngressPath{
+														{
+															Path: "/svc-3",
+															Backend: networking.IngressBackend{
+																Service: &networking.IngressServiceBackend{
+																	Name: ns_1_svc_3.Name,
+																	Port: networking.ServiceBackendPort{
+																		Name: "https",
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantStackPatch: `
+{
+    "id":"ns-1/ing-1",
+    "resources":{
+		"AWS::WAFv2::WebACLAssociation":{
+			"LoadBalancer":{
+				"spec":{
+					"resourceARN":{
+						"$ref":"#/resources/AWS::ElasticLoadBalancingV2::LoadBalancer/LoadBalancer/status/loadBalancerARN"
+					},
+					"webACLARN":"alb.ingress.kubernetes.io/wafv2-acl-arn: arn:aws:wafv2:us-west-2:xxxxx:regional/webacl/xxxxxxx/3ab78708-85b0-49d3-b4e1-7a9615a6613b"
+				}
+			}
+		}
+    }
+}`,
+		},
+		{
 			name: "Ingress - not using subnet auto-discovery and internal",
 			env: env{
 				svcs: []*corev1.Service{ns_1_svc_1, ns_1_svc_2, ns_1_svc_3},


### PR DESCRIPTION
### Issue

part of #2311

### Description

 Add wafv2AclArn field to IngressClassParams.

- The field is optional.
- When the field is absent or empty, the controller behave as same as `wafv2-acl-arn` annotation.
- When different arns are set between params and annotations, the error occurs as same as when different arns are set between multiple annotations.

<!--
Please explain the changes you made here.

Help your reviewers by guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
