### PR TITLE
Allow specifying the same certificate for both default and SNI

### DIFF
--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -787,7 +787,9 @@ TLS support can be controlled with the following annotations:
 - <a name="certificate-arn">`alb.ingress.kubernetes.io/certificate-arn`</a> specifies the ARN of one or more certificate managed by [AWS Certificate Manager](https://aws.amazon.com/certificate-manager)
 
     !!!tip ""
-        The first certificate in the list will be added as default certificate. And remaining certificate will be added to the optional certificate list.
+        The first certificate in the list will be added as the default certificate.
+        The remaining certificates will be added to the optional SNI certificate list.
+        If the same certificate as the default certificate is also listed again (either explicitly in the list or via annotations from other IngressGroup members), it will still be added to the SNI list as well.
         See [SSL Certificates](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#https-listener-certificates) for more details.
 
     !!!tip "Certificate Discovery"

--- a/pkg/ingress/model_builder.go
+++ b/pkg/ingress/model_builder.go
@@ -313,12 +313,22 @@ func (t *defaultModelBuildTask) mergeListenPortConfigs(_ context.Context, listen
 	var mergedSSLPolicy *string
 
 	var mergedTLSCerts []string
+
+	// Set the default cert as the first cert
+	// This process allows the same certificate to be specified for both the default certificate and the SNI certificate.
+	for _, cfg := range listenPortConfigs {
+		if len(cfg.listenPortConfig.tlsCerts) > 0 {
+			mergedTLSCerts = append(mergedTLSCerts, cfg.listenPortConfig.tlsCerts[0])
+			break
+		}
+	}
+
 	mergedTLSCertsSet := sets.NewString()
 
 	var mergedMtlsAttributesProvider *types.NamespacedName
 	var mergedMtlsAttributes *elbv2model.MutualAuthenticationAttributes
 
-	for _, cfg := range listenPortConfigs {
+	for i, cfg := range listenPortConfigs {
 		if mergedProtocolProvider == nil {
 			mergedProtocolProvider = &cfg.ingKey
 			mergedProtocol = cfg.listenPortConfig.protocol
@@ -361,7 +371,12 @@ func (t *defaultModelBuildTask) mergeListenPortConfigs(_ context.Context, listen
 			}
 		}
 
-		for _, cert := range cfg.listenPortConfig.tlsCerts {
+		for j, cert := range cfg.listenPortConfig.tlsCerts {
+			// Ignore the first cert as it is the default cert
+			// Default cert is already added to the mergedTLSCerts
+			if i == 0 && j == 0 {
+				continue
+			}
 			if mergedTLSCertsSet.Has(cert) {
 				continue
 			}

--- a/pkg/ingress/model_builder.go
+++ b/pkg/ingress/model_builder.go
@@ -316,9 +316,11 @@ func (t *defaultModelBuildTask) mergeListenPortConfigs(_ context.Context, listen
 
 	// Set the default cert as the first cert
 	// This process allows the same certificate to be specified for both the default certificate and the SNI certificate.
-	for _, cfg := range listenPortConfigs {
+	var defaultCertMemberIndex int
+	for i, cfg := range listenPortConfigs {
 		if len(cfg.listenPortConfig.tlsCerts) > 0 {
 			mergedTLSCerts = append(mergedTLSCerts, cfg.listenPortConfig.tlsCerts[0])
+			defaultCertMemberIndex = i
 			break
 		}
 	}
@@ -372,9 +374,8 @@ func (t *defaultModelBuildTask) mergeListenPortConfigs(_ context.Context, listen
 		}
 
 		for j, cert := range cfg.listenPortConfig.tlsCerts {
-			// Ignore the first cert as it is the default cert
-			// Default cert is already added to the mergedTLSCerts
-			if i == 0 && j == 0 {
+			// The first certificate is ignored as it is the default certificate, which has already been added to the mergedTLSCerts.
+			if i == defaultCertMemberIndex && j == 0 {
 				continue
 			}
 			if mergedTLSCertsSet.Has(cert) {

--- a/pkg/ingress/model_builder_test.go
+++ b/pkg/ingress/model_builder_test.go
@@ -1006,6 +1006,295 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 }`,
 		},
 		{
+			name: "Ingress - using acm and internet-facing case with the same acm certificate for default and sni listener",
+			env: env{
+				svcs: []*corev1.Service{ns_1_svc_1, ns_1_svc_2, ns_1_svc_3},
+			},
+			fields: fields{
+				resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternetFacingLB},
+				listLoadBalancersCalls:   []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
+				enableBackendSG:          true,
+			},
+			args: args{
+				ingGroup: Group{
+					ID: GroupID{Namespace: "ns-1", Name: "ing-1"},
+					Members: []ClassifiedIngress{
+						{
+							Ing: &networking.Ingress{ObjectMeta: metav1.ObjectMeta{
+								Namespace: "ns-1",
+								Name:      "ing-1",
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/scheme":                "internet-facing",
+									"alb.ingress.kubernetes.io/certificate-arn":       "arn:aws:acm:us-east-1:9999999:certificate/11111111,arn:aws:acm:us-east-1:9999999:certificate/33333333,arn:aws:acm:us-east-1:9999999:certificate/22222222,,arn:aws:acm:us-east-1:9999999:certificate/11111111",
+									"alb.ingress.kubernetes.io/mutual-authentication": `[{"port":443,"mode":"off"}]`,
+								},
+							},
+								Spec: networking.IngressSpec{
+									Rules: []networking.IngressRule{
+										{
+											Host: "app-1.example.com",
+											IngressRuleValue: networking.IngressRuleValue{
+												HTTP: &networking.HTTPIngressRuleValue{
+													Paths: []networking.HTTPIngressPath{
+														{
+															Path: "/svc-1",
+															Backend: networking.IngressBackend{
+																Service: &networking.IngressServiceBackend{
+																	Name: ns_1_svc_1.Name,
+																	Port: networking.ServiceBackendPort{
+																		Name: "http",
+																	},
+																},
+															},
+														},
+														{
+															Path: "/svc-2",
+															Backend: networking.IngressBackend{
+																Service: &networking.IngressServiceBackend{
+																	Name: ns_1_svc_2.Name,
+																	Port: networking.ServiceBackendPort{
+																		Name: "http",
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+										{
+											Host: "app-2.example.com",
+											IngressRuleValue: networking.IngressRuleValue{
+												HTTP: &networking.HTTPIngressRuleValue{
+													Paths: []networking.HTTPIngressPath{
+														{
+															Path: "/svc-3",
+															Backend: networking.IngressBackend{
+																Service: &networking.IngressServiceBackend{
+																	Name: ns_1_svc_3.Name,
+																	Port: networking.ServiceBackendPort{
+																		Name: "https",
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantStackPatch: `
+{
+	"resources": {
+		"AWS::EC2::SecurityGroup": {
+			"ManagedLBSecurityGroup": {
+				"spec": {
+					"ingress": [
+						{
+							"fromPort": 443,
+							"ipProtocol": "tcp",
+							"ipRanges": [
+								{
+									"cidrIP": "0.0.0.0/0"
+								}
+							],
+							"toPort": 443
+						}
+					]
+				}
+			}
+		},
+		"AWS::ElasticLoadBalancingV2::Listener": {
+			"443": {
+				"spec": {
+					"certificates": [
+						{
+							"certificateARN": "arn:aws:acm:us-east-1:9999999:certificate/11111111"
+						},
+						{
+							"certificateARN": "arn:aws:acm:us-east-1:9999999:certificate/33333333"
+						},
+						{
+							"certificateARN": "arn:aws:acm:us-east-1:9999999:certificate/22222222"
+						},
+						{
+							"certificateARN": "arn:aws:acm:us-east-1:9999999:certificate/11111111"
+						}
+					],
+					"defaultActions": [
+						{
+							"fixedResponseConfig": {
+								"contentType": "text/plain",
+								"statusCode": "404"
+							},
+							"type": "fixed-response"
+						}
+					],
+					"loadBalancerARN": {
+						"$ref": "#/resources/AWS::ElasticLoadBalancingV2::LoadBalancer/LoadBalancer/status/loadBalancerARN"
+					},
+					"port": 443,
+					"protocol": "HTTPS",
+					"sslPolicy": "ELBSecurityPolicy-2016-08",
+                    "mutualAuthentication" : {
+						"mode" : "off",
+                        "trustStoreArn": ""
+					}
+				}
+			},
+			"80": null
+		},
+		"AWS::ElasticLoadBalancingV2::ListenerRule": {
+			"443:1": {
+				"spec": {
+					"actions": [
+						{
+							"forwardConfig": {
+								"targetGroups": [
+									{
+										"targetGroupARN": {
+											"$ref": "#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/ns-1/ing-1-svc-1:http/status/targetGroupARN"
+										}
+									}
+								]
+							},
+							"type": "forward"
+						}
+					],
+					"conditions": [
+						{
+							"field": "host-header",
+							"hostHeaderConfig": {
+								"values": [
+									"app-1.example.com"
+								]
+							}
+						},
+						{
+							"field": "path-pattern",
+							"pathPatternConfig": {
+								"values": [
+									"/svc-1"
+								]
+							}
+						}
+					],
+					"listenerARN": {
+						"$ref": "#/resources/AWS::ElasticLoadBalancingV2::Listener/443/status/listenerARN"
+					},
+					"priority": 1
+				}
+			},
+			"443:2": {
+				"spec": {
+					"actions": [
+						{
+							"forwardConfig": {
+								"targetGroups": [
+									{
+										"targetGroupARN": {
+											"$ref": "#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/ns-1/ing-1-svc-2:http/status/targetGroupARN"
+										}
+									}
+								]
+							},
+							"type": "forward"
+						}
+					],
+					"conditions": [
+						{
+							"field": "host-header",
+							"hostHeaderConfig": {
+								"values": [
+									"app-1.example.com"
+								]
+							}
+						},
+						{
+							"field": "path-pattern",
+							"pathPatternConfig": {
+								"values": [
+									"/svc-2"
+								]
+							}
+						}
+					],
+					"listenerARN": {
+						"$ref": "#/resources/AWS::ElasticLoadBalancingV2::Listener/443/status/listenerARN"
+					},
+					"priority": 2
+				}
+			},
+			"443:3": {
+				"spec": {
+					"actions": [
+						{
+							"forwardConfig": {
+								"targetGroups": [
+									{
+										"targetGroupARN": {
+											"$ref": "#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/ns-1/ing-1-svc-3:https/status/targetGroupARN"
+										}
+									}
+								]
+							},
+							"type": "forward"
+						}
+					],
+					"conditions": [
+						{
+							"field": "host-header",
+							"hostHeaderConfig": {
+								"values": [
+									"app-2.example.com"
+								]
+							}
+						},
+						{
+							"field": "path-pattern",
+							"pathPatternConfig": {
+								"values": [
+									"/svc-3"
+								]
+							}
+						}
+					],
+					"listenerARN": {
+						"$ref": "#/resources/AWS::ElasticLoadBalancingV2::Listener/443/status/listenerARN"
+					},
+					"priority": 3
+				}
+			},
+			"80:1": null,
+			"80:2": null,
+			"80:3": null
+		},
+		"AWS::ElasticLoadBalancingV2::LoadBalancer": {
+			"LoadBalancer": {
+				"spec": {
+					"name": "k8s-ns1-ing1-159dd7a143",
+					"scheme": "internet-facing",
+					"subnetMapping": [
+						{
+							"subnetID": "subnet-c"
+						},
+						{
+							"subnetID": "subnet-d"
+						}
+					]
+				}
+			}
+		}
+	}
+}`,
+		},
+		{
 			name: "Ingress - using acm and internet-facing",
 			env: env{
 				svcs: []*corev1.Service{ns_1_svc_1, ns_1_svc_2, ns_1_svc_3},


### PR DESCRIPTION
### Issue
#3070
<!-- Please link the GitHub issues related to this PR, if available -->

### Description

<!--
Please explain the changes you made here.

Help your reviewers by guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

As described in issue #3070, previously a certificate selected as the default certificate could not also be selected as an SNI certificate.
However, according to ALB specifications, this configuration is allowed and there is a real use case demand for it.
Therefore, this PR modifies the behavior to allow the same certificate to be used for both the default and SNI.

The image shows the deployment of an Ingress with the following annotation configured.

```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: ingress-sample
  annotations:
    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:ap-northeast-1:xxxxxxxxxxxx:certificate/23cecxxxxxxxxx,arn:aws:acm:ap-northeast-1:xxxxxxxxxxx:certificate/0796adxxxxxxxxx,arn:aws:acm:ap-northeast-1:xxxxxxxxxxxxx:certificate/23cecxxxxxxxx
....
```
<img width="968" alt="スクリーンショット 2025-03-29 21 58 23" src="https://github.com/user-attachments/assets/82ee16af-f351-4f24-92b4-5a66845b7bbf" />



### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
