### PR TITLE
[bug fix] fix tls protocol not being detected when generating SG rules

### DIFF
--- a/pkg/service/model_build_target_group.go
+++ b/pkg/service/model_build_target_group.go
@@ -479,6 +479,7 @@ func (t *defaultModelBuildTask) buildTargetGroupBindingSpec(ctx context.Context,
 
 func (t *defaultModelBuildTask) buildTargetGroupBindingNetworking(_ context.Context, tgPort intstr.IntOrString,
 	hcPort intstr.IntOrString, tgProtocol elbv2model.Protocol) (*elbv2model.TargetGroupBindingNetworking, error) {
+
 	if t.backendSGIDToken == nil {
 		return nil, nil
 	}
@@ -499,6 +500,8 @@ func (t *defaultModelBuildTask) buildTargetGroupBindingNetworking(_ context.Cont
 		}
 	} else {
 		switch tgProtocol {
+		case elbv2model.ProtocolTLS:
+			fallthrough
 		case elbv2model.ProtocolTCP:
 			ports = append(ports, elbv2api.NetworkingPort{
 				Protocol: &protocolTCP,

--- a/pkg/service/model_build_target_group_test.go
+++ b/pkg/service/model_build_target_group_test.go
@@ -1433,6 +1433,30 @@ func Test_defaultModelBuilderTask_buildTargetGroupBindingNetworking(t *testing.T
 			},
 		},
 		{
+			name:             "tls with port restricted rules",
+			tgPort:           port80,
+			hcPort:           trafficPort,
+			tgProtocol:       elbv2.ProtocolTLS,
+			backendSGIDToken: core.LiteralStringToken(sgBackend),
+			want: &elbv2.TargetGroupBindingNetworking{
+				Ingress: []elbv2.NetworkingIngressRule{
+					{
+						From: []elbv2.NetworkingPeer{
+							{
+								SecurityGroup: &elbv2.SecurityGroup{GroupID: core.LiteralStringToken(sgBackend)},
+							},
+						},
+						Ports: []elbv2api.NetworkingPort{
+							{
+								Protocol: &networkingProtocolTCP,
+								Port:     &port80,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name:             "udp with port restricted rules",
 			tgPort:           port80,
 			hcPort:           trafficPort,


### PR DESCRIPTION
### Issue

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4181

### Description

Service SG generation was refactored to using TG protocol rather than service protocol when generating SG rules. I forgot to add a case for the TLS protocol, which exists in ELB TG Protocol but not Service Protocol. I validated that this code change generates the same LB that a v2.12.0 controller also generates, by comparing the calculated model json

### Checklist
- [X] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [X] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
