### PR TITLE
docs: Change AWS Cognito Domain tip to warning

### DIFF
--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -630,7 +630,7 @@ ALB supports authentication with Cognito or OIDC. See [Authenticate Users Using 
 
 - <a name="auth-idp-cognito">`alb.ingress.kubernetes.io/auth-idp-cognito`</a> specifies the cognito idp configuration.
 
-    !!!tip ""
+    !!!warning "For Amazon Cognito Domain only"
         If you are using Amazon Cognito Domain, the `userPoolDomain` should be set to the domain prefix(my-domain) instead of full domain(https://my-domain.auth.us-west-2.amazoncognito.com)
 
     !!!example


### PR DESCRIPTION
### Issue

Since it is easy for people to miss this tip in between the examples, I propose to promote this dialog box as a warning.

### Description

Updated docs to clearly indicate how to configure the AWS Cognito domain when using its annotation

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
