### PR TITLE
[feat gw api] add support for infra labels + annotations

### DIFF
--- a/pkg/deploy/elbv2/target_group_binding_manager_test.go
+++ b/pkg/deploy/elbv2/target_group_binding_manager_test.go
@@ -1,0 +1,509 @@
+package elbv2
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/tracking"
+	coremodel "sigs.k8s.io/aws-load-balancer-controller/pkg/model/core"
+	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/testutils"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"testing"
+	"time"
+)
+
+func Test_defaultTargetGroupBindingManager_Create(t *testing.T) {
+	instanceTargetType := elbv2api.TargetTypeInstance
+	ipv4AddressType := elbv2api.IPAddressTypeIPV4
+	testCases := []struct {
+		name     string
+		spec     elbv2model.TargetGroupBindingResourceSpec
+		expected elbv2api.TargetGroupBinding
+	}{
+		{
+			name: "just spec, no labels or annotation",
+			spec: elbv2model.TargetGroupBindingResourceSpec{
+				Template: elbv2model.TargetGroupBindingTemplate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tgb",
+						Namespace: "tgb-ns",
+					},
+					Spec: elbv2model.TargetGroupBindingSpec{
+						TargetGroupARN: coremodel.LiteralStringToken("arn:aws:elasticloadbalancing:us-east-1:565768096483:targetgroup/k8s-echoserv-brokentg-0b7ba7f4ef/ae85b8ea9fb69748"),
+						TargetType:     &instanceTargetType,
+						ServiceRef: elbv2api.ServiceReference{
+							Name: "my-svc",
+							Port: intstr.FromString("my-port"),
+						},
+						IPAddressType: elbv2api.TargetGroupIPAddressTypeIPv4,
+					},
+				},
+			},
+			expected: elbv2api.TargetGroupBinding{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tgb",
+					Namespace: "tgb-ns",
+					Labels: map[string]string{
+						"ingress.k8s.aws/stack-name":      "test-stack",
+						"ingress.k8s.aws/stack-namespace": "test-ns",
+					},
+					ResourceVersion: "1",
+				},
+				Spec: elbv2api.TargetGroupBindingSpec{
+					TargetGroupARN: "arn:aws:elasticloadbalancing:us-east-1:565768096483:targetgroup/k8s-echoserv-brokentg-0b7ba7f4ef/ae85b8ea9fb69748",
+					TargetType:     &instanceTargetType,
+					ServiceRef: elbv2api.ServiceReference{
+						Name: "my-svc",
+						Port: intstr.FromString("my-port"),
+					},
+					IPAddressType: (*elbv2api.TargetGroupIPAddressType)(&ipv4AddressType),
+				},
+			},
+		},
+		{
+			name: "just spec, labels. no annotation",
+			spec: elbv2model.TargetGroupBindingResourceSpec{
+				Template: elbv2model.TargetGroupBindingTemplate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tgb",
+						Namespace: "tgb-ns",
+						Labels: map[string]string{
+							"foo": "bar",
+							"baz": "bat",
+						},
+					},
+					Spec: elbv2model.TargetGroupBindingSpec{
+						TargetGroupARN: coremodel.LiteralStringToken("arn:aws:elasticloadbalancing:us-east-1:565768096483:targetgroup/k8s-echoserv-brokentg-0b7ba7f4ef/ae85b8ea9fb69748"),
+						TargetType:     &instanceTargetType,
+						ServiceRef: elbv2api.ServiceReference{
+							Name: "my-svc",
+							Port: intstr.FromString("my-port"),
+						},
+						IPAddressType: elbv2api.TargetGroupIPAddressTypeIPv4,
+					},
+				},
+			},
+			expected: elbv2api.TargetGroupBinding{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tgb",
+					Namespace: "tgb-ns",
+					Labels: map[string]string{
+						"ingress.k8s.aws/stack-name":      "test-stack",
+						"ingress.k8s.aws/stack-namespace": "test-ns",
+						"foo":                             "bar",
+						"baz":                             "bat",
+					},
+					ResourceVersion: "1",
+				},
+				Spec: elbv2api.TargetGroupBindingSpec{
+					TargetGroupARN: "arn:aws:elasticloadbalancing:us-east-1:565768096483:targetgroup/k8s-echoserv-brokentg-0b7ba7f4ef/ae85b8ea9fb69748",
+					TargetType:     &instanceTargetType,
+					ServiceRef: elbv2api.ServiceReference{
+						Name: "my-svc",
+						Port: intstr.FromString("my-port"),
+					},
+					IPAddressType: (*elbv2api.TargetGroupIPAddressType)(&ipv4AddressType),
+				},
+			},
+		},
+		{
+			name: "spec, labels, annotation",
+			spec: elbv2model.TargetGroupBindingResourceSpec{
+				Template: elbv2model.TargetGroupBindingTemplate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tgb",
+						Namespace: "tgb-ns",
+						Labels: map[string]string{
+							"foo": "bar",
+							"baz": "bat",
+						},
+						Annotations: map[string]string{
+							"ann1": "ann2",
+							"ann3": "ann4",
+						},
+					},
+					Spec: elbv2model.TargetGroupBindingSpec{
+						TargetGroupARN: coremodel.LiteralStringToken("arn:aws:elasticloadbalancing:us-east-1:565768096483:targetgroup/k8s-echoserv-brokentg-0b7ba7f4ef/ae85b8ea9fb69748"),
+						TargetType:     &instanceTargetType,
+						ServiceRef: elbv2api.ServiceReference{
+							Name: "my-svc",
+							Port: intstr.FromString("my-port"),
+						},
+						IPAddressType: elbv2api.TargetGroupIPAddressTypeIPv4,
+					},
+				},
+			},
+			expected: elbv2api.TargetGroupBinding{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tgb",
+					Namespace: "tgb-ns",
+					Labels: map[string]string{
+						"ingress.k8s.aws/stack-name":      "test-stack",
+						"ingress.k8s.aws/stack-namespace": "test-ns",
+						"foo":                             "bar",
+						"baz":                             "bat",
+					},
+					Annotations: map[string]string{
+						"ann1": "ann2",
+						"ann3": "ann4",
+					},
+					ResourceVersion: "1",
+				},
+				Spec: elbv2api.TargetGroupBindingSpec{
+					TargetGroupARN: "arn:aws:elasticloadbalancing:us-east-1:565768096483:targetgroup/k8s-echoserv-brokentg-0b7ba7f4ef/ae85b8ea9fb69748",
+					TargetType:     &instanceTargetType,
+					ServiceRef: elbv2api.ServiceReference{
+						Name: "my-svc",
+						Port: intstr.FromString("my-port"),
+					},
+					IPAddressType: (*elbv2api.TargetGroupIPAddressType)(&ipv4AddressType),
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			stack := coremodel.NewDefaultStack(coremodel.StackID(types.NamespacedName{
+				Namespace: "test-ns",
+				Name:      "test-stack",
+			}))
+			resTGB := elbv2model.NewTargetGroupBindingResource(stack, "my-tgb", tc.spec)
+			manager, k8sClient := createTestDefaultTargetGroupBindingManager()
+			status, err := manager.Create(context.Background(), resTGB)
+			assert.NoError(t, err)
+			res := &elbv2api.TargetGroupBinding{}
+			err = k8sClient.Get(context.Background(), types.NamespacedName{
+				Namespace: status.TargetGroupBindingRef.Namespace,
+				Name:      status.TargetGroupBindingRef.Name,
+			}, res)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected.Spec, res.Spec)
+			assert.Equal(t, tc.expected.ObjectMeta, res.ObjectMeta)
+		})
+	}
+}
+
+func Test_defaultTargetGroupBindingManager_Update(t *testing.T) {
+	instanceTargetType := elbv2api.TargetTypeInstance
+	ipv4AddressType := elbv2api.IPAddressTypeIPV4
+	testCases := []struct {
+		name     string
+		spec     elbv2model.TargetGroupBindingResourceSpec
+		existing elbv2api.TargetGroupBinding
+		expected elbv2api.TargetGroupBinding
+	}{
+		{
+			name: "just spec, no labels or annotation",
+			spec: elbv2model.TargetGroupBindingResourceSpec{
+				Template: elbv2model.TargetGroupBindingTemplate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tgb",
+						Namespace: "tgb-ns",
+					},
+					Spec: elbv2model.TargetGroupBindingSpec{
+						TargetGroupARN: coremodel.LiteralStringToken("arn:aws:elasticloadbalancing:us-east-1:565768096483:targetgroup/k8s-echoserv-brokentg-0b7ba7f4ef/ae85b8ea9fb69748"),
+						TargetType:     &instanceTargetType,
+						ServiceRef: elbv2api.ServiceReference{
+							Name: "my-svc",
+							Port: intstr.FromString("my-port"),
+						},
+						IPAddressType: elbv2api.TargetGroupIPAddressTypeIPv4,
+					},
+				},
+			},
+			existing: elbv2api.TargetGroupBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tgb",
+					Namespace: "tgb-ns",
+					Labels: map[string]string{
+						"ingress.k8s.aws/stack-name":      "test-stack-123",
+						"ingress.k8s.aws/stack-namespace": "test-ns-1",
+					},
+				},
+				Spec: elbv2api.TargetGroupBindingSpec{
+					TargetGroupARN: "arn:aws:elasticloadbalancing:us-east-1:565768096483:targetgroup/k8s-echoserv-brokentg-0b7ba7f4ef/ae85b8ea9fb69748",
+					TargetType:     &instanceTargetType,
+					ServiceRef: elbv2api.ServiceReference{
+						Name: "my-svc2",
+						Port: intstr.FromString("my-port"),
+					},
+					IPAddressType: (*elbv2api.TargetGroupIPAddressType)(&ipv4AddressType),
+				},
+			},
+			expected: elbv2api.TargetGroupBinding{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tgb",
+					Namespace: "tgb-ns",
+					Labels: map[string]string{
+						"ingress.k8s.aws/stack-name":      "test-stack",
+						"ingress.k8s.aws/stack-namespace": "test-ns",
+					},
+					ResourceVersion: "2",
+				},
+				Spec: elbv2api.TargetGroupBindingSpec{
+					TargetGroupARN: "arn:aws:elasticloadbalancing:us-east-1:565768096483:targetgroup/k8s-echoserv-brokentg-0b7ba7f4ef/ae85b8ea9fb69748",
+					TargetType:     &instanceTargetType,
+					ServiceRef: elbv2api.ServiceReference{
+						Name: "my-svc",
+						Port: intstr.FromString("my-port"),
+					},
+					IPAddressType: (*elbv2api.TargetGroupIPAddressType)(&ipv4AddressType),
+				},
+			},
+		},
+		{
+			name: "spec labels annotation",
+			spec: elbv2model.TargetGroupBindingResourceSpec{
+				Template: elbv2model.TargetGroupBindingTemplate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tgb",
+						Namespace: "tgb-ns",
+						Labels: map[string]string{
+							"some label": "some label value",
+						},
+						Annotations: map[string]string{
+							"ann1": "ann2",
+							"ann3": "ann4",
+						},
+					},
+					Spec: elbv2model.TargetGroupBindingSpec{
+						TargetGroupARN: coremodel.LiteralStringToken("arn:aws:elasticloadbalancing:us-east-1:565768096483:targetgroup/k8s-echoserv-brokentg-0b7ba7f4ef/ae85b8ea9fb69748"),
+						TargetType:     &instanceTargetType,
+						ServiceRef: elbv2api.ServiceReference{
+							Name: "my-svc",
+							Port: intstr.FromString("my-port"),
+						},
+						IPAddressType: elbv2api.TargetGroupIPAddressTypeIPv4,
+					},
+				},
+			},
+			existing: elbv2api.TargetGroupBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tgb",
+					Namespace: "tgb-ns",
+					Labels: map[string]string{
+						"ingress.k8s.aws/stack-name":      "test-stack-123",
+						"ingress.k8s.aws/stack-namespace": "test-ns-1",
+					},
+				},
+				Spec: elbv2api.TargetGroupBindingSpec{
+					TargetGroupARN: "arn:aws:elasticloadbalancing:us-east-1:565768096483:targetgroup/k8s-echoserv-brokentg-0b7ba7f4ef/ae85b8ea9fb69748",
+					TargetType:     &instanceTargetType,
+					ServiceRef: elbv2api.ServiceReference{
+						Name: "my-svc2",
+						Port: intstr.FromString("my-port"),
+					},
+					IPAddressType: (*elbv2api.TargetGroupIPAddressType)(&ipv4AddressType),
+				},
+			},
+			expected: elbv2api.TargetGroupBinding{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tgb",
+					Namespace: "tgb-ns",
+					Labels: map[string]string{
+						"ingress.k8s.aws/stack-name":      "test-stack",
+						"ingress.k8s.aws/stack-namespace": "test-ns",
+						"some label":                      "some label value",
+					},
+					Annotations: map[string]string{
+						"ann1": "ann2",
+						"ann3": "ann4",
+					},
+					ResourceVersion: "2",
+				},
+				Spec: elbv2api.TargetGroupBindingSpec{
+					TargetGroupARN: "arn:aws:elasticloadbalancing:us-east-1:565768096483:targetgroup/k8s-echoserv-brokentg-0b7ba7f4ef/ae85b8ea9fb69748",
+					TargetType:     &instanceTargetType,
+					ServiceRef: elbv2api.ServiceReference{
+						Name: "my-svc",
+						Port: intstr.FromString("my-port"),
+					},
+					IPAddressType: (*elbv2api.TargetGroupIPAddressType)(&ipv4AddressType),
+				},
+			},
+		},
+		{
+			name: "only diff is checkpoint annotation, no update",
+			spec: elbv2model.TargetGroupBindingResourceSpec{
+				Template: elbv2model.TargetGroupBindingTemplate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tgb",
+						Namespace: "tgb-ns",
+						Labels: map[string]string{
+							"some label": "some label value",
+						},
+						Annotations: map[string]string{
+							"ann1": "ann2",
+							"ann3": "ann4",
+						},
+					},
+					Spec: elbv2model.TargetGroupBindingSpec{
+						TargetGroupARN: coremodel.LiteralStringToken("arn:aws:elasticloadbalancing:us-east-1:565768096483:targetgroup/k8s-echoserv-brokentg-0b7ba7f4ef/ae85b8ea9fb69748"),
+						TargetType:     &instanceTargetType,
+						ServiceRef: elbv2api.ServiceReference{
+							Name: "my-svc",
+							Port: intstr.FromString("my-port"),
+						},
+						IPAddressType: elbv2api.TargetGroupIPAddressTypeIPv4,
+					},
+				},
+			},
+			existing: elbv2api.TargetGroupBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tgb",
+					Namespace: "tgb-ns",
+					Labels: map[string]string{
+						"some label":                      "some label value",
+						"ingress.k8s.aws/stack-name":      "test-stack",
+						"ingress.k8s.aws/stack-namespace": "test-ns",
+					},
+					Annotations: map[string]string{
+						"ann1": "ann2",
+						"ann3": "ann4",
+						annotations.AnnotationCheckPointTimestamp: "foo",
+						annotations.AnnotationCheckPoint:          "bar",
+					},
+				},
+				Spec: elbv2api.TargetGroupBindingSpec{
+					TargetGroupARN: "arn:aws:elasticloadbalancing:us-east-1:565768096483:targetgroup/k8s-echoserv-brokentg-0b7ba7f4ef/ae85b8ea9fb69748",
+					TargetType:     &instanceTargetType,
+					ServiceRef: elbv2api.ServiceReference{
+						Name: "my-svc",
+						Port: intstr.FromString("my-port"),
+					},
+					IPAddressType: (*elbv2api.TargetGroupIPAddressType)(&ipv4AddressType),
+				},
+			},
+			expected: elbv2api.TargetGroupBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tgb",
+					Namespace: "tgb-ns",
+					Labels: map[string]string{
+						"some label":                      "some label value",
+						"ingress.k8s.aws/stack-name":      "test-stack",
+						"ingress.k8s.aws/stack-namespace": "test-ns",
+					},
+					Annotations: map[string]string{
+						"ann1": "ann2",
+						"ann3": "ann4",
+						annotations.AnnotationCheckPointTimestamp: "foo",
+						annotations.AnnotationCheckPoint:          "bar",
+					},
+					ResourceVersion: "1",
+				},
+				Spec: elbv2api.TargetGroupBindingSpec{
+					TargetGroupARN: "arn:aws:elasticloadbalancing:us-east-1:565768096483:targetgroup/k8s-echoserv-brokentg-0b7ba7f4ef/ae85b8ea9fb69748",
+					TargetType:     &instanceTargetType,
+					ServiceRef: elbv2api.ServiceReference{
+						Name: "my-svc",
+						Port: intstr.FromString("my-port"),
+					},
+					IPAddressType: (*elbv2api.TargetGroupIPAddressType)(&ipv4AddressType),
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			stack := coremodel.NewDefaultStack(coremodel.StackID(types.NamespacedName{
+				Namespace: "test-ns",
+				Name:      "test-stack",
+			}))
+			resTGB := elbv2model.NewTargetGroupBindingResource(stack, "my-tgb", tc.spec)
+			manager, k8sClient := createTestDefaultTargetGroupBindingManager()
+
+			err := k8sClient.Create(context.Background(), &tc.existing)
+			assert.NoError(t, err)
+
+			status, err := manager.Update(context.Background(), resTGB, &tc.existing)
+			assert.NoError(t, err)
+			res := &elbv2api.TargetGroupBinding{}
+			err = k8sClient.Get(context.Background(), types.NamespacedName{
+				Namespace: status.TargetGroupBindingRef.Namespace,
+				Name:      status.TargetGroupBindingRef.Name,
+			}, res)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected.Spec, res.Spec)
+			assert.Equal(t, tc.expected.ObjectMeta, res.ObjectMeta)
+		})
+	}
+}
+
+func Test_defaultTargetGroupBindingManager_Delete(t *testing.T) {
+	instanceTargetType := elbv2api.TargetTypeInstance
+	ipv4AddressType := elbv2api.IPAddressTypeIPV4
+	testCases := []struct {
+		name     string
+		existing elbv2api.TargetGroupBinding
+	}{
+		{
+			name: "delete",
+			existing: elbv2api.TargetGroupBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tgb",
+					Namespace: "tgb-ns",
+					Labels: map[string]string{
+						"ingress.k8s.aws/stack-name":      "test-stack-123",
+						"ingress.k8s.aws/stack-namespace": "test-ns-1",
+					},
+				},
+				Spec: elbv2api.TargetGroupBindingSpec{
+					TargetGroupARN: "arn:aws:elasticloadbalancing:us-east-1:565768096483:targetgroup/k8s-echoserv-brokentg-0b7ba7f4ef/ae85b8ea9fb69748",
+					TargetType:     &instanceTargetType,
+					ServiceRef: elbv2api.ServiceReference{
+						Name: "my-svc2",
+						Port: intstr.FromString("my-port"),
+					},
+					IPAddressType: (*elbv2api.TargetGroupIPAddressType)(&ipv4AddressType),
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			manager, k8sClient := createTestDefaultTargetGroupBindingManager()
+
+			err := k8sClient.Create(context.Background(), &tc.existing)
+			assert.NoError(t, err)
+
+			err = manager.Delete(context.Background(), &tc.existing)
+			assert.NoError(t, err)
+			res := &elbv2api.TargetGroupBinding{}
+			err = k8sClient.Get(context.Background(), types.NamespacedName{
+				Namespace: tc.existing.Namespace,
+				Name:      tc.existing.Name,
+			}, res)
+			assert.Error(t, err)
+			assert.NoError(t, client.IgnoreNotFound(err))
+		})
+	}
+}
+
+func createTestDefaultTargetGroupBindingManager() (defaultTargetGroupBindingManager, client.Client) {
+	k8sClient := testutils.GenerateTestClient()
+	manager := defaultTargetGroupBindingManager{
+		k8sClient:        k8sClient,
+		trackingProvider: tracking.NewDefaultProvider("ingress.k8s.aws", "foo"),
+		logger:           logr.Discard(),
+
+		waitTGBObservedPollInterval: 10 * time.Millisecond,
+		waitTGBObservedTimout:       100 * time.Millisecond,
+		waitTGBDeletionPollInterval: 10 * time.Millisecond,
+		waitTGBDeletionTimeout:      100 * time.Millisecond,
+	}
+	return manager, k8sClient
+}

--- a/pkg/model/elbv2/load_balancer.go
+++ b/pkg/model/elbv2/load_balancer.go
@@ -2,7 +2,6 @@ package elbv2
 
 import (
 	"context"
-
 	"github.com/pkg/errors"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/core"
 )


### PR DESCRIPTION
### Description

Adds support for attaching labels and annotations from the Gateway to the created TargetGroupBinding(s) for a Gateway:
https://gateway-api.sigs.k8s.io/reference/spec/#gatewayinfrastructure


I had to refactor the TargetGroupBinding manager to support changing of annotations and labels. While making these changes I backfilled tests as the TGB manager had no tests previously.

E2E tests:

- Gateway that has no labels / annotations
- Gateway that has only labels, no annotations
- Gateway that has only annotations, no labels
- Gateway that has annotations and labels
- TGB reconciles don't trigger un-neccessary patches.
- Service reconciles still work
- Ingress reconciles still work.


Tested:
```
apiVersion: v1
items:
- apiVersion: elbv2.k8s.aws/v1beta1
  kind: TargetGroupBinding
  metadata:
    annotations:
      annfoo3: annbar3
      elbv2.k8s.aws/checkpoint: PbfnUfSBkLuy55ms0JcKGKB5F6F8rWHDj49LCpvaRQE/5_Y2kXP4aJv81kgYF7I1U-ZE4WlqR-sLG2E-WXmJhUM
      elbv2.k8s.aws/checkpoint-timestamp: "1747837898"
    creationTimestamp: "2025-05-20T15:28:35Z"
    finalizers:
    - elbv2.k8s.aws/resources
    generation: 1
    labels:
      foo3: bar3
      gateway.k8s.aws.nlb/stack-name: test-gw-nlb
      gateway.k8s.aws.nlb/stack-namespace: gateway-nlb
    name: k8s-gatewayn-tcpapp1-0ddf17a33d
    namespace: gateway-nlb
    resourceVersion: "28321176"
    uid: 5741d762-7c62-4113-b012-44f0a1cfa91c
  spec:
    ipAddressType: ipv4
    networking:
      ingress:
      - from:
        - securityGroup:
            groupID: sg-09dbde371ea398a10
        ports:
        - port: 30265
          protocol: TCP
    serviceRef:
      name: echoserver
      port: 80
    targetGroupARN: arn:aws:elasticloadbalancing:us-east-1:565768096483:targetgroup/k8s-gatewayn-tcpapp1-8cfc832478/4a9f1df33dd36c18
    targetType: instance
    vpcID: vpc-02c95a92410c1c1f2
  status:
    observedGeneration: 1
kind: List
metadata:
  resourceVersion: ""
```

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [x] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
