### PR TITLE
fix failing test

### DIFF
--- a/pkg/service/model_builder_test.go
+++ b/pkg/service/model_builder_test.go
@@ -6501,6 +6501,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
              "type":"network",
              "scheme":"internet-facing",
              "securityGroupsInboundRulesOnPrivateLink":"on",
+             "enablePrefixForIpv6SourceNat": "off",
              "ipAddressType":"ipv4",
              "subnetMapping":[
                 {


### PR DESCRIPTION
The main branch is failing because of this unit test missing `enablePrefixForIpv6SourceNat`.