### PR TITLE
Add `targetType` field to IngressClassParams

### DIFF
--- a/apis/elbv2/v1beta1/ingressclassparams_types.go
+++ b/apis/elbv2/v1beta1/ingressclassparams_types.go
@@ -152,6 +152,10 @@ type IngressClassParamsSpec struct {
 	// Tags defines list of Tags on AWS resources provisioned for Ingresses that belong to IngressClass with this IngressClassParams.
 	Tags []Tag `json:"tags,omitempty"`
 
+	// TargetType defines the target type of target groups for all Ingresses that belong to IngressClass with this IngressClassParams.
+	// +optional
+	TargetType TargetType `json:"targetType,omitempty"`
+
 	// LoadBalancerAttributes define the custom attributes to LoadBalancers for all Ingress that that belong to IngressClass with this IngressClassParams.
 	// +optional
 	LoadBalancerAttributes []Attribute `json:"loadBalancerAttributes,omitempty"`

--- a/config/crd/bases/elbv2.k8s.aws_ingressclassparams.yaml
+++ b/config/crd/bases/elbv2.k8s.aws_ingressclassparams.yaml
@@ -261,6 +261,13 @@ spec:
                   - value
                   type: object
                 type: array
+              targetType:
+                description: TargetType defines the target type of target groups for
+                  all Ingresses that belong to IngressClass with this IngressClassParams.
+                enum:
+                - instance
+                - ip
+                type: string
             type: object
         type: object
     served: true

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:

--- a/docs/guide/ingress/ingress_class.md
+++ b/docs/guide/ingress/ingress_class.md
@@ -150,6 +150,15 @@ You can use IngressClassParams to enforce settings for a set of Ingresses.
       minimumLoadBalancerCapacity:
         capacityUnits: 1000
     ```
+    - with targetType
+    ```
+    apiVersion: elbv2.k8s.aws/v1beta1
+    kind: IngressClassParams
+    metadata:
+      name: class2048-config
+    spec:
+      targetType: ip
+    ```
 
 ### IngressClassParams specification
 

--- a/docs/guide/ingress/ingress_class.md
+++ b/docs/guide/ingress/ingress_class.md
@@ -188,7 +188,7 @@ If the field is specified, LBC will ignore the `alb.ingress.kubernetes.io/inboun
 
 #### spec.certificateArn
 Cluster administrators can use the optional `certificateARN` field to specify the ARN of the certificates for all Ingresses that belong to IngressClass with this IngressClassParams.
-    
+
 If the field is specified, LBC will ignore the `alb.ingress.kubernetes.io/certificate-arn` annotation.
 
 #### spec.sslPolicy
@@ -234,6 +234,13 @@ Cluster administrators can use `tags` field to specify the custom tags for AWS r
     1. controller-level flag `--default-tags` will have the highest priority.
     2. `spec.tags` in IngressClassParams will have the middle priority.
     3. `alb.ingress.kubernetes.io/tags` annotation will have the lowest priority.
+
+#### spec.targetType
+
+`targetType` is an optional setting. The available options are `instance` or `ip`.
+
+This defines the target type of target groups for all Ingresses that belong to IngressClass with this IngressClassParams.
+If the field is specified, LBC will ignore the `alb.ingress.kubernetes.io/target-type` annotation.
 
 #### spec.loadBalancerAttributes
 

--- a/helm/aws-load-balancer-controller/crds/crds.yaml
+++ b/helm/aws-load-balancer-controller/crds/crds.yaml
@@ -260,6 +260,13 @@ spec:
                   - value
                   type: object
                 type: array
+              targetType:
+                description: TargetType defines the target type of target groups for
+                  all Ingresses that belong to IngressClass with this IngressClassParams.
+                enum:
+                - instance
+                - ip
+                type: string
             type: object
         type: object
     served: true


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

#3518 

### Description

Add `targetType` field to IngressClassParams.

- The field is optional.
- If the field is specified, LBC will ignore the `alb.ingress.kubernetes.io/target-type` annotation.

<!--
Please explain the changes you made here.

Help your reviewers by guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
