### PR TITLE
docs: added annotation behaviour note

### DIFF
--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -174,6 +174,10 @@ Traffic Routing can be controlled with following annotations:
 
         - Once defined on a single Ingress, it impacts every Ingress within the IngressGroup.
 
+    !!!note "Annotation Behavior"
+    
+        - This annotation **takes effect only during the creation** of the Ingress. If the Ingress already exists, the change will not be applied until the Ingress is **deleted and recreated**.
+        
     !!!example
         ```
         alb.ingress.kubernetes.io/load-balancer-name: custom-name


### PR DESCRIPTION
### Issue
<!-- No specific GitHub issue related to this PR, but it addresses the behavior of the `alb.ingress.kubernetes.io/load-balancer-name` annotation. -->

### Description
This PR updates the documentation in the `annotations.md` regarding the behavior of the `alb.ingress.kubernetes.io/load-balancer-name` annotation.

- The documentation now clarifies that the `alb.ingress.kubernetes.io/load-balancer-name` annotation **only takes effect when the Ingress is created**.
- If the Ingress resource already exists, the annotation change will **not be applied** unless the Ingress is **deleted and recreated**.

This update is important to avoid confusion and ensure that users understand how the annotation behaves in different lifecycle stages of the Ingress.

### Checklist
- [ ] Added tests that cover your change (if possible) *(N/A for documentation change)*
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
<img width="711" alt="Screenshot 2025-01-08 at 12 54 16 PM" src="https://github.com/user-attachments/assets/76af838b-603a-4fe0-beb1-00a27d48deb3" />

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in the same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
