### PR TITLE
[feat: gw api][bug fix] generate sg rules using listener protocols

### DIFF
--- a/controllers/gateway/eventhandlers/gateway_class_events.go
+++ b/controllers/gateway/eventhandlers/gateway_class_events.go
@@ -3,7 +3,6 @@ package eventhandlers
 import (
 	"context"
 	"github.com/go-logr/logr"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
@@ -42,16 +41,7 @@ func (h *enqueueRequestsForGatewayClassEvent) Create(ctx context.Context, e even
 }
 
 func (h *enqueueRequestsForGatewayClassEvent) Update(ctx context.Context, e event.TypedUpdateEvent[*gatewayv1.GatewayClass], queue workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	gwClassOld := e.ObjectOld
 	gwClassNew := e.ObjectNew
-
-	// we only care below update event:
-	//  1. GatewayClass spec updates
-	//  3. GatewayClass deletions
-	if equality.Semantic.DeepEqual(gwClassOld.Spec, gwClassNew.Spec) &&
-		equality.Semantic.DeepEqual(gwClassOld.DeletionTimestamp.IsZero(), gwClassNew.DeletionTimestamp.IsZero()) {
-		return
-	}
 
 	h.logger.V(1).Info("enqueue gatewayclass update event", "gatewayclass", gwClassNew.Name)
 	h.enqueueImpactedGateways(ctx, gwClassNew, queue)

--- a/pkg/gateway/model/model_build_listener.go
+++ b/pkg/gateway/model/model_build_listener.go
@@ -146,7 +146,7 @@ func (l listenerBuilderImpl) buildL4ListenerSpec(ctx context.Context, stack core
 
 	// For L4 Gateways we will assume that each L4 gateway Listener will have a single L4 route and each route will only have a single backendRef as weighted tgs are not supported for NLBs.
 	if len(routes) > 1 {
-		return &elbv2model.ListenerSpec{}, errors.Errorf("multiple routes %v are not supported for listener on port:protocol %v:%v for gateway %v", routes, port, listenerSpec.Protocol, k8s.NamespacedName(gw))
+		return &elbv2model.ListenerSpec{}, errors.Errorf("multiple routes %+v are not supported for listener %v:%v for gateway %v", routes, listenerSpec.Protocol, port, k8s.NamespacedName(gw))
 	}
 	routeDescriptor := routes[0]
 	if routeDescriptor.GetAttachedRules()[0].GetBackends() == nil || len(routeDescriptor.GetAttachedRules()[0].GetBackends()) == 0 {


### PR DESCRIPTION
### Description

1. This PR fixes the generation of sg rules using listener protocols instead  route protocols and its corresponding tests
2. I have removed the the check of spec and deletion updates from gwclass event handler since we want to reconcile the gateways impacted by gatewayclass if we change the lb configuration attached to gateway. We update the last updated version on gw class when we change the lb conf referrered by gwclass. Hence as soon as it changes, we wanna enqueue all the impacted gateways. 
3. Small logger update. 

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
