### PR TITLE
[feat: gw api] Add common listener config for gateway api

### DIFF
--- a/controllers/gateway/gateway_controller.go
+++ b/controllers/gateway/gateway_controller.go
@@ -205,7 +205,7 @@ func (r *gatewayReconciler) reconcileHelper(ctx context.Context, req reconcile.R
 	return r.reconcileUpdate(ctx, gw, stack, lb, backendSGRequired)
 }
 
-func (r *gatewayReconciler) reconcileDelete(ctx context.Context, gw *gwv1.Gateway, routes map[int][]routeutils.RouteDescriptor) error {
+func (r *gatewayReconciler) reconcileDelete(ctx context.Context, gw *gwv1.Gateway, routes map[int32][]routeutils.RouteDescriptor) error {
 	for _, routeList := range routes {
 		if len(routeList) != 0 {
 			// TODO - Better error messaging (e.g. tell user the routes that are still attached)
@@ -259,7 +259,7 @@ func (r *gatewayReconciler) deployModel(ctx context.Context, gw *gwv1.Gateway, s
 	return nil
 }
 
-func (r *gatewayReconciler) buildModel(ctx context.Context, gw *gwv1.Gateway, gwClass *gwv1.GatewayClass, listenerToRoute map[int][]routeutils.RouteDescriptor) (core.Stack, *elbv2model.LoadBalancer, bool, error) {
+func (r *gatewayReconciler) buildModel(ctx context.Context, gw *gwv1.Gateway, gwClass *gwv1.GatewayClass, listenerToRoute map[int32][]routeutils.RouteDescriptor) (core.Stack, *elbv2model.LoadBalancer, bool, error) {
 	stack, lb, backendSGRequired, err := r.modelBuilder.Build(ctx, gw, &elbv2gw.LoadBalancerConfiguration{}, listenerToRoute)
 	if err != nil {
 		r.eventRecorder.Event(gw, corev1.EventTypeWarning, k8s.ServiceEventReasonFailedBuildModel, fmt.Sprintf("Failed build model due to %v", err))

--- a/pkg/gateway/model/model_build_listener.go
+++ b/pkg/gateway/model/model_build_listener.go
@@ -1,0 +1,350 @@
+package model
+
+import (
+	"fmt"
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/gateway/routeutils"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/ingress"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/core"
+	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+	"strconv"
+	"strings"
+)
+
+// TODO: Add more relevant info like TLS settings and hostnames later wherever applicable
+type gwListenerConfig struct {
+	protocol  elbv2model.Protocol
+	hostnames []string
+}
+
+type listenerBuilder interface {
+	buildListeners(stack core.Stack, lb *elbv2model.LoadBalancer, securityGroups securityGroupOutput, gw *gwv1.Gateway, routes map[int32][]routeutils.RouteDescriptor, lbConf *elbv2gw.LoadBalancerConfiguration) error
+	buildListenerSpec(stack core.Stack, lb *elbv2model.LoadBalancer, securityGroups securityGroupOutput, gw *gwv1.Gateway, port int32, routes []routeutils.RouteDescriptor, lbCfg *elbv2gw.LoadBalancerConfiguration, gwLsCfg *gwListenerConfig, lbLsCfg *elbv2gw.ListenerConfiguration) (*elbv2model.ListenerSpec, error)
+	buildL7ListenerSpec(stack core.Stack, lb *elbv2model.LoadBalancer, securityGroups securityGroupOutput, gw *gwv1.Gateway, lbCfg *elbv2gw.LoadBalancerConfiguration, port int32, routes []routeutils.RouteDescriptor, gwLsCfg *gwListenerConfig, lbLsCfg *elbv2gw.ListenerConfiguration) (*elbv2model.ListenerSpec, error)
+	buildL4ListenerSpec(stack core.Stack, lb *elbv2model.LoadBalancer, securityGroups securityGroupOutput, gw *gwv1.Gateway, lbCfg *elbv2gw.LoadBalancerConfiguration, port int32, routes []routeutils.RouteDescriptor, gwLsCfg *gwListenerConfig, lbLsCfg *elbv2gw.ListenerConfiguration) (*elbv2model.ListenerSpec, error)
+}
+
+type listenerBuilderImpl struct {
+	loadBalancerType elbv2model.LoadBalancerType
+	clusterName      string
+	tagHelper        tagHelper
+	tgBuilder        targetGroupBuilder
+	defaultSSLPolicy string
+	logger           logr.Logger
+}
+
+func (l listenerBuilderImpl) buildListeners(stack core.Stack, lb *elbv2model.LoadBalancer, securityGroups securityGroupOutput, gw *gwv1.Gateway, routes map[int32][]routeutils.RouteDescriptor, lbCfg *elbv2gw.LoadBalancerConfiguration) error {
+	gwLsCfgs, err := mapGatewayListenerConfigsByPort(gw)
+	if err != nil {
+		return err
+	}
+	gwLsPorts := sets.Int32KeySet(gwLsCfgs)
+	portsWithRoutes := sets.Int32KeySet(routes)
+	// Materialise the listener only if listener has associated routes
+	if len(gwLsPorts.Intersection(portsWithRoutes).List()) != 0 {
+		lbLsCfgs := mapLoadBalancerListenerConfigsByPort(lbCfg)
+		for _, port := range gwLsPorts.Intersection(portsWithRoutes).List() {
+			ls, err := l.buildListener(stack, lb, securityGroups, gw, port, routes[port], lbCfg, gwLsCfgs[port], lbLsCfgs[port])
+			if err != nil {
+				return err
+			}
+			// build rules only for L7 gateways
+			if l.loadBalancerType == elbv2model.LoadBalancerTypeApplication {
+				if err := l.buildListenerRules(stack, ls, lb, securityGroups, gw, port, lbCfg, routes); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (l listenerBuilderImpl) buildListener(stack core.Stack, lb *elbv2model.LoadBalancer, securityGroups securityGroupOutput, gw *gwv1.Gateway, port int32, routes []routeutils.RouteDescriptor, lbCfg *elbv2gw.LoadBalancerConfiguration, gwLsCfg *gwListenerConfig, lbLsCfg *elbv2gw.ListenerConfiguration) (*elbv2model.Listener, error) {
+	var listenerSpec elbv2model.ListenerSpec
+	if l.loadBalancerType == elbv2model.LoadBalancerTypeApplication {
+		ls, err := l.buildL7ListenerSpec(stack, lb, securityGroups, gw, lbCfg, port, routes, gwLsCfg, lbLsCfg)
+		if err != nil {
+			return nil, err
+		}
+		listenerSpec = *ls
+	} else {
+		ls, err := l.buildL4ListenerSpec(stack, lb, securityGroups, gw, lbCfg, port, routes, gwLsCfg, lbLsCfg)
+		if err != nil {
+			return nil, err
+		}
+		listenerSpec = *ls
+	}
+	lsResID := fmt.Sprintf("%v", port)
+	return elbv2model.NewListener(stack, lsResID, listenerSpec), nil
+}
+
+func (l listenerBuilderImpl) buildListenerSpec(stack core.Stack, lb *elbv2model.LoadBalancer, securityGroups securityGroupOutput, gw *gwv1.Gateway, port int32, routes []routeutils.RouteDescriptor, lbCfg *elbv2gw.LoadBalancerConfiguration, gwLsCfg *gwListenerConfig, lbLsCfg *elbv2gw.ListenerConfiguration) (*elbv2model.ListenerSpec, error) {
+	tags, err := l.buildListenerTags(gw, port, lbCfg, lbLsCfg)
+	if err != nil {
+		return &elbv2model.ListenerSpec{}, err
+	}
+	lsAttributes, attributesErr := buildListenerAttributes(lbLsCfg)
+	if attributesErr != nil {
+		return &elbv2model.ListenerSpec{}, attributesErr
+	}
+	sslPolicy, sslPolicyErr := l.buildSSLPolicy(gwLsCfg, lbLsCfg)
+	if sslPolicyErr != nil {
+		return &elbv2model.ListenerSpec{}, sslPolicyErr
+	}
+	certificates, certsErr := l.buildCertificates(gw, gwLsCfg, lbLsCfg)
+	if certsErr != nil {
+		return &elbv2model.ListenerSpec{}, certsErr
+	}
+	listenerSpec := &elbv2model.ListenerSpec{
+		LoadBalancerARN:    lb.LoadBalancerARN(),
+		Port:               port,
+		Protocol:           gwLsCfg.protocol,
+		Certificates:       certificates,
+		SSLPolicy:          sslPolicy,
+		Tags:               tags,
+		ListenerAttributes: lsAttributes,
+	}
+	return listenerSpec, nil
+}
+
+func (l listenerBuilderImpl) buildL7ListenerSpec(stack core.Stack, lb *elbv2model.LoadBalancer, securityGroups securityGroupOutput, gw *gwv1.Gateway, lbCfg *elbv2gw.LoadBalancerConfiguration, port int32, routes []routeutils.RouteDescriptor, gwLsCfg *gwListenerConfig, lbLsCfg *elbv2gw.ListenerConfiguration) (*elbv2model.ListenerSpec, error) {
+	listenerSpec, err := l.buildListenerSpec(stack, lb, securityGroups, gw, port, routes, lbCfg, gwLsCfg, lbLsCfg)
+	if err != nil {
+		return &elbv2model.ListenerSpec{}, err
+	}
+	listenerSpec.DefaultActions = buildL7ListenerDefaultActions()
+	mutualAuth, err := buildMutualAuthenticationAttributes(gwLsCfg, lbLsCfg)
+	if err != nil {
+		return &elbv2model.ListenerSpec{}, err
+	}
+	listenerSpec.MutualAuthentication = mutualAuth
+	return listenerSpec, nil
+}
+
+func (l listenerBuilderImpl) buildL4ListenerSpec(stack core.Stack, lb *elbv2model.LoadBalancer, securityGroups securityGroupOutput, gw *gwv1.Gateway, lbCfg *elbv2gw.LoadBalancerConfiguration, port int32, routes []routeutils.RouteDescriptor, gwLsCfg *gwListenerConfig, lbLsCfg *elbv2gw.ListenerConfiguration) (*elbv2model.ListenerSpec, error) {
+	listenerSpec, err := l.buildListenerSpec(stack, lb, securityGroups, gw, port, routes, lbCfg, gwLsCfg, lbLsCfg)
+	if err != nil {
+		return &elbv2model.ListenerSpec{}, err
+	}
+	alpnPolicy, err := buildListenerALPNPolicy(listenerSpec.Protocol, lbLsCfg)
+	if err != nil {
+		return &elbv2model.ListenerSpec{}, err
+	}
+	listenerSpec.ALPNPolicy = alpnPolicy
+
+	// For L4 Gateways we will assume that each L4 gateway Listener will have a single L4 route and each route will only have a single backendRef as weighted tgs are not supported for NLBs.
+	if len(routes) > 1 {
+		return &elbv2model.ListenerSpec{}, errors.Errorf("multiple routes %v are not supported for listener on port:protocol %v:%v for gateway %v", routes, port, listenerSpec.Protocol, k8s.NamespacedName(gw))
+	}
+	routeDescriptor := routes[0]
+	if routeDescriptor.GetAttachedRules()[0].GetBackends() == nil || len(routeDescriptor.GetAttachedRules()[0].GetBackends()) == 0 {
+		return &elbv2model.ListenerSpec{}, errors.Errorf("no backend refs found for route %v for gateway %v, one backend ref must be specified", routeDescriptor.GetRouteNamespacedName(), k8s.NamespacedName(gw))
+	}
+	if len(routeDescriptor.GetAttachedRules()[0].GetBackends()) > 1 {
+		return &elbv2model.ListenerSpec{}, errors.Errorf("multiple backend refs found for route %v for listener on port:protocol %v:%v for gateway %v , only one must be specified", routeDescriptor.GetRouteNamespacedName(), port, listenerSpec.Protocol, k8s.NamespacedName(gw))
+	}
+	backend := routeDescriptor.GetAttachedRules()[0].GetBackends()[0]
+	targetGroup, tgErr := l.tgBuilder.buildTargetGroup(stack, gw, lbCfg, lb.Spec.IPAddressType, routeDescriptor, backend, securityGroups.backendSecurityGroupToken)
+	if tgErr != nil {
+		return &elbv2model.ListenerSpec{}, tgErr
+	}
+	listenerSpec.DefaultActions = buildL4ListenerDefaultActions(targetGroup)
+	return listenerSpec, nil
+}
+
+func (l listenerBuilderImpl) buildListenerRules(stack core.Stack, ls *elbv2model.Listener, lb *elbv2model.LoadBalancer, securityGroups securityGroupOutput, gw *gwv1.Gateway, port int32, lbCfg *elbv2gw.LoadBalancerConfiguration, routes map[int32][]routeutils.RouteDescriptor) error {
+	// TODO for L7 Gateway Implementation
+	// This is throw away code
+	// This is temporary implementation for supporting basic multiple HTTPRoute for simple backend refs. We will create default forward action for all the backend refs for all HTTPRoutes for this listener
+	var rules []ingress.Rule
+	for _, descriptors := range routes {
+		for _, descriptor := range descriptors {
+			for _, rule := range descriptor.GetAttachedRules() {
+				for _, backend := range rule.GetBackends() {
+					targetGroup, tgErr := l.tgBuilder.buildTargetGroup(stack, gw, lbCfg, lb.Spec.IPAddressType, descriptor, backend, securityGroups.backendSecurityGroupToken)
+					if tgErr != nil {
+						return tgErr
+					}
+					// Basic condition
+					conditions := []elbv2model.RuleCondition{{
+						Field: elbv2model.RuleConditionFieldPathPattern,
+						PathPatternConfig: &elbv2model.PathPatternConditionConfig{
+							Values: []string{"/*"},
+						},
+					},
+					}
+					actions := buildL4ListenerDefaultActions(targetGroup)
+					tags, tagsErr := l.tagHelper.getGatewayTags(lbCfg)
+					if tagsErr != nil {
+						return tagsErr
+					}
+					rules = append(rules, ingress.Rule{
+						Conditions: conditions,
+						Actions:    actions,
+						Tags:       tags,
+					})
+				}
+			}
+		}
+	}
+
+	priority := int32(1)
+	for _, rule := range rules {
+		ruleResID := fmt.Sprintf("%v:%v", port, priority)
+		_ = elbv2model.NewListenerRule(stack, ruleResID, elbv2model.ListenerRuleSpec{
+			ListenerARN: ls.ListenerARN(),
+			Priority:    priority,
+			Conditions:  rule.Conditions,
+			Actions:     rule.Actions,
+			Tags:        rule.Tags,
+		})
+		priority += 1
+	}
+	return nil
+}
+
+func (l listenerBuilderImpl) buildListenerTags(gw *gwv1.Gateway, port int32, lbCfg *elbv2gw.LoadBalancerConfiguration, lbLsCfg *elbv2gw.ListenerConfiguration) (map[string]string, error) {
+	// TODO Add proper gateway tags for listener
+	return l.tagHelper.getGatewayTags(lbCfg)
+}
+
+func buildListenerAttributes(lsCfg *elbv2gw.ListenerConfiguration) ([]elbv2model.ListenerAttribute, error) {
+	if lsCfg == nil || lsCfg.ListenerAttributes == nil || len(lsCfg.ListenerAttributes) == 0 {
+		return []elbv2model.ListenerAttribute{}, nil
+	}
+	attributes := make([]elbv2model.ListenerAttribute, 0, len(lsCfg.ListenerAttributes))
+	for _, attr := range lsCfg.ListenerAttributes {
+		attributes = append(attributes, elbv2model.ListenerAttribute{
+			Key:   attr.Key,
+			Value: attr.Value,
+		})
+	}
+	return attributes, nil
+}
+
+func (l listenerBuilderImpl) buildCertificates(gw *gwv1.Gateway, gwLsCfg *gwListenerConfig, lbLsCfg *elbv2gw.ListenerConfiguration) ([]elbv2model.Certificate, error) {
+	// TODO for cert discovery and secure listeners during L7 and L4 gateways implementations
+	return nil, nil
+}
+
+// L7 listeners will always have 404 as default actions since we don't have dedicated backend
+func buildL7ListenerDefaultActions() []elbv2model.Action {
+	action404 := elbv2model.Action{
+		Type: elbv2model.ActionTypeFixedResponse,
+		FixedResponseConfig: &elbv2model.FixedResponseActionConfig{
+			ContentType: awssdk.String("text/plain"),
+			StatusCode:  "404",
+		},
+	}
+	return []elbv2model.Action{action404}
+}
+
+func buildL4ListenerDefaultActions(targetGroup *elbv2model.TargetGroup) []elbv2model.Action {
+	return []elbv2model.Action{
+		{
+			Type: elbv2model.ActionTypeForward,
+			ForwardConfig: &elbv2model.ForwardActionConfig{
+				TargetGroups: []elbv2model.TargetGroupTuple{
+					{
+						TargetGroupARN: targetGroup.TargetGroupARN(),
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildMutualAuthenticationAttributes(gwLsCfg *gwListenerConfig, lbLsCfg *elbv2gw.ListenerConfiguration) (*elbv2model.MutualAuthenticationAttributes, error) {
+	// TODO for L7 gateway
+	return nil, nil
+}
+
+func (l listenerBuilderImpl) buildSSLPolicy(gwLsCfg *gwListenerConfig, lbLsCfg *elbv2gw.ListenerConfiguration) (*string, error) {
+	if !isHTTPSOrTLSProtocol(gwLsCfg.protocol) {
+		return nil, nil
+	}
+	if lbLsCfg == nil || lbLsCfg.SslPolicy == nil {
+		return &l.defaultSSLPolicy, nil
+	}
+	return lbLsCfg.SslPolicy, nil
+}
+
+func isHTTPSOrTLSProtocol(protocol elbv2model.Protocol) bool {
+	return protocol == elbv2model.ProtocolHTTPS || protocol == elbv2model.ProtocolTLS
+}
+
+func buildListenerALPNPolicy(listenerProtocol elbv2model.Protocol, lbLsCfg *elbv2gw.ListenerConfiguration) ([]string, error) {
+	if listenerProtocol != elbv2model.ProtocolTLS {
+		return nil, nil
+	}
+	if lbLsCfg == nil || lbLsCfg.ALPNPolicy == nil {
+		return nil, nil
+	}
+	rawALPNPolicy := *lbLsCfg.ALPNPolicy
+	switch rawALPNPolicy {
+	case elbv2gw.ALPNPolicyNone, elbv2gw.ALPNPolicyHTTP1Only, elbv2gw.ALPNPolicyHTTP2Only,
+		elbv2gw.ALPNPolicyHTTP2Preferred, elbv2gw.ALPNPolicyHTTP2Optional:
+		return []string{string(rawALPNPolicy)}, nil
+	default:
+		return nil, errors.Errorf("invalid ALPN policy %v, policy must be one of [%v, %v, %v, %v, %v]",
+			string(rawALPNPolicy), elbv2gw.ALPNPolicyNone, elbv2gw.ALPNPolicyHTTP1Only, elbv2gw.ALPNPolicyHTTP2Only,
+			elbv2gw.ALPNPolicyHTTP2Optional, elbv2gw.ALPNPolicyHTTP2Preferred)
+	}
+
+}
+
+// mapGatewayListenerConfigsByPort creates a mapping of ports to listener configurations from the Gateway listeners.
+func mapGatewayListenerConfigsByPort(gw *gwv1.Gateway) (map[int32]*gwListenerConfig, error) {
+	gwListenerConfigs := make(map[int32]*gwListenerConfig)
+	for _, listener := range gw.Spec.Listeners {
+		port := int32(listener.Port)
+		protocol := listener.Protocol
+		if gwListenerConfigs[port] != nil && string(gwListenerConfigs[port].protocol) != string(protocol) {
+			return nil, fmt.Errorf("invalid listeners on gateway, listeners with same ports cannot have different protocols")
+		}
+		if gwListenerConfigs[port] == nil {
+			gwListenerConfigs[port] = &gwListenerConfig{
+				protocol:  elbv2model.Protocol(protocol),
+				hostnames: []string{},
+			}
+		}
+		hostnames := gwListenerConfigs[port].hostnames
+		if listener.Hostname != nil {
+			hostnames = append(hostnames, string(*listener.Hostname))
+			gwListenerConfigs[port].hostnames = hostnames
+		}
+	}
+	return gwListenerConfigs, nil
+}
+
+// mapLoadBalancerListenerConfigsByPort creates a mapping of ports to their corresponding
+// listener configurations from the LoadBalancer configuration.
+func mapLoadBalancerListenerConfigsByPort(lbCfg *elbv2gw.LoadBalancerConfiguration) map[int32]*elbv2gw.ListenerConfiguration {
+	lbLsCfgs := make(map[int32]*elbv2gw.ListenerConfiguration)
+	if lbCfg == nil || lbCfg.Spec.ListenerConfigurations == nil {
+		return lbLsCfgs
+	}
+	for _, lsCfg := range *lbCfg.Spec.ListenerConfigurations {
+		port, _ := strconv.ParseInt(strings.Split(string(lsCfg.ProtocolPort), ":")[1], 10, 64)
+		lbLsCfgs[int32(port)] = &lsCfg
+	}
+	return lbLsCfgs
+}
+
+func newListenerBuilder(loadBalancerType elbv2model.LoadBalancerType, tgBuilder targetGroupBuilder, tagHelper tagHelper, clusterName string, defaultSSLPolicy string, logger logr.Logger) listenerBuilder {
+	return &listenerBuilderImpl{
+		loadBalancerType: loadBalancerType,
+		tgBuilder:        tgBuilder,
+		clusterName:      clusterName,
+		tagHelper:        tagHelper,
+		defaultSSLPolicy: defaultSSLPolicy,
+		logger:           logger,
+	}
+}

--- a/pkg/gateway/model/model_build_listener_test.go
+++ b/pkg/gateway/model/model_build_listener_test.go
@@ -1,0 +1,350 @@
+package model
+
+import (
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
+	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+	"testing"
+)
+
+func Test_mapGatewayListenerConfigsByPort(t *testing.T) {
+	fooHostname := gwv1.Hostname("foo.example.com")
+	barHostname := gwv1.Hostname("bar.example.com")
+	tests := []struct {
+		name    string
+		gateway *gwv1.Gateway
+		want    map[int32]*gwListenerConfig
+		wantErr bool
+	}{
+		{
+			name: "single HTTP listener",
+			gateway: &gwv1.Gateway{
+				Spec: gwv1.GatewaySpec{
+					Listeners: []gwv1.Listener{
+						{
+							Name:     "http",
+							Port:     80,
+							Protocol: gwv1.HTTPProtocolType,
+						},
+					},
+				},
+			},
+			want: map[int32]*gwListenerConfig{
+				80: {
+					protocol:  elbv2model.ProtocolHTTP,
+					hostnames: []string{},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "single TCP listener",
+			gateway: &gwv1.Gateway{
+				Spec: gwv1.GatewaySpec{
+					Listeners: []gwv1.Listener{
+						{
+							Name:     "tcp",
+							Port:     443,
+							Protocol: gwv1.TCPProtocolType,
+						},
+					},
+				},
+			},
+			want: map[int32]*gwListenerConfig{
+				443: {
+					protocol:  elbv2model.ProtocolTCP,
+					hostnames: []string{},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "multiple listeners with different protocols",
+			gateway: &gwv1.Gateway{
+				Spec: gwv1.GatewaySpec{
+					Listeners: []gwv1.Listener{
+						{
+							Name:     "http-1",
+							Port:     80,
+							Protocol: gwv1.HTTPProtocolType,
+						},
+						{
+							Name:     "https",
+							Port:     443,
+							Protocol: gwv1.HTTPSProtocolType,
+						},
+						{
+							Name:     "http-2",
+							Port:     8080,
+							Protocol: gwv1.HTTPProtocolType,
+						},
+					},
+				},
+			},
+			want: map[int32]*gwListenerConfig{
+				80: {
+					protocol:  elbv2model.ProtocolHTTP,
+					hostnames: []string{},
+				},
+				443: {
+					protocol:  elbv2model.ProtocolHTTPS,
+					hostnames: []string{},
+				},
+				8080: {
+					protocol:  elbv2model.ProtocolHTTP,
+					hostnames: []string{},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "listeners with hostnames",
+			gateway: &gwv1.Gateway{
+				Spec: gwv1.GatewaySpec{
+					Listeners: []gwv1.Listener{
+						{
+							Name:     "http",
+							Port:     80,
+							Protocol: gwv1.HTTPProtocolType,
+							Hostname: &fooHostname,
+						},
+						{
+							Name:     "https",
+							Port:     443,
+							Protocol: gwv1.HTTPSProtocolType,
+							Hostname: &fooHostname,
+						},
+					},
+				},
+			},
+			want: map[int32]*gwListenerConfig{
+				80: {
+					protocol:  elbv2model.ProtocolHTTP,
+					hostnames: []string{"foo.example.com"},
+				},
+				443: {
+					protocol:  elbv2model.ProtocolHTTPS,
+					hostnames: []string{"foo.example.com"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "duplicate ports with different protocols",
+			gateway: &gwv1.Gateway{
+				Spec: gwv1.GatewaySpec{
+					Listeners: []gwv1.Listener{
+						{
+							Name:     "http",
+							Port:     80,
+							Protocol: gwv1.HTTPProtocolType,
+						},
+						{
+							Name:     "https",
+							Port:     80,
+							Protocol: gwv1.HTTPSProtocolType,
+						},
+					},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "multiple hostnames for same port",
+			gateway: &gwv1.Gateway{
+				Spec: gwv1.GatewaySpec{
+					Listeners: []gwv1.Listener{
+						{
+							Name:     "http-1",
+							Port:     80,
+							Protocol: gwv1.HTTPProtocolType,
+							Hostname: &fooHostname,
+						},
+						{
+							Name:     "http-2",
+							Port:     80,
+							Protocol: gwv1.HTTPProtocolType,
+							Hostname: &barHostname,
+						},
+					},
+				},
+			},
+			want: map[int32]*gwListenerConfig{
+				80: {
+					protocol:  elbv2model.ProtocolHTTP,
+					hostnames: []string{"foo.example.com", "bar.example.com"},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := mapGatewayListenerConfigsByPort(tt.gateway)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_mapLoadBalancerListenerConfigsByPort(t *testing.T) {
+	// Helper function to create listener configurations
+	createListenerConfigs := func(protocolPorts ...string) *[]elbv2gw.ListenerConfiguration {
+		configs := make([]elbv2gw.ListenerConfiguration, len(protocolPorts))
+		for i, pp := range protocolPorts {
+			configs[i] = elbv2gw.ListenerConfiguration{
+				ProtocolPort: elbv2gw.ProtocolPort(pp),
+			}
+		}
+		return &configs
+	}
+
+	// Test cases
+	tests := []struct {
+		name  string
+		lbCfg *elbv2gw.LoadBalancerConfiguration
+		want  map[int32]*elbv2gw.ListenerConfiguration
+	}{
+		{
+			name:  "nil configuration",
+			lbCfg: nil,
+			want:  map[int32]*elbv2gw.ListenerConfiguration{},
+		},
+		{
+			name: "nil listener configurations",
+			lbCfg: &elbv2gw.LoadBalancerConfiguration{
+				Spec: elbv2gw.LoadBalancerConfigurationSpec{
+					ListenerConfigurations: nil,
+				},
+			},
+			want: map[int32]*elbv2gw.ListenerConfiguration{},
+		},
+		{
+			name: "empty listener configurations",
+			lbCfg: &elbv2gw.LoadBalancerConfiguration{
+				Spec: elbv2gw.LoadBalancerConfigurationSpec{
+					ListenerConfigurations: createListenerConfigs(),
+				},
+			},
+			want: map[int32]*elbv2gw.ListenerConfiguration{},
+		},
+		{
+			name: "single HTTP listener",
+			lbCfg: &elbv2gw.LoadBalancerConfiguration{
+				Spec: elbv2gw.LoadBalancerConfigurationSpec{
+					ListenerConfigurations: createListenerConfigs("HTTP:80"),
+				},
+			},
+			want: map[int32]*elbv2gw.ListenerConfiguration{
+				80: {
+					ProtocolPort: "HTTP:80",
+				},
+			},
+		},
+		{
+			name: "multiple valid listeners",
+			lbCfg: &elbv2gw.LoadBalancerConfiguration{
+				Spec: elbv2gw.LoadBalancerConfigurationSpec{
+					ListenerConfigurations: createListenerConfigs(
+						"HTTP:80",
+						"HTTPS:443",
+						"HTTP:8080",
+					),
+				},
+			},
+			want: map[int32]*elbv2gw.ListenerConfiguration{
+				80: {
+					ProtocolPort: "HTTP:80",
+				},
+				443: {
+					ProtocolPort: "HTTPS:443",
+				},
+				8080: {
+					ProtocolPort: "HTTP:8080",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapLoadBalancerListenerConfigsByPort(tt.lbCfg)
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_buildListenerALPNPolicy(t *testing.T) {
+	ALPNPolicyHTTP1Only := elbv2gw.ALPNPolicyHTTP1Only
+	invalidALPNPoilcy := elbv2gw.ALPNPolicy("invalid")
+	tests := []struct {
+		name             string
+		listenerProtocol elbv2model.Protocol
+		lbLsCfg          *elbv2gw.ListenerConfiguration
+		want             []string
+		wantErr          error
+	}{
+		{
+			name:             "listener with non-TLS protocol",
+			lbLsCfg:          &elbv2gw.ListenerConfiguration{},
+			listenerProtocol: elbv2model.ProtocolTCP,
+			want:             nil,
+			wantErr:          nil,
+		},
+		{
+			name:             "TLS listener without listener config",
+			lbLsCfg:          nil,
+			listenerProtocol: elbv2model.ProtocolTLS,
+			want:             nil,
+			wantErr:          nil,
+		},
+		{
+			name:             "TLS listener with HTTP1Only policy",
+			listenerProtocol: elbv2model.ProtocolTLS,
+			lbLsCfg: &elbv2gw.ListenerConfiguration{
+				ALPNPolicy: &ALPNPolicyHTTP1Only,
+			},
+			want:    []string{string(elbv2gw.ALPNPolicyHTTP1Only)},
+			wantErr: nil,
+		},
+		{
+			name:             "TLS listener with invalid ALPN policy",
+			listenerProtocol: elbv2model.ProtocolTLS,
+			lbLsCfg: &elbv2gw.ListenerConfiguration{
+				ALPNPolicy: &invalidALPNPoilcy,
+			},
+			want:    nil,
+			wantErr: errors.New("invalid ALPN policy InvalidPolicy, policy must be one of [None, HTTP1Only, HTTP2Only, HTTP2Optional, HTTP2Preferred]"),
+		},
+		{
+			name:             "TCP listener with ALPN policy",
+			listenerProtocol: elbv2model.ProtocolTCP,
+			lbLsCfg: &elbv2gw.ListenerConfiguration{
+				ALPNPolicy: &ALPNPolicyHTTP1Only,
+			},
+			want:    nil,
+			wantErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildListenerALPNPolicy(tt.listenerProtocol, tt.lbLsCfg)
+			if tt.wantErr != nil {
+				assert.Error(t, err, tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}

--- a/pkg/gateway/model/model_build_security_group.go
+++ b/pkg/gateway/model/model_build_security_group.go
@@ -40,7 +40,7 @@ type securityGroupOutput struct {
 }
 
 type securityGroupBuilder interface {
-	buildSecurityGroups(ctx context.Context, stack core.Stack, lbConf *elbv2gw.LoadBalancerConfiguration, gw *gwv1.Gateway, routes map[int][]routeutils.RouteDescriptor, ipAddressType elbv2model.IPAddressType) (securityGroupOutput, error)
+	buildSecurityGroups(ctx context.Context, stack core.Stack, lbConf *elbv2gw.LoadBalancerConfiguration, gw *gwv1.Gateway, routes map[int32][]routeutils.RouteDescriptor, ipAddressType elbv2model.IPAddressType) (securityGroupOutput, error)
 }
 
 type securityGroupBuilderImpl struct {
@@ -64,7 +64,7 @@ func newSecurityGroupBuilder(tagHelper tagHelper, clusterName string, enableBack
 	}
 }
 
-func (builder *securityGroupBuilderImpl) buildSecurityGroups(ctx context.Context, stack core.Stack, lbConf *elbv2gw.LoadBalancerConfiguration, gw *gwv1.Gateway, routes map[int][]routeutils.RouteDescriptor, ipAddressType elbv2model.IPAddressType) (securityGroupOutput, error) {
+func (builder *securityGroupBuilderImpl) buildSecurityGroups(ctx context.Context, stack core.Stack, lbConf *elbv2gw.LoadBalancerConfiguration, gw *gwv1.Gateway, routes map[int32][]routeutils.RouteDescriptor, ipAddressType elbv2model.IPAddressType) (securityGroupOutput, error) {
 	var sgNameOrIds []string
 	if lbConf != nil && lbConf.Spec.SecurityGroups != nil {
 		sgNameOrIds = *lbConf.Spec.SecurityGroups
@@ -77,7 +77,7 @@ func (builder *securityGroupBuilderImpl) buildSecurityGroups(ctx context.Context
 	return builder.handleExplicitSecurityGroups(ctx, lbConf, gw, sgNameOrIds)
 }
 
-func (builder *securityGroupBuilderImpl) handleManagedSecurityGroup(ctx context.Context, stack core.Stack, lbConf *elbv2gw.LoadBalancerConfiguration, gw *gwv1.Gateway, routes map[int][]routeutils.RouteDescriptor, ipAddressType elbv2model.IPAddressType) (securityGroupOutput, error) {
+func (builder *securityGroupBuilderImpl) handleManagedSecurityGroup(ctx context.Context, stack core.Stack, lbConf *elbv2gw.LoadBalancerConfiguration, gw *gwv1.Gateway, routes map[int32][]routeutils.RouteDescriptor, ipAddressType elbv2model.IPAddressType) (securityGroupOutput, error) {
 	var lbSGTokens []core.StringToken
 	managedSG, err := builder.buildManagedSecurityGroup(stack, lbConf, gw, routes, ipAddressType)
 	if err != nil {
@@ -144,7 +144,7 @@ func (builder *securityGroupBuilderImpl) getBackendSecurityGroup(ctx context.Con
 	return core.LiteralStringToken(backendSGID), nil
 }
 
-func (builder *securityGroupBuilderImpl) buildManagedSecurityGroup(stack core.Stack, lbConf *elbv2gw.LoadBalancerConfiguration, gw *gwv1.Gateway, routes map[int][]routeutils.RouteDescriptor, ipAddressType elbv2model.IPAddressType) (*ec2model.SecurityGroup, error) {
+func (builder *securityGroupBuilderImpl) buildManagedSecurityGroup(stack core.Stack, lbConf *elbv2gw.LoadBalancerConfiguration, gw *gwv1.Gateway, routes map[int32][]routeutils.RouteDescriptor, ipAddressType elbv2model.IPAddressType) (*ec2model.SecurityGroup, error) {
 	name := builder.buildManagedSecurityGroupName(gw)
 	tags, err := builder.tagHelper.getGatewayTags(lbConf)
 	if err != nil {
@@ -173,7 +173,7 @@ func (builder *securityGroupBuilderImpl) buildManagedSecurityGroupName(gw *gwv1.
 	return fmt.Sprintf("k8s-%.8s-%.8s-%.10s", sanitizedNamespace, sanitizedName, uuid)
 }
 
-func (builder *securityGroupBuilderImpl) buildManagedSecurityGroupIngressPermissions(lbConf *elbv2gw.LoadBalancerConfiguration, routes map[int][]routeutils.RouteDescriptor, ipAddressType elbv2model.IPAddressType) []ec2model.IPPermission {
+func (builder *securityGroupBuilderImpl) buildManagedSecurityGroupIngressPermissions(lbConf *elbv2gw.LoadBalancerConfiguration, routes map[int32][]routeutils.RouteDescriptor, ipAddressType elbv2model.IPAddressType) []ec2model.IPPermission {
 	var permissions []ec2model.IPPermission
 
 	// Default to 0.0.0.0/0 and ::/0

--- a/pkg/gateway/model/model_build_security_group_test.go
+++ b/pkg/gateway/model/model_build_security_group_test.go
@@ -188,7 +188,7 @@ func Test_BuildSecurityGroups_Specified(t *testing.T) {
 			stack := coremodel.NewDefaultStack(coremodel.StackID{Namespace: "namespace", Name: "name"})
 			builder := newSecurityGroupBuilder(mockTagger, clusterName, tc.enableBackendSg, mockSgResolver, mockSgProvider, logr.Discard())
 
-			out, err := builder.buildSecurityGroups(context.Background(), stack, tc.lbConf, gw, make(map[int][]routeutils.RouteDescriptor), tc.ipAddressType)
+			out, err := builder.buildSecurityGroups(context.Background(), stack, tc.lbConf, gw, make(map[int32][]routeutils.RouteDescriptor), tc.ipAddressType)
 
 			if tc.expectErr {
 				assert.Error(t, err)
@@ -293,7 +293,7 @@ func Test_BuildSecurityGroups_Allocate(t *testing.T) {
 			stack := coremodel.NewDefaultStack(coremodel.StackID{Namespace: "namespace", Name: "name"})
 			builder := newSecurityGroupBuilder(mockTagger, clusterName, tc.enableBackendSg, mockSgResolver, mockSgProvider, logr.Discard())
 
-			out, err := builder.buildSecurityGroups(context.Background(), stack, tc.lbConf, gw, make(map[int][]routeutils.RouteDescriptor), tc.ipAddressType)
+			out, err := builder.buildSecurityGroups(context.Background(), stack, tc.lbConf, gw, make(map[int32][]routeutils.RouteDescriptor), tc.ipAddressType)
 
 			if tc.expectErr {
 				assert.Error(t, err)
@@ -317,7 +317,7 @@ func Test_BuildSecurityGroups_BuildManagedSecurityGroupIngressPermissions(t *tes
 		name          string
 		lbConf        *elbv2gw.LoadBalancerConfiguration
 		ipAddressType elbv2model.IPAddressType
-		routes        map[int][]routeutils.RouteDescriptor
+		routes        map[int32][]routeutils.RouteDescriptor
 		expected      []ec2model.IPPermission
 	}{
 		{
@@ -330,7 +330,7 @@ func Test_BuildSecurityGroups_BuildManagedSecurityGroupIngressPermissions(t *tes
 			lbConf: &elbv2gw.LoadBalancerConfiguration{
 				Spec: elbv2gw.LoadBalancerConfigurationSpec{},
 			},
-			routes: map[int][]routeutils.RouteDescriptor{
+			routes: map[int32][]routeutils.RouteDescriptor{
 				80: {
 					&routeutils.MockRoute{
 						Kind: routeutils.TCPRouteKind,
@@ -361,7 +361,7 @@ func Test_BuildSecurityGroups_BuildManagedSecurityGroupIngressPermissions(t *tes
 					},
 				},
 			},
-			routes: map[int][]routeutils.RouteDescriptor{
+			routes: map[int32][]routeutils.RouteDescriptor{
 				80: {
 					&routeutils.MockRoute{
 						Kind: routeutils.TCPRouteKind,
@@ -412,7 +412,7 @@ func Test_BuildSecurityGroups_BuildManagedSecurityGroupIngressPermissions(t *tes
 					},
 				},
 			},
-			routes: map[int][]routeutils.RouteDescriptor{
+			routes: map[int32][]routeutils.RouteDescriptor{
 				80: {
 					&routeutils.MockRoute{
 						Kind: routeutils.UDPRouteKind,
@@ -462,7 +462,7 @@ func Test_BuildSecurityGroups_BuildManagedSecurityGroupIngressPermissions(t *tes
 					EnableICMP: true,
 				},
 			},
-			routes: map[int][]routeutils.RouteDescriptor{
+			routes: map[int32][]routeutils.RouteDescriptor{
 				80: {
 					&routeutils.MockRoute{
 						Kind: routeutils.UDPRouteKind,
@@ -503,7 +503,7 @@ func Test_BuildSecurityGroups_BuildManagedSecurityGroupIngressPermissions(t *tes
 					},
 				},
 			},
-			routes: map[int][]routeutils.RouteDescriptor{
+			routes: map[int32][]routeutils.RouteDescriptor{
 				80: {
 					&routeutils.MockRoute{
 						Kind: routeutils.TCPRouteKind,
@@ -557,7 +557,7 @@ func Test_BuildSecurityGroups_BuildManagedSecurityGroupIngressPermissions(t *tes
 					},
 				},
 			},
-			routes: map[int][]routeutils.RouteDescriptor{
+			routes: map[int32][]routeutils.RouteDescriptor{
 				80: {
 					&routeutils.MockRoute{
 						Kind: routeutils.TCPRouteKind,
@@ -682,7 +682,7 @@ func Test_BuildSecurityGroups_BuildManagedSecurityGroupIngressPermissions(t *tes
 			lbConf: &elbv2gw.LoadBalancerConfiguration{
 				Spec: elbv2gw.LoadBalancerConfigurationSpec{},
 			},
-			routes: map[int][]routeutils.RouteDescriptor{
+			routes: map[int32][]routeutils.RouteDescriptor{
 				80: {
 					&routeutils.MockRoute{
 						Kind: routeutils.TCPRouteKind,
@@ -725,7 +725,7 @@ func Test_BuildSecurityGroups_BuildManagedSecurityGroupIngressPermissions(t *tes
 					},
 				},
 			},
-			routes: map[int][]routeutils.RouteDescriptor{
+			routes: map[int32][]routeutils.RouteDescriptor{
 				80: {
 					&routeutils.MockRoute{
 						Kind: routeutils.TCPRouteKind,
@@ -795,7 +795,7 @@ func Test_BuildSecurityGroups_BuildManagedSecurityGroupIngressPermissions(t *tes
 					},
 				},
 			},
-			routes: map[int][]routeutils.RouteDescriptor{
+			routes: map[int32][]routeutils.RouteDescriptor{
 				80: {
 					&routeutils.MockRoute{
 						Kind: routeutils.TCPRouteKind,
@@ -836,7 +836,7 @@ func Test_BuildSecurityGroups_BuildManagedSecurityGroupIngressPermissions(t *tes
 					},
 				},
 			},
-			routes: map[int][]routeutils.RouteDescriptor{
+			routes: map[int32][]routeutils.RouteDescriptor{
 				80: {
 					&routeutils.MockRoute{
 						Kind: routeutils.TCPRouteKind,
@@ -866,7 +866,7 @@ func Test_BuildSecurityGroups_BuildManagedSecurityGroupIngressPermissions(t *tes
 					SecurityGroupPrefixes: &[]string{"pl1", "pl2"},
 				},
 			},
-			routes: map[int][]routeutils.RouteDescriptor{
+			routes: map[int32][]routeutils.RouteDescriptor{
 				80: {
 					&routeutils.MockRoute{
 						Kind: routeutils.TCPRouteKind,

--- a/pkg/gateway/model/model_build_target_group.go
+++ b/pkg/gateway/model/model_build_target_group.go
@@ -28,8 +28,10 @@ type buildTargetGroupOutput struct {
 }
 
 type targetGroupBuilder interface {
-	buildTargetGroup(tgByResID *map[string]buildTargetGroupOutput,
-		gw *gwv1.Gateway, lbConfig *elbv2gw.LoadBalancerConfiguration, lbIPType elbv2model.IPAddressType, routeDescriptor routeutils.RouteDescriptor, backend routeutils.Backend, backendSGIDToken core.StringToken) (buildTargetGroupOutput, error)
+	buildTargetGroup(stack core.Stack,
+		gw *gwv1.Gateway, lbConfig *elbv2gw.LoadBalancerConfiguration, lbIPType elbv2model.IPAddressType, routeDescriptor routeutils.RouteDescriptor, backend routeutils.Backend, backendSGIDToken core.StringToken) (*elbv2model.TargetGroup, error)
+	buildTargetGroupSpec(gw *gwv1.Gateway, route routeutils.RouteDescriptor, lbConfig *elbv2gw.LoadBalancerConfiguration, lbIPType elbv2model.IPAddressType, backend routeutils.Backend, targetGroupProps *elbv2gw.TargetGroupProps) (elbv2model.TargetGroupSpec, error)
+	buildTargetGroupBindingSpec(tgProps *elbv2gw.TargetGroupProps, tgSpec elbv2model.TargetGroupSpec, nodeSelector *metav1.LabelSelector, backend routeutils.Backend, backendSGIDToken core.StringToken) elbv2model.TargetGroupBindingResourceSpec
 }
 
 type targetGroupBuilderImpl struct {
@@ -39,6 +41,7 @@ type targetGroupBuilderImpl struct {
 	vpcID       string
 
 	tagHelper                tagHelper
+	tgByResID                map[string]*elbv2model.TargetGroup
 	disableRestrictedSGRules bool
 
 	defaultTargetType elbv2model.TargetType
@@ -57,16 +60,17 @@ type targetGroupBuilderImpl struct {
 
 func newTargetGroupBuilder(clusterName string, vpcId string, tagHelper tagHelper, loadBalancerType elbv2model.LoadBalancerType, disableRestrictedSGRules bool, defaultTargetType string) targetGroupBuilder {
 	return &targetGroupBuilderImpl{
-		loadBalancerType:                          loadBalancerType,
-		clusterName:                               clusterName,
-		vpcID:                                     vpcId,
-		tagHelper:                                 tagHelper,
-		disableRestrictedSGRules:                  disableRestrictedSGRules,
-		defaultTargetType:                         elbv2model.TargetType(defaultTargetType),
-		defaultHealthCheckMatcherHTTPCode:         "200-399",
-		defaultHealthCheckMatcherGRPCCode:         "12",
-		defaultHealthCheckPathHTTP:                "/",
-		defaultHealthCheckPathGRPC:                "/AWS.ALB/healthcheck",
+		loadBalancerType:                  loadBalancerType,
+		clusterName:                       clusterName,
+		vpcID:                             vpcId,
+		tgByResID:                         make(map[string]*elbv2model.TargetGroup),
+		tagHelper:                         tagHelper,
+		disableRestrictedSGRules:          disableRestrictedSGRules,
+		defaultTargetType:                 elbv2model.TargetType(defaultTargetType),
+		defaultHealthCheckMatcherHTTPCode: "200-399",
+		defaultHealthCheckMatcherGRPCCode: "12",
+		defaultHealthCheckPathHTTP:        "/",
+		defaultHealthCheckPathGRPC:        "/AWS.ALB/healthcheck",
 		defaultHealthCheckUnhealthyThresholdCount: 3,
 		defaultHealthyThresholdCount:              3,
 		defaultHealthCheckTimeout:                 5,
@@ -74,30 +78,32 @@ func newTargetGroupBuilder(clusterName string, vpcId string, tagHelper tagHelper
 	}
 }
 
-func (builder *targetGroupBuilderImpl) buildTargetGroup(tgByResID *map[string]buildTargetGroupOutput,
-	gw *gwv1.Gateway, lbConfig *elbv2gw.LoadBalancerConfiguration, lbIPType elbv2model.IPAddressType, routeDescriptor routeutils.RouteDescriptor, backend routeutils.Backend, backendSGIDToken core.StringToken) (buildTargetGroupOutput, error) {
+func (t *targetGroupBuilderImpl) buildTargetGroup(stack core.Stack,
+	gw *gwv1.Gateway, lbConfig *elbv2gw.LoadBalancerConfiguration, lbIPType elbv2model.IPAddressType, routeDescriptor routeutils.RouteDescriptor, backend routeutils.Backend, backendSGIDToken core.StringToken) (*elbv2model.TargetGroup, error) {
 
-	targetGroupProps := builder.getTargetGroupProps(routeDescriptor, backend)
+	targetGroupProps := t.getTargetGroupProps(routeDescriptor, backend)
 
-	tgResID := builder.buildTargetGroupResourceID(k8s.NamespacedName(gw), k8s.NamespacedName(backend.Service), routeDescriptor.GetRouteNamespacedName(), backend.ServicePort.TargetPort)
-	if tg, exists := (*tgByResID)[tgResID]; exists {
+	tgResID := t.buildTargetGroupResourceID(k8s.NamespacedName(gw), k8s.NamespacedName(backend.Service), routeDescriptor.GetRouteNamespacedName(), backend.ServicePort.TargetPort)
+	if tg, exists := t.tgByResID[tgResID]; exists {
 		return tg, nil
 	}
 
-	tgSpec, err := builder.buildTargetGroupSpec(gw, routeDescriptor, lbConfig, lbIPType, backend, targetGroupProps)
+	tgSpec, err := t.buildTargetGroupSpec(gw, routeDescriptor, lbConfig, lbIPType, backend, targetGroupProps)
 	if err != nil {
-		return buildTargetGroupOutput{}, err
+		return nil, err
 	}
-	nodeSelector := builder.buildTargetGroupBindingNodeSelector(targetGroupProps, tgSpec.TargetType)
-	bindingSpec := builder.buildTargetGroupBindingSpec(targetGroupProps, tgSpec, nodeSelector, backend, backendSGIDToken)
+	nodeSelector := t.buildTargetGroupBindingNodeSelector(targetGroupProps, tgSpec.TargetType)
+	bindingSpec := t.buildTargetGroupBindingSpec(targetGroupProps, tgSpec, nodeSelector, backend, backendSGIDToken)
 
-	output := buildTargetGroupOutput{
+	tgOut := buildTargetGroupOutput{
 		targetGroupSpec: tgSpec,
 		bindingSpec:     bindingSpec,
 	}
-
-	(*tgByResID)[tgResID] = output
-	return output, nil
+	tg := elbv2model.NewTargetGroup(stack, tgResID, tgOut.targetGroupSpec)
+	tgOut.bindingSpec.Template.Spec.TargetGroupARN = tg.TargetGroupARN()
+	elbv2model.NewTargetGroupBindingResource(stack, tg.ID(), tgOut.bindingSpec)
+	t.tgByResID[tgResID] = tg
+	return tg, nil
 }
 
 func (builder *targetGroupBuilderImpl) getTargetGroupProps(routeDescriptor routeutils.RouteDescriptor, backend routeutils.Backend) *elbv2gw.TargetGroupProps {

--- a/pkg/gateway/model/model_build_target_group_test.go
+++ b/pkg/gateway/model/model_build_target_group_test.go
@@ -17,7 +17,275 @@ import (
 	"testing"
 )
 
-func Test_buildTargetGroup(t *testing.T) {
+func Test_buildTargetGroupSpec(t *testing.T) {
+	http1 := elbv2model.ProtocolVersionHTTP1
+	testCases := []struct {
+		name                     string
+		tags                     map[string]string
+		lbType                   elbv2model.LoadBalancerType
+		disableRestrictedSGRules bool
+		defaultTargetType        string
+		gateway                  *gwv1.Gateway
+		route                    *routeutils.MockRoute
+		backend                  routeutils.Backend
+		tagErr                   error
+		expectErr                bool
+		expectedTgSpec           elbv2model.TargetGroupSpec
+	}{
+		{
+			name:                     "no tg config - instance - nlb",
+			tags:                     make(map[string]string),
+			lbType:                   elbv2model.LoadBalancerTypeNetwork,
+			disableRestrictedSGRules: false,
+			defaultTargetType:        string(elbv2model.TargetTypeInstance),
+			gateway: &gwv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "my-gw-ns",
+					Name:      "my-gw",
+				},
+			},
+			route: &routeutils.MockRoute{
+				Kind:      routeutils.TCPRouteKind,
+				Name:      "my-route",
+				Namespace: "my-route-ns",
+			},
+			backend: routeutils.Backend{
+				Service: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "my-svc-ns",
+						Name:      "my-svc",
+					},
+				},
+				ServicePort: &corev1.ServicePort{
+					Protocol: corev1.ProtocolTCP,
+					Port:     80,
+					TargetPort: intstr.IntOrString{
+						IntVal: 80,
+						Type:   intstr.Int,
+					},
+					NodePort: 8080,
+				},
+			},
+			expectedTgSpec: elbv2model.TargetGroupSpec{
+				Name:          "k8s-myrouten-myroute-d02da2803b",
+				TargetType:    elbv2model.TargetTypeInstance,
+				Port:          awssdk.Int32(8080),
+				Protocol:      elbv2model.ProtocolTCP,
+				IPAddressType: elbv2model.TargetGroupIPAddressTypeIPv4,
+				HealthCheckConfig: &elbv2model.TargetGroupHealthCheckConfig{
+					Port: &intstr.IntOrString{
+						StrVal: shared_constants.HealthCheckPortTrafficPort,
+						Type:   intstr.String,
+					},
+					Protocol:                elbv2model.ProtocolTCP,
+					IntervalSeconds:         awssdk.Int32(15),
+					TimeoutSeconds:          awssdk.Int32(5),
+					HealthyThresholdCount:   awssdk.Int32(3),
+					UnhealthyThresholdCount: awssdk.Int32(3),
+				},
+				TargetGroupAttributes: make([]elbv2model.TargetGroupAttribute, 0),
+				Tags:                  make(map[string]string),
+			},
+		},
+		{
+			name:                     "no tg config - instance - alb",
+			tags:                     make(map[string]string),
+			lbType:                   elbv2model.LoadBalancerTypeApplication,
+			disableRestrictedSGRules: false,
+			defaultTargetType:        string(elbv2model.TargetTypeInstance),
+			gateway: &gwv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "my-gw-ns",
+					Name:      "my-gw",
+				},
+			},
+			route: &routeutils.MockRoute{
+				Kind:      routeutils.HTTPRouteKind,
+				Name:      "my-route",
+				Namespace: "my-route-ns",
+			},
+			backend: routeutils.Backend{
+				Service: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "my-svc-ns",
+						Name:      "my-svc",
+					},
+				},
+				ServicePort: &corev1.ServicePort{
+					Protocol: corev1.ProtocolTCP,
+					Port:     80,
+					TargetPort: intstr.IntOrString{
+						IntVal: 80,
+						Type:   intstr.Int,
+					},
+					NodePort: 8080,
+				},
+			},
+			expectedTgSpec: elbv2model.TargetGroupSpec{
+				Name:            "k8s-myrouten-myroute-d146029dfb",
+				TargetType:      elbv2model.TargetTypeInstance,
+				Port:            awssdk.Int32(8080),
+				Protocol:        elbv2model.ProtocolHTTP,
+				ProtocolVersion: &http1,
+				IPAddressType:   elbv2model.TargetGroupIPAddressTypeIPv4,
+				HealthCheckConfig: &elbv2model.TargetGroupHealthCheckConfig{
+					Port: &intstr.IntOrString{
+						StrVal: shared_constants.HealthCheckPortTrafficPort,
+						Type:   intstr.String,
+					},
+					Path: awssdk.String("/"),
+					Matcher: &elbv2model.HealthCheckMatcher{
+						HTTPCode: awssdk.String("200-399"),
+					},
+					Protocol:                elbv2model.ProtocolHTTP,
+					IntervalSeconds:         awssdk.Int32(15),
+					TimeoutSeconds:          awssdk.Int32(5),
+					HealthyThresholdCount:   awssdk.Int32(3),
+					UnhealthyThresholdCount: awssdk.Int32(3),
+				},
+				TargetGroupAttributes: make([]elbv2model.TargetGroupAttribute, 0),
+				Tags:                  make(map[string]string),
+			},
+		},
+		{
+			name:                     "no tg config - ip - nlb",
+			tags:                     make(map[string]string),
+			lbType:                   elbv2model.LoadBalancerTypeNetwork,
+			disableRestrictedSGRules: false,
+			defaultTargetType:        string(elbv2model.TargetTypeIP),
+			gateway: &gwv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "my-gw-ns",
+					Name:      "my-gw",
+				},
+			},
+			route: &routeutils.MockRoute{
+				Kind:      routeutils.TCPRouteKind,
+				Name:      "my-route",
+				Namespace: "my-route-ns",
+			},
+			backend: routeutils.Backend{
+				Service: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "my-svc-ns",
+						Name:      "my-svc",
+					},
+				},
+				ServicePort: &corev1.ServicePort{
+					Protocol: corev1.ProtocolTCP,
+					Port:     80,
+					TargetPort: intstr.IntOrString{
+						IntVal: 80,
+						Type:   intstr.Int,
+					},
+					NodePort: 8080,
+				},
+			},
+			expectedTgSpec: elbv2model.TargetGroupSpec{
+				Name:          "k8s-myrouten-myroute-d9d6c4e6eb",
+				TargetType:    elbv2model.TargetTypeIP,
+				Port:          awssdk.Int32(80),
+				Protocol:      elbv2model.ProtocolTCP,
+				IPAddressType: elbv2model.TargetGroupIPAddressTypeIPv4,
+				HealthCheckConfig: &elbv2model.TargetGroupHealthCheckConfig{
+					Port: &intstr.IntOrString{
+						StrVal: shared_constants.HealthCheckPortTrafficPort,
+						Type:   intstr.String,
+					},
+					Protocol:                elbv2model.ProtocolTCP,
+					IntervalSeconds:         awssdk.Int32(15),
+					TimeoutSeconds:          awssdk.Int32(5),
+					HealthyThresholdCount:   awssdk.Int32(3),
+					UnhealthyThresholdCount: awssdk.Int32(3),
+				},
+				TargetGroupAttributes: make([]elbv2model.TargetGroupAttribute, 0),
+				Tags:                  make(map[string]string),
+			},
+		},
+		{
+			name:                     "no tg config - ip - alb",
+			tags:                     make(map[string]string),
+			lbType:                   elbv2model.LoadBalancerTypeApplication,
+			disableRestrictedSGRules: false,
+			defaultTargetType:        string(elbv2model.TargetTypeIP),
+			gateway: &gwv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "my-gw-ns",
+					Name:      "my-gw",
+				},
+			},
+			route: &routeutils.MockRoute{
+				Kind:      routeutils.HTTPRouteKind,
+				Name:      "my-route",
+				Namespace: "my-route-ns",
+			},
+			backend: routeutils.Backend{
+				Service: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "my-svc-ns",
+						Name:      "my-svc",
+					},
+				},
+				ServicePort: &corev1.ServicePort{
+					Protocol: corev1.ProtocolTCP,
+					Port:     80,
+					TargetPort: intstr.IntOrString{
+						IntVal: 80,
+						Type:   intstr.Int,
+					},
+					NodePort: 8080,
+				},
+			},
+			expectedTgSpec: elbv2model.TargetGroupSpec{
+				Name:            "k8s-myrouten-myroute-400113e816",
+				TargetType:      elbv2model.TargetTypeIP,
+				Port:            awssdk.Int32(80),
+				Protocol:        elbv2model.ProtocolHTTP,
+				ProtocolVersion: &http1,
+				IPAddressType:   elbv2model.TargetGroupIPAddressTypeIPv4,
+				HealthCheckConfig: &elbv2model.TargetGroupHealthCheckConfig{
+					Port: &intstr.IntOrString{
+						StrVal: shared_constants.HealthCheckPortTrafficPort,
+						Type:   intstr.String,
+					},
+					Path: awssdk.String("/"),
+					Matcher: &elbv2model.HealthCheckMatcher{
+						HTTPCode: awssdk.String("200-399"),
+					},
+					Protocol:                elbv2model.ProtocolHTTP,
+					IntervalSeconds:         awssdk.Int32(15),
+					TimeoutSeconds:          awssdk.Int32(5),
+					HealthyThresholdCount:   awssdk.Int32(3),
+					UnhealthyThresholdCount: awssdk.Int32(3),
+				},
+				TargetGroupAttributes: make([]elbv2model.TargetGroupAttribute, 0),
+				Tags:                  make(map[string]string),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			tagger := &mockTagHelper{
+				tags: tc.tags,
+				err:  tc.tagErr,
+			}
+
+			builder := newTargetGroupBuilder("my-cluster", "vpc-xxx", tagger, tc.lbType, tc.disableRestrictedSGRules, tc.defaultTargetType)
+
+			out, err := builder.buildTargetGroupSpec(tc.gateway, tc.route, nil, elbv2model.IPAddressTypeIPV4, tc.backend, nil)
+			if tc.expectErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedTgSpec, out)
+		})
+	}
+}
+
+func Test_buildTargetGroupBindingSpec(t *testing.T) {
 	instanceType := elbv2api.TargetType(elbv2model.TargetTypeInstance)
 	ipType := elbv2api.TargetType(elbv2model.TargetTypeIP)
 	http1 := elbv2model.ProtocolVersionHTTP1
@@ -345,21 +613,9 @@ func Test_buildTargetGroup(t *testing.T) {
 
 			builder := newTargetGroupBuilder("my-cluster", "vpc-xxx", tagger, tc.lbType, tc.disableRestrictedSGRules, tc.defaultTargetType)
 
-			result := make(map[string]buildTargetGroupOutput)
+			out := builder.buildTargetGroupBindingSpec(nil, tc.expectedTgSpec, nil, tc.backend, nil)
 
-			out, err := builder.buildTargetGroup(&result, tc.gateway, nil, elbv2model.IPAddressTypeIPV4, tc.route, tc.backend, nil)
-			if tc.expectErr {
-				assert.Error(t, err)
-				return
-			}
-			assert.NoError(t, err)
-			assert.Equal(t, tc.expectedTgSpec, out.targetGroupSpec)
-			assert.Equal(t, tc.expectedTgBindingSpec, out.bindingSpec)
-			assert.Equal(t, 1, len(result))
-			for _, v := range result {
-				assert.Equal(t, tc.expectedTgSpec, v.targetGroupSpec)
-				assert.Equal(t, tc.expectedTgBindingSpec, v.bindingSpec)
-			}
+			assert.Equal(t, tc.expectedTgBindingSpec, out)
 		})
 	}
 }

--- a/pkg/gateway/routeutils/loader_test.go
+++ b/pkg/gateway/routeutils/loader_test.go
@@ -139,7 +139,7 @@ func TestLoadRoutesForGateway(t *testing.T) {
 	testCases := []struct {
 		name                    string
 		acceptedKinds           sets.Set[RouteKind]
-		expectedMap             map[int][]RouteDescriptor
+		expectedMap             map[int32][]RouteDescriptor
 		expectedPreloadMap      map[int][]preLoadRouteDescriptor
 		expectedPreMappedRoutes []preLoadRouteDescriptor
 		expectError             bool
@@ -148,7 +148,7 @@ func TestLoadRoutesForGateway(t *testing.T) {
 			name:                    "filter allows no routes",
 			acceptedKinds:           make(sets.Set[RouteKind]),
 			expectedPreMappedRoutes: make([]preLoadRouteDescriptor, 0),
-			expectedMap:             make(map[int][]RouteDescriptor),
+			expectedMap:             make(map[int32][]RouteDescriptor),
 		},
 		{
 			name:                    "filter only allows http route",
@@ -157,7 +157,7 @@ func TestLoadRoutesForGateway(t *testing.T) {
 			expectedPreloadMap: map[int][]preLoadRouteDescriptor{
 				80: preLoadHTTPRoutes,
 			},
-			expectedMap: map[int][]RouteDescriptor{
+			expectedMap: map[int32][]RouteDescriptor{
 				80: loadedHTTPRoutes,
 			},
 		},
@@ -169,7 +169,7 @@ func TestLoadRoutesForGateway(t *testing.T) {
 				80:  preLoadHTTPRoutes,
 				443: preLoadHTTPRoutes,
 			},
-			expectedMap: map[int][]RouteDescriptor{
+			expectedMap: map[int32][]RouteDescriptor{
 				80:  loadedHTTPRoutes,
 				443: loadedHTTPRoutes,
 			},
@@ -181,7 +181,7 @@ func TestLoadRoutesForGateway(t *testing.T) {
 			expectedPreloadMap: map[int][]preLoadRouteDescriptor{
 				80: preLoadTCPRoutes,
 			},
-			expectedMap: map[int][]RouteDescriptor{
+			expectedMap: map[int32][]RouteDescriptor{
 				80: loadedTCPRoutes,
 			},
 		},
@@ -193,7 +193,7 @@ func TestLoadRoutesForGateway(t *testing.T) {
 				80:  preLoadTCPRoutes,
 				443: preLoadHTTPRoutes,
 			},
-			expectedMap: map[int][]RouteDescriptor{
+			expectedMap: map[int32][]RouteDescriptor{
 				80:  loadedTCPRoutes,
 				443: loadedHTTPRoutes,
 			},


### PR DESCRIPTION
### Description

This PR adds a translation logic for gateway listeners to elb listeners. This is only supporting the basic HTTPRoute and TCPRoute with simplest config for ALB and NLBs respectively. We will add more L4 and L7 related configuration during the individual implementation. 


### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
