### PR TITLE
Follow up for 3691 [TargetGroupBindings can now manipulate target groups from different aws accounts]

### DIFF
--- a/apis/elbv2/v1alpha1/targetgroupbinding_types.go
+++ b/apis/elbv2/v1alpha1/targetgroupbinding_types.go
@@ -128,6 +128,14 @@ type TargetGroupBindingSpec struct {
 	// networking provides the networking setup for ELBV2 LoadBalancer to access targets in TargetGroup.
 	// +optional
 	Networking *TargetGroupBindingNetworking `json:"networking,omitempty"`
+
+	// IAM Role ARN to assume when calling AWS APIs. Useful if the target group is in a different AWS account
+	// +optional
+	IamRoleArnToAssume string `json:"iamRoleArnToAssume,omitempty"`
+
+	// IAM Role ARN to assume when calling AWS APIs. Needed to assume a role in another account and prevent the confused deputy problem. https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html
+	// +optional
+	AssumeRoleExternalId string `json:"assumeRoleExternalId,omitempty"`
 }
 
 // TargetGroupBindingStatus defines the observed state of TargetGroupBinding

--- a/apis/elbv2/v1beta1/targetgroupbinding_types.go
+++ b/apis/elbv2/v1beta1/targetgroupbinding_types.go
@@ -160,11 +160,11 @@ type TargetGroupBindingSpec struct {
 
 	// IAM Role ARN to assume when calling AWS APIs. Useful if the target group is in a different AWS account
 	// +optional
-	IamRoleArnToAssume string `json:"-"` // `json:"iamRoleArnToAssume,omitempty"`
+	IamRoleArnToAssume string `json:"iamRoleArnToAssume,omitempty"`
 
 	// IAM Role ARN to assume when calling AWS APIs. Needed to assume a role in another account and prevent the confused deputy problem. https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html
 	// +optional
-	AssumeRoleExternalId string `json:"-"` // `json:"assumeRoleExternalId,omitempty"`
+	AssumeRoleExternalId string `json:"assumeRoleExternalId,omitempty"`
 }
 
 // TargetGroupBindingStatus defines the observed state of TargetGroupBinding

--- a/config/crd/bases/elbv2.k8s.aws_targetgroupbindings.yaml
+++ b/config/crd/bases/elbv2.k8s.aws_targetgroupbindings.yaml
@@ -65,6 +65,15 @@ spec:
           spec:
             description: TargetGroupBindingSpec defines the desired state of TargetGroupBinding
             properties:
+              assumeRoleExternalId:
+                description: IAM Role ARN to assume when calling AWS APIs. Needed
+                  to assume a role in another account and prevent the confused deputy
+                  problem. https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html
+                type: string
+              iamRoleArnToAssume:
+                description: IAM Role ARN to assume when calling AWS APIs. Useful
+                  if the target group is in a different AWS account
+                type: string
               multiClusterTargetGroup:
                 description: MultiClusterTargetGroup Denotes if the TargetGroup is
                   shared among multiple clusters
@@ -242,6 +251,15 @@ spec:
           spec:
             description: TargetGroupBindingSpec defines the desired state of TargetGroupBinding
             properties:
+              assumeRoleExternalId:
+                description: IAM Role ARN to assume when calling AWS APIs. Needed
+                  to assume a role in another account and prevent the confused deputy
+                  problem. https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html
+                type: string
+              iamRoleArnToAssume:
+                description: IAM Role ARN to assume when calling AWS APIs. Useful
+                  if the target group is in a different AWS account
+                type: string
               ipAddressType:
                 description: ipAddressType specifies whether the target group is of
                   type IPv4 or IPv6. If unspecified, it will be automatically inferred.

--- a/docs/guide/targetgroupbinding/spec.md
+++ b/docs/guide/targetgroupbinding/spec.md
@@ -55,15 +55,6 @@ Kubernetes meta/v1.ObjectMeta
 <table>
 <tr><td><code>annotations</code></td><td>
 
-<table>
-<tr><td><code>alb.ingress.kubernetes.io/IamRoleArnToAssume</code><br><i>string</i></td>
-<td><i>(Optional)</i> In case the target group is in a differet AWS account, you put here the role that needs to be assumed in order to manipulate the target group.
-</td></tr>
-<tr><td><code>alb.ingress.kubernetes.io/AssumeRoleExternalId</code><br><i>string</i></td>
-<td><i>(Optional)</i> The external ID for the assume role operation. Optional, but recommended. It helps you to prevent the <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html" target="_blank">confused deputy problem</a>.
-</td></tr>
-</table>
-
 <tr><td colspan=2>
 Refer to the Kubernetes API documentation for the other fields of the
 <code>metadata</code> field.

--- a/docs/guide/targetgroupbinding/targetgroupbinding.md
+++ b/docs/guide/targetgroupbinding/targetgroupbinding.md
@@ -112,10 +112,10 @@ spec:
 ### AssumeRole
 
 Sometimes the AWS LoadBalancer controller needs to manipulate target groups from different AWS accounts.
-The way to do that is assuming a role from such account. There are annotations that can help you with that:
+The way to do that is assuming a role from such account. The following spec fields help you with that.
 
-* `alb.ingress.kubernetes.io/IamRoleArnToAssume`: the ARN that you need to assume
-* `alb.ingress.kubernetes.io/AssumeRoleExternalId`: the external ID for the assume role operation. Optional, but recommended. It helps you to prevent the confused deputy problem ( https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html )
+* `iamRoleArnToAssume`: the ARN that you need to assume
+* `assumeRoleExternalId`: the external ID for the assume role operation. Optional, but recommended. It helps you to prevent the confused deputy problem ( https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html )
 
 
 ## Sample YAML
@@ -125,10 +125,9 @@ apiVersion: elbv2.k8s.aws/v1beta1
 kind: TargetGroupBinding
 metadata:
   name: my-tgb
-  annotations:
-    alb.ingress.kubernetes.io/IamRoleArnToAssume: "arn:aws:iam::999999999999:role/alb-controller-policy-to-assume"
-    alb.ingress.kubernetes.io/AssumeRoleExternalId: "some-magic-string"
 spec:
+  iamRoleArnToAssume: "arn:aws:iam::999999999999:role/alb-controller-policy-to-assume"
+  assumeRoleExternalId: "some-magic-string"
   ...
 ```
 

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,7 @@ github.com/aws/aws-sdk-go-v2/service/ec2 v1.173.0 h1:ta62lid9JkIpKZtZZXSj6rP2AqY
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.173.0/go.mod h1:o6QDjdVKpP5EF0dp/VlvqckzuSDATr1rLdHt3A5m0YY=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.43.1 h1:L9Wt9zgtoYKIlaeFTy+EztGjL4oaXBBGtVXA+jaeYko=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.43.1/go.mod h1:yxzLdxt7bVGvIOPYIKFtiaJCJnx2ChlIIvlhW4QgI6M=
+github.com/aws/aws-sdk-go-v2/service/iam v1.36.3/go.mod h1:HSvujsK8xeEHMIB18oMXjSfqaN9cVqpo/MtHJIksQRk=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.11.3 h1:dT3MqvGhSoaIhRseqw2I0yH81l7wiR2vjs57O51EAm8=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.11.3/go.mod h1:GlAeCkHwugxdHaueRr4nhPuY+WW+gR8UjlcqzPr1SPI=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.17 h1:HGErhhrxZlQ044RiM+WdoZxp0p+EGM62y3L6pwA4olE=

--- a/helm/aws-load-balancer-controller/crds/crds.yaml
+++ b/helm/aws-load-balancer-controller/crds/crds.yaml
@@ -317,6 +317,15 @@ spec:
           spec:
             description: TargetGroupBindingSpec defines the desired state of TargetGroupBinding
             properties:
+              assumeRoleExternalId:
+                description: IAM Role ARN to assume when calling AWS APIs. Needed
+                  to assume a role in another account and prevent the confused deputy
+                  problem. https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html
+                type: string
+              iamRoleArnToAssume:
+                description: IAM Role ARN to assume when calling AWS APIs. Useful
+                  if the target group is in a different AWS account
+                type: string
               multiClusterTargetGroup:
                 description: MultiClusterTargetGroup Denotes if the TargetGroup is
                   shared among multiple clusters
@@ -494,6 +503,15 @@ spec:
           spec:
             description: TargetGroupBindingSpec defines the desired state of TargetGroupBinding
             properties:
+              assumeRoleExternalId:
+                description: IAM Role ARN to assume when calling AWS APIs. Needed
+                  to assume a role in another account and prevent the confused deputy
+                  problem. https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html
+                type: string
+              iamRoleArnToAssume:
+                description: IAM Role ARN to assume when calling AWS APIs. Useful
+                  if the target group is in a different AWS account
+                type: string
               ipAddressType:
                 description: ipAddressType specifies whether the target group is of
                   type IPv4 or IPv6. If unspecified, it will be automatically inferred.

--- a/main.go
+++ b/main.go
@@ -90,7 +90,7 @@ func main() {
 		awsMetricsCollector = awsmetrics.NewCollector(metrics.Registry)
 	}
 
-	cloud, err := aws.NewCloud(controllerCFG.AWSConfig, awsMetricsCollector, ctrl.Log, nil)
+	cloud, err := aws.NewCloud(controllerCFG.AWSConfig, controllerCFG.ClusterName, awsMetricsCollector, ctrl.Log, nil)
 	if err != nil {
 		setupLog.Error(err, "unable to initialize AWS cloud")
 		os.Exit(1)

--- a/pkg/aws/aws_config.go
+++ b/pkg/aws/aws_config.go
@@ -1,0 +1,81 @@
+package aws
+
+import (
+	"context"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsmiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
+	"github.com/aws/aws-sdk-go-v2/aws/ratelimit"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
+	smithymiddleware "github.com/aws/smithy-go/middleware"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/throttle"
+	awsmetrics "sigs.k8s.io/aws-load-balancer-controller/pkg/metrics/aws"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/version"
+)
+
+const (
+	userAgent = "elbv2.k8s.aws"
+)
+
+func NewAWSConfigGenerator(cfg CloudConfig, ec2IMDSEndpointMode imds.EndpointModeState, metricsCollector *awsmetrics.Collector) AWSConfigGenerator {
+	return &awsConfigGeneratorImpl{
+		cfg:                 cfg,
+		ec2IMDSEndpointMode: ec2IMDSEndpointMode,
+		metricsCollector:    metricsCollector,
+	}
+
+}
+
+// AWSConfigGenerator is responsible for generating an aws config based on the running environment
+type AWSConfigGenerator interface {
+	GenerateAWSConfig(optFns ...func(*config.LoadOptions) error) (aws.Config, error)
+}
+
+type awsConfigGeneratorImpl struct {
+	cfg                 CloudConfig
+	ec2IMDSEndpointMode imds.EndpointModeState
+	metricsCollector    *awsmetrics.Collector
+}
+
+func (gen *awsConfigGeneratorImpl) GenerateAWSConfig(optFns ...func(*config.LoadOptions) error) (aws.Config, error) {
+
+	defaultOpts := []func(*config.LoadOptions) error{
+		config.WithRegion(gen.cfg.Region),
+		config.WithRetryer(func() aws.Retryer {
+			return retry.NewStandard(func(o *retry.StandardOptions) {
+				o.RateLimiter = ratelimit.None
+				o.MaxAttempts = gen.cfg.MaxRetries
+			})
+		}),
+		config.WithEC2IMDSEndpointMode(gen.ec2IMDSEndpointMode),
+		config.WithAPIOptions([]func(stack *smithymiddleware.Stack) error{
+			awsmiddleware.AddUserAgentKeyValue(userAgent, version.GitVersion),
+		}),
+	}
+
+	defaultOpts = append(defaultOpts, optFns...)
+
+	awsConfig, err := config.LoadDefaultConfig(context.TODO(),
+		defaultOpts...,
+	)
+
+	if err != nil {
+		return aws.Config{}, err
+	}
+
+	if gen.cfg.ThrottleConfig != nil {
+		throttler := throttle.NewThrottler(gen.cfg.ThrottleConfig)
+		awsConfig.APIOptions = append(awsConfig.APIOptions, func(stack *smithymiddleware.Stack) error {
+			return throttle.WithSDKRequestThrottleMiddleware(throttler)(stack)
+		})
+	}
+
+	if gen.metricsCollector != nil {
+		awsConfig.APIOptions = awsmetrics.WithSDKMetricCollector(gen.metricsCollector, awsConfig.APIOptions)
+	}
+
+	return awsConfig, nil
+}
+
+var _ AWSConfigGenerator = &awsConfigGeneratorImpl{}

--- a/pkg/aws/cloud_util.go
+++ b/pkg/aws/cloud_util.go
@@ -1,0 +1,25 @@
+package aws
+
+import (
+	"fmt"
+	"regexp"
+)
+
+const (
+	sessionNamePrefix    = "AWS-LBC-"
+	maxSessionNameLength = 2047
+)
+
+var illegalValuesInSessionName = regexp.MustCompile(`[^a-zA-Z0-9=,.@\-_]+`)
+
+func generateAssumeRoleSessionName(clusterName string) string {
+	safeClusterName := illegalValuesInSessionName.ReplaceAllString(clusterName, "")
+
+	sessionName := fmt.Sprintf("%s%s", sessionNamePrefix, safeClusterName)
+
+	if len(sessionName) > maxSessionNameLength {
+		return sessionName[:maxSessionNameLength]
+	}
+
+	return sessionName
+}

--- a/pkg/aws/cloud_util_test.go
+++ b/pkg/aws/cloud_util_test.go
@@ -1,0 +1,42 @@
+package aws
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestUpdateTrackedTargets(t *testing.T) {
+	testCases := []struct {
+		name                string
+		clusterName         string
+		expectedSessionName string
+	}{
+		{
+			name:                "no mods",
+			clusterName:         "my-cluster-name",
+			expectedSessionName: "AWS-LBC-my-cluster-name",
+		},
+		{
+			name:                "mix lower and upper case",
+			clusterName:         "My-ClUsTeR-name",
+			expectedSessionName: "AWS-LBC-My-ClUsTeR-name",
+		},
+		{
+			name:                "with legal characters",
+			clusterName:         "my_cluster-name=foo,something@here.",
+			expectedSessionName: "AWS-LBC-my_cluster-name=foo,something@here.",
+		},
+		{
+			name:                "with illegal characters",
+			clusterName:         "my&*&*cluster()!(&name",
+			expectedSessionName: "AWS-LBC-myclustername",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := generateAssumeRoleSessionName(tc.clusterName)
+			assert.Equal(t, tc.expectedSessionName, result)
+		})
+	}
+}

--- a/pkg/aws/provider/provider.go
+++ b/pkg/aws/provider/provider.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
 	"github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi"
 	"github.com/aws/aws-sdk-go-v2/service/shield"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/aws/aws-sdk-go-v2/service/wafregional"
 	"github.com/aws/aws-sdk-go-v2/service/wafv2"
 )
@@ -20,6 +21,6 @@ type AWSClientsProvider interface {
 	GetWAFRegionClient(ctx context.Context, operationName string) (*wafregional.Client, error)
 	GetShieldClient(ctx context.Context, operationName string) (*shield.Client, error)
 	GetRGTClient(ctx context.Context, operationName string) (*resourcegroupstaggingapi.Client, error)
-
-	GetAWSConfig(ctx context.Context, operationName string) (*aws.Config, error)
+	GetSTSClient(ctx context.Context, operationName string) (*sts.Client, error)
+	GenerateNewELBv2Client(cfg aws.Config) *elasticloadbalancingv2.Client
 }

--- a/pkg/aws/services/cloudInterface.go
+++ b/pkg/aws/services/cloudInterface.go
@@ -30,5 +30,5 @@ type Cloud interface {
 	// VpcID for the LoadBalancer resources.
 	VpcID() string
 
-	GetAssumedRoleELBV2(ctx context.Context, assumeRoleArn string, externalId string) ELBV2
+	GetAssumedRoleELBV2(ctx context.Context, assumeRoleArn string, externalId string) (ELBV2, error)
 }

--- a/pkg/aws/services/elbv2.go
+++ b/pkg/aws/services/elbv2.go
@@ -70,9 +70,17 @@ func NewELBV2(awsClientsProvider provider.AWSClientsProvider, cloud Cloud) ELBV2
 	}
 }
 
+func NewELBV2FromStaticClient(staticELBClient *elasticloadbalancingv2.Client, cloud Cloud) ELBV2 {
+	return &elbv2Client{
+		staticELBClient: staticELBClient,
+		cloud:           cloud,
+	}
+}
+
 // default implementation for ELBV2.
 type elbv2Client struct {
 	awsClientsProvider provider.AWSClientsProvider
+	staticELBClient    *elasticloadbalancingv2.Client
 	cloud              Cloud
 }
 
@@ -84,7 +92,7 @@ func (c *elbv2Client) AssumeRole(ctx context.Context, assumeRoleArn string, exte
 }
 
 func (c *elbv2Client) AddListenerCertificatesWithContext(ctx context.Context, input *elasticloadbalancingv2.AddListenerCertificatesInput) (*elasticloadbalancingv2.AddListenerCertificatesOutput, error) {
-	client, err := c.awsClientsProvider.GetELBv2Client(ctx, "AddListenerCertificates")
+	client, err := c.getClient(ctx, "AddListenerCertificates")
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +100,7 @@ func (c *elbv2Client) AddListenerCertificatesWithContext(ctx context.Context, in
 }
 
 func (c *elbv2Client) RemoveListenerCertificatesWithContext(ctx context.Context, input *elasticloadbalancingv2.RemoveListenerCertificatesInput) (*elasticloadbalancingv2.RemoveListenerCertificatesOutput, error) {
-	client, err := c.awsClientsProvider.GetELBv2Client(ctx, "RemoveListenerCertificates")
+	client, err := c.getClient(ctx, "RemoveListenerCertificates")
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +108,7 @@ func (c *elbv2Client) RemoveListenerCertificatesWithContext(ctx context.Context,
 }
 
 func (c *elbv2Client) DescribeListenersWithContext(ctx context.Context, input *elasticloadbalancingv2.DescribeListenersInput) (*elasticloadbalancingv2.DescribeListenersOutput, error) {
-	client, err := c.awsClientsProvider.GetELBv2Client(ctx, "DescribeListeners")
+	client, err := c.getClient(ctx, "DescribeListeners")
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +116,7 @@ func (c *elbv2Client) DescribeListenersWithContext(ctx context.Context, input *e
 }
 
 func (c *elbv2Client) DescribeRulesWithContext(ctx context.Context, input *elasticloadbalancingv2.DescribeRulesInput) (*elasticloadbalancingv2.DescribeRulesOutput, error) {
-	client, err := c.awsClientsProvider.GetELBv2Client(ctx, "DescribeRules")
+	client, err := c.getClient(ctx, "DescribeRules")
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +124,7 @@ func (c *elbv2Client) DescribeRulesWithContext(ctx context.Context, input *elast
 }
 
 func (c *elbv2Client) RegisterTargetsWithContext(ctx context.Context, input *elasticloadbalancingv2.RegisterTargetsInput) (*elasticloadbalancingv2.RegisterTargetsOutput, error) {
-	client, err := c.awsClientsProvider.GetELBv2Client(ctx, "RegisterTargets")
+	client, err := c.getClient(ctx, "RegisterTargets")
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +132,7 @@ func (c *elbv2Client) RegisterTargetsWithContext(ctx context.Context, input *ela
 }
 
 func (c *elbv2Client) DeregisterTargetsWithContext(ctx context.Context, input *elasticloadbalancingv2.DeregisterTargetsInput) (*elasticloadbalancingv2.DeregisterTargetsOutput, error) {
-	client, err := c.awsClientsProvider.GetELBv2Client(ctx, "DeregisterTargets")
+	client, err := c.getClient(ctx, "DeregisterTargets")
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +140,7 @@ func (c *elbv2Client) DeregisterTargetsWithContext(ctx context.Context, input *e
 }
 
 func (c *elbv2Client) DescribeTrustStoresWithContext(ctx context.Context, input *elasticloadbalancingv2.DescribeTrustStoresInput) (*elasticloadbalancingv2.DescribeTrustStoresOutput, error) {
-	client, err := c.awsClientsProvider.GetELBv2Client(ctx, "DescribeTrustStores")
+	client, err := c.getClient(ctx, "DescribeTrustStores")
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +148,7 @@ func (c *elbv2Client) DescribeTrustStoresWithContext(ctx context.Context, input 
 }
 
 func (c *elbv2Client) ModifyRuleWithContext(ctx context.Context, input *elasticloadbalancingv2.ModifyRuleInput) (*elasticloadbalancingv2.ModifyRuleOutput, error) {
-	client, err := c.awsClientsProvider.GetELBv2Client(ctx, "ModifyRule")
+	client, err := c.getClient(ctx, "ModifyRule")
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +156,7 @@ func (c *elbv2Client) ModifyRuleWithContext(ctx context.Context, input *elasticl
 }
 
 func (c *elbv2Client) DeleteRuleWithContext(ctx context.Context, input *elasticloadbalancingv2.DeleteRuleInput) (*elasticloadbalancingv2.DeleteRuleOutput, error) {
-	client, err := c.awsClientsProvider.GetELBv2Client(ctx, "DeleteRule")
+	client, err := c.getClient(ctx, "DeleteRule")
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +164,7 @@ func (c *elbv2Client) DeleteRuleWithContext(ctx context.Context, input *elasticl
 }
 
 func (c *elbv2Client) CreateRuleWithContext(ctx context.Context, input *elasticloadbalancingv2.CreateRuleInput) (*elasticloadbalancingv2.CreateRuleOutput, error) {
-	client, err := c.awsClientsProvider.GetELBv2Client(ctx, "CreateRule")
+	client, err := c.getClient(ctx, "CreateRule")
 	if err != nil {
 		return nil, err
 	}
@@ -164,7 +172,7 @@ func (c *elbv2Client) CreateRuleWithContext(ctx context.Context, input *elasticl
 }
 
 func (c *elbv2Client) WaitUntilLoadBalancerAvailableWithContext(ctx context.Context, input *elasticloadbalancingv2.DescribeLoadBalancersInput) error {
-	client, err := c.awsClientsProvider.GetELBv2Client(ctx, "DescribeLoadBalancers")
+	client, err := c.getClient(ctx, "DescribeLoadBalancers")
 	if err != nil {
 		return err
 	}
@@ -174,7 +182,7 @@ func (c *elbv2Client) WaitUntilLoadBalancerAvailableWithContext(ctx context.Cont
 }
 
 func (c *elbv2Client) DescribeLoadBalancersWithContext(ctx context.Context, input *elasticloadbalancingv2.DescribeLoadBalancersInput) (*elasticloadbalancingv2.DescribeLoadBalancersOutput, error) {
-	client, err := c.awsClientsProvider.GetELBv2Client(ctx, "DescribeLoadBalancers")
+	client, err := c.getClient(ctx, "DescribeLoadBalancers")
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +190,7 @@ func (c *elbv2Client) DescribeLoadBalancersWithContext(ctx context.Context, inpu
 }
 
 func (c *elbv2Client) DescribeTargetHealthWithContext(ctx context.Context, input *elasticloadbalancingv2.DescribeTargetHealthInput) (*elasticloadbalancingv2.DescribeTargetHealthOutput, error) {
-	client, err := c.awsClientsProvider.GetELBv2Client(ctx, "DescribeTargetHealth")
+	client, err := c.getClient(ctx, "DescribeTargetHealth")
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +198,7 @@ func (c *elbv2Client) DescribeTargetHealthWithContext(ctx context.Context, input
 }
 
 func (c *elbv2Client) DescribeTargetGroupsWithContext(ctx context.Context, input *elasticloadbalancingv2.DescribeTargetGroupsInput) (*elasticloadbalancingv2.DescribeTargetGroupsOutput, error) {
-	client, err := c.awsClientsProvider.GetELBv2Client(ctx, "DescribeTargetGroups")
+	client, err := c.getClient(ctx, "DescribeTargetGroups")
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +206,7 @@ func (c *elbv2Client) DescribeTargetGroupsWithContext(ctx context.Context, input
 }
 
 func (c *elbv2Client) DeleteTargetGroupWithContext(ctx context.Context, input *elasticloadbalancingv2.DeleteTargetGroupInput) (*elasticloadbalancingv2.DeleteTargetGroupOutput, error) {
-	client, err := c.awsClientsProvider.GetELBv2Client(ctx, "DeleteTargetGroup")
+	client, err := c.getClient(ctx, "DeleteTargetGroup")
 	if err != nil {
 		return nil, err
 	}
@@ -206,7 +214,7 @@ func (c *elbv2Client) DeleteTargetGroupWithContext(ctx context.Context, input *e
 }
 
 func (c *elbv2Client) ModifyTargetGroupWithContext(ctx context.Context, input *elasticloadbalancingv2.ModifyTargetGroupInput) (*elasticloadbalancingv2.ModifyTargetGroupOutput, error) {
-	client, err := c.awsClientsProvider.GetELBv2Client(ctx, "ModifyTargetGroup")
+	client, err := c.getClient(ctx, "ModifyTargetGroup")
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +222,7 @@ func (c *elbv2Client) ModifyTargetGroupWithContext(ctx context.Context, input *e
 }
 
 func (c *elbv2Client) CreateTargetGroupWithContext(ctx context.Context, input *elasticloadbalancingv2.CreateTargetGroupInput) (*elasticloadbalancingv2.CreateTargetGroupOutput, error) {
-	client, err := c.awsClientsProvider.GetELBv2Client(ctx, "CreateTargetGroup")
+	client, err := c.getClient(ctx, "CreateTargetGroup")
 	if err != nil {
 		return nil, err
 	}
@@ -222,7 +230,7 @@ func (c *elbv2Client) CreateTargetGroupWithContext(ctx context.Context, input *e
 }
 
 func (c *elbv2Client) DescribeTargetGroupAttributesWithContext(ctx context.Context, input *elasticloadbalancingv2.DescribeTargetGroupAttributesInput) (*elasticloadbalancingv2.DescribeTargetGroupAttributesOutput, error) {
-	client, err := c.awsClientsProvider.GetELBv2Client(ctx, "DescribeTargetGroupAttributes")
+	client, err := c.getClient(ctx, "DescribeTargetGroupAttributes")
 	if err != nil {
 		return nil, err
 	}
@@ -230,7 +238,7 @@ func (c *elbv2Client) DescribeTargetGroupAttributesWithContext(ctx context.Conte
 }
 
 func (c *elbv2Client) ModifyTargetGroupAttributesWithContext(ctx context.Context, input *elasticloadbalancingv2.ModifyTargetGroupAttributesInput) (*elasticloadbalancingv2.ModifyTargetGroupAttributesOutput, error) {
-	client, err := c.awsClientsProvider.GetELBv2Client(ctx, "ModifyTargetGroupAttributes")
+	client, err := c.getClient(ctx, "ModifyTargetGroupAttributes")
 	if err != nil {
 		return nil, err
 	}
@@ -238,7 +246,7 @@ func (c *elbv2Client) ModifyTargetGroupAttributesWithContext(ctx context.Context
 }
 
 func (c *elbv2Client) SetSecurityGroupsWithContext(ctx context.Context, input *elasticloadbalancingv2.SetSecurityGroupsInput) (*elasticloadbalancingv2.SetSecurityGroupsOutput, error) {
-	client, err := c.awsClientsProvider.GetELBv2Client(ctx, "SetSecurityGroups")
+	client, err := c.getClient(ctx, "SetSecurityGroups")
 	if err != nil {
 		return nil, err
 	}
@@ -246,7 +254,7 @@ func (c *elbv2Client) SetSecurityGroupsWithContext(ctx context.Context, input *e
 }
 
 func (c *elbv2Client) SetSubnetsWithContext(ctx context.Context, input *elasticloadbalancingv2.SetSubnetsInput) (*elasticloadbalancingv2.SetSubnetsOutput, error) {
-	client, err := c.awsClientsProvider.GetELBv2Client(ctx, "SetSubnets")
+	client, err := c.getClient(ctx, "SetSubnets")
 	if err != nil {
 		return nil, err
 	}
@@ -254,7 +262,7 @@ func (c *elbv2Client) SetSubnetsWithContext(ctx context.Context, input *elasticl
 }
 
 func (c *elbv2Client) SetIpAddressTypeWithContext(ctx context.Context, input *elasticloadbalancingv2.SetIpAddressTypeInput) (*elasticloadbalancingv2.SetIpAddressTypeOutput, error) {
-	client, err := c.awsClientsProvider.GetELBv2Client(ctx, "SetIpAddressType")
+	client, err := c.getClient(ctx, "SetIpAddressType")
 	if err != nil {
 		return nil, err
 	}
@@ -262,7 +270,7 @@ func (c *elbv2Client) SetIpAddressTypeWithContext(ctx context.Context, input *el
 }
 
 func (c *elbv2Client) DeleteLoadBalancerWithContext(ctx context.Context, input *elasticloadbalancingv2.DeleteLoadBalancerInput) (*elasticloadbalancingv2.DeleteLoadBalancerOutput, error) {
-	client, err := c.awsClientsProvider.GetELBv2Client(ctx, "DeleteLoadBalancer")
+	client, err := c.getClient(ctx, "DeleteLoadBalancer")
 	if err != nil {
 		return nil, err
 	}
@@ -270,7 +278,7 @@ func (c *elbv2Client) DeleteLoadBalancerWithContext(ctx context.Context, input *
 }
 
 func (c *elbv2Client) CreateLoadBalancerWithContext(ctx context.Context, input *elasticloadbalancingv2.CreateLoadBalancerInput) (*elasticloadbalancingv2.CreateLoadBalancerOutput, error) {
-	client, err := c.awsClientsProvider.GetELBv2Client(ctx, "CreateLoadBalancer")
+	client, err := c.getClient(ctx, "CreateLoadBalancer")
 	if err != nil {
 		return nil, err
 	}
@@ -278,7 +286,7 @@ func (c *elbv2Client) CreateLoadBalancerWithContext(ctx context.Context, input *
 }
 
 func (c *elbv2Client) DescribeLoadBalancerAttributesWithContext(ctx context.Context, input *elasticloadbalancingv2.DescribeLoadBalancerAttributesInput) (*elasticloadbalancingv2.DescribeLoadBalancerAttributesOutput, error) {
-	client, err := c.awsClientsProvider.GetELBv2Client(ctx, "DescribeLoadBalancerAttributes")
+	client, err := c.getClient(ctx, "DescribeLoadBalancerAttributes")
 	if err != nil {
 		return nil, err
 	}
@@ -286,7 +294,7 @@ func (c *elbv2Client) DescribeLoadBalancerAttributesWithContext(ctx context.Cont
 }
 
 func (c *elbv2Client) ModifyLoadBalancerAttributesWithContext(ctx context.Context, input *elasticloadbalancingv2.ModifyLoadBalancerAttributesInput) (*elasticloadbalancingv2.ModifyLoadBalancerAttributesOutput, error) {
-	client, err := c.awsClientsProvider.GetELBv2Client(ctx, "ModifyLoadBalancerAttributes")
+	client, err := c.getClient(ctx, "ModifyLoadBalancerAttributes")
 	if err != nil {
 		return nil, err
 	}
@@ -294,7 +302,7 @@ func (c *elbv2Client) ModifyLoadBalancerAttributesWithContext(ctx context.Contex
 }
 
 func (c *elbv2Client) ModifyListenerWithContext(ctx context.Context, input *elasticloadbalancingv2.ModifyListenerInput) (*elasticloadbalancingv2.ModifyListenerOutput, error) {
-	client, err := c.awsClientsProvider.GetELBv2Client(ctx, "ModifyListener")
+	client, err := c.getClient(ctx, "ModifyListener")
 	if err != nil {
 		return nil, err
 	}
@@ -302,7 +310,7 @@ func (c *elbv2Client) ModifyListenerWithContext(ctx context.Context, input *elas
 }
 
 func (c *elbv2Client) DeleteListenerWithContext(ctx context.Context, input *elasticloadbalancingv2.DeleteListenerInput) (*elasticloadbalancingv2.DeleteListenerOutput, error) {
-	client, err := c.awsClientsProvider.GetELBv2Client(ctx, "DeleteListener")
+	client, err := c.getClient(ctx, "DeleteListener")
 	if err != nil {
 		return nil, err
 	}
@@ -310,7 +318,7 @@ func (c *elbv2Client) DeleteListenerWithContext(ctx context.Context, input *elas
 }
 
 func (c *elbv2Client) CreateListenerWithContext(ctx context.Context, input *elasticloadbalancingv2.CreateListenerInput) (*elasticloadbalancingv2.CreateListenerOutput, error) {
-	client, err := c.awsClientsProvider.GetELBv2Client(ctx, "CreateListener")
+	client, err := c.getClient(ctx, "CreateListener")
 	if err != nil {
 		return nil, err
 	}
@@ -318,7 +326,7 @@ func (c *elbv2Client) CreateListenerWithContext(ctx context.Context, input *elas
 }
 
 func (c *elbv2Client) DescribeTagsWithContext(ctx context.Context, input *elasticloadbalancingv2.DescribeTagsInput) (*elasticloadbalancingv2.DescribeTagsOutput, error) {
-	client, err := c.awsClientsProvider.GetELBv2Client(ctx, "DescribeTags")
+	client, err := c.getClient(ctx, "DescribeTags")
 	if err != nil {
 		return nil, err
 	}
@@ -326,7 +334,7 @@ func (c *elbv2Client) DescribeTagsWithContext(ctx context.Context, input *elasti
 }
 
 func (c *elbv2Client) AddTagsWithContext(ctx context.Context, input *elasticloadbalancingv2.AddTagsInput) (*elasticloadbalancingv2.AddTagsOutput, error) {
-	client, err := c.awsClientsProvider.GetELBv2Client(ctx, "AddTags")
+	client, err := c.getClient(ctx, "AddTags")
 	if err != nil {
 		return nil, err
 	}
@@ -334,7 +342,7 @@ func (c *elbv2Client) AddTagsWithContext(ctx context.Context, input *elasticload
 }
 
 func (c *elbv2Client) RemoveTagsWithContext(ctx context.Context, input *elasticloadbalancingv2.RemoveTagsInput) (*elasticloadbalancingv2.RemoveTagsOutput, error) {
-	client, err := c.awsClientsProvider.GetELBv2Client(ctx, "RemoveTags")
+	client, err := c.getClient(ctx, "RemoveTags")
 	if err != nil {
 		return nil, err
 	}
@@ -345,7 +353,7 @@ func (c *elbv2Client) DescribeLoadBalancersAsList(ctx context.Context, input *el
 	var result []types.LoadBalancer
 	var client *elasticloadbalancingv2.Client
 	var err error
-	client, err = c.awsClientsProvider.GetELBv2Client(ctx, "DescribeLoadBalancers")
+	client, err = c.getClient(ctx, "DescribeLoadBalancers")
 	if err != nil {
 		return nil, err
 	}
@@ -364,7 +372,7 @@ func (c *elbv2Client) DescribeTargetGroupsAsList(ctx context.Context, input *ela
 	var result []types.TargetGroup
 	var client *elasticloadbalancingv2.Client
 	var err error
-	client, err = c.awsClientsProvider.GetELBv2Client(ctx, "DescribeTargetGroups")
+	client, err = c.getClient(ctx, "DescribeTargetGroups")
 	if err != nil {
 		return nil, err
 	}
@@ -383,7 +391,7 @@ func (c *elbv2Client) DescribeListenersAsList(ctx context.Context, input *elasti
 	var result []types.Listener
 	var client *elasticloadbalancingv2.Client
 	var err error
-	client, err = c.awsClientsProvider.GetELBv2Client(ctx, "DescribeListeners")
+	client, err = c.getClient(ctx, "DescribeListeners")
 	if err != nil {
 		return nil, err
 	}
@@ -402,7 +410,7 @@ func (c *elbv2Client) DescribeListenerCertificatesAsList(ctx context.Context, in
 	var result []types.Certificate
 	var client *elasticloadbalancingv2.Client
 	var err error
-	client, err = c.awsClientsProvider.GetELBv2Client(ctx, "DescribeListenerCertificates")
+	client, err = c.getClient(ctx, "DescribeListenerCertificates")
 	if err != nil {
 		return nil, err
 	}
@@ -421,7 +429,7 @@ func (c *elbv2Client) DescribeRulesAsList(ctx context.Context, input *elasticloa
 	var result []types.Rule
 	var client *elasticloadbalancingv2.Client
 	var err error
-	client, err = c.awsClientsProvider.GetELBv2Client(ctx, "DescribeRules")
+	client, err = c.getClient(ctx, "DescribeRules")
 	if err != nil {
 		return nil, err
 	}
@@ -437,7 +445,7 @@ func (c *elbv2Client) DescribeRulesAsList(ctx context.Context, input *elasticloa
 }
 
 func (c *elbv2Client) DescribeListenerAttributesWithContext(ctx context.Context, input *elasticloadbalancingv2.DescribeListenerAttributesInput) (*elasticloadbalancingv2.DescribeListenerAttributesOutput, error) {
-	client, err := c.awsClientsProvider.GetELBv2Client(ctx, "DescribeListenerAttributes")
+	client, err := c.getClient(ctx, "DescribeListenerAttributes")
 	if err != nil {
 		return nil, err
 	}
@@ -445,7 +453,7 @@ func (c *elbv2Client) DescribeListenerAttributesWithContext(ctx context.Context,
 }
 
 func (c *elbv2Client) ModifyListenerAttributesWithContext(ctx context.Context, input *elasticloadbalancingv2.ModifyListenerAttributesInput) (*elasticloadbalancingv2.ModifyListenerAttributesOutput, error) {
-	client, err := c.awsClientsProvider.GetELBv2Client(ctx, "ModifyListenerAttributes")
+	client, err := c.getClient(ctx, "ModifyListenerAttributes")
 	if err != nil {
 		return nil, err
 	}
@@ -453,7 +461,7 @@ func (c *elbv2Client) ModifyListenerAttributesWithContext(ctx context.Context, i
 }
 
 func (c *elbv2Client) ModifyCapacityReservationWithContext(ctx context.Context, input *elasticloadbalancingv2.ModifyCapacityReservationInput) (*elasticloadbalancingv2.ModifyCapacityReservationOutput, error) {
-	client, err := c.awsClientsProvider.GetELBv2Client(ctx, "ModifyCapacityReservation")
+	client, err := c.getClient(ctx, "ModifyCapacityReservation")
 	if err != nil {
 		return nil, err
 	}
@@ -461,9 +469,16 @@ func (c *elbv2Client) ModifyCapacityReservationWithContext(ctx context.Context, 
 }
 
 func (c *elbv2Client) DescribeCapacityReservationWithContext(ctx context.Context, input *elasticloadbalancingv2.DescribeCapacityReservationInput) (*elasticloadbalancingv2.DescribeCapacityReservationOutput, error) {
-	client, err := c.awsClientsProvider.GetELBv2Client(ctx, "DescribeCapacityReservation")
+	client, err := c.getClient(ctx, "DescribeCapacityReservation")
 	if err != nil {
 		return nil, err
 	}
 	return client.DescribeCapacityReservation(ctx, input)
+}
+
+func (c *elbv2Client) getClient(ctx context.Context, operation string) (*elasticloadbalancingv2.Client, error) {
+	if c.staticELBClient != nil {
+		return c.staticELBClient, nil
+	}
+	return c.awsClientsProvider.GetELBv2Client(ctx, operation)
 }

--- a/pkg/aws/services/elbv2.go
+++ b/pkg/aws/services/elbv2.go
@@ -60,7 +60,7 @@ type ELBV2 interface {
 	ModifyListenerAttributesWithContext(ctx context.Context, input *elasticloadbalancingv2.ModifyListenerAttributesInput) (*elasticloadbalancingv2.ModifyListenerAttributesOutput, error)
 	ModifyCapacityReservationWithContext(ctx context.Context, input *elasticloadbalancingv2.ModifyCapacityReservationInput) (*elasticloadbalancingv2.ModifyCapacityReservationOutput, error)
 	DescribeCapacityReservationWithContext(ctx context.Context, input *elasticloadbalancingv2.DescribeCapacityReservationInput) (*elasticloadbalancingv2.DescribeCapacityReservationOutput, error)
-	AssumeRole(ctx context.Context, assumeRoleArn string, externalId string) ELBV2
+	AssumeRole(ctx context.Context, assumeRoleArn string, externalId string) (ELBV2, error)
 }
 
 func NewELBV2(awsClientsProvider provider.AWSClientsProvider, cloud Cloud) ELBV2 {
@@ -76,9 +76,9 @@ type elbv2Client struct {
 	cloud              Cloud
 }
 
-func (c *elbv2Client) AssumeRole(ctx context.Context, assumeRoleArn string, externalId string) ELBV2 {
+func (c *elbv2Client) AssumeRole(ctx context.Context, assumeRoleArn string, externalId string) (ELBV2, error) {
 	if assumeRoleArn == "" {
-		return c
+		return c, nil
 	}
 	return c.cloud.GetAssumedRoleELBV2(ctx, assumeRoleArn, externalId)
 }

--- a/pkg/aws/services/elbv2_mocks.go
+++ b/pkg/aws/services/elbv2_mocks.go
@@ -67,11 +67,12 @@ func (mr *MockELBV2MockRecorder) AddTagsWithContext(arg0, arg1 interface{}) *gom
 }
 
 // AssumeRole mocks base method.
-func (m *MockELBV2) AssumeRole(arg0 context.Context, arg1, arg2 string) ELBV2 {
+func (m *MockELBV2) AssumeRole(arg0 context.Context, arg1, arg2 string) (ELBV2, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssumeRole", arg0, arg1, arg2)
 	ret0, _ := ret[0].(ELBV2)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // AssumeRole indicates an expected call of AssumeRole.

--- a/pkg/targetgroupbinding/resource_manager.go
+++ b/pkg/targetgroupbinding/resource_manager.go
@@ -552,7 +552,7 @@ func (m *defaultResourceManager) registerPodEndpoints(ctx context.Context, tgb *
 
 	var overrideAzFn func(addr netip.Addr) bool
 	if tgb.Spec.IamRoleArnToAssume != "" {
-		// If we're interacting with another account, then we should always be sitting "all" AZ to allow this
+		// If we're interacting with another account, then we should always be setting "all" AZ to allow this
 		// target to get registered by the ELB API.
 		overrideAzFn = func(_ netip.Addr) bool {
 			return true

--- a/pkg/targetgroupbinding/targets_manager.go
+++ b/pkg/targetgroupbinding/targets_manager.go
@@ -89,7 +89,13 @@ func (m *cachedTargetsManager) RegisterTargets(ctx context.Context, tgb *elbv2ap
 		m.logger.Info("registering targets",
 			"arn", tgARN,
 			"targets", targetsChunk)
-		_, err := m.elbv2Client.AssumeRole(ctx, tgb.Spec.IamRoleArnToAssume, tgb.Spec.AssumeRoleExternalId).RegisterTargetsWithContext(ctx, req)
+
+		clientToUse, err := m.elbv2Client.AssumeRole(ctx, tgb.Spec.IamRoleArnToAssume, tgb.Spec.AssumeRoleExternalId)
+		if err != nil {
+			return err
+		}
+
+		_, err = clientToUse.RegisterTargetsWithContext(ctx, req)
 		if err != nil {
 			return err
 		}
@@ -111,7 +117,11 @@ func (m *cachedTargetsManager) DeregisterTargets(ctx context.Context, tgb *elbv2
 		m.logger.Info("deRegistering targets",
 			"arn", tgARN,
 			"targets", targetsChunk)
-		_, err := m.elbv2Client.AssumeRole(ctx, tgb.Spec.IamRoleArnToAssume, tgb.Spec.AssumeRoleExternalId).DeregisterTargetsWithContext(ctx, req)
+		clientToUse, err := m.elbv2Client.AssumeRole(ctx, tgb.Spec.IamRoleArnToAssume, tgb.Spec.AssumeRoleExternalId)
+		if err != nil {
+			return err
+		}
+		_, err = clientToUse.DeregisterTargetsWithContext(ctx, req)
 		if err != nil {
 			return err
 		}
@@ -199,7 +209,11 @@ func (m *cachedTargetsManager) listTargetsFromAWS(ctx context.Context, tgb *elbv
 		TargetGroupArn: aws.String(tgARN),
 		Targets:        pointerizeTargetDescriptions(targets),
 	}
-	resp, err := m.elbv2Client.AssumeRole(ctx, tgb.Spec.IamRoleArnToAssume, tgb.Spec.AssumeRoleExternalId).DescribeTargetHealthWithContext(ctx, req)
+	clientToUse, err := m.elbv2Client.AssumeRole(ctx, tgb.Spec.IamRoleArnToAssume, tgb.Spec.AssumeRoleExternalId)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := clientToUse.DescribeTargetHealthWithContext(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/targetgroupbinding/targets_manager_test.go
+++ b/pkg/targetgroupbinding/targets_manager_test.go
@@ -280,7 +280,7 @@ func Test_cachedTargetsManager_RegisterTargets(t *testing.T) {
 			ctx := context.Background()
 			for _, call := range tt.fields.registerTargetsWithContextCalls {
 				elbv2Client.EXPECT().RegisterTargetsWithContext(gomock.Any(), call.req).Return(call.resp, call.err)
-				elbv2Client.EXPECT().AssumeRole(ctx, gomock.Any(), gomock.Any()).Return(elbv2Client)
+				elbv2Client.EXPECT().AssumeRole(ctx, gomock.Any(), gomock.Any()).Return(elbv2Client, nil)
 			}
 
 			targetsCache := cache.NewExpiring()
@@ -526,7 +526,7 @@ func Test_cachedTargetsManager_DeregisterTargets(t *testing.T) {
 			ctx := context.Background()
 			for _, call := range tt.fields.deregisterTargetsWithContextCalls {
 				elbv2Client.EXPECT().DeregisterTargetsWithContext(gomock.Any(), call.req).Return(call.resp, call.err)
-				elbv2Client.EXPECT().AssumeRole(ctx, gomock.Any(), gomock.Any()).Return(elbv2Client)
+				elbv2Client.EXPECT().AssumeRole(ctx, gomock.Any(), gomock.Any()).Return(elbv2Client, nil)
 			}
 
 			targetsCache := cache.NewExpiring()
@@ -792,7 +792,7 @@ func Test_cachedTargetsManager_ListTargets(t *testing.T) {
 			elbv2Client := services.NewMockELBV2(ctrl)
 			for _, call := range tt.fields.describeTargetHealthWithContextCalls {
 				elbv2Client.EXPECT().DescribeTargetHealthWithContext(gomock.Any(), call.req).Return(call.resp, call.err)
-				elbv2Client.EXPECT().AssumeRole(ctx, gomock.Any(), gomock.Any()).Return(elbv2Client)
+				elbv2Client.EXPECT().AssumeRole(ctx, gomock.Any(), gomock.Any()).Return(elbv2Client, nil)
 			}
 			targetsCache := cache.NewExpiring()
 			targetsCacheTTL := 1 * time.Minute
@@ -1203,7 +1203,7 @@ func Test_cachedTargetsManager_refreshUnhealthyTargets(t *testing.T) {
 			elbv2Client := services.NewMockELBV2(ctrl)
 			for _, call := range tt.fields.describeTargetHealthWithContextCalls {
 				elbv2Client.EXPECT().DescribeTargetHealthWithContext(gomock.Any(), call.req).Return(call.resp, call.err)
-				elbv2Client.EXPECT().AssumeRole(ctx, gomock.Any(), gomock.Any()).Return(elbv2Client)
+				elbv2Client.EXPECT().AssumeRole(ctx, gomock.Any(), gomock.Any()).Return(elbv2Client, nil)
 			}
 			m := &cachedTargetsManager{
 				elbv2Client: elbv2Client,
@@ -1367,7 +1367,7 @@ func Test_cachedTargetsManager_listTargetsFromAWS(t *testing.T) {
 			elbv2Client := services.NewMockELBV2(ctrl)
 			for _, call := range tt.fields.describeTargetHealthWithContextCalls {
 				elbv2Client.EXPECT().DescribeTargetHealthWithContext(gomock.Any(), call.req).Return(call.resp, call.err)
-				elbv2Client.EXPECT().AssumeRole(ctx, gomock.Any(), gomock.Any()).Return(elbv2Client)
+				elbv2Client.EXPECT().AssumeRole(ctx, gomock.Any(), gomock.Any()).Return(elbv2Client, nil)
 			}
 
 			m := &cachedTargetsManager{

--- a/pkg/targetgroupbinding/utils.go
+++ b/pkg/targetgroupbinding/utils.go
@@ -25,26 +25,7 @@ const (
 
 	// Index Key for "ServiceReference" index.
 	IndexKeyServiceRefName = "spec.serviceRef.name"
-
-	// Annotation for IAM Role ARN to assume when calling AWS APIs.
-	AnnotationIamRoleArnToAssume = "alb.ingress.kubernetes.io/IamRoleArnToAssume"
-
-	// Annotation for IAM Role External ID to use when calling AWS APIs.
-	AnnotationAssumeRoleExternalId = "alb.ingress.kubernetes.io/AssumeRoleExternalId"
 )
-
-// AnnotationsToFields converts annotations to fields. Currently it's tgb.Spec.IamRoleArnToAssume and tgb.Spec.AssumeRoleExternalId
-func AnnotationsToFields(tgb *elbv2api.TargetGroupBinding) {
-	for key, value := range tgb.Annotations {
-		if key == AnnotationIamRoleArnToAssume {
-			tgb.Spec.IamRoleArnToAssume = value
-		} else {
-			if key == AnnotationAssumeRoleExternalId {
-				tgb.Spec.AssumeRoleExternalId = value
-			}
-		}
-	}
-}
 
 // BuildTargetHealthPodConditionType constructs the condition type for TargetHealth pod condition.
 func BuildTargetHealthPodConditionType(tgb *elbv2api.TargetGroupBinding) corev1.PodConditionType {

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -63,7 +63,7 @@ func InitFramework() (*Framework, error) {
 		VpcID:          globalOptions.AWSVPCID,
 		MaxRetries:     3,
 		ThrottleConfig: throttle.NewDefaultServiceOperationsThrottleConfig(),
-	}, nil, logger, nil)
+	}, "clusterName", nil, logger, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/webhooks/elbv2/targetgroup_helper.go
+++ b/webhooks/elbv2/targetgroup_helper.go
@@ -1,0 +1,45 @@
+package elbv2
+
+import (
+	"context"
+	elbv2sdk "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	"github.com/pkg/errors"
+	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/services"
+)
+
+// getTargetGroupFromAWS returns the AWS target group corresponding to the arn
+func getTargetGroupFromAWS(ctx context.Context, elbv2Client services.ELBV2, tgb *elbv2api.TargetGroupBinding) (*elbv2types.TargetGroup, error) {
+	tgARN := tgb.Spec.TargetGroupARN
+	req := &elbv2sdk.DescribeTargetGroupsInput{
+		TargetGroupArns: []string{tgARN},
+	}
+	return getTargetGroupHelper(ctx, elbv2Client, tgb, tgARN, req)
+}
+
+// getTargetGroupsByNameFromAWS returns the AWS target group corresponding to the name
+func getTargetGroupsByNameFromAWS(ctx context.Context, elbv2Client services.ELBV2, tgb *elbv2api.TargetGroupBinding) (*elbv2types.TargetGroup, error) {
+	req := &elbv2sdk.DescribeTargetGroupsInput{
+		Names: []string{tgb.Spec.TargetGroupName},
+	}
+
+	return getTargetGroupHelper(ctx, elbv2Client, tgb, tgb.Spec.TargetGroupName, req)
+}
+
+func getTargetGroupHelper(ctx context.Context, elbv2Client services.ELBV2, tgb *elbv2api.TargetGroupBinding, tgIdentifier string, req *elbv2sdk.DescribeTargetGroupsInput) (*elbv2types.TargetGroup, error) {
+	clientToUse, err := elbv2Client.AssumeRole(ctx, tgb.Spec.IamRoleArnToAssume, tgb.Spec.AssumeRoleExternalId)
+
+	if err != nil {
+		return nil, err
+	}
+
+	tgList, err := clientToUse.DescribeTargetGroupsAsList(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if len(tgList) != 1 {
+		return nil, errors.Errorf("expecting a single targetGroup with query [%s] but got %v", tgIdentifier, len(tgList))
+	}
+	return &tgList[0], nil
+}

--- a/webhooks/elbv2/targetgroupbinding_mutator_test.go
+++ b/webhooks/elbv2/targetgroupbinding_mutator_test.go
@@ -308,7 +308,7 @@ func Test_targetGroupBindingMutator_MutateCreate(t *testing.T) {
 			ctx := context.Background()
 			for _, call := range tt.fields.describeTargetGroupsAsListCalls {
 				elbv2Client.EXPECT().DescribeTargetGroupsAsList(gomock.Any(), call.req).Return(call.resp, call.err).AnyTimes()
-				elbv2Client.EXPECT().AssumeRole(ctx, gomock.Any(), gomock.Any()).Return(elbv2Client).AnyTimes()
+				elbv2Client.EXPECT().AssumeRole(ctx, gomock.Any(), gomock.Any()).Return(elbv2Client, nil).AnyTimes()
 			}
 
 			m := &targetGroupBindingMutator{
@@ -415,7 +415,7 @@ func Test_targetGroupBindingMutator_obtainSDKTargetTypeFromAWS(t *testing.T) {
 			elbv2Client := services.NewMockELBV2(ctrl)
 			for _, call := range tt.fields.describeTargetGroupsAsListCalls {
 				elbv2Client.EXPECT().DescribeTargetGroupsAsList(gomock.Any(), call.req).Return(call.resp, call.err)
-				elbv2Client.EXPECT().AssumeRole(ctx, gomock.Any(), gomock.Any()).Return(elbv2Client).AnyTimes()
+				elbv2Client.EXPECT().AssumeRole(ctx, gomock.Any(), gomock.Any()).Return(elbv2Client, nil).AnyTimes()
 			}
 
 			m := &targetGroupBindingMutator{
@@ -545,7 +545,7 @@ func Test_targetGroupBindingMutator_getIPAddressTypeFromAWS(t *testing.T) {
 			elbv2Client := services.NewMockELBV2(ctrl)
 			for _, call := range tt.fields.describeTargetGroupsAsListCalls {
 				elbv2Client.EXPECT().DescribeTargetGroupsAsList(gomock.Any(), call.req).Return(call.resp, call.err)
-				elbv2Client.EXPECT().AssumeRole(ctx, gomock.Any(), gomock.Any()).Return(elbv2Client).AnyTimes()
+				elbv2Client.EXPECT().AssumeRole(ctx, gomock.Any(), gomock.Any()).Return(elbv2Client, nil).AnyTimes()
 			}
 
 			m := &targetGroupBindingMutator{
@@ -631,7 +631,7 @@ func Test_targetGroupBindingMutator_obtainSDKVpcIDFromAWS(t *testing.T) {
 			elbv2Client := services.NewMockELBV2(ctrl)
 			for _, call := range tt.fields.describeTargetGroupsAsListCalls {
 				elbv2Client.EXPECT().DescribeTargetGroupsAsList(gomock.Any(), call.req).Return(call.resp, call.err)
-				elbv2Client.EXPECT().AssumeRole(ctx, gomock.Any(), gomock.Any()).Return(elbv2Client).AnyTimes()
+				elbv2Client.EXPECT().AssumeRole(ctx, gomock.Any(), gomock.Any()).Return(elbv2Client, nil).AnyTimes()
 			}
 
 			m := &targetGroupBindingMutator{

--- a/webhooks/elbv2/targetgroupbinding_validator.go
+++ b/webhooks/elbv2/targetgroupbinding_validator.go
@@ -9,7 +9,6 @@ import (
 	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
-	elbv2sdk "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -110,7 +109,7 @@ func (v *targetGroupBindingValidator) checkRequiredFields(ctx context.Context, t
 				By changing the object here I guarantee as early as possible that that assumption is true.
 			*/
 
-			tgObj, err := v.getTargetGroupsByNameFromAWS(ctx, tgb.Spec.TargetGroupName)
+			tgObj, err := getTargetGroupsByNameFromAWS(ctx, v.elbv2Client, tgb)
 			if err != nil {
 				return fmt.Errorf("searching TargetGroup with name %s: %w", tgb.Spec.TargetGroupName, err)
 			}
@@ -212,7 +211,7 @@ func (v *targetGroupBindingValidator) checkTargetGroupVpcID(ctx context.Context,
 
 // getTargetGroupIPAddressTypeFromAWS returns the target group IP address type of AWS target group
 func (v *targetGroupBindingValidator) getTargetGroupIPAddressTypeFromAWS(ctx context.Context, tgb *elbv2api.TargetGroupBinding) (elbv2api.TargetGroupIPAddressType, error) {
-	targetGroup, err := v.getTargetGroupFromAWS(ctx, tgb)
+	targetGroup, err := getTargetGroupFromAWS(ctx, v.elbv2Client, tgb)
 	if err != nil {
 		return "", err
 	}
@@ -228,49 +227,12 @@ func (v *targetGroupBindingValidator) getTargetGroupIPAddressTypeFromAWS(ctx con
 	return ipAddressType, nil
 }
 
-// getTargetGroupFromAWS returns the AWS target group corresponding to the ARN
-func (v *targetGroupBindingValidator) getTargetGroupFromAWS(ctx context.Context, tgb *elbv2api.TargetGroupBinding) (*elbv2types.TargetGroup, error) {
-	tgARN := tgb.Spec.TargetGroupARN
-	req := &elbv2sdk.DescribeTargetGroupsInput{
-		TargetGroupArns: []string{tgARN},
-	}
-
-	clientToUse, err := v.elbv2Client.AssumeRole(ctx, tgb.Spec.IamRoleArnToAssume, tgb.Spec.AssumeRoleExternalId)
-	if err != nil {
-		return nil, err
-	}
-
-	tgList, err := clientToUse.DescribeTargetGroupsAsList(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-	if len(tgList) != 1 {
-		return nil, errors.Errorf("expecting a single targetGroup but got %v", len(tgList))
-	}
-	return &tgList[0], nil
-}
-
 func (v *targetGroupBindingValidator) getVpcIDFromAWS(ctx context.Context, tgb *elbv2api.TargetGroupBinding) (string, error) {
-	targetGroup, err := v.getTargetGroupFromAWS(ctx, tgb)
+	targetGroup, err := getTargetGroupFromAWS(ctx, v.elbv2Client, tgb)
 	if err != nil {
 		return "", err
 	}
 	return awssdk.ToString(targetGroup.VpcId), nil
-}
-
-// getTargetGroupFromAWS returns the AWS target group corresponding to the tgName
-func (v *targetGroupBindingValidator) getTargetGroupsByNameFromAWS(ctx context.Context, tgName string) (*elbv2types.TargetGroup, error) {
-	req := &elbv2sdk.DescribeTargetGroupsInput{
-		Names: []string{tgName},
-	}
-	tgList, err := v.elbv2Client.DescribeTargetGroupsAsList(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-	if len(tgList) != 1 {
-		return nil, errors.Errorf("expecting a single targetGroup with name [%s] but got %v", tgName, len(tgList))
-	}
-	return &tgList[0], nil
 }
 
 // +kubebuilder:webhook:path=/validate-elbv2-k8s-aws-v1beta1-targetgroupbinding,mutating=false,failurePolicy=fail,groups=elbv2.k8s.aws,resources=targetgroupbindings,verbs=create;update,versions=v1beta1,name=vtargetgroupbinding.elbv2.k8s.aws,sideEffects=None,webhookVersions=v1,admissionReviewVersions=v1beta1

--- a/webhooks/elbv2/targetgroupbinding_validator_test.go
+++ b/webhooks/elbv2/targetgroupbinding_validator_test.go
@@ -333,7 +333,7 @@ func Test_targetGroupBindingValidator_ValidateCreate(t *testing.T) {
 			elbv2Client := services.NewMockELBV2(ctrl)
 			for _, call := range tt.fields.describeTargetGroupsAsListCalls {
 				elbv2Client.EXPECT().DescribeTargetGroupsAsList(gomock.Any(), call.req).Return(call.resp, call.err)
-				elbv2Client.EXPECT().AssumeRole(ctx, gomock.Any(), gomock.Any()).Return(elbv2Client).AnyTimes()
+				elbv2Client.EXPECT().AssumeRole(ctx, gomock.Any(), gomock.Any()).Return(elbv2Client, nil).AnyTimes()
 			}
 			v := &targetGroupBindingValidator{
 				k8sClient:   k8sClient,
@@ -1395,7 +1395,7 @@ func Test_targetGroupBindingValidator_checkTargetGroupVpcID(t *testing.T) {
 			elbv2Client := services.NewMockELBV2(ctrl)
 			for _, call := range tt.fields.describeTargetGroupsAsListCalls {
 				elbv2Client.EXPECT().DescribeTargetGroupsAsList(gomock.Any(), call.req).Return(call.resp, call.err)
-				elbv2Client.EXPECT().AssumeRole(ctx, gomock.Any(), gomock.Any()).Return(elbv2Client).AnyTimes()
+				elbv2Client.EXPECT().AssumeRole(ctx, gomock.Any(), gomock.Any()).Return(elbv2Client, nil).AnyTimes()
 			}
 			v := &targetGroupBindingValidator{
 				k8sClient:   k8sClient,


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

Previous PR, https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3691

Issue, https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/3634

### Description

The original PR (#3691) was a very good start to implementing cross account Target Group management and I used the same logic. This PR mostly fixes up bugs in the approach, as 3691 didn't work using SDKv2. Things I've added / changed:

- Use a singleton STS client.
- Use a garbage collected cache.
- Do not hold on to assumed role elbv2 clients indefinitely, these clients eventually expire and need to be recreated.
- Remove annotation based configuration for the Target Group Binding, instead rely only on the TGB spec to hold configuration data.
- Fix TG ARN resolution (the previous PR didn't apply the same logic between ARN / name specification for the TG). Also refactored the logic to remove code duplication.
- Add webhook validation to prevent specifying instance target groups + assume role. ELB API doesn't allow cross account instance registration.
- Added documentation and examples.


Test Cases:
- Same account TGB interactions work the same.
- Cross account with valid role + external id works.
- Cross account with invalid external id gracefully fails in the webhook validation.
- Long running controller (5 days) has no significant memory increase nor any errors related to the AssumeRole management.


### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [x] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:
