### PR TITLE
Checking for taint `karpenter.sh/disrupted:NoSchedule` while checking if node is suitable to handle traffic.

### DIFF
--- a/pkg/backend/endpoint_utils_test.go
+++ b/pkg/backend/endpoint_utils_test.go
@@ -131,6 +131,31 @@ func TestIsNodeSuitableAsTrafficProxy(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "node is ready but tainted with karpenter.sh/disrupted",
+			args: args{
+				node: &corev1.Node{
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+					Spec: corev1.NodeSpec{
+						Unschedulable: false,
+						Taints: []corev1.Taint{
+							{
+								Key:    toBeDeletedByKarpenterTaint,
+								Effect: corev1.TaintEffectNoSchedule,
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### Issue

#4023

### Description

Checking if the current node is tainted with Karpenter and avoid marking that node as healthy so that it could be removed from load balancer target groups.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:
