### PR TITLE
add toggle to adjust failurePolicy of pod webhook and documentations

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -11,7 +11,7 @@ webhooks:
         name: webhook-service
         namespace: system
         path: /mutate-v1-pod
-    failurePolicy: Fail
+    failurePolicy: Ignore
     name: mpod.elbv2.k8s.aws
     rules:
       - apiGroups:

--- a/helm/aws-load-balancer-controller/templates/webhook.yaml
+++ b/helm/aws-load-balancer-controller/templates/webhook.yaml
@@ -19,7 +19,7 @@ webhooks:
       name: {{ template "aws-load-balancer-controller.webhookService" . }}
       namespace: {{ $.Release.Namespace }}
       path: /mutate-v1-pod
-  failurePolicy: Ignore
+  failurePolicy: {{ .Values.podMutatorWebhookConfig.failurePolicy }}
   name: mpod.elbv2.k8s.aws
   admissionReviewVersions:
   - v1beta1

--- a/helm/aws-load-balancer-controller/test.yaml
+++ b/helm/aws-load-balancer-controller/test.yaml
@@ -353,3 +353,7 @@ serviceMutatorWebhookConfig:
   operations:
   - CREATE
   # - UPDATE
+
+podMutatorWebhookConfig:
+  # whether or not to fail the pod creation if the webhook fails
+  failurePolicy: Ignore

--- a/helm/aws-load-balancer-controller/values.yaml
+++ b/helm/aws-load-balancer-controller/values.yaml
@@ -430,6 +430,11 @@ serviceMutatorWebhookConfig:
   - CREATE
     # - UPDATE
 
+# podMutatorWebhookConfig contains configurations specific to the service mutator webhook
+podMutatorWebhookConfig:
+  # whether or not to fail the pod creation if the webhook fails
+  failurePolicy: Ignore
+
 # serviceTargetENISGTags specifies AWS tags, in addition to the cluster tags, for finding the target ENI SG to which to add inbound rules from NLBs.
 serviceTargetENISGTags:
 


### PR DESCRIPTION
### Issue

<n/a>

### Description
add a toggle(`--set podMutatorWebhookConfig.failurePolicy`) to adjust the failurePolicy of pod Webhook and related documentations.

### Rendered docs

<img width="708" alt="Screenshot 2025-02-18 at 3 58 12 PM" src="https://github.com/user-attachments/assets/46621e10-08a5-4f0a-b5c5-d3ba02a6d63c" />

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
