### PR TITLE
fix(docs): update broken link to TargetGroupBinding CRD page

### DIFF
--- a/docs/guide/use_cases/self_managed_lb/index.md
+++ b/docs/guide/use_cases/self_managed_lb/index.md
@@ -80,7 +80,7 @@ Have this information available:
 
 ## Create TargetGroupBinding CRD
 
-1. Create the [TargetGroupBinding CRD](/guide/targetgroupbinding/targetgroupbinding.md)
+1. Create the [TargetGroupBinding CRD](/docs/guide/targetgroupbinding/targetgroupbinding.md)
 
 Insert the ARN of the Target Group, as created above.
 


### PR DESCRIPTION
### Description

Link associated with "Create the [TargetGroupBinding CRD](https://kubernetes-sigs.github.io/guide/targetgroupbinding/targetgroupbinding.md)" on [the Self-Managed LB page](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/use_cases/self_managed_lb/#create-targetgroupbinding-crd) of the documentation results in a 404.
PR fixes the link with the updated path.


### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
