### PR TITLE
fix bug(introduced by #4109) in subnet resolver

### DIFF
--- a/pkg/networking/subnet_resolver.go
+++ b/pkg/networking/subnet_resolver.go
@@ -458,20 +458,20 @@ func (r *defaultSubnetsResolver) chooseSubnetsPerAZ(subnets []ec2types.Subnet) [
 	for az, azSubnets := range subnetsByAZ {
 		if len(azSubnets) == 1 {
 			chosenSubnets = append(chosenSubnets, azSubnets[0])
-		} else if len(subnets) > 1 {
-			sort.Slice(subnets, func(i, j int) bool {
-				subnetIHasCurrentClusterTag := r.isSubnetContainsCurrentClusterTag(subnets[i])
-				subnetJHasCurrentClusterTag := r.isSubnetContainsCurrentClusterTag(subnets[j])
+		} else if len(azSubnets) > 1 {
+			sort.Slice(azSubnets, func(i, j int) bool {
+				subnetIHasCurrentClusterTag := r.isSubnetContainsCurrentClusterTag(azSubnets[i])
+				subnetJHasCurrentClusterTag := r.isSubnetContainsCurrentClusterTag(azSubnets[j])
 				if subnetIHasCurrentClusterTag && (!subnetJHasCurrentClusterTag) {
 					return true
 				} else if (!subnetIHasCurrentClusterTag) && subnetJHasCurrentClusterTag {
 					return false
 				}
-				return awssdk.ToString(subnets[i].SubnetId) < awssdk.ToString(subnets[j].SubnetId)
+				return awssdk.ToString(azSubnets[i].SubnetId) < awssdk.ToString(azSubnets[j].SubnetId)
 			})
 			r.logger.V(1).Info("multiple subnets in the same AvailabilityZone", "AvailabilityZone", az,
-				"chosen", subnets[0].SubnetId, "ignored", extractSubnetIDs(subnets[1:]))
-			chosenSubnets = append(chosenSubnets, subnets[0])
+				"chosen", azSubnets[0].SubnetId, "ignored", extractSubnetIDs(azSubnets[1:]))
+			chosenSubnets = append(chosenSubnets, azSubnets[0])
 		}
 	}
 	sortSubnetsByID(chosenSubnets)
@@ -528,9 +528,9 @@ func (r *defaultSubnetsResolver) isSubnetContainsSufficientIPAddresses(subnet ec
 // subnets passed-in must be non-empty
 func (r *defaultSubnetsResolver) validateSubnetsAZExclusivity(subnets []ec2types.Subnet) error {
 	subnetsByAZ := mapSDKSubnetsByAZ(subnets)
-	for az, subnets := range subnetsByAZ {
-		if len(subnets) > 1 {
-			return fmt.Errorf("multiple subnets in same Availability Zone %v: %v", az, extractSubnetIDs(subnets))
+	for az, azSubnets := range subnetsByAZ {
+		if len(azSubnets) > 1 {
+			return fmt.Errorf("multiple subnets in same Availability Zone %v: %v", az, extractSubnetIDs(azSubnets))
 		}
 	}
 	return nil


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description
Fix a bug introduced by #4109.  When there are multiple candidate subnets in 2+ AZs, the chosen subnet is incorrect. 
It wasn't captured by initial UT/manual test, only triggers when there are multiple subnets in 2+ zones.
Updated the test case to capture this.

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [x] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
