### PR TITLE
[feat gw api] Implement Gateway Status + Some bug fixes for Gateway

### DIFF
--- a/controllers/gateway/utils.go
+++ b/controllers/gateway/utils.go
@@ -14,16 +14,21 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 const (
 	gatewayClassAnnotationLastProcessedConfig          = "elbv2.k8s.aws/last-processed-config"
 	gatewayClassAnnotationLastProcessedConfigTimestamp = gatewayClassAnnotationLastProcessedConfig + "-timestamp"
+
+	// The max message that can be stored in a condition
+	maxMessageLength = 32700
 )
 
+// updateGatewayClassLastProcessedConfig updates the gateway class annotations with the last processed lb config resource version or "" if no lb config is attached to the gatewayclass
 func updateGatewayClassLastProcessedConfig(ctx context.Context, k8sClient client.Client, gwClass *gwv1.GatewayClass, lbConf *elbv2gw.LoadBalancerConfiguration) error {
 
-	calculatedVersion := gatewayClassAnnotationLastProcessedConfig
+	calculatedVersion := ""
 
 	if lbConf != nil {
 		calculatedVersion = lbConf.ResourceVersion
@@ -36,12 +41,16 @@ func updateGatewayClassLastProcessedConfig(ctx context.Context, k8sClient client
 	}
 
 	gwClassOld := gwClass.DeepCopy()
+	if gwClass.Annotations == nil {
+		gwClass.Annotations = make(map[string]string)
+	}
 	gwClass.Annotations[gatewayClassAnnotationLastProcessedConfig] = calculatedVersion
 	gwClass.Annotations[gatewayClassAnnotationLastProcessedConfigTimestamp] = strconv.FormatInt(time.Now().Unix(), 10)
 
 	return k8sClient.Patch(ctx, gwClass, client.MergeFrom(gwClassOld))
 }
 
+// getStoredProcessedConfig retrieves the resource version attached to the lb config referenced by the gateway class or nil if no such mapping exists.
 func getStoredProcessedConfig(gwClass *gwv1.GatewayClass) *string {
 	var storedVersion *string
 
@@ -54,10 +63,20 @@ func getStoredProcessedConfig(gwClass *gwv1.GatewayClass) *string {
 	return storedVersion
 }
 
+// updateGatewayClassAcceptedCondition updates the 'accepted' condition on the gateway class to the passed in parameters. if no 'Accepted' condition exists, do nothing.
 func updateGatewayClassAcceptedCondition(ctx context.Context, k8sClient client.Client, gwClass *gwv1.GatewayClass, newStatus metav1.ConditionStatus, reason string, message string) error {
-	derivedStatus, indxToUpdate := deriveGatewayClassAcceptedStatus(gwClass)
+	indxToUpdate, ok := deriveAcceptedConditionIndex(gwClass)
 
-	if indxToUpdate != -1 && derivedStatus != newStatus {
+	if ok {
+
+		storedStatus := gwClass.Status.Conditions[indxToUpdate].Status
+		storedMessage := gwClass.Status.Conditions[indxToUpdate].Message
+		storedReason := gwClass.Status.Conditions[indxToUpdate].Reason
+
+		if storedStatus == newStatus && storedMessage == message && storedReason == reason {
+			return nil
+		}
+
 		gwClassOld := gwClass.DeepCopy()
 		gwClass.Status.Conditions[indxToUpdate].LastTransitionTime = metav1.NewTime(time.Now())
 		gwClass.Status.Conditions[indxToUpdate].ObservedGeneration = gwClass.Generation
@@ -71,15 +90,56 @@ func updateGatewayClassAcceptedCondition(ctx context.Context, k8sClient client.C
 	return nil
 }
 
-func deriveGatewayClassAcceptedStatus(gwClass *gwv1.GatewayClass) (metav1.ConditionStatus, int) {
-	for i, v := range gwClass.Status.Conditions {
-		if v.Type == string(gwv1.GatewayClassReasonAccepted) {
-			return v.Status, i
+// prepareGatewayConditionUpdate inserts the necessary data into the condition field of the gateway. The caller should patch the corresponding gateway. Returns false when no change was performed.
+func prepareGatewayConditionUpdate(gw *gwv1.Gateway, targetConditionType string, newStatus metav1.ConditionStatus, reason string, message string) bool {
+
+	indxToUpdate := -1
+	var derivedCondition metav1.Condition
+	for i, condition := range gw.Status.Conditions {
+		if condition.Type == targetConditionType {
+			indxToUpdate = i
+			derivedCondition = condition
+			break
 		}
 	}
-	return metav1.ConditionFalse, -1
+
+	// 32768 is the max message limit
+	truncatedMessage := truncateMessage(message)
+
+	if indxToUpdate != -1 {
+		if derivedCondition.Status != newStatus || derivedCondition.Message != truncatedMessage || derivedCondition.Reason != reason {
+			gw.Status.Conditions[indxToUpdate].LastTransitionTime = metav1.NewTime(time.Now())
+			gw.Status.Conditions[indxToUpdate].ObservedGeneration = gw.Generation
+			gw.Status.Conditions[indxToUpdate].Status = newStatus
+			gw.Status.Conditions[indxToUpdate].Message = truncatedMessage
+			gw.Status.Conditions[indxToUpdate].Reason = reason
+			return true
+		}
+	}
+	return false
 }
 
+func truncateMessage(s string) string {
+	if utf8.RuneCountInString(s) <= maxMessageLength {
+		return s
+	}
+
+	runes := []rune(s)
+	return string(runes[:maxMessageLength]) + "..."
+}
+
+// deriveAcceptedConditionIndex returns the index of the condition pertaining to the accepted condition.
+// -1 if the condition doesn't exist
+func deriveAcceptedConditionIndex(gwClass *gwv1.GatewayClass) (int, bool) {
+	for i, v := range gwClass.Status.Conditions {
+		if v.Type == string(gwv1.GatewayClassReasonAccepted) {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
+// resolveLoadBalancerConfig returns the lb config referenced in the ParametersReference.
 func resolveLoadBalancerConfig(ctx context.Context, k8sClient client.Client, reference *gwv1.ParametersReference) (*elbv2gw.LoadBalancerConfiguration, error) {
 	var lbConf *elbv2gw.LoadBalancerConfiguration
 

--- a/controllers/gateway/utils_test.go
+++ b/controllers/gateway/utils_test.go
@@ -1,10 +1,759 @@
 package gateway
 
 import (
+	"context"
+	"fmt"
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/gateway/routeutils"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/testutils"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+	"strconv"
 	"testing"
+	"time"
 )
+
+func Test_updateGatewayClassLastProcessedConfig(t *testing.T) {
+	testCases := []struct {
+		name            string
+		gwClass         gwv1.GatewayClass
+		lbConf          *elbv2gw.LoadBalancerConfiguration
+		expectedVersion string
+		noPatch         bool
+	}{
+		{
+			name: "no lb conf, no prior annotation",
+			gwClass: gwv1.GatewayClass{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "gwclass",
+				},
+			},
+			expectedVersion: "",
+		},
+		{
+			name: "no lb conf, with prior annotation",
+			gwClass: gwv1.GatewayClass{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "gwclass",
+					Annotations: map[string]string{
+						gatewayClassAnnotationLastProcessedConfig:          "foo",
+						gatewayClassAnnotationLastProcessedConfigTimestamp: "0",
+					},
+				},
+			},
+			expectedVersion: "",
+		},
+		{
+			name: "with lb conf, no prior annotation",
+			lbConf: &elbv2gw.LoadBalancerConfiguration{
+				ObjectMeta: v1.ObjectMeta{
+					ResourceVersion: "bar",
+				},
+			},
+			gwClass: gwv1.GatewayClass{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "gwclass",
+				},
+			},
+			expectedVersion: "bar",
+		},
+		{
+			name: "with lb conf, with prior annotation",
+			lbConf: &elbv2gw.LoadBalancerConfiguration{
+				ObjectMeta: v1.ObjectMeta{
+					ResourceVersion: "bar",
+				},
+			},
+			gwClass: gwv1.GatewayClass{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "gwclass",
+					Annotations: map[string]string{
+						gatewayClassAnnotationLastProcessedConfig:          "foo",
+						gatewayClassAnnotationLastProcessedConfigTimestamp: "0",
+					},
+				},
+			},
+			expectedVersion: "bar",
+		},
+		{
+			name: "no change in stored version should not trigger patch",
+			lbConf: &elbv2gw.LoadBalancerConfiguration{
+				ObjectMeta: v1.ObjectMeta{
+					ResourceVersion: "foo",
+				},
+			},
+			gwClass: gwv1.GatewayClass{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "gwclass",
+					Annotations: map[string]string{
+						gatewayClassAnnotationLastProcessedConfig:          "foo",
+						gatewayClassAnnotationLastProcessedConfigTimestamp: "10",
+					},
+				},
+			},
+			expectedVersion: "foo",
+			noPatch:         true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := testutils.GenerateTestClient()
+			original := tc.gwClass.DeepCopy()
+			err := client.Create(context.Background(), original)
+			assert.NoError(t, err)
+			err = updateGatewayClassLastProcessedConfig(context.Background(), client, original, tc.lbConf)
+			assert.NoError(t, err)
+			stored := &gwv1.GatewayClass{}
+			err = client.Get(context.Background(), k8s.NamespacedName(original), stored)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedVersion, stored.Annotations[gatewayClassAnnotationLastProcessedConfig])
+
+			ts, err := strconv.Atoi(stored.Annotations[gatewayClassAnnotationLastProcessedConfigTimestamp])
+			assert.NoError(t, err)
+			assert.NotZero(t, ts)
+			if tc.noPatch {
+				assert.Equal(t, tc.gwClass.Annotations[gatewayClassAnnotationLastProcessedConfigTimestamp], stored.Annotations[gatewayClassAnnotationLastProcessedConfigTimestamp])
+			}
+		})
+	}
+}
+
+func Test_updateGatewayClassAcceptedCondition(t *testing.T) {
+	testCases := []struct {
+		name    string
+		gwClass gwv1.GatewayClass
+		status  metav1.ConditionStatus
+		reason  string
+		message string
+
+		expectedConditions []metav1.Condition
+		noPatch            bool
+	}{
+		{
+			name: "nil conditions",
+			gwClass: gwv1.GatewayClass{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "gwclass",
+				},
+			},
+		},
+		{
+			name: "no conditions",
+			gwClass: gwv1.GatewayClass{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "gwclass",
+				},
+				Status: gwv1.GatewayClassStatus{
+					Conditions: make([]v1.Condition, 0),
+				},
+			},
+		},
+		{
+			name:    "flip condition to true",
+			status:  metav1.ConditionTrue,
+			reason:  "flip to true",
+			message: "test message",
+			gwClass: gwv1.GatewayClass{
+				ObjectMeta: v1.ObjectMeta{
+					Name:       "gwclass-flip-true",
+					Generation: 100,
+				},
+				Status: gwv1.GatewayClassStatus{
+					Conditions: []v1.Condition{
+						{
+							Type:               "other condition",
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: 1000,
+							Reason:             "other reason",
+							Message:            "other message",
+						},
+						{
+							Type:               string(gwv1.GatewayClassReasonAccepted),
+							Status:             metav1.ConditionFalse,
+							ObservedGeneration: 1000,
+							Reason:             "",
+							Message:            "",
+						},
+					},
+				},
+			},
+			expectedConditions: []v1.Condition{
+				{
+					Type:               "other condition",
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: 1000,
+					Reason:             "other reason",
+					Message:            "other message",
+				},
+				{
+					Type:               string(gwv1.GatewayClassReasonAccepted),
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: 100,
+					Reason:             "flip to true",
+					Message:            "test message",
+				},
+			},
+		},
+		{
+			name:    "flip condition to false",
+			status:  metav1.ConditionFalse,
+			reason:  "flip to false",
+			message: "test message",
+			gwClass: gwv1.GatewayClass{
+				ObjectMeta: v1.ObjectMeta{
+					Name:       "gwclass-flip",
+					Generation: 100,
+				},
+				Status: gwv1.GatewayClassStatus{
+					Conditions: []v1.Condition{
+						{
+							Type:               "other condition",
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: 1000,
+							Reason:             "other reason",
+							Message:            "other message",
+						},
+						{
+							Type:               string(gwv1.GatewayClassReasonAccepted),
+							Status:             metav1.ConditionFalse,
+							ObservedGeneration: 1000,
+							Reason:             "",
+							Message:            "",
+						},
+					},
+				},
+			},
+			expectedConditions: []v1.Condition{
+				{
+					Type:               "other condition",
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: 1000,
+					Reason:             "other reason",
+					Message:            "other message",
+				},
+				{
+					Type:               string(gwv1.GatewayClassReasonAccepted),
+					Status:             metav1.ConditionFalse,
+					ObservedGeneration: 100,
+					Reason:             "flip to false",
+					Message:            "test message",
+				},
+			},
+		},
+		{
+			name:    "no change results in no patch",
+			status:  metav1.ConditionFalse,
+			reason:  "reason",
+			message: "msg",
+			gwClass: gwv1.GatewayClass{
+				ObjectMeta: v1.ObjectMeta{
+					Name:       "gwclass-flip",
+					Generation: 100,
+				},
+				Status: gwv1.GatewayClassStatus{
+					Conditions: []v1.Condition{
+						{
+							Type:               "other condition",
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: 1000,
+							Reason:             "other reason",
+							Message:            "other message",
+						},
+						{
+							Type:               string(gwv1.GatewayClassReasonAccepted),
+							Status:             metav1.ConditionFalse,
+							ObservedGeneration: 1000,
+							Reason:             "reason",
+							Message:            "msg",
+						},
+					},
+				},
+			},
+			expectedConditions: []v1.Condition{
+				{
+					Type:               "other condition",
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: 1000,
+					Reason:             "other reason",
+					Message:            "other message",
+				},
+				{
+					Type:               string(gwv1.GatewayClassReasonAccepted),
+					Status:             metav1.ConditionFalse,
+					ObservedGeneration: 1000,
+					Reason:             "reason",
+					Message:            "msg",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockClient := testutils.GenerateTestClient()
+			err := mockClient.Create(context.Background(), &tc.gwClass)
+			assert.NoError(t, err)
+			time.Sleep(1 * time.Second)
+
+			stored := &gwv1.GatewayClass{}
+			err = mockClient.Get(context.Background(), k8s.NamespacedName(&tc.gwClass), stored)
+			assert.NoError(t, err)
+
+			err = updateGatewayClassAcceptedCondition(context.Background(), mockClient, tc.gwClass.DeepCopy(), tc.status, tc.reason, tc.message)
+			assert.NoError(t, err)
+			stored = &gwv1.GatewayClass{}
+			err = mockClient.Get(context.Background(), k8s.NamespacedName(&tc.gwClass), stored)
+			assert.NoError(t, err)
+
+			fixedTime := metav1.NewTime(time.Now())
+
+			// In order to use equals(), we need to make the time fields are fixed.
+			if tc.expectedConditions != nil {
+				for i := range tc.expectedConditions {
+					tmp := &tc.expectedConditions[i]
+					tmp.LastTransitionTime = fixedTime
+				}
+			}
+
+			if stored.Status.Conditions != nil {
+				for i := range stored.Status.Conditions {
+					tmp := &stored.Status.Conditions[i]
+					tmp.LastTransitionTime = fixedTime
+				}
+			}
+
+			assert.Equal(t, tc.expectedConditions, stored.Status.Conditions)
+		})
+	}
+}
+
+func Test_prepareGatewayConditionUpdate(t *testing.T) {
+
+	longString := ""
+	for i := 0; i < 50000; i++ {
+		longString = fmt.Sprintf("%s%s", longString, "a")
+	}
+	truncatedString := ""
+	for i := 0; i < 32700; i++ {
+		truncatedString = fmt.Sprintf("%s%s", truncatedString, "a")
+	}
+	truncatedString = fmt.Sprintf("%s...", truncatedString)
+
+	testCases := []struct {
+		name                string
+		gw                  gwv1.Gateway
+		targetConditionType string
+		newStatus           metav1.ConditionStatus
+		reason              string
+		message             string
+
+		expectedGw gwv1.Gateway
+		expected   bool
+	}{
+		{
+			name: "target condition not found",
+			gw: gwv1.Gateway{
+				Status: gwv1.GatewayStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               "other condition",
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: 1000,
+							Reason:             "other reason",
+							Message:            "other message",
+						},
+						{
+							Type:               "other condition2",
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: 1001,
+							Reason:             "other reason2",
+							Message:            "other message2",
+						},
+					},
+				},
+			},
+			expectedGw: gwv1.Gateway{
+				Status: gwv1.GatewayStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               "other condition",
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: 1000,
+							Reason:             "other reason",
+							Message:            "other message",
+						},
+						{
+							Type:               "other condition2",
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: 1001,
+							Reason:             "other reason2",
+							Message:            "other message2",
+						},
+					},
+				},
+			},
+			targetConditionType: string(gwv1.GatewayConditionAccepted),
+			newStatus:           metav1.ConditionTrue,
+			reason:              "other reason",
+			message:             "other message",
+		},
+		{
+			name: "target condition found",
+			gw: gwv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 50,
+				},
+				Status: gwv1.GatewayStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               "other condition",
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: 1000,
+							Reason:             "other reason",
+							Message:            "other message",
+						},
+						{
+							Type:    string(gwv1.GatewayConditionAccepted),
+							Status:  metav1.ConditionFalse,
+							Reason:  "other reason",
+							Message: "other message",
+						},
+						{
+							Type:               "other condition2",
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: 1001,
+							Reason:             "other reason2",
+							Message:            "other message2",
+						},
+					},
+				},
+			},
+			expectedGw: gwv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 50,
+				},
+				Status: gwv1.GatewayStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               "other condition",
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: 1000,
+							Reason:             "other reason",
+							Message:            "other message",
+						},
+						{
+							Type:               string(gwv1.GatewayConditionAccepted),
+							Status:             metav1.ConditionTrue,
+							Reason:             "new reason",
+							Message:            "new message",
+							ObservedGeneration: 50,
+						},
+						{
+							Type:               "other condition2",
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: 1001,
+							Reason:             "other reason2",
+							Message:            "other message2",
+						},
+					},
+				},
+			},
+			targetConditionType: string(gwv1.GatewayConditionAccepted),
+			newStatus:           metav1.ConditionTrue,
+			reason:              "new reason",
+			message:             "new message",
+			expected:            true,
+		},
+		{
+			name: "target condition found - long message truncated",
+			gw: gwv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 50,
+				},
+				Status: gwv1.GatewayStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               "other condition",
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: 1000,
+							Reason:             "other reason",
+							Message:            "other message",
+						},
+						{
+							Type:    string(gwv1.GatewayConditionAccepted),
+							Status:  metav1.ConditionFalse,
+							Reason:  "other reason",
+							Message: "other message",
+						},
+						{
+							Type:               "other condition2",
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: 1001,
+							Reason:             "other reason2",
+							Message:            "other message2",
+						},
+					},
+				},
+			},
+			expectedGw: gwv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 50,
+				},
+				Status: gwv1.GatewayStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               "other condition",
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: 1000,
+							Reason:             "other reason",
+							Message:            "other message",
+						},
+						{
+							Type:               string(gwv1.GatewayConditionAccepted),
+							Status:             metav1.ConditionTrue,
+							Reason:             "new reason",
+							Message:            truncatedString,
+							ObservedGeneration: 50,
+						},
+						{
+							Type:               "other condition2",
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: 1001,
+							Reason:             "other reason2",
+							Message:            "other message2",
+						},
+					},
+				},
+			},
+			targetConditionType: string(gwv1.GatewayConditionAccepted),
+			newStatus:           metav1.ConditionTrue,
+			reason:              "new reason",
+			message:             longString,
+			expected:            true,
+		},
+		{
+			name: "target condition found already correct",
+			gw: gwv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 50,
+				},
+				Status: gwv1.GatewayStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               "other condition",
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: 1000,
+							Reason:             "other reason",
+							Message:            "other message",
+						},
+						{
+							Type:               string(gwv1.GatewayConditionAccepted),
+							Status:             metav1.ConditionTrue,
+							Reason:             "new reason",
+							Message:            "new message",
+							ObservedGeneration: 1000,
+						},
+						{
+							Type:               "other condition2",
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: 1001,
+							Reason:             "other reason2",
+							Message:            "other message2",
+						},
+					},
+				},
+			},
+			expectedGw: gwv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 50,
+				},
+				Status: gwv1.GatewayStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               "other condition",
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: 1000,
+							Reason:             "other reason",
+							Message:            "other message",
+						},
+						{
+							Type:               string(gwv1.GatewayConditionAccepted),
+							Status:             metav1.ConditionTrue,
+							Reason:             "new reason",
+							Message:            "new message",
+							ObservedGeneration: 1000,
+						},
+						{
+							Type:               "other condition2",
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: 1001,
+							Reason:             "other reason2",
+							Message:            "other message2",
+						},
+					},
+				},
+			},
+			targetConditionType: string(gwv1.GatewayConditionAccepted),
+			newStatus:           metav1.ConditionTrue,
+			reason:              "new reason",
+			message:             "new message",
+		},
+		{
+			name: "target condition found - long message truncated",
+			gw: gwv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 50,
+				},
+				Status: gwv1.GatewayStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               "other condition",
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: 1000,
+							Reason:             "other reason",
+							Message:            "other message",
+						},
+						{
+							Type:               string(gwv1.GatewayConditionAccepted),
+							Status:             metav1.ConditionTrue,
+							Reason:             "other reason",
+							Message:            truncatedString,
+							ObservedGeneration: 1000,
+						},
+						{
+							Type:               "other condition2",
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: 1001,
+							Reason:             "other reason2",
+							Message:            "other message2",
+						},
+					},
+				},
+			},
+			expectedGw: gwv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 50,
+				},
+				Status: gwv1.GatewayStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               "other condition",
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: 1000,
+							Reason:             "other reason",
+							Message:            "other message",
+						},
+						{
+							Type:               string(gwv1.GatewayConditionAccepted),
+							Status:             metav1.ConditionTrue,
+							Reason:             "other reason",
+							Message:            truncatedString,
+							ObservedGeneration: 1000,
+						},
+						{
+							Type:               "other condition2",
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: 1001,
+							Reason:             "other reason2",
+							Message:            "other message2",
+						},
+					},
+				},
+			},
+			targetConditionType: string(gwv1.GatewayConditionAccepted),
+			newStatus:           metav1.ConditionTrue,
+			reason:              "other reason",
+			message:             longString,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := prepareGatewayConditionUpdate(&tc.gw, tc.targetConditionType, tc.newStatus, tc.reason, tc.message)
+
+			// In order to use equals(), we need to make the time fields are fixed.
+			fixedTime := metav1.NewTime(time.Now())
+			if tc.gw.Status.Conditions != nil {
+				for i := range tc.gw.Status.Conditions {
+					tmp := &tc.gw.Status.Conditions[i]
+					tmp.LastTransitionTime = fixedTime
+				}
+			}
+
+			if tc.expectedGw.Status.Conditions != nil {
+				for i := range tc.expectedGw.Status.Conditions {
+					tmp := &tc.expectedGw.Status.Conditions[i]
+					tmp.LastTransitionTime = fixedTime
+				}
+			}
+
+			assert.Equal(t, tc.expected, res)
+			assert.Equal(t, tc.expectedGw, tc.gw)
+		})
+	}
+}
+
+func Test_resolveLoadBalancerConfig(t *testing.T) {
+	testCases := []struct {
+		name      string
+		reference *gwv1.ParametersReference
+		lbConf    *elbv2gw.LoadBalancerConfiguration
+		expectErr bool
+	}{
+		{
+			name: "lb conf found",
+			reference: &gwv1.ParametersReference{
+				Name:      "foo",
+				Namespace: (*gwv1.Namespace)(awssdk.String("ns")),
+			},
+			lbConf: &elbv2gw.LoadBalancerConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "ns",
+				},
+			},
+		},
+		{
+			name: "no lb conf",
+			reference: &gwv1.ParametersReference{
+				Name:      "foo",
+				Namespace: (*gwv1.Namespace)(awssdk.String("ns")),
+			},
+			expectErr: true,
+		},
+		{
+			name: "no namespace",
+			reference: &gwv1.ParametersReference{
+				Name: "foo",
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockClient := testutils.GenerateTestClient()
+			if tc.lbConf != nil {
+				err := mockClient.Create(context.Background(), tc.lbConf)
+				assert.NoError(t, err)
+			}
+			time.Sleep(1 * time.Second)
+
+			res, err := resolveLoadBalancerConfig(context.Background(), mockClient, tc.reference)
+			if tc.expectErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.lbConf, res)
+		})
+	}
+}
 
 func Test_generateRouteList(t *testing.T) {
 	testCases := []struct {

--- a/pkg/deploy/elbv2/load_balancer_manager.go
+++ b/pkg/deploy/elbv2/load_balancer_manager.go
@@ -391,8 +391,9 @@ func buildSDKSubnetMapping(modelSubnetMapping elbv2model.SubnetMapping) elbv2typ
 
 func buildResLoadBalancerStatus(sdkLB LoadBalancerWithTags) elbv2model.LoadBalancerStatus {
 	return elbv2model.LoadBalancerStatus{
-		LoadBalancerARN: awssdk.ToString(sdkLB.LoadBalancer.LoadBalancerArn),
-		DNSName:         awssdk.ToString(sdkLB.LoadBalancer.DNSName),
+		LoadBalancerARN:   awssdk.ToString(sdkLB.LoadBalancer.LoadBalancerArn),
+		DNSName:           awssdk.ToString(sdkLB.LoadBalancer.DNSName),
+		ProvisioningState: sdkLB.LoadBalancer.State,
 	}
 }
 

--- a/pkg/deploy/elbv2/load_balancer_manager_test.go
+++ b/pkg/deploy/elbv2/load_balancer_manager_test.go
@@ -429,12 +429,20 @@ func Test_buildResLoadBalancerStatus(t *testing.T) {
 					LoadBalancer: &elbv2types.LoadBalancer{
 						LoadBalancerArn: awssdk.String("my-arn"),
 						DNSName:         awssdk.String("www.example.com"),
+						State: &elbv2types.LoadBalancerState{
+							Code:   elbv2types.LoadBalancerStateEnumProvisioning,
+							Reason: awssdk.String("foo"),
+						},
 					},
 				},
 			},
 			want: elbv2model.LoadBalancerStatus{
 				LoadBalancerARN: "my-arn",
 				DNSName:         "www.example.com",
+				ProvisioningState: &elbv2types.LoadBalancerState{
+					Code:   elbv2types.LoadBalancerStateEnumProvisioning,
+					Reason: awssdk.String("foo"),
+				},
 			},
 		},
 	}

--- a/pkg/gateway/routeutils/backend_test.go
+++ b/pkg/gateway/routeutils/backend_test.go
@@ -283,7 +283,7 @@ func TestCommonBackendLoader(t *testing.T) {
 					Port:      portConverter(80),
 				},
 			},
-			expectNoResult: true,
+			expectErr: true,
 		},
 		{
 			name: "missing port in backend ref should result in an error",

--- a/pkg/gateway/routeutils/grpc.go
+++ b/pkg/gateway/routeutils/grpc.go
@@ -128,5 +128,5 @@ func ListGRPCRoutes(context context.Context, k8sClient client.Client) ([]preLoad
 		result = append(result, convertGRPCRoute(item))
 	}
 
-	return result, err
+	return result, nil
 }

--- a/pkg/gateway/routeutils/http.go
+++ b/pkg/gateway/routeutils/http.go
@@ -128,5 +128,5 @@ func ListHTTPRoutes(context context.Context, k8sClient client.Client) ([]preLoad
 		result = append(result, convertHTTPRoute(item))
 	}
 
-	return result, err
+	return result, nil
 }

--- a/pkg/gateway/routeutils/listener_attachment_helper.go
+++ b/pkg/gateway/routeutils/listener_attachment_helper.go
@@ -2,7 +2,9 @@ package routeutils
 
 import (
 	"context"
+	"fmt"
 	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -145,8 +147,10 @@ func (attachmentHelper *listenerAttachmentHelperImpl) hostnameCheck(listener gwv
 	isListenerHostnameValid, err := IsHostNameInValidFormat(string(*listener.Hostname))
 	if err != nil {
 		attachmentHelper.logger.Error(err, "listener hostname is not valid", "listener", listener.Name, "hostname", *listener.Hostname)
-		return false, err
+		initialErrorMessage := fmt.Sprintf("listener hostname %s is not valid (listener name %s)", listener.Name, *listener.Hostname)
+		return false, wrapError(errors.Errorf("%s", initialErrorMessage), gwv1.GatewayReasonListenersNotValid, gwv1.RouteReasonUnsupportedValue)
 	}
+
 	if !isListenerHostnameValid {
 		return false, nil
 	}

--- a/pkg/gateway/routeutils/loader_error.go
+++ b/pkg/gateway/routeutils/loader_error.go
@@ -1,0 +1,42 @@
+package routeutils
+
+import (
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+type LoaderError interface {
+	Error() string
+	GetRawError() error
+	GetGatewayReason() gwv1.GatewayConditionReason
+	GetRouteReason() gwv1.RouteConditionReason
+}
+
+type loaderErrorImpl struct {
+	resolvedGatewayCondition gwv1.GatewayConditionReason
+	resolvedRouteCondition   gwv1.RouteConditionReason
+	underlyingErr            error
+}
+
+func wrapError(underlyingErr error, gatewayCondition gwv1.GatewayConditionReason, routeCondition gwv1.RouteConditionReason) LoaderError {
+	return &loaderErrorImpl{
+		underlyingErr:            underlyingErr,
+		resolvedGatewayCondition: gatewayCondition,
+		resolvedRouteCondition:   routeCondition,
+	}
+}
+
+func (e *loaderErrorImpl) GetRawError() error {
+	return e.underlyingErr
+}
+
+func (e *loaderErrorImpl) GetGatewayReason() gwv1.GatewayConditionReason {
+	return e.resolvedGatewayCondition
+}
+
+func (e *loaderErrorImpl) GetRouteReason() gwv1.RouteConditionReason {
+	return e.resolvedRouteCondition
+}
+
+func (e *loaderErrorImpl) Error() string {
+	return e.underlyingErr.Error()
+}

--- a/pkg/gateway/routeutils/namespace_selector.go
+++ b/pkg/gateway/routeutils/namespace_selector.go
@@ -2,10 +2,12 @@ package routeutils
 
 import (
 	"context"
+	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 // namespaceSelector is an internal utility
@@ -33,7 +35,7 @@ func (n *namespaceSelectorImpl) getNamespacesFromSelector(context context.Contex
 
 	convertedSelector, err := metav1.LabelSelectorAsSelector(selector)
 	if err != nil {
-		return nil, err
+		return nil, wrapError(errors.Wrapf(err, "Unable to parse selector %s", selector), gwv1.GatewayReasonListenersNotValid, gwv1.RouteReasonUnsupportedValue)
 	}
 
 	err = n.k8sClient.List(context, &namespaceList, client.MatchingLabelsSelector{Selector: convertedSelector})

--- a/pkg/gateway/routeutils/route_listener_mapper.go
+++ b/pkg/gateway/routeutils/route_listener_mapper.go
@@ -8,7 +8,7 @@ import (
 )
 
 // listenerToRouteMapper is an internal utility that will map a list of routes to the listeners of a gateway
-// if the gateway and/or route are incompatible, then route is discarded.
+// if the gateway and/or route are incompatible, then the route is discarded.
 type listenerToRouteMapper interface {
 	mapGatewayAndRoutes(context context.Context, gw gwv1.Gateway, routes []preLoadRouteDescriptor, deferredRouteReconciler RouteReconciler) (map[int][]preLoadRouteDescriptor, error)
 }

--- a/pkg/gateway/routeutils/tcp.go
+++ b/pkg/gateway/routeutils/tcp.go
@@ -128,5 +128,5 @@ func ListTCPRoutes(context context.Context, k8sClient client.Client) ([]preLoadR
 	for _, item := range routeList.Items {
 		result = append(result, convertTCPRoute(item))
 	}
-	return result, err
+	return result, nil
 }

--- a/pkg/gateway/routeutils/tls.go
+++ b/pkg/gateway/routeutils/tls.go
@@ -127,5 +127,5 @@ func ListTLSRoutes(context context.Context, k8sClient client.Client) ([]preLoadR
 		result = append(result, convertTLSRoute(item))
 	}
 
-	return result, err
+	return result, nil
 }

--- a/pkg/gateway/routeutils/udp.go
+++ b/pkg/gateway/routeutils/udp.go
@@ -126,5 +126,5 @@ func ListUDPRoutes(context context.Context, k8sClient client.Client) ([]preLoadR
 		result = append(result, convertUDPRoute(item))
 	}
 
-	return result, err
+	return result, nil
 }

--- a/pkg/gateway/routeutils/utils_test.go
+++ b/pkg/gateway/routeutils/utils_test.go
@@ -163,7 +163,6 @@ func Test_ListL4Routes(t *testing.T) {
 				return k8sClient
 			},
 			expectedRoutes: 3,
-			expectedErr:    nil,
 		},
 		{
 			name: "Handles error in TCP routes",
@@ -188,7 +187,11 @@ func Test_ListL4Routes(t *testing.T) {
 			client := tt.mockSetup(ctrl)
 			routes, err := ListL4Routes(context.Background(), client)
 
-			assert.Equal(t, err, tt.expectedErr)
+			if tt.expectedErr == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.Equal(t, tt.expectedErr.Error(), err.Error())
+			}
 			assert.Len(t, routes, tt.expectedRoutes)
 
 		})
@@ -293,7 +296,11 @@ func Test_ListL7Routes(t *testing.T) {
 			client := tt.mockSetup(ctrl)
 			routes, err := ListL7Routes(context.Background(), client)
 
-			assert.Equal(t, err, tt.expectedErr)
+			if tt.expectedErr == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.Equal(t, tt.expectedErr.Error(), err.Error())
+			}
 			assert.Len(t, routes, tt.expectedRoutes)
 
 		})

--- a/pkg/model/elbv2/load_balancer.go
+++ b/pkg/model/elbv2/load_balancer.go
@@ -2,6 +2,7 @@ package elbv2
 
 import (
 	"context"
+	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/core"
 )
@@ -212,4 +213,7 @@ type LoadBalancerStatus struct {
 
 	// The public DNS name of the load balancer.
 	DNSName string `json:"dnsName"`
+
+	// The current state of the load balancer (active, provisioning, etc)
+	ProvisioningState *elbv2types.LoadBalancerState `json:"provisioningState"`
 }

--- a/pkg/testutils/client_test_utils.go
+++ b/pkg/testutils/client_test_utils.go
@@ -52,5 +52,5 @@ func GenerateTestClient() client.Client {
 	elbv2gw.AddToScheme(k8sSchema)
 	gwbeta1.AddToScheme(k8sSchema)
 
-	return testclient.NewClientBuilder().WithScheme(k8sSchema).Build()
+	return testclient.NewClientBuilder().WithStatusSubresource(&gwv1.GatewayClass{}).WithStatusSubresource(&gwv1.Gateway{}).WithScheme(k8sSchema).Build()
 }


### PR DESCRIPTION
### Description

Implements Gateway conditions for both Programmed and Accepted. I had to refactor the route util in order to propagate the exact problem back to the gateway controller in order to properly implement the various failure causes on the Accepted condition.

I had to refactor the deployer to get back the LB status to correctly implement requeuing the Gateway in order to update the programmed condition when the LB finishes provisioning. 

Added support infrastructure annotations, they get propagated to the TGB created by the Gateway.


### Tests

- Verified Accepted / Program conditions:
```
nixozach@80a997300bd5 aws-load-balancer-controller % kubectl -n gateway-nlb get gateway test-gw-nlb -o yaml
	apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  annotations:
    foo: baz
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"gateway.networking.k8s.io/v1","kind":"Gateway","metadata":{"annotations":{},"name":"test-gw-nlb","namespace":"gateway-nlb"},"spec":{"gatewayClassName":"nlb-gateway","listeners":[{"allowedRoutes":{"namespaces":{"from":"Same"}},"name":"test-2024","port":80,"protocol":"TCP"}]}}
  creationTimestamp: "2025-04-17T05:38:04Z"
  finalizers:
  - gateway.k8s.aws/nlb
  generation: 3
  name: test-gw-nlb
  namespace: gateway-nlb
  resourceVersion: "26639358"
  uid: 823cdc65-4ea0-4dfc-b8b5-48b3a7e86516
spec:
  gatewayClassName: nlb-gateway
  infrastructure:
    parametersRef:
      group: gateway.k8s.aws
      kind: LoadBalancerConfiguration
      name: local-nlb
  listeners:
  - allowedRoutes:
      namespaces:
        from: Same
    name: test-2024
    port: 80
    protocol: TCP
status:
  addresses:
  - type: Hostname
    value: k8s-gatewayn-testgwnl-3797607738-fbef7aa6d15b46aa.elb.us-east-1.amazonaws.com
  conditions:
  - lastTransitionTime: "2025-05-15T22:13:13Z"
    message: ""
    observedGeneration: 3
    reason: Accepted
    status: "True"
    type: Accepted
  - lastTransitionTime: "2025-05-16T23:03:00Z"
    message: arn:aws:elasticloadbalancing:us-east-1:565768096483:loadbalancer/net/k8s-gatewayn-testgwnl-3797607738/fbef7aa6d15b46aa
    observedGeneration: 3
    reason: Programmed
    status: "True"
    type: Programmed
```

- Verified labels / annotations are applied from Gateway infrastructure parameter to TGB. (also backfilled tests here)

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [x] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:
