### PR TITLE
 bug: fix misformated crd url in CRD cleanup

### DIFF
--- a/scripts/run-e2e-test.sh
+++ b/scripts/run-e2e-test.sh
@@ -53,7 +53,7 @@ function cleanUp(){
   if [[ $ADC_REGIONS == *"$REGION"* ]]; then
     kubectl delete -k "$SCRIPT_DIR"/../helm/aws-load-balancer-controller/crds --timeout=30s || true
   else
-    kubectl delete -k "github.com/aws/eks-charts/stable/aws-load-balancer-controller//crds?ref=master" --timeout=30s || true
+    kubectl delete -k "github.com/aws/eks-charts//stable/aws-load-balancer-controller/crds?ref=master" --timeout=30s || true
   fi
 }
 


### PR DESCRIPTION
### Issue
run into below failure during test
```
"error: failed to run '/usr/bin/git fetch --depth=1 https://github.com/aws/eks-charts/stable/aws-load-balancer-controller master': remote: Not Found"
```

### Test
**reproduction**
```
helm install aws-load-balancer-controller eks/aws-load-balancer-controller --namespace kube-system --set clusterName=clustername
kubectl delete -k "github.com/aws/eks-charts/stable/aws-load-balancer-controller//crds?ref=master" --timeout=30s 
error: failed to run '/usr/bin/git fetch --depth=1 https://github.com/aws/eks-charts/stable/aws-load-balancer-controller master': remote: Not Found
fatal: repository 'https://github.com/aws/eks-charts/stable/aws-load-balancer-controller/' not found
: exit status 128
```
**fix verification**
```
kubectl delete -k "github.com/aws/eks-charts//stable/aws-load-balancer-controller/crds?ref=master" --timeout=30s 
customresourcedefinition.apiextensions.k8s.io "ingressclassparams.elbv2.k8s.aws" deleted
```


### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [x] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:
