### PR TITLE
adding a customizable value for controller class

### DIFF
--- a/controllers/ingress/group_controller.go
+++ b/controllers/ingress/group_controller.go
@@ -52,7 +52,7 @@ func NewGroupReconciler(cloud aws.Cloud, k8sClient client.Client, eventRecorder 
 	annotationParser := annotations.NewSuffixAnnotationParser(annotations.AnnotationPrefixIngress)
 	authConfigBuilder := ingress.NewDefaultAuthConfigBuilder(annotationParser)
 	enhancedBackendBuilder := ingress.NewDefaultEnhancedBackendBuilder(k8sClient, annotationParser, authConfigBuilder, controllerConfig.IngressConfig.TolerateNonExistentBackendService, controllerConfig.IngressConfig.TolerateNonExistentBackendAction)
-	referenceIndexer := ingress.NewDefaultReferenceIndexer(enhancedBackendBuilder, authConfigBuilder, logger)
+	referenceIndexer := ingress.NewDefaultReferenceIndexer(enhancedBackendBuilder, authConfigBuilder, logger, controllerConfig.IngressConfig.ControllerClass)
 	trackingProvider := tracking.NewDefaultProvider(ingressTagPrefix, controllerConfig.ClusterName)
 	modelBuilder := ingress.NewDefaultModelBuilder(k8sClient, eventRecorder,
 		cloud.EC2(), cloud.ELBV2(), cloud.ACM(),
@@ -64,10 +64,10 @@ func NewGroupReconciler(cloud aws.Cloud, k8sClient client.Client, eventRecorder 
 	stackMarshaller := deploy.NewDefaultStackMarshaller()
 	stackDeployer := deploy.NewDefaultStackDeployer(cloud, k8sClient, networkingSGManager, networkingSGReconciler, elbv2TaggingManager,
 		controllerConfig, ingressTagPrefix, logger)
-	classLoader := ingress.NewDefaultClassLoader(k8sClient, true)
+	classLoader := ingress.NewDefaultClassLoader(k8sClient, true, controllerConfig.IngressConfig.ControllerClass)
 	classAnnotationMatcher := ingress.NewDefaultClassAnnotationMatcher(controllerConfig.IngressConfig.IngressClass)
 	manageIngressesWithoutIngressClass := controllerConfig.IngressConfig.IngressClass == ""
-	groupLoader := ingress.NewDefaultGroupLoader(k8sClient, eventRecorder, annotationParser, classLoader, classAnnotationMatcher, manageIngressesWithoutIngressClass)
+	groupLoader := ingress.NewDefaultGroupLoader(k8sClient, eventRecorder, annotationParser, classLoader, classAnnotationMatcher, manageIngressesWithoutIngressClass, controllerConfig.IngressConfig.ControllerClass)
 	groupFinalizerManager := ingress.NewDefaultFinalizerManager(finalizerManager)
 
 	return &groupReconciler{

--- a/pkg/config/ingress_config.go
+++ b/pkg/config/ingress_config.go
@@ -10,12 +10,14 @@ const (
 	flagTolerateNonExistentBackendService    = "tolerate-non-existent-backend-service"
 	flagTolerateNonExistentBackendAction     = "tolerate-non-existent-backend-action"
 	flagAllowedCAArns                        = "allowed-certificate-authority-arns"
+	flagControllerClass                      = "controller-class"
 	defaultIngressClass                      = "alb"
 	defaultDisableIngressClassAnnotation     = false
 	defaultDisableIngressGroupNameAnnotation = false
 	defaultMaxIngressConcurrentReconciles    = 3
 	defaultTolerateNonExistentBackendService = true
 	defaultTolerateNonExistentBackendAction  = true
+	defaultControllerClass                   = "ingress.k8s.aws/alb"
 )
 
 // IngressConfig contains the configurations for the Ingress controller
@@ -46,6 +48,9 @@ type IngressConfig struct {
 
 	// AllowedCertificateAuthoritiyARNs contains a list of all CAs to consider when discovering certificates for ingress resources
 	AllowedCertificateAuthorityARNs []string
+
+	// ControllerClass is the class for the ingress controller
+	ControllerClass string
 }
 
 // BindFlags binds the command line flags to the fields in the config object
@@ -63,4 +68,5 @@ func (cfg *IngressConfig) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&cfg.TolerateNonExistentBackendAction, flagTolerateNonExistentBackendAction, defaultTolerateNonExistentBackendAction,
 		"Tolerate rules that specify a non-existent backend action")
 	fs.StringSliceVar(&cfg.AllowedCertificateAuthorityARNs, flagAllowedCAArns, []string{}, "Specify an optional list of CA ARNs to filter on in cert discovery")
+	fs.StringVar(&cfg.ControllerClass, flagControllerClass, defaultControllerClass, "ControllerClass is the class for the ingress controller, the default value is \"ingress.k8s.aws/alb\".")
 }

--- a/pkg/ingress/class_loader.go
+++ b/pkg/ingress/class_loader.go
@@ -18,7 +18,6 @@ import (
 
 const (
 	// the controller name used in IngressClass for ALB.
-	IngressClassControllerALB = "ingress.k8s.aws/alb"
 	// the Kind for IngressClassParams CRD.
 	ingressClassParamsKind = "IngressClassParams"
 	// default class from ingressClass
@@ -35,17 +34,19 @@ type ClassLoader interface {
 }
 
 // NewDefaultClassLoader constructs new defaultClassLoader instance.
-func NewDefaultClassLoader(client client.Client, loadParams bool) ClassLoader {
+func NewDefaultClassLoader(client client.Client, loadParams bool, controllerClass string) ClassLoader {
 	return &defaultClassLoader{
-		client:     client,
-		loadParams: loadParams,
+		client:          client,
+		loadParams:      loadParams,
+		controllerClass: controllerClass,
 	}
 }
 
 // default implementation for ClassLoader
 type defaultClassLoader struct {
-	client     client.Client
-	loadParams bool
+	client          client.Client
+	loadParams      bool
+	controllerClass string
 }
 
 // GetDefaultIngressClass returns the default IngressClass from the list of IngressClasses.
@@ -93,7 +94,7 @@ func (l *defaultClassLoader) Load(ctx context.Context, ing *networking.Ingress) 
 		}
 		return ClassConfiguration{}, err
 	}
-	if ingClass.Spec.Controller != IngressClassControllerALB || ingClass.Spec.Parameters == nil || !l.loadParams {
+	if ingClass.Spec.Controller != l.controllerClass || ingClass.Spec.Parameters == nil || !l.loadParams {
 		return ClassConfiguration{
 			IngClass: ingClass,
 		}, nil

--- a/pkg/ingress/class_loader.go
+++ b/pkg/ingress/class_loader.go
@@ -17,7 +17,6 @@ import (
 )
 
 const (
-	// the controller name used in IngressClass for ALB.
 	// the Kind for IngressClassParams CRD.
 	ingressClassParamsKind = "IngressClassParams"
 	// default class from ingressClass

--- a/pkg/ingress/group_loader.go
+++ b/pkg/ingress/group_loader.go
@@ -45,7 +45,7 @@ type GroupLoader interface {
 }
 
 // NewDefaultGroupLoader constructs new GroupLoader instance.
-func NewDefaultGroupLoader(client client.Client, eventRecorder record.EventRecorder, annotationParser annotations.Parser, classLoader ClassLoader, classAnnotationMatcher ClassAnnotationMatcher, manageIngressesWithoutIngressClass bool) *defaultGroupLoader {
+func NewDefaultGroupLoader(client client.Client, eventRecorder record.EventRecorder, annotationParser annotations.Parser, classLoader ClassLoader, classAnnotationMatcher ClassAnnotationMatcher, manageIngressesWithoutIngressClass bool, controllerClass string) *defaultGroupLoader {
 	return &defaultGroupLoader{
 		client:           client,
 		eventRecorder:    eventRecorder,
@@ -54,6 +54,7 @@ func NewDefaultGroupLoader(client client.Client, eventRecorder record.EventRecor
 		classLoader:                        classLoader,
 		classAnnotationMatcher:             classAnnotationMatcher,
 		manageIngressesWithoutIngressClass: manageIngressesWithoutIngressClass,
+		controllerClass:                    controllerClass,
 	}
 }
 
@@ -74,6 +75,7 @@ type defaultGroupLoader struct {
 	// manageIngressesWithoutIngressClass specifies whether ingresses without "kubernetes.io/ingress.class" annotation
 	// and "spec.ingressClassName" should be managed or not.
 	manageIngressesWithoutIngressClass bool
+	controllerClass                    string
 }
 
 func (m *defaultGroupLoader) Load(ctx context.Context, groupID GroupID) (Group, error) {
@@ -219,7 +221,7 @@ func (m *defaultGroupLoader) classifyIngress(ctx context.Context, ing *networkin
 		return ClassifiedIngress{
 			Ing:            ing,
 			IngClassConfig: ingClassConfig,
-		}, ingClassConfig.IngClass.Spec.Controller == IngressClassControllerALB, nil
+		}, ingClassConfig.IngClass.Spec.Controller == m.controllerClass, nil
 	}
 
 	return ClassifiedIngress{

--- a/pkg/ingress/reference_indexer.go
+++ b/pkg/ingress/reference_indexer.go
@@ -35,11 +35,12 @@ type ReferenceIndexer interface {
 }
 
 // NewDefaultReferenceIndexer constructs new defaultReferenceIndexer.
-func NewDefaultReferenceIndexer(enhancedBackendBuilder EnhancedBackendBuilder, authConfigBuilder AuthConfigBuilder, logger logr.Logger) *defaultReferenceIndexer {
+func NewDefaultReferenceIndexer(enhancedBackendBuilder EnhancedBackendBuilder, authConfigBuilder AuthConfigBuilder, logger logr.Logger, controllerClass string) *defaultReferenceIndexer {
 	return &defaultReferenceIndexer{
 		enhancedBackendBuilder: enhancedBackendBuilder,
 		authConfigBuilder:      authConfigBuilder,
 		logger:                 logger,
+		controllerClass:        controllerClass,
 	}
 }
 
@@ -50,6 +51,7 @@ type defaultReferenceIndexer struct {
 	enhancedBackendBuilder EnhancedBackendBuilder
 	authConfigBuilder      AuthConfigBuilder
 	logger                 logr.Logger
+	controllerClass        string
 }
 
 func (i *defaultReferenceIndexer) BuildServiceRefIndexes(ctx context.Context, ing *networking.Ingress) []string {
@@ -103,7 +105,7 @@ func (i *defaultReferenceIndexer) BuildIngressClassRefIndexes(_ context.Context,
 }
 
 func (i *defaultReferenceIndexer) BuildIngressClassParamsRefIndexes(_ context.Context, ingClass *networking.IngressClass) []string {
-	if ingClass.Spec.Controller != IngressClassControllerALB || ingClass.Spec.Parameters == nil {
+	if ingClass.Spec.Controller != i.controllerClass || ingClass.Spec.Parameters == nil {
 		return nil
 	}
 	if ingClass.Spec.Parameters.APIGroup == nil ||


### PR DESCRIPTION
### Issue

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/3946
https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/3634

### Description
This PR introduces support for setting a customizable value for the controller class in the AWS Load Balancer Controller.

Key Changes

- Added a new configuration option to allow users to specify a custom value for the controller class.
- Updated the controller logic to use the provided value if specified; defaults remain intact for backward compatibility, the default value will remain the same as the previously hardcoded value (`ingress.k8s.aws/alb`).
- Adjusted the documentation to include instructions on how to configure the custom controller class.

Benefits

- Provides greater flexibility for users managing multiple controllers within the same cluster.
- Enhances compatibility with diverse use cases where unique controller class names are necessary.

<!--
Please explain the changes you made here.

Help your reviewers by guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
