### PR TITLE
[bug fix] HandleReconcileError not detecting wrapped errors

### DIFF
--- a/pkg/runtime/reconcile.go
+++ b/pkg/runtime/reconcile.go
@@ -3,26 +3,41 @@ package runtime
 import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
+	errmetrics "sigs.k8s.io/aws-load-balancer-controller/pkg/error"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 // HandleReconcileError will handle errors from reconcile handlers, which respects runtime errors.
-func HandleReconcileError(err error, log logr.Logger) (ctrl.Result, error) {
-	if err == nil {
+func HandleReconcileError(inputErr error, log logr.Logger) (ctrl.Result, error) {
+	resolvedErr := handleNestedError(inputErr)
+	if resolvedErr == nil {
 		return ctrl.Result{}, nil
 	}
 
 	var requeueNeededAfter *RequeueNeededAfter
-	if errors.As(err, &requeueNeededAfter) {
+	if errors.As(resolvedErr, &requeueNeededAfter) {
 		log.V(1).Info("requeue after", "duration", requeueNeededAfter.Duration(), "reason", requeueNeededAfter.Reason())
 		return ctrl.Result{RequeueAfter: requeueNeededAfter.Duration()}, nil
 	}
 
 	var requeueNeeded *RequeueNeeded
-	if errors.As(err, &requeueNeeded) {
+	if errors.As(resolvedErr, &requeueNeeded) {
 		log.V(1).Info("requeue", "reason", requeueNeeded.Reason())
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	return ctrl.Result{}, err
+	return ctrl.Result{}, inputErr
+}
+
+func handleNestedError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	var wrappedError *errmetrics.ErrorWithMetrics
+	if errors.As(err, &wrappedError) {
+		return wrappedError.Err
+	}
+
+	return err
 }


### PR DESCRIPTION
### Issue

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4176

### Description

We've added `errmetrics.ErrorWithMetrics` to track reconcile errors but didn't update `HandleReconcileError` to be aware of it. This means that sentinel errors for reconcile requeues are showing up in customer prometheus metrics. 

This PR fixes the issue by having `HandleReconcileError` check for the wrapped error type when checking for sentinel values.
### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
