### PR TITLE
raise an error when multiple backendSGs exist

### DIFF
--- a/pkg/networking/backend_sg_provider_test.go
+++ b/pkg/networking/backend_sg_provider_test.go
@@ -115,6 +115,28 @@ func Test_defaultBackendSGProvider_Get(t *testing.T) {
 			want: "sg-autogen",
 		},
 		{
+			name: "backend sg enabled, auto-gen, multiple SGs exist",
+			fields: fields{
+				describeSGCalls: []describeSecurityGroupsAsListCall{
+					{
+						req: &ec2sdk.DescribeSecurityGroupsInput{
+							Filters: defaultEC2Filters,
+						},
+						resp: []ec2types.SecurityGroup{
+							{
+								GroupId: awssdk.String("sg-autogen"),
+							},
+							{
+								GroupId: awssdk.String("sg-other"),
+							},
+						},
+					},
+				},
+				ingResources: []*networking.Ingress{ing, ing1},
+			},
+			wantErr: errors.New("Found multiple SGs with vpc-id vpc-xxxyyy and tags elbv2.k8s.aws/cluster=testCluster, elbv2.k8s.aws/resource=backend-sg"),
+		},
+		{
 			name: "backend sg enabled, auto-gen new SG",
 			fields: fields{
 				describeSGCalls: []describeSecurityGroupsAsListCall{


### PR DESCRIPTION
### Issue

#3953

### Description

Raise an error when multiple backendSGs with same vpc-id and tags exist instead of using the first one found.

### Checklist
- [X] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [X] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
