### PR TITLE
[feat: gw api] support gw deletion

### DIFF
--- a/controllers/gateway/utils_test.go
+++ b/controllers/gateway/utils_test.go
@@ -1,0 +1,122 @@
+package gateway
+
+import (
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/gateway/routeutils"
+	"testing"
+)
+
+func Test_generateRouteList(t *testing.T) {
+	testCases := []struct {
+		name     string
+		routes   map[int32][]routeutils.RouteDescriptor
+		expected string
+	}{
+		{
+			name:     "no routes",
+			routes:   make(map[int32][]routeutils.RouteDescriptor),
+			expected: "",
+		},
+		{
+			name: "some routes",
+			routes: map[int32][]routeutils.RouteDescriptor{
+				1: {
+					&routeutils.MockRoute{
+						Name:      "1-1-r",
+						Namespace: "1-1-ns",
+						Kind:      routeutils.GRPCRouteKind,
+					},
+					&routeutils.MockRoute{
+						Name:      "1-2-r",
+						Namespace: "1-2-ns",
+						Kind:      routeutils.TCPRouteKind,
+					},
+					&routeutils.MockRoute{
+						Name:      "1-3-r",
+						Namespace: "1-3-ns",
+						Kind:      routeutils.HTTPRouteKind,
+					},
+					&routeutils.MockRoute{
+						Name:      "1-4-r",
+						Namespace: "1-4-ns",
+						Kind:      routeutils.UDPRouteKind,
+					},
+				},
+				2: {
+					&routeutils.MockRoute{
+						Name:      "2-1-r",
+						Namespace: "2-1-ns",
+						Kind:      routeutils.GRPCRouteKind,
+					},
+					&routeutils.MockRoute{
+						Name:      "2-2-r",
+						Namespace: "2-2-ns",
+						Kind:      routeutils.TCPRouteKind,
+					},
+					&routeutils.MockRoute{
+						Name:      "2-3-r",
+						Namespace: "2-3-ns",
+						Kind:      routeutils.HTTPRouteKind,
+					},
+					&routeutils.MockRoute{
+						Name:      "2-4-r",
+						Namespace: "2-4-ns",
+						Kind:      routeutils.UDPRouteKind,
+					},
+				},
+				3: {
+					&routeutils.MockRoute{
+						Name:      "3-1-r",
+						Namespace: "3-1-ns",
+						Kind:      routeutils.GRPCRouteKind,
+					},
+					&routeutils.MockRoute{
+						Name:      "3-2-r",
+						Namespace: "3-2-ns",
+						Kind:      routeutils.TCPRouteKind,
+					},
+					&routeutils.MockRoute{
+						Name:      "3-3-r",
+						Namespace: "3-3-ns",
+						Kind:      routeutils.HTTPRouteKind,
+					},
+					&routeutils.MockRoute{
+						Name:      "3-4-r",
+						Namespace: "3-4-ns",
+						Kind:      routeutils.UDPRouteKind,
+					},
+				},
+				4: {
+					&routeutils.MockRoute{
+						Name:      "4-1-r",
+						Namespace: "4-1-ns",
+						Kind:      routeutils.GRPCRouteKind,
+					},
+					&routeutils.MockRoute{
+						Name:      "4-2-r",
+						Namespace: "4-2-ns",
+						Kind:      routeutils.TCPRouteKind,
+					},
+					&routeutils.MockRoute{
+						Name:      "4-3-r",
+						Namespace: "4-3-ns",
+						Kind:      routeutils.HTTPRouteKind,
+					},
+					&routeutils.MockRoute{
+						Name:      "4-4-r",
+						Namespace: "4-4-ns",
+						Kind:      routeutils.UDPRouteKind,
+					},
+				},
+			},
+			expected: "(GRPCRoute, 1-1-ns:1-1-r),(GRPCRoute, 2-1-ns:2-1-r),(GRPCRoute, 3-1-ns:3-1-r),(GRPCRoute, 4-1-ns:4-1-r),(HTTPRoute, 1-3-ns:1-3-r),(HTTPRoute, 2-3-ns:2-3-r),(HTTPRoute, 3-3-ns:3-3-r),(HTTPRoute, 4-3-ns:4-3-r),(TCPRoute, 1-2-ns:1-2-r),(TCPRoute, 2-2-ns:2-2-r),(TCPRoute, 3-2-ns:3-2-r),(TCPRoute, 4-2-ns:4-2-r),(UDPRoute, 1-4-ns:1-4-r),(UDPRoute, 2-4-ns:2-4-r),(UDPRoute, 3-4-ns:3-4-r),(UDPRoute, 4-4-ns:4-4-r)",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := generateRouteList(tc.routes)
+			assert.Equal(t, tc.expected, res)
+		})
+	}
+}

--- a/pkg/k8s/events.go
+++ b/pkg/k8s/events.go
@@ -28,4 +28,13 @@ const (
 	TargetGroupBindingEventReasonFailedNetworkReconcile = "FailedNetworkReconcile"
 	TargetGroupBindingEventReasonBackendNotFound        = "BackendNotFound"
 	TargetGroupBindingEventReasonSuccessfullyReconciled = "SuccessfullyReconciled"
+
+	// Gateway events
+	GatewayEventReasonFailedAddFinalizer             = "FailedAddFinalizer"
+	GatewayEventReasonFailedRemoveFinalizer          = "FailedRemoveFinalizer"
+	GatewayEventReasonFailedDeleteWithRoutesAttached = "FailedDeleteRoutesAttached"
+	GatewayEventReasonFailedUpdateStatus             = "FailedUpdateStatus"
+	GatewayEventReasonSuccessfullyReconciled         = "SuccessfullyReconciled"
+	GatewayEventReasonFailedDeployModel              = "FailedDeployModel"
+	GatewayEventReasonFailedBuildModel               = "FailedBuildModel"
 )


### PR DESCRIPTION
### Description

Originally, we missed adding the deletion logic to Gateways, meaning that the AWS resources would not get cleaned up after Gateway deletion.

- Added deletion logic
- Refactored gateway controller to use gateway specific events
- Removed redundant LB config resolver function

Testing:
- Deleted an NLB and ALB gateway. 

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [x] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
