### PR TITLE
Feat(performance): Use protobuf as default type instead of json

### DIFF
--- a/pkg/config/runtime_config.go
+++ b/pkg/config/runtime_config.go
@@ -109,7 +109,6 @@ func BuildRestConfig(rtCfg RuntimeConfig) (*rest.Config, error) {
 	}
 
 	restCFG.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
-	restCFG.ContentType = "application/vnd.kubernetes.protobuf"
 	restCFG.QPS = defaultQPS
 	restCFG.Burst = defaultBurst
 	return restCFG, nil

--- a/pkg/config/runtime_config.go
+++ b/pkg/config/runtime_config.go
@@ -108,6 +108,8 @@ func BuildRestConfig(rtCfg RuntimeConfig) (*rest.Config, error) {
 		return nil, err
 	}
 
+	restCFG.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
+	restCFG.ContentType = "application/vnd.kubernetes.protobuf"
 	restCFG.QPS = defaultQPS
 	restCFG.Burst = defaultBurst
 	return restCFG, nil


### PR DESCRIPTION
### Issue

Currently the controller only accepts the JSON responses from kube-apiserver. Accepting the more efficient Protobuf representation responses will improve performance at scale. This affects majorly the Pod cache ListWatch that is set [here](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/pkg/k8s/pod_info_repo.go#L37) and can act as a bottleneck in clusters with large amount of pods.

By default, Kubernetes returns objects serialized to JSON with content type application/json. This is the default serialization format for the API. However, clients may request the more efficient [Protobuf representation](https://kubernetes.io/docs/reference/using-api/api-concepts/#protobuf-encoding) of these objects for better performance at scale.

Discussion on issue 3749 requested protobuf as the default vs. using flags to enable.
https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3749

### Description

<!--
Added the following two lines to runtime_config.go

	restCFG.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
	restCFG.ContentType = "application/vnd.kubernetes.protobuf"
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
