### PR TITLE
add prometheus metrics

### DIFF
--- a/controllers/elbv2/targetgroupbinding_controller.go
+++ b/controllers/elbv2/targetgroupbinding_controller.go
@@ -19,10 +19,11 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"time"
+
 	discv1 "k8s.io/api/discovery/v1"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/pkg/errors"
@@ -31,16 +32,19 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/aws-load-balancer-controller/controllers/elbv2/eventhandlers"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/config"
+	errmetrics "sigs.k8s.io/aws-load-balancer-controller/pkg/error"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/runtime"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/targetgroupbinding"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	"github.com/go-logr/logr"
+	lbcmetrics "sigs.k8s.io/aws-load-balancer-controller/pkg/metrics/lbc"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
+	metricsutil "sigs.k8s.io/aws-load-balancer-controller/pkg/metrics/util"
 )
 
 const (
@@ -51,7 +55,7 @@ const (
 // NewTargetGroupBindingReconciler constructs new targetGroupBindingReconciler
 func NewTargetGroupBindingReconciler(k8sClient client.Client, eventRecorder record.EventRecorder, finalizerManager k8s.FinalizerManager,
 	tgbResourceManager targetgroupbinding.ResourceManager, config config.ControllerConfig, deferredTargetGroupBindingReconciler DeferredTargetGroupBindingReconciler,
-	logger logr.Logger) *targetGroupBindingReconciler {
+	logger logr.Logger, metricsCollector lbcmetrics.MetricCollector, reconcileCounters *metricsutil.ReconcileCounters) *targetGroupBindingReconciler {
 
 	return &targetGroupBindingReconciler{
 		k8sClient:                            k8sClient,
@@ -60,6 +64,8 @@ func NewTargetGroupBindingReconciler(k8sClient client.Client, eventRecorder reco
 		tgbResourceManager:                   tgbResourceManager,
 		deferredTargetGroupBindingReconciler: deferredTargetGroupBindingReconciler,
 		logger:                               logger,
+		metricsCollector:                     metricsCollector,
+		reconcileCounters:                    reconcileCounters,
 
 		maxConcurrentReconciles:    config.TargetGroupBindingMaxConcurrentReconciles,
 		maxExponentialBackoffDelay: config.TargetGroupBindingMaxExponentialBackoffDelay,
@@ -75,6 +81,8 @@ type targetGroupBindingReconciler struct {
 	tgbResourceManager                   targetgroupbinding.ResourceManager
 	deferredTargetGroupBindingReconciler DeferredTargetGroupBindingReconciler
 	logger                               logr.Logger
+	metricsCollector                     lbcmetrics.MetricCollector
+	reconcileCounters                    *metricsutil.ReconcileCounters
 
 	maxConcurrentReconciles    int
 	maxExponentialBackoffDelay time.Duration
@@ -93,13 +101,19 @@ type targetGroupBindingReconciler struct {
 // +kubebuilder:rbac:groups="discovery.k8s.io",resources=endpointslices,verbs=get;list;watch
 
 func (r *targetGroupBindingReconciler) Reconcile(ctx context.Context, req reconcile.Request) (ctrl.Result, error) {
+	r.reconcileCounters.IncrementTGB(req.NamespacedName)
 	r.logger.V(1).Info("Reconcile request", "name", req.Name)
 	return runtime.HandleReconcileError(r.reconcile(ctx, req), r.logger)
 }
 
 func (r *targetGroupBindingReconciler) reconcile(ctx context.Context, req reconcile.Request) error {
 	tgb := &elbv2api.TargetGroupBinding{}
-	if err := r.k8sClient.Get(ctx, req.NamespacedName, tgb); err != nil {
+	var err error
+	fetchTargetGroupBindingFn := func() {
+		err = r.k8sClient.Get(ctx, req.NamespacedName, tgb)
+	}
+	r.metricsCollector.ObserveControllerReconcileLatency(controllerName, "fetch_targetGroupBinding", fetchTargetGroupBindingFn)
+	if err != nil {
 		return client.IgnoreNotFound(err)
 	}
 
@@ -110,15 +124,23 @@ func (r *targetGroupBindingReconciler) reconcile(ctx context.Context, req reconc
 }
 
 func (r *targetGroupBindingReconciler) reconcileTargetGroupBinding(ctx context.Context, tgb *elbv2api.TargetGroupBinding) error {
-	if err := r.finalizerManager.AddFinalizers(ctx, tgb, targetGroupBindingFinalizer); err != nil {
+	var err error
+	finalizerFn := func() {
+		err = r.finalizerManager.AddFinalizers(ctx, tgb, targetGroupBindingFinalizer)
+	}
+	r.metricsCollector.ObserveControllerReconcileLatency(controllerName, "add_finalizers", finalizerFn)
+	if err != nil {
 		r.eventRecorder.Event(tgb, corev1.EventTypeWarning, k8s.TargetGroupBindingEventReasonFailedAddFinalizer, fmt.Sprintf("Failed add finalizer due to %v", err))
-		return err
+		return errmetrics.NewErrorWithMetrics(controllerName, "add_finalizers_error", err, r.metricsCollector)
 	}
 
-	deferred, err := r.tgbResourceManager.Reconcile(ctx, tgb)
-
+	var deferred bool
+	tgbResourceFn := func() {
+		deferred, err = r.tgbResourceManager.Reconcile(ctx, tgb)
+	}
+	r.metricsCollector.ObserveControllerReconcileLatency(controllerName, "reconcile_targetgroupbinding", tgbResourceFn)
 	if err != nil {
-		return err
+		return errmetrics.NewErrorWithMetrics(controllerName, "reconcile_targetgroupbinding_error", err, r.metricsCollector)
 	}
 
 	if deferred {
@@ -126,9 +148,12 @@ func (r *targetGroupBindingReconciler) reconcileTargetGroupBinding(ctx context.C
 		return nil
 	}
 
-	if err := r.updateTargetGroupBindingStatus(ctx, tgb); err != nil {
-		r.eventRecorder.Event(tgb, corev1.EventTypeWarning, k8s.TargetGroupBindingEventReasonFailedUpdateStatus, fmt.Sprintf("Failed update status due to %v", err))
-		return err
+	updateTargetGroupBindingStatusFn := func() {
+		err = r.updateTargetGroupBindingStatus(ctx, tgb)
+	}
+	r.metricsCollector.ObserveControllerReconcileLatency(controllerName, "update_status", updateTargetGroupBindingStatusFn)
+	if err != nil {
+		return errmetrics.NewErrorWithMetrics(controllerName, "update_status_error", err, r.metricsCollector)
 	}
 
 	r.eventRecorder.Event(tgb, corev1.EventTypeNormal, k8s.TargetGroupBindingEventReasonSuccessfullyReconciled, "Successfully reconciled")

--- a/controllers/service/service_controller.go
+++ b/controllers/service/service_controller.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/go-logr/logr"
@@ -17,7 +18,10 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy"
 	elbv2deploy "sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/elbv2"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/tracking"
+	errmetrics "sigs.k8s.io/aws-load-balancer-controller/pkg/error"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
+	lbcmetrics "sigs.k8s.io/aws-load-balancer-controller/pkg/metrics/lbc"
+	metricsutil "sigs.k8s.io/aws-load-balancer-controller/pkg/metrics/util"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/core"
 	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/networking"
@@ -39,7 +43,7 @@ func NewServiceReconciler(cloud services.Cloud, k8sClient client.Client, eventRe
 	finalizerManager k8s.FinalizerManager, networkingSGManager networking.SecurityGroupManager,
 	networkingSGReconciler networking.SecurityGroupReconciler, subnetsResolver networking.SubnetsResolver,
 	vpcInfoProvider networking.VPCInfoProvider, elbv2TaggingManager elbv2deploy.TaggingManager, controllerConfig config.ControllerConfig,
-	backendSGProvider networking.BackendSGProvider, sgResolver networking.SecurityGroupResolver, logger logr.Logger) *serviceReconciler {
+	backendSGProvider networking.BackendSGProvider, sgResolver networking.SecurityGroupResolver, logger logr.Logger, metricsCollector lbcmetrics.MetricCollector, reconcileCounters *metricsutil.ReconcileCounters) *serviceReconciler {
 
 	annotationParser := annotations.NewSuffixAnnotationParser(serviceAnnotationPrefix)
 	trackingProvider := tracking.NewDefaultProvider(serviceTagPrefix, controllerConfig.ClusterName)
@@ -47,9 +51,9 @@ func NewServiceReconciler(cloud services.Cloud, k8sClient client.Client, eventRe
 	modelBuilder := service.NewDefaultModelBuilder(annotationParser, subnetsResolver, vpcInfoProvider, cloud.VpcID(), trackingProvider,
 		elbv2TaggingManager, cloud.EC2(), controllerConfig.FeatureGates, controllerConfig.ClusterName, controllerConfig.DefaultTags, controllerConfig.ExternalManagedTags,
 		controllerConfig.DefaultSSLPolicy, controllerConfig.DefaultTargetType, controllerConfig.DefaultLoadBalancerScheme, controllerConfig.FeatureGates.Enabled(config.EnableIPTargetType), serviceUtils,
-		backendSGProvider, sgResolver, controllerConfig.EnableBackendSecurityGroup, controllerConfig.DisableRestrictedSGRules, logger)
+		backendSGProvider, sgResolver, controllerConfig.EnableBackendSecurityGroup, controllerConfig.DisableRestrictedSGRules, logger, metricsCollector)
 	stackMarshaller := deploy.NewDefaultStackMarshaller()
-	stackDeployer := deploy.NewDefaultStackDeployer(cloud, k8sClient, networkingSGManager, networkingSGReconciler, elbv2TaggingManager, controllerConfig, serviceTagPrefix, logger)
+	stackDeployer := deploy.NewDefaultStackDeployer(cloud, k8sClient, networkingSGManager, networkingSGReconciler, elbv2TaggingManager, controllerConfig, serviceTagPrefix, logger, metricsCollector, controllerName)
 	return &serviceReconciler{
 		k8sClient:         k8sClient,
 		eventRecorder:     eventRecorder,
@@ -65,6 +69,8 @@ func NewServiceReconciler(cloud services.Cloud, k8sClient client.Client, eventRe
 		logger:          logger,
 
 		maxConcurrentReconciles: controllerConfig.ServiceMaxConcurrentReconciles,
+		metricsCollector:        metricsCollector,
+		reconcileCounters:       reconcileCounters,
 	}
 }
 
@@ -77,10 +83,12 @@ type serviceReconciler struct {
 	serviceUtils      service.ServiceUtils
 	backendSGProvider networking.BackendSGProvider
 
-	modelBuilder    service.ModelBuilder
-	stackMarshaller deploy.StackMarshaller
-	stackDeployer   deploy.StackDeployer
-	logger          logr.Logger
+	modelBuilder      service.ModelBuilder
+	stackMarshaller   deploy.StackMarshaller
+	stackDeployer     deploy.StackDeployer
+	logger            logr.Logger
+	metricsCollector  lbcmetrics.MetricCollector
+	reconcileCounters *metricsutil.ReconcileCounters
 
 	maxConcurrentReconciles int
 }
@@ -90,26 +98,46 @@ type serviceReconciler struct {
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 func (r *serviceReconciler) Reconcile(ctx context.Context, req reconcile.Request) (ctrl.Result, error) {
+	r.reconcileCounters.IncrementService(req.NamespacedName)
 	return runtime.HandleReconcileError(r.reconcile(ctx, req), r.logger)
 }
 
 func (r *serviceReconciler) reconcile(ctx context.Context, req reconcile.Request) error {
 	svc := &corev1.Service{}
-	if err := r.k8sClient.Get(ctx, req.NamespacedName, svc); err != nil {
+	var err error
+	fetchServiceFn := func() {
+		err = r.k8sClient.Get(ctx, req.NamespacedName, svc)
+	}
+	r.metricsCollector.ObserveControllerReconcileLatency(controllerName, "fetch_service", fetchServiceFn)
+	if err != nil {
 		return client.IgnoreNotFound(err)
 	}
-	stack, lb, backendSGRequired, err := r.buildModel(ctx, svc)
-	if err != nil {
-		return err
+
+	var stack core.Stack
+	var lb *elbv2model.LoadBalancer
+	var backendSGRequired bool
+	buildModelFn := func() {
+		stack, lb, backendSGRequired, err = r.buildModel(ctx, svc)
 	}
+	r.metricsCollector.ObserveControllerReconcileLatency(controllerName, "build_model", buildModelFn)
+	if err != nil {
+		return errmetrics.NewErrorWithMetrics(controllerName, "build_model_error", err, r.metricsCollector)
+	}
+
 	if lb == nil {
-		return r.cleanupLoadBalancerResources(ctx, svc, stack)
+		cleanupLoadBalancerFn := func() {
+			err = r.cleanupLoadBalancerResources(ctx, svc, stack)
+		}
+		r.metricsCollector.ObserveControllerReconcileLatency(controllerName, "cleanup_load_balancer", cleanupLoadBalancerFn)
+		if err != nil {
+			return errmetrics.NewErrorWithMetrics(controllerName, "cleanup_load_balancer_error", err, r.metricsCollector)
+		}
 	}
 	return r.reconcileLoadBalancerResources(ctx, svc, stack, lb, backendSGRequired)
 }
 
 func (r *serviceReconciler) buildModel(ctx context.Context, svc *corev1.Service) (core.Stack, *elbv2model.LoadBalancer, bool, error) {
-	stack, lb, backendSGRequired, err := r.modelBuilder.Build(ctx, svc)
+	stack, lb, backendSGRequired, err := r.modelBuilder.Build(ctx, svc, r.metricsCollector)
 	if err != nil {
 		r.eventRecorder.Event(svc, corev1.EventTypeWarning, k8s.ServiceEventReasonFailedBuildModel, fmt.Sprintf("Failed build model due to %v", err))
 		return nil, nil, false, err
@@ -124,7 +152,7 @@ func (r *serviceReconciler) buildModel(ctx context.Context, svc *corev1.Service)
 }
 
 func (r *serviceReconciler) deployModel(ctx context.Context, svc *corev1.Service, stack core.Stack) error {
-	if err := r.stackDeployer.Deploy(ctx, stack); err != nil {
+	if err := r.stackDeployer.Deploy(ctx, stack, r.metricsCollector, "service"); err != nil {
 		var requeueNeededAfter *runtime.RequeueNeededAfter
 		if errors.As(err, &requeueNeededAfter) {
 			return err
@@ -139,28 +167,47 @@ func (r *serviceReconciler) deployModel(ctx context.Context, svc *corev1.Service
 
 func (r *serviceReconciler) reconcileLoadBalancerResources(ctx context.Context, svc *corev1.Service, stack core.Stack,
 	lb *elbv2model.LoadBalancer, backendSGRequired bool) error {
-	if err := r.finalizerManager.AddFinalizers(ctx, svc, serviceFinalizer); err != nil {
+
+	var err error
+	addFinalizersFn := func() {
+		err = r.finalizerManager.AddFinalizers(ctx, svc, serviceFinalizer)
+	}
+	r.metricsCollector.ObserveControllerReconcileLatency(controllerName, "add_finalizers", addFinalizersFn)
+	if err != nil {
 		r.eventRecorder.Event(svc, corev1.EventTypeWarning, k8s.ServiceEventReasonFailedAddFinalizer, fmt.Sprintf("Failed add finalizer due to %v", err))
-		return err
+		return errmetrics.NewErrorWithMetrics(controllerName, "add_finalizers_error", err, r.metricsCollector)
 	}
-	err := r.deployModel(ctx, svc, stack)
-	if err != nil {
-		return err
+
+	deployModelFn := func() {
+		err = r.deployModel(ctx, svc, stack)
 	}
-	lbDNS, err := lb.DNSName().Resolve(ctx)
+	r.metricsCollector.ObserveControllerReconcileLatency(controllerName, "deploy_model", deployModelFn)
 	if err != nil {
-		return err
+		return errmetrics.NewErrorWithMetrics(controllerName, "deploy_model_error", err, r.metricsCollector)
+	}
+
+	var lbDNS string
+	dnsResolveFn := func() {
+		lbDNS, err = lb.DNSName().Resolve(ctx)
+	}
+	r.metricsCollector.ObserveControllerReconcileLatency(controllerName, "DNS_resolve", dnsResolveFn)
+	if err != nil {
+		return errmetrics.NewErrorWithMetrics(controllerName, "dns_resolve_error", err, r.metricsCollector)
 	}
 
 	if !backendSGRequired {
 		if err := r.backendSGProvider.Release(ctx, networking.ResourceTypeService, []types.NamespacedName{k8s.NamespacedName(svc)}); err != nil {
-			return err
+			return errmetrics.NewErrorWithMetrics(controllerName, "release_auto_generated_backend_sg_error", err, r.metricsCollector)
 		}
 	}
 
-	if err = r.updateServiceStatus(ctx, lbDNS, svc); err != nil {
+	updateStatusFn := func() {
+		err = r.updateServiceStatus(ctx, lbDNS, svc)
+	}
+	r.metricsCollector.ObserveControllerReconcileLatency(controllerName, "update_status", updateStatusFn)
+	if err != nil {
 		r.eventRecorder.Event(svc, corev1.EventTypeWarning, k8s.ServiceEventReasonFailedUpdateStatus, fmt.Sprintf("Failed update status due to %v", err))
-		return err
+		return errmetrics.NewErrorWithMetrics(controllerName, "update_status_error", err, r.metricsCollector)
 	}
 	r.eventRecorder.Event(svc, corev1.EventTypeNormal, k8s.ServiceEventReasonSuccessfullyReconciled, "Successfully reconciled")
 	return nil

--- a/docs/guide/metrics/prometheus/index.md
+++ b/docs/guide/metrics/prometheus/index.md
@@ -1,0 +1,81 @@
+# Monitoring Controller Metrics with Prometheus
+This document describes how to set up Prometheus for monitoring your AWS Load Balancer Controller, what are available metrics and how to access and query them for insights.
+
+## Setting Up Prometheus
+### Set up Prometheus with kube-prometheus-stack
+To monitor the controller, Prometheus needs to be deployed and configured to scrape metrics from the controller’s HTTP endpoint, This can be done by manually deploy [Promethues Operator](https://github.com/prometheus-operator/prometheus-operator) and the controller expose a metric service and define ServiceMonitor to allow Prometheus to scrape its metric. The easiest way to do this is to install the [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) Helm chart by following the readme file, which provide an automated solution that performs all the set up for you.
+
+### Verify Metric Collection
+Based on your metric service config, running the similar command to access it locally
+
+```bash
+kubectl port-forward -n kube-system svc/aws-load-balancer-controller-metrics 8080:8080
+```
+
+Navigate to [http://localhost:8080/metrics](http://localhost:8080/metrics), you should be able to see all metric in one place.
+
+## Metrics Available
+### Controller-Runtime Build in Metric
+This project use controller-runtime to implement controllers and admission webhooks, which automatically exposes key metrics for controllers and webhooks following kubernetes instrumentation guidelines. They are available via HTTP endpoint in prometheus metric format
+
+Following metrics are instrumented by default: 
+
+* Latency of processing admission requests.
+* Current number of admission requests being served
+* Histogram of the latency of processing admission requests
+* Total number of admission requests by HTTP status code
+* Total number of reconciliations per controller
+* Total number of reconciliation errors per controller
+* Total number of terminal reconciliation errors per controller
+* Total number of reconciliation panics per controller
+* Length of time per reconciliation per controller
+* Maximum number of concurrent reconciles per controller
+* Number of currently used workers per controller
+
+### Custom Metrics from AWS Load Balancer Controller
+In addition to the default metrics provided by controller-runtime, this project emits several custom metrics to provide fine-grained view of its behavior and performances. 
+
+Following metrics are added: 
+
+| Name | Type | Description |
+|------|------|-------------|
+| aws_api_calls_total | Counter | Total number of SDK API calls from the customer's code to AWS services |
+| aws_api_call_duration_seconds | Histogram | Perceived latency from when your code makes an SDK call, includes retries |
+| aws_api_call_call_retries | Counter | Number of times the SDK retried requests to AWS services for SDK API calls |
+| aws_api_requests_total | Counter | Total number of HTTP requests that the SDK made |
+| aws_request_duration_seconds | Histogram | Latency of an individual HTTP request to the service endpoint |
+| api_call_permission_errors_total | Counter | Number of failed AWS API calls due to auth or authorization failures |
+| api_call_service_limit_exceeded_errors_total | Counter | Number of failed AWS API calls due to exceeding service limit |
+| api_call_throttled_errors_total | Counter| Number of failed AWS API calls due to throttling error |
+| api_call_validation_errors_total | Counter | Number of failed AWS API calls due to validation error |
+| awslbc_readiness_gate_ready_seconds | Histogram | Time to flip a readiness gate to true |
+| awslbc_reconcile_stage_duration | Histogram | Latency of different reconcile stages |
+| awslbc_reconcile_errors_total | Counter | Number of controller errors by error type |
+| awslbc_webhook_validation_failures_total | Counter | Number of validation errors by webhook type |
+| awslbc_webhook_mutation_failures_total | Counter | Number of mutation errors by webhook type |
+| awslbc_top_talkers | Gauge | Number of reconciliations by resource |
+
+
+##  Accessing and Querying the Metrics in Prometheus UI
+To explore and query the collected metrics, access the Prometheus web UI. Running the following command to access it locally
+
+```bash
+kubectl port-forward -n prometheus svc/prometheus-operated 9090:9090
+```
+
+Navigate to [http://localhost:9090](http://localhost:9090) and check the Status - Target Health page. Ensure that your controller’s endpoint is listed and marked as UP.
+
+Once inside the Prometheus UI, you can use PromQL queries. Here are some examples:
+
+* Get the total reconcile count :  `sum(awslbc_controller_reconcile_errors_total)`
+* Get the average reconcile duration for stage : `avg(awslbc_controller_reconcile_stage_duration_sum{controller="service", reconcile_stage="DNS_resolve"})`
+* Get the cached object: `sum(awslbc_cache_object_total)`
+
+
+
+##  Visualizing Metrics
+If you want to further visualize there metrics, one of option is to use Grafana, For set up you can
+
+* Use the Grafana instance included in the kube-promethues-stack.
+* Deploy Grafana separately and connect it to Prometheus as a data source.
+* Import or create custom dashboards to display relevant metrics.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,8 @@ nav:
         - Frontend Security Groups: guide/use_cases/frontend_sg/index.md
         - Blue/Green: guide/use_cases/blue_green/index.md
         - MultiCluster Target Groups: guide/use_cases/multi_cluster/index.md
+      - Metrics:
+        - Prometheus: guide/metrics/prometheus/index.md
   - Examples:
     - EchoServer: examples/echo_server.md
     - gRPCServer: examples/grpc_server.md

--- a/pkg/error/error_with_metrics.go
+++ b/pkg/error/error_with_metrics.go
@@ -1,0 +1,25 @@
+package errmetrics
+
+import (
+	lbcmetrics "sigs.k8s.io/aws-load-balancer-controller/pkg/metrics/lbc"
+)
+
+type ErrorWithMetrics struct {
+	ResourceType  string
+	ErrorCategory string
+	Err           error
+}
+
+func NewErrorWithMetrics(resourceType string, errorCategory string, err error, metricCollector lbcmetrics.MetricCollector) *ErrorWithMetrics {
+	reconcileErr := &ErrorWithMetrics{
+		ResourceType:  resourceType,
+		ErrorCategory: errorCategory,
+		Err:           err,
+	}
+	metricCollector.ObserveControllerReconcileError(resourceType, errorCategory)
+	return reconcileErr
+}
+
+func (e *ErrorWithMetrics) Error() string {
+	return e.Err.Error()
+}

--- a/pkg/ingress/model_builder.go
+++ b/pkg/ingress/model_builder.go
@@ -2,9 +2,10 @@ package ingress
 
 import (
 	"context"
-	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 	"reflect"
 	"strconv"
+
+	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/go-logr/logr"
@@ -19,7 +20,9 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/config"
 	elbv2deploy "sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/elbv2"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/tracking"
+	errmetrics "sigs.k8s.io/aws-load-balancer-controller/pkg/error"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
+	lbcmetrics "sigs.k8s.io/aws-load-balancer-controller/pkg/metrics/lbc"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/core"
 	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
 	networkingpkg "sigs.k8s.io/aws-load-balancer-controller/pkg/networking"
@@ -28,12 +31,13 @@ import (
 
 const (
 	lbAttrsDeletionProtectionEnabled = "deletion_protection.enabled"
+	controllerName                   = "ingress"
 )
 
 // ModelBuilder is responsible for build mode stack for a IngressGroup.
 type ModelBuilder interface {
 	// build mode stack for a IngressGroup.
-	Build(ctx context.Context, ingGroup Group) (core.Stack, *elbv2model.LoadBalancer, []types.NamespacedName, bool, error)
+	Build(ctx context.Context, ingGroup Group, metricsCollector lbcmetrics.MetricCollector) (core.Stack, *elbv2model.LoadBalancer, []types.NamespacedName, bool, error)
 }
 
 // NewDefaultModelBuilder constructs new defaultModelBuilder.
@@ -44,7 +48,7 @@ func NewDefaultModelBuilder(k8sClient client.Client, eventRecorder record.EventR
 	trackingProvider tracking.Provider, elbv2TaggingManager elbv2deploy.TaggingManager, featureGates config.FeatureGates,
 	vpcID string, clusterName string, defaultTags map[string]string, externalManagedTags []string, defaultSSLPolicy string, defaultTargetType string, defaultLoadBalancerScheme string,
 	backendSGProvider networkingpkg.BackendSGProvider, sgResolver networkingpkg.SecurityGroupResolver,
-	enableBackendSG bool, disableRestrictedSGRules bool, allowedCAARNs []string, enableIPTargetType bool, logger logr.Logger) *defaultModelBuilder {
+	enableBackendSG bool, disableRestrictedSGRules bool, allowedCAARNs []string, enableIPTargetType bool, logger logr.Logger, metricsCollector lbcmetrics.MetricCollector) *defaultModelBuilder {
 	certDiscovery := NewACMCertDiscovery(acmClient, allowedCAARNs, logger)
 	ruleOptimizer := NewDefaultRuleOptimizer(logger)
 	return &defaultModelBuilder{
@@ -74,6 +78,7 @@ func NewDefaultModelBuilder(k8sClient client.Client, eventRecorder record.EventR
 		disableRestrictedSGRules:  disableRestrictedSGRules,
 		enableIPTargetType:        enableIPTargetType,
 		logger:                    logger,
+		metricsCollector:          metricsCollector,
 	}
 }
 
@@ -109,11 +114,12 @@ type defaultModelBuilder struct {
 	disableRestrictedSGRules  bool
 	enableIPTargetType        bool
 
-	logger logr.Logger
+	logger           logr.Logger
+	metricsCollector lbcmetrics.MetricCollector
 }
 
 // build mode stack for a IngressGroup.
-func (b *defaultModelBuilder) Build(ctx context.Context, ingGroup Group) (core.Stack, *elbv2model.LoadBalancer, []types.NamespacedName, bool, error) {
+func (b *defaultModelBuilder) Build(ctx context.Context, ingGroup Group, metricsCollector lbcmetrics.MetricCollector) (core.Stack, *elbv2model.LoadBalancer, []types.NamespacedName, bool, error) {
 	stack := core.NewDefaultStack(core.StackID(ingGroup.ID))
 	task := &defaultModelBuildTask{
 		k8sClient:                b.k8sClient,
@@ -137,6 +143,7 @@ func (b *defaultModelBuilder) Build(ctx context.Context, ingGroup Group) (core.S
 		enableBackendSG:          b.enableBackendSG,
 		disableRestrictedSGRules: b.disableRestrictedSGRules,
 		enableIPTargetType:       b.enableIPTargetType,
+		metricsCollector:         b.metricsCollector,
 
 		ingGroup: ingGroup,
 		stack:    stack,
@@ -219,6 +226,8 @@ type defaultModelBuildTask struct {
 	tgByResID       map[string]*elbv2model.TargetGroup
 	backendServices map[types.NamespacedName]*corev1.Service
 	secretKeys      []types.NamespacedName
+
+	metricsCollector lbcmetrics.MetricCollector
 }
 
 func (t *defaultModelBuildTask) run(ctx context.Context) error {
@@ -265,29 +274,26 @@ func (t *defaultModelBuildTask) run(ctx context.Context) error {
 
 	lb, err := t.buildLoadBalancer(ctx, listenPortConfigByPort)
 	if err != nil {
-		return err
+		return errmetrics.NewErrorWithMetrics(controllerName, "build_load_balancer_error", err, t.metricsCollector)
 	}
 
 	t.sslRedirectConfig, err = t.buildSSLRedirectConfig(ctx, listenPortConfigByPort)
 	if err != nil {
-		return err
-	}
-	if err != nil {
-		return err
+		return errmetrics.NewErrorWithMetrics(controllerName, "build_ssl_redirct_config_error", err, t.metricsCollector)
 	}
 	for port, cfg := range listenPortConfigByPort {
 		ingList := ingListByPort[port]
 		ls, err := t.buildListener(ctx, lb.LoadBalancerARN(), port, cfg, ingList)
 		if err != nil {
-			return err
+			return errmetrics.NewErrorWithMetrics(controllerName, "build_listener_error", err, t.metricsCollector)
 		}
 		if err := t.buildListenerRules(ctx, ls.ListenerARN(), port, cfg.protocol, ingList); err != nil {
-			return err
+			return errmetrics.NewErrorWithMetrics(controllerName, "build_listener_rule_error", err, t.metricsCollector)
 		}
 	}
 
 	if err := t.buildLoadBalancerAddOns(ctx, lb.LoadBalancerARN()); err != nil {
-		return err
+		return errmetrics.NewErrorWithMetrics(controllerName, "build_load_balancer_addons", err, t.metricsCollector)
 	}
 	return nil
 }

--- a/pkg/metrics/lbc/collector.go
+++ b/pkg/metrics/lbc/collector.go
@@ -1,18 +1,38 @@
 package lbc
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
+	"context"
+	"fmt"
 	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
+	networking "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
+	metricsutil "sigs.k8s.io/aws-load-balancer-controller/pkg/metrics/util"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type MetricCollector interface {
 	// ObservePodReadinessGateReady this metric is useful to determine how fast pods are becoming ready in the load balancer.
 	// Due to some architectural constraints, we can only emit this metric for pods that are using readiness gates.
 	ObservePodReadinessGateReady(namespace string, tgbName string, duration time.Duration)
+	ObserveControllerReconcileError(controller string, errorType string)
+	ObserveControllerReconcileLatency(controller string, stage string, fn func())
+	ObserveWebhookValidationError(webhookName string, errorType string)
+	ObserveWebhookMutationError(webhookName string, errorType string)
+	StartCollectTopTalkers(ctx context.Context)
+	StartCollectCacheSize(ctx context.Context)
 }
 
 type collector struct {
 	instruments *instruments
+	mgr         ctrl.Manager
+	counter     *metricsutil.ReconcileCounters
+	logger      logr.Logger
 }
 
 type noOpCollector struct{}
@@ -20,7 +40,28 @@ type noOpCollector struct{}
 func (n *noOpCollector) ObservePodReadinessGateReady(_ string, _ string, _ time.Duration) {
 }
 
-func NewCollector(registerer prometheus.Registerer) MetricCollector {
+func (n *noOpCollector) ObserveControllerReconcileError(_ string, _ string) {
+}
+
+func (n *noOpCollector) ObserveWebhookValidationError(_ string, _ string) {
+}
+
+func (n *noOpCollector) ObserveWebhookMutationError(_ string, _ string) {
+}
+
+func (n *noOpCollector) ObserveControllerCacheSize(_ string, _ int) {
+}
+
+func (n *noOpCollector) ObserveControllerReconcileLatency(_ string, _ string, fn func()) {
+}
+
+func (n *noOpCollector) StartCollectTopTalkers(_ context.Context) {
+}
+
+func (n *noOpCollector) StartCollectCacheSize(_ context.Context) {
+}
+
+func NewCollector(registerer prometheus.Registerer, mgr ctrl.Manager, reconcileCounters *metricsutil.ReconcileCounters, logger logr.Logger) MetricCollector {
 	if registerer == nil {
 		return &noOpCollector{}
 	}
@@ -28,6 +69,9 @@ func NewCollector(registerer prometheus.Registerer) MetricCollector {
 	instruments := newInstruments(registerer)
 	return &collector{
 		instruments: instruments,
+		mgr:         mgr,
+		counter:     reconcileCounters,
+		logger:      logger,
 	}
 }
 
@@ -36,4 +80,111 @@ func (c *collector) ObservePodReadinessGateReady(namespace string, tgbName strin
 		labelNamespace: namespace,
 		labelName:      tgbName,
 	}).Observe(duration.Seconds())
+}
+
+func (c *collector) ObserveControllerReconcileError(controller string, errorCategory string) {
+	c.instruments.controllerReconcileErrors.With(prometheus.Labels{
+		labelController:    controller,
+		labelErrorCategory: errorCategory,
+	}).Inc()
+}
+
+func (c *collector) ObserveControllerReconcileLatency(controller string, stage string, fn func()) {
+	start := time.Now()
+	defer func() {
+		c.instruments.controllerReconcileLatency.With(prometheus.Labels{
+			labelController:     controller,
+			labelReconcileStage: stage,
+		}).Observe(time.Since(start).Seconds())
+	}()
+	fn()
+}
+
+func (c *collector) ObserveWebhookValidationError(webhookName string, errorCategory string) {
+	c.instruments.webhookValidationFailure.With(prometheus.Labels{
+		labelWebhookName:   webhookName,
+		labelErrorCategory: errorCategory,
+	}).Inc()
+}
+
+func (c *collector) ObserveWebhookMutationError(webhookName string, errorCategory string) {
+	c.instruments.webhookMutationFailure.With(prometheus.Labels{
+		labelWebhookName:   webhookName,
+		labelErrorCategory: errorCategory,
+	}).Inc()
+}
+
+func (c *collector) ObserveControllerCacheSize(resource string, count int) {
+	c.instruments.controllerCacheObjectCount.With(prometheus.Labels{
+		LabelResource: resource,
+	}).Set(float64(count))
+}
+
+func (c *collector) ObserveControllerTopThreeTalkers(controller, namespace string, name string, count int) {
+	c.instruments.controllerReconcileTopTalkers.With(prometheus.Labels{
+		labelController: controller,
+		labelNamespace:  namespace,
+		labelName:       name,
+	}).Set(float64(count))
+}
+
+func (c *collector) StartCollectCacheSize(ctx context.Context) {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := c.CollectCacheSize(ctx); err != nil {
+				c.logger.Error(err, "failed to collect cache size")
+			}
+		}
+	}
+}
+
+func (c *collector) CollectCacheSize(ctx context.Context) error {
+	cache := c.mgr.GetCache()
+	collectableResources := map[string]client.ObjectList{
+		"service":            &corev1.ServiceList{},
+		"ingress":            &networking.IngressList{},
+		"targetgroupbinding": &elbv2api.TargetGroupBindingList{},
+	}
+	for resourceType, resourceList := range collectableResources {
+		if err := cache.List(ctx, resourceList); err != nil {
+			return fmt.Errorf("failed to list %s: %w", resourceType, err)
+		}
+		items, err := meta.ExtractList(resourceList)
+		if err != nil {
+			return fmt.Errorf("failed to extract items from %s list: %w", resourceType, err)
+		}
+
+		c.ObserveControllerCacheSize(resourceType, len(items))
+	}
+	return nil
+}
+
+func (c *collector) StartCollectTopTalkers(ctx context.Context) {
+	ticker := time.NewTicker(3 * time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			c.CollectTopTalker(ctx)
+		}
+	}
+}
+
+func (c *collector) CollectTopTalker(ctx context.Context) {
+	topThreeReconciles := c.counter.GetTopReconciles(3)
+	for resourceType, items := range topThreeReconciles {
+		for _, item := range items {
+			c.ObserveControllerTopThreeTalkers(resourceType, item.Resource.Namespace, item.Resource.Name, item.Count)
+		}
+	}
+	c.counter.ResetCounter()
 }

--- a/pkg/metrics/lbc/instruments.go
+++ b/pkg/metrics/lbc/instruments.go
@@ -12,15 +12,38 @@ const (
 const (
 	// MetricPodReadinessGateReady tracks the time to flip a readiness gate to true
 	MetricPodReadinessGateReady = "readiness_gate_ready_seconds"
+	// MetricControllerReconcileErrors tracks the total number of controller errors by error type.
+	MetricControllerReconcileErrors = "controller_reconcile_errors_total"
+	// MetricControllerReconcileStageDuration tracks latencies of different reconcile stages.
+	MetricControllerReconcileStageDuration = "controller_reconcile_stage_duration"
+	// MetricWebhookValidationFailure tracks the total number of validation errors by error type.
+	MetricWebhookValidationFailure = "webhook_validation_failure_total"
+	// MetricWebhookMutationFailure tracks the total number of mutation errors by error type.
+	MetricWebhookMutationFailure = "webhook_mutation_failure_total"
+	// MetricControllerCacheObjectCount tracks the total number of object in the controller runtime cache.
+	MetricControllerCacheObjectCount = "controller_cache_object_total"
+	// MetricTopTalker tracks what resources are causing the most reconciles.
+	MetricControllerTopTalkers = "controller_top_talkers"
 )
 
 const (
-	labelNamespace = "namespace"
-	labelName      = "name"
+	labelNamespace      = "namespace"
+	labelName           = "name"
+	labelController     = "controller"
+	labelErrorCategory  = "error_category"
+	labelReconcileStage = "reconcile_stage"
+	labelWebhookName    = "webhook_name"
+	LabelResource       = "resource"
 )
 
 type instruments struct {
-	podReadinessFlipSeconds *prometheus.HistogramVec
+	podReadinessFlipSeconds       *prometheus.HistogramVec
+	controllerReconcileErrors     *prometheus.CounterVec
+	controllerReconcileLatency    *prometheus.HistogramVec
+	webhookValidationFailure      *prometheus.CounterVec
+	webhookMutationFailure        *prometheus.CounterVec
+	controllerCacheObjectCount    *prometheus.GaugeVec
+	controllerReconcileTopTalkers *prometheus.GaugeVec
 }
 
 // newInstruments allocates and register new metrics to registerer
@@ -32,8 +55,51 @@ func newInstruments(registerer prometheus.Registerer) *instruments {
 		Buckets:   []float64{10, 30, 60, 120, 180, 240, 300, 360, 420, 480, 540, 600},
 	}, []string{labelNamespace, labelName})
 
-	registerer.MustRegister(podReadinessFlipSeconds)
+	controllerReconcileErrors := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Subsystem: metricSubsystem,
+		Name:      MetricControllerReconcileErrors,
+		Help:      "Counts the number of reconcile error, categorized by error type.",
+	}, []string{labelController, labelErrorCategory})
+
+	controllerReconcileStageDuration := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Subsystem: metricSubsystem,
+		Name:      MetricControllerReconcileStageDuration,
+		Help:      "latencies of different reconcile stages.",
+		Buckets:   prometheus.DefBuckets,
+	}, []string{labelController, labelReconcileStage})
+
+	webhookValidationFailure := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Subsystem: metricSubsystem,
+		Name:      MetricWebhookValidationFailure,
+		Help:      "Counts the number of webhook validation failure, categorized by error type.",
+	}, []string{labelWebhookName, labelErrorCategory})
+
+	webhookMutationFailure := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Subsystem: metricSubsystem,
+		Name:      MetricWebhookMutationFailure,
+		Help:      "Counts the number of webhook mutation failure, categorized by error type.",
+	}, []string{labelWebhookName, labelErrorCategory})
+
+	controllerCacheObjectCount := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: metricSubsystem,
+		Name:      MetricControllerCacheObjectCount,
+		Help:      "Counts the number of objects in the controller cache.",
+	}, []string{LabelResource})
+
+	controllerReconcileTopTalkers := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: metricSubsystem,
+		Name:      MetricControllerTopTalkers,
+		Help:      "Counts the number of reconciliations triggered per resource",
+	}, []string{labelController, labelNamespace, labelName})
+
+	registerer.MustRegister(podReadinessFlipSeconds, controllerReconcileErrors, controllerReconcileStageDuration, webhookValidationFailure, webhookMutationFailure, controllerCacheObjectCount, controllerReconcileTopTalkers)
 	return &instruments{
-		podReadinessFlipSeconds: podReadinessFlipSeconds,
+		podReadinessFlipSeconds:       podReadinessFlipSeconds,
+		controllerReconcileErrors:     controllerReconcileErrors,
+		controllerReconcileLatency:    controllerReconcileStageDuration,
+		webhookValidationFailure:      webhookValidationFailure,
+		webhookMutationFailure:        webhookMutationFailure,
+		controllerCacheObjectCount:    controllerCacheObjectCount,
+		controllerReconcileTopTalkers: controllerReconcileTopTalkers,
 	}
 }

--- a/pkg/metrics/lbc/mockcollector.go
+++ b/pkg/metrics/lbc/mockcollector.go
@@ -1,11 +1,23 @@
 package lbc
 
 import (
+	"context"
+	"fmt"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	networking "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
+	metricsutil "sigs.k8s.io/aws-load-balancer-controller/pkg/metrics/util"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type MockCollector struct {
 	Invocations map[string][]interface{}
+	mgr         ctrl.Manager
+	counter     *metricsutil.ReconcileCounters
 }
 
 type MockHistogramMetric struct {
@@ -14,8 +26,60 @@ type MockHistogramMetric struct {
 	duration  time.Duration
 }
 
+type MockCounterMetric struct {
+	labelController    string
+	labelErrorCategory string
+	labelNamespace     string
+	labelName          string
+	resource           string
+	webhookName        string
+	errorType          string
+}
+
 func (m *MockCollector) ObservePodReadinessGateReady(namespace string, tgbName string, d time.Duration) {
 	m.recordHistogram(MetricPodReadinessGateReady, namespace, tgbName, d)
+}
+
+func (m *MockCollector) ObserveControllerReconcileError(controller string, errorCategory string) {
+	m.Invocations[MetricControllerReconcileErrors] = append(m.Invocations[MetricControllerReconcileErrors], MockCounterMetric{
+		labelController:    controller,
+		labelErrorCategory: errorCategory,
+	})
+}
+
+func (m *MockCollector) ObserveControllerReconcileLatency(controller string, stage string, fn func()) {
+	m.Invocations[MetricControllerReconcileStageDuration] = append(m.Invocations[MetricControllerReconcileStageDuration], MockCounterMetric{
+		labelController:    controller,
+		labelErrorCategory: stage,
+	})
+}
+
+func (m *MockCollector) ObserveWebhookValidationError(webhookName string, errorCategory string) {
+	m.Invocations[MetricWebhookValidationFailure] = append(m.Invocations[MetricWebhookValidationFailure], MockCounterMetric{
+		webhookName:        webhookName,
+		labelErrorCategory: errorCategory,
+	})
+}
+
+func (m *MockCollector) ObserveWebhookMutationError(webhookName string, errorCategory string) {
+	m.Invocations[MetricWebhookMutationFailure] = append(m.Invocations[MetricWebhookMutationFailure], MockCounterMetric{
+		webhookName:        webhookName,
+		labelErrorCategory: errorCategory,
+	})
+}
+
+func (m *MockCollector) ObserveControllerCacheSize(resource string, count int) {
+	m.Invocations[MetricControllerCacheObjectCount] = append(m.Invocations[MetricControllerCacheObjectCount], MockCounterMetric{
+		resource: resource,
+	})
+}
+
+func (m *MockCollector) ObserveControllerTopTalkers(controller, namespace string, name string) {
+	m.Invocations[MetricControllerTopTalkers] = append(m.Invocations[MetricControllerTopTalkers], MockCounterMetric{
+		labelController: controller,
+		labelNamespace:  namespace,
+		labelName:       name,
+	})
 }
 
 func (m *MockCollector) recordHistogram(metricName string, namespace string, name string, d time.Duration) {
@@ -26,10 +90,75 @@ func (m *MockCollector) recordHistogram(metricName string, namespace string, nam
 	})
 }
 
-func NewMockCollector() MetricCollector {
+func (m *MockCollector) CollectTopTalker(ctx context.Context) {
+	topThreeReconciles := m.counter.GetTopReconciles(3)
+	for resourceType, items := range topThreeReconciles {
+		for _, item := range items {
+			m.ObserveControllerTopTalkers(resourceType, item.Resource.Namespace, item.Resource.Name)
+		}
+	}
+}
 
+func (m *MockCollector) StartCollectTopTalkers(ctx context.Context) {
+	ticker := time.NewTicker(30 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.CollectTopTalker(ctx)
+		}
+	}
+
+}
+
+func (m *MockCollector) StartCollectCacheSize(ctx context.Context) {
+	ticker := time.NewTicker(30 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.CollectCacheSize(ctx)
+		}
+	}
+
+}
+
+func (c *MockCollector) CollectCacheSize(ctx context.Context) error {
+	cache := c.mgr.GetCache()
+	collectableResources := map[string]client.ObjectList{
+		"service":            &corev1.ServiceList{},
+		"ingress":            &networking.IngressList{},
+		"targetgroupbinding": &elbv2api.TargetGroupBindingList{},
+	}
+	for resourceType, resourceList := range collectableResources {
+		if err := cache.List(ctx, resourceList); err != nil {
+			return fmt.Errorf("failed to list %s: %w", resourceType, err)
+		}
+		items, err := meta.ExtractList(resourceList)
+		if err != nil {
+			return fmt.Errorf("failed to extract items from %s list: %w", resourceType, err)
+		}
+
+		c.ObserveControllerCacheSize(resourceType, len(items))
+	}
+	return nil
+}
+
+func NewMockCollector() MetricCollector {
 	mockInvocations := make(map[string][]interface{})
 	mockInvocations[MetricPodReadinessGateReady] = make([]interface{}, 0)
+	mockInvocations[MetricControllerReconcileErrors] = make([]interface{}, 0)
+	mockInvocations[MetricControllerReconcileStageDuration] = make([]interface{}, 0)
+	mockInvocations[MetricWebhookValidationFailure] = make([]interface{}, 0)
+	mockInvocations[MetricWebhookMutationFailure] = make([]interface{}, 0)
+	mockInvocations[MetricControllerCacheObjectCount] = make([]interface{}, 0)
+	mockInvocations[MetricControllerTopTalkers] = make([]interface{}, 0)
 
 	return &MockCollector{
 		Invocations: mockInvocations,

--- a/pkg/metrics/util/reconcile_counter.go
+++ b/pkg/metrics/util/reconcile_counter.go
@@ -1,0 +1,81 @@
+package util
+
+import (
+	"sort"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type ReconcileCounters struct {
+	serviceReconciles map[types.NamespacedName]int
+	ingressReconciles map[types.NamespacedName]int
+	tgbReconciles     map[types.NamespacedName]int
+	mutex             sync.Mutex
+}
+
+type ResourceReconcileCount struct {
+	Resource types.NamespacedName
+	Count    int
+}
+
+func NewReconcileCounters() *ReconcileCounters {
+	return &ReconcileCounters{
+		serviceReconciles: make(map[types.NamespacedName]int),
+		ingressReconciles: make(map[types.NamespacedName]int),
+		tgbReconciles:     make(map[types.NamespacedName]int),
+		mutex:             sync.Mutex{},
+	}
+}
+
+func (c *ReconcileCounters) IncrementService(namespaceName types.NamespacedName) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.serviceReconciles[namespaceName]++
+}
+
+func (c *ReconcileCounters) IncrementIngress(namespaceName types.NamespacedName) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.ingressReconciles[namespaceName]++
+}
+
+func (c *ReconcileCounters) IncrementTGB(namespaceName types.NamespacedName) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.tgbReconciles[namespaceName]++
+}
+
+func (c *ReconcileCounters) GetTopReconciles(n int) map[string][]ResourceReconcileCount {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	topReconciles := make(map[string][]ResourceReconcileCount)
+	getTopN := func(m map[types.NamespacedName]int) []ResourceReconcileCount {
+		reconciles := make([]ResourceReconcileCount, 0, len(m))
+		for k, v := range m {
+			reconciles = append(reconciles, ResourceReconcileCount{Resource: k, Count: v})
+		}
+
+		sort.Slice(reconciles, func(i, j int) bool {
+			return reconciles[i].Count > reconciles[j].Count
+		})
+		if len(reconciles) > n {
+			reconciles = reconciles[:n]
+		}
+		return reconciles
+	}
+
+	topReconciles["service"] = getTopN(c.serviceReconciles)
+	topReconciles["ingress"] = getTopN(c.ingressReconciles)
+	topReconciles["targetgroupbinding"] = getTopN(c.tgbReconciles)
+
+	return topReconciles
+}
+
+func (c *ReconcileCounters) ResetCounter() {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.serviceReconciles = make(map[types.NamespacedName]int)
+	c.ingressReconciles = make(map[types.NamespacedName]int)
+	c.tgbReconciles = make(map[types.NamespacedName]int)
+}

--- a/pkg/service/model_builder.go
+++ b/pkg/service/model_builder.go
@@ -2,9 +2,10 @@ package service
 
 import (
 	"context"
-	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"strconv"
 	"sync"
+
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -15,7 +16,9 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/config"
 	elbv2deploy "sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/elbv2"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/tracking"
+	errmetrics "sigs.k8s.io/aws-load-balancer-controller/pkg/error"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
+	lbcmetrics "sigs.k8s.io/aws-load-balancer-controller/pkg/metrics/lbc"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/core"
 	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/networking"
@@ -27,12 +30,13 @@ const (
 	LoadBalancerTargetTypeIP       = "ip"
 	LoadBalancerTargetTypeInstance = "instance"
 	lbAttrsDeletionProtection      = "deletion_protection.enabled"
+	controllerName                 = "service"
 )
 
 // ModelBuilder builds the model stack for the service resource.
 type ModelBuilder interface {
 	// Build model stack for service
-	Build(ctx context.Context, service *corev1.Service) (core.Stack, *elbv2model.LoadBalancer, bool, error)
+	Build(ctx context.Context, service *corev1.Service, metricsCollector lbcmetrics.MetricCollector) (core.Stack, *elbv2model.LoadBalancer, bool, error)
 }
 
 // NewDefaultModelBuilder construct a new defaultModelBuilder
@@ -41,7 +45,7 @@ func NewDefaultModelBuilder(annotationParser annotations.Parser, subnetsResolver
 	elbv2TaggingManager elbv2deploy.TaggingManager, ec2Client services.EC2, featureGates config.FeatureGates, clusterName string, defaultTags map[string]string,
 	externalManagedTags []string, defaultSSLPolicy string, defaultTargetType string, defaultLoadBalancerScheme string, enableIPTargetType bool, serviceUtils ServiceUtils,
 	backendSGProvider networking.BackendSGProvider, sgResolver networking.SecurityGroupResolver, enableBackendSG bool,
-	disableRestrictedSGRules bool, logger logr.Logger) *defaultModelBuilder {
+	disableRestrictedSGRules bool, logger logr.Logger, metricsCollector lbcmetrics.MetricCollector) *defaultModelBuilder {
 	return &defaultModelBuilder{
 		annotationParser:          annotationParser,
 		subnetsResolver:           subnetsResolver,
@@ -64,6 +68,7 @@ func NewDefaultModelBuilder(annotationParser annotations.Parser, subnetsResolver
 		enableBackendSG:           enableBackendSG,
 		disableRestrictedSGRules:  disableRestrictedSGRules,
 		logger:                    logger,
+		metricsCollector:          metricsCollector,
 	}
 }
 
@@ -92,9 +97,10 @@ type defaultModelBuilder struct {
 	defaultLoadBalancerScheme elbv2model.LoadBalancerScheme
 	enableIPTargetType        bool
 	logger                    logr.Logger
+	metricsCollector          lbcmetrics.MetricCollector
 }
 
-func (b *defaultModelBuilder) Build(ctx context.Context, service *corev1.Service) (core.Stack, *elbv2model.LoadBalancer, bool, error) {
+func (b *defaultModelBuilder) Build(ctx context.Context, service *corev1.Service, metricsCollector lbcmetrics.MetricCollector) (core.Stack, *elbv2model.LoadBalancer, bool, error) {
 	stack := core.NewDefaultStack(core.StackID(k8s.NamespacedName(service)))
 	task := &defaultModelBuildTask{
 		clusterName:              b.clusterName,
@@ -113,6 +119,7 @@ func (b *defaultModelBuilder) Build(ctx context.Context, service *corev1.Service
 		enableBackendSG:          b.enableBackendSG,
 		disableRestrictedSGRules: b.disableRestrictedSGRules,
 		logger:                   b.logger,
+		metricsCollector:         b.metricsCollector,
 
 		service:   service,
 		stack:     stack,
@@ -170,6 +177,7 @@ type defaultModelBuildTask struct {
 	enableIPTargetType  bool
 	ec2Client           services.EC2
 	logger              logr.Logger
+	metricsCollector    lbcmetrics.MetricCollector
 
 	service *corev1.Service
 
@@ -239,19 +247,19 @@ func (t *defaultModelBuildTask) run(ctx context.Context) error {
 func (t *defaultModelBuildTask) buildModel(ctx context.Context) error {
 	scheme, err := t.buildLoadBalancerScheme(ctx)
 	if err != nil {
-		return err
+		return errmetrics.NewErrorWithMetrics(controllerName, "build_load_balancer_scheme_error", err, t.metricsCollector)
 	}
 	t.ec2Subnets, err = t.buildLoadBalancerSubnets(ctx, scheme)
 	if err != nil {
-		return err
+		return errmetrics.NewErrorWithMetrics(controllerName, "build_load_balancer_subnets_error", err, t.metricsCollector)
 	}
 	err = t.buildLoadBalancer(ctx, scheme)
 	if err != nil {
-		return err
+		return errmetrics.NewErrorWithMetrics(controllerName, "build_load_balancer_error", err, t.metricsCollector)
 	}
 	err = t.buildListeners(ctx, scheme)
 	if err != nil {
-		return err
+		return errmetrics.NewErrorWithMetrics(controllerName, "build_listeners_error", err, t.metricsCollector)
 	}
 	return nil
 }

--- a/webhooks/core/service_mutator.go
+++ b/webhooks/core/service_mutator.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	lbcmetrics "sigs.k8s.io/aws-load-balancer-controller/pkg/metrics/lbc"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/webhook"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -16,10 +17,11 @@ const (
 )
 
 // NewServiceMutator returns a mutator for Service.
-func NewServiceMutator(lbClass string, logger logr.Logger) *serviceMutator {
+func NewServiceMutator(lbClass string, logger logr.Logger, metricsCollector lbcmetrics.MetricCollector) *serviceMutator {
 	return &serviceMutator{
 		logger:            logger,
 		loadBalancerClass: lbClass,
+		metricsCollector:  metricsCollector,
 	}
 }
 
@@ -28,6 +30,7 @@ var _ webhook.Mutator = &serviceMutator{}
 type serviceMutator struct {
 	logger            logr.Logger
 	loadBalancerClass string
+	metricsCollector  lbcmetrics.MetricCollector
 }
 
 func (m *serviceMutator) Prototype(_ admission.Request) (runtime.Object, error) {

--- a/webhooks/networking/ingress_validator_test.go
+++ b/webhooks/networking/ingress_validator_test.go
@@ -17,6 +17,7 @@ import (
 	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/ingress"
+	lbcmetrics "sigs.k8s.io/aws-load-balancer-controller/pkg/metrics/lbc"
 	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -243,11 +244,13 @@ func Test_ingressValidator_checkIngressClass(t *testing.T) {
 				assert.NoError(t, k8sClient.Create(ctx, ingClass.DeepCopy()))
 			}
 			classAnnotationMatcher := ingress.NewDefaultClassAnnotationMatcher(tt.configuredIngressClass)
+			mockMetricsCollector := lbcmetrics.NewMockCollector()
 			v := &ingressValidator{
 				classLoader:                        ingress.NewDefaultClassLoader(k8sClient, false),
 				classAnnotationMatcher:             classAnnotationMatcher,
 				manageIngressesWithoutIngressClass: tt.configuredIngressClass == "",
 				logger:                             logr.New(&log.NullLogSink{}),
+				metricsCollector:                   mockMetricsCollector,
 			}
 			skip, err := v.checkIngressClass(ctx, tt.ing)
 			if tt.expectedErr == "" {


### PR DESCRIPTION
### Description

-  metricAPIPermissionErrorsTotal
-  metricAPILimitExceededTotal
-  metricAPIThrottledTotal
-  metricAPIValidationErrorTotal
-  MetricControllerReconcileErrors tracks the total number of controller errors by error type.
-  MetricControllerReconcileStageDuration tracks latencies of different reconcile stages.
-  MetricWebhookValidationFailure tracks the total number of validation errors by error type.
-  MetricWebhookMutationFailure tracks the total number of mutation errors by error type.
-  MetricControllerCacheObjectCount tracks the total number of object in the controller runtime cache.
-  MetricControllerTopTalker 


### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
