### PR TITLE
[gw api] Add Gateway API integ framework

### DIFF
--- a/controllers/gateway/utils.go
+++ b/controllers/gateway/utils.go
@@ -35,6 +35,10 @@ func updateGatewayClassLastProcessedConfig(ctx context.Context, k8sClient client
 		return nil
 	}
 
+	if gwClass.Annotations == nil {
+		gwClass.Annotations = make(map[string]string)
+	}
+
 	gwClassOld := gwClass.DeepCopy()
 	gwClass.Annotations[gatewayClassAnnotationLastProcessedConfig] = calculatedVersion
 	gwClass.Annotations[gatewayClassAnnotationLastProcessedConfigTimestamp] = strconv.FormatInt(time.Now().Unix(), 10)

--- a/pkg/gateway/routeutils/tcp.go
+++ b/pkg/gateway/routeutils/tcp.go
@@ -73,7 +73,6 @@ func (tcpRoute *tcpRouteDescription) loadAttachedRules(ctx context.Context, k8sC
 
 		convertedRules = append(convertedRules, convertTCPRouteRule(&rule, convertedBackends))
 	}
-
 	tcpRoute.rules = convertedRules
 	return tcpRoute, nil
 }

--- a/test/e2e/gateway/alb_instance_target.go
+++ b/test/e2e/gateway/alb_instance_target.go
@@ -7,6 +7,7 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 type ALBInstanceTestStack struct {
@@ -17,7 +18,7 @@ func (s *ALBInstanceTestStack) Deploy(ctx context.Context, f *framework.Framewor
 	dp := buildDeploymentSpec(f.Options.TestImageRegistry)
 	svc := buildServiceSpec()
 	gwc := buildGatewayClassSpec("gateway.k8s.aws/alb")
-	gw := buildGatewaySpec(gwc)
+	gw := buildBasicGatewaySpec(gwc, gwv1.HTTPProtocolType)
 	lbc := buildLoadBalancerConfig(spec)
 	httpr := buildHTTPRoute()
 	s.albResourceStack = newALBResourceStack(dp, svc, gwc, gw, lbc, httpr, "service-instance-e2e", false)
@@ -30,6 +31,7 @@ func (s *ALBInstanceTestStack) ScaleDeployment(ctx context.Context, f *framework
 }
 
 func (s *ALBInstanceTestStack) Cleanup(ctx context.Context, f *framework.Framework) {
+	_ = f.K8sClient.Delete(ctx, s.albResourceStack.httpr)
 	s.albResourceStack.Cleanup(ctx, f)
 }
 

--- a/test/e2e/gateway/alb_instance_target.go
+++ b/test/e2e/gateway/alb_instance_target.go
@@ -9,35 +9,35 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type NLBInstanceTestStack struct {
-	nlbResourceStack *nlbResourceStack
+type ALBInstanceTestStack struct {
+	albResourceStack *albResourceStack
 }
 
-func (s *NLBInstanceTestStack) Deploy(ctx context.Context, f *framework.Framework, spec elbv2gw.LoadBalancerConfigurationSpec) error {
+func (s *ALBInstanceTestStack) Deploy(ctx context.Context, f *framework.Framework, spec elbv2gw.LoadBalancerConfigurationSpec) error {
 	dp := buildDeploymentSpec(f.Options.TestImageRegistry)
 	svc := buildServiceSpec()
-	gwc := buildGatewayClassSpec("gateway.k8s.aws/nlb")
+	gwc := buildGatewayClassSpec("gateway.k8s.aws/alb")
 	gw := buildGatewaySpec(gwc)
 	lbc := buildLoadBalancerConfig(spec)
-	tcpr := buildTCPRoute()
-	s.nlbResourceStack = newNLBResourceStack(dp, svc, gwc, gw, lbc, tcpr, "service-instance-e2e", false)
+	httpr := buildHTTPRoute()
+	s.albResourceStack = newALBResourceStack(dp, svc, gwc, gw, lbc, httpr, "service-instance-e2e", false)
 
-	return s.nlbResourceStack.Deploy(ctx, f)
+	return s.albResourceStack.Deploy(ctx, f)
 }
 
-func (s *NLBInstanceTestStack) ScaleDeployment(ctx context.Context, f *framework.Framework, numReplicas int32) error {
-	return s.nlbResourceStack.ScaleDeployment(ctx, f, numReplicas)
+func (s *ALBInstanceTestStack) ScaleDeployment(ctx context.Context, f *framework.Framework, numReplicas int32) error {
+	return s.albResourceStack.ScaleDeployment(ctx, f, numReplicas)
 }
 
-func (s *NLBInstanceTestStack) Cleanup(ctx context.Context, f *framework.Framework) {
-	s.nlbResourceStack.Cleanup(ctx, f)
+func (s *ALBInstanceTestStack) Cleanup(ctx context.Context, f *framework.Framework) {
+	s.albResourceStack.Cleanup(ctx, f)
 }
 
-func (s *NLBInstanceTestStack) GetLoadBalancerIngressHostName() string {
-	return s.nlbResourceStack.GetLoadBalancerIngressHostname()
+func (s *ALBInstanceTestStack) GetLoadBalancerIngressHostName() string {
+	return s.albResourceStack.GetLoadBalancerIngressHostname()
 }
 
-func (s *NLBInstanceTestStack) GetWorkerNodes(ctx context.Context, f *framework.Framework) ([]corev1.Node, error) {
+func (s *ALBInstanceTestStack) GetWorkerNodes(ctx context.Context, f *framework.Framework) ([]corev1.Node, error) {
 	allNodes := &corev1.NodeList{}
 	err := f.K8sClient.List(ctx, allNodes)
 	if err != nil {
@@ -52,7 +52,7 @@ func (s *NLBInstanceTestStack) GetWorkerNodes(ctx context.Context, f *framework.
 	return nodeList, nil
 }
 
-func (s *NLBInstanceTestStack) ApplyNodeLabels(ctx context.Context, f *framework.Framework, node *corev1.Node, labels map[string]string) error {
+func (s *ALBInstanceTestStack) ApplyNodeLabels(ctx context.Context, f *framework.Framework, node *corev1.Node, labels map[string]string) error {
 	f.Logger.Info("applying node labels", "node", k8s.NamespacedName(node))
 	oldNode := node.DeepCopy()
 	for key, value := range labels {

--- a/test/e2e/gateway/alb_instance_target_test.go
+++ b/test/e2e/gateway/alb_instance_target_test.go
@@ -11,21 +11,21 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework/verifier"
 )
 
-var _ = Describe("test nlb gateway reconciled by the aws load balancer controller", func() {
+var _ = Describe("test k8s alb gateway reconciled by the aws load balancer controller", func() {
 	var (
 		ctx     context.Context
-		stack   NLBInstanceTestStack
+		stack   ALBInstanceTestStack
 		dnsName string
 		lbARN   string
 	)
 	BeforeEach(func() {
 		ctx = context.Background()
-		stack = NLBInstanceTestStack{}
+		stack = ALBInstanceTestStack{}
 	})
 	AfterEach(func() {
 		stack.Cleanup(ctx, tf)
 	})
-	Context("with NLB instance target configuration", func() {
+	Context("with ALB instance target configuration", func() {
 		BeforeEach(func() {})
 		It("should provision internet-facing load balancer resources", func() {
 			interf := elbv2gw.LoadBalancerSchemeInternetFacing
@@ -53,14 +53,14 @@ var _ = Describe("test nlb gateway reconciled by the aws load balancer controlle
 				nodeList, err := stack.GetWorkerNodes(ctx, tf)
 				Expect(err).ToNot(HaveOccurred())
 				err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
-					Type:         "network",
+					Type:         "application",
 					Scheme:       "internet-facing",
 					TargetType:   "instance",
-					Listeners:    stack.nlbResourceStack.getListenersPortMap(),
-					TargetGroups: stack.nlbResourceStack.getTargetGroupNodePortMap(),
+					Listeners:    stack.albResourceStack.getListenersPortMap(),
+					TargetGroups: stack.albResourceStack.getTargetGroupNodePortMap(),
 					NumTargets:   len(nodeList),
 					TargetGroupHC: &verifier.TargetGroupHC{
-						Protocol:           "TCP",
+						Protocol:           "HTTP",
 						Port:               "traffic-port",
 						Interval:           15,
 						Timeout:            5,

--- a/test/e2e/gateway/alb_instance_target_test.go
+++ b/test/e2e/gateway/alb_instance_target_test.go
@@ -19,6 +19,9 @@ var _ = Describe("test k8s alb gateway reconciled by the aws load balancer contr
 		lbARN   string
 	)
 	BeforeEach(func() {
+		if !tf.Options.EnableGatewayTests {
+			Skip("Skipping gateway tests")
+		}
 		ctx = context.Background()
 		stack = ALBInstanceTestStack{}
 	})
@@ -62,6 +65,7 @@ var _ = Describe("test k8s alb gateway reconciled by the aws load balancer contr
 					TargetGroupHC: &verifier.TargetGroupHC{
 						Protocol:           "HTTP",
 						Port:               "traffic-port",
+						Path:               "/",
 						Interval:           15,
 						Timeout:            5,
 						HealthyThreshold:   3,

--- a/test/e2e/gateway/alb_resource_stack.go
+++ b/test/e2e/gateway/alb_resource_stack.go
@@ -1,0 +1,74 @@
+package gateway
+
+import (
+	"context"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
+	"sigs.k8s.io/aws-load-balancer-controller/test/framework"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func newALBResourceStack(dp *appsv1.Deployment, svc *corev1.Service, gwc *gwv1.GatewayClass, gw *gwv1.Gateway, lbc *elbv2gw.LoadBalancerConfiguration, httpr *gwv1.HTTPRoute, baseName string, enablePodReadinessGate bool) *albResourceStack {
+
+	commonStack := newCommonResourceStack(dp, svc, gwc, gw, lbc, baseName, enablePodReadinessGate)
+	return &albResourceStack{
+		httpr:       httpr,
+		commonStack: commonStack,
+	}
+}
+
+// resourceStack containing the deployment and service resources
+type albResourceStack struct {
+	commonStack *commonResourceStack
+	httpr       *gwv1.HTTPRoute
+}
+
+func (s *albResourceStack) Deploy(ctx context.Context, f *framework.Framework) error {
+	return s.commonStack.Deploy(ctx, f, func(ctx context.Context, f *framework.Framework, namespace string) error {
+		s.httpr.Namespace = namespace
+		return s.createHTTPRoute(ctx, f)
+	})
+}
+
+func (s *albResourceStack) ScaleDeployment(ctx context.Context, f *framework.Framework, numReplicas int32) error {
+	return s.commonStack.ScaleDeployment(ctx, f, numReplicas)
+}
+
+func (s *albResourceStack) Cleanup(ctx context.Context, f *framework.Framework) {
+	s.commonStack.Cleanup(ctx, f)
+}
+
+func (s *albResourceStack) GetLoadBalancerIngressHostname() string {
+	return s.commonStack.GetLoadBalancerIngressHostname()
+}
+
+func (s *albResourceStack) GetStackName() string {
+	return s.commonStack.GetStackName()
+}
+
+func (s *albResourceStack) getListenersPortMap() map[string]string {
+	return s.commonStack.getListenersPortMap()
+}
+
+func (s *albResourceStack) getTargetGroupNodePortMap() map[string]string {
+	return s.commonStack.getTargetGroupNodePortMap()
+}
+
+func (s *albResourceStack) getHealthCheckNodePort() string {
+	return s.commonStack.getHealthCheckNodePort()
+}
+
+func (s *albResourceStack) waitUntilDeploymentReady(ctx context.Context, f *framework.Framework) error {
+	return s.commonStack.waitUntilDeploymentReady(ctx, f)
+}
+
+func (s *albResourceStack) createHTTPRoute(ctx context.Context, f *framework.Framework) error {
+	f.Logger.Info("creating http route", "httpr", k8s.NamespacedName(s.httpr))
+	return f.K8sClient.Create(ctx, s.httpr)
+}
+
+func (s *albResourceStack) deleteHTTPRoute(ctx context.Context, f *framework.Framework) error {
+	return f.K8sClient.Delete(ctx, s.httpr)
+}

--- a/test/e2e/gateway/alb_resource_stack.go
+++ b/test/e2e/gateway/alb_resource_stack.go
@@ -53,7 +53,16 @@ func (s *albResourceStack) getListenersPortMap() map[string]string {
 }
 
 func (s *albResourceStack) getTargetGroupNodePortMap() map[string]string {
-	return s.commonStack.getTargetGroupNodePortMap()
+	res := s.commonStack.getTargetGroupNodePortMap()
+
+	for p := range res {
+		// TODO - kinda a hack to get HTTP to work.
+		if res[p] == string(corev1.ProtocolTCP) {
+			res[p] = "HTTP"
+		}
+	}
+
+	return res
 }
 
 func (s *albResourceStack) getHealthCheckNodePort() string {

--- a/test/e2e/gateway/consts.go
+++ b/test/e2e/gateway/consts.go
@@ -1,0 +1,9 @@
+package gateway
+
+const (
+	appContainerPort        = 80
+	defaultNumReplicas      = 3
+	defaultName             = "gateway-e2e"
+	defaultGatewayClassName = "gwclass-e2e"
+	defaultLbConfigName     = "lbconfig-e2e"
+)

--- a/test/e2e/gateway/gateway_suite_test.go
+++ b/test/e2e/gateway/gateway_suite_test.go
@@ -1,0 +1,23 @@
+package gateway
+
+import (
+	"testing"
+
+	"sigs.k8s.io/aws-load-balancer-controller/test/framework"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var tf *framework.Framework
+
+func TestGateway(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Gateway Suite")
+}
+
+var _ = BeforeSuite(func() {
+	var err error
+	tf, err = framework.InitFramework()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/test/e2e/gateway/nlb_instance_target.go
+++ b/test/e2e/gateway/nlb_instance_target.go
@@ -7,6 +7,7 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 type NLBInstanceTestStack struct {
@@ -17,7 +18,7 @@ func (s *NLBInstanceTestStack) Deploy(ctx context.Context, f *framework.Framewor
 	dp := buildDeploymentSpec(f.Options.TestImageRegistry)
 	svc := buildServiceSpec()
 	gwc := buildGatewayClassSpec("gateway.k8s.aws/nlb")
-	gw := buildGatewaySpec(gwc)
+	gw := buildBasicGatewaySpec(gwc, gwv1.TCPProtocolType)
 	lbc := buildLoadBalancerConfig(spec)
 	tcpr := buildTCPRoute()
 	s.nlbResourceStack = newNLBResourceStack(dp, svc, gwc, gw, lbc, tcpr, "service-instance-e2e", false)
@@ -30,6 +31,7 @@ func (s *NLBInstanceTestStack) ScaleDeployment(ctx context.Context, f *framework
 }
 
 func (s *NLBInstanceTestStack) Cleanup(ctx context.Context, f *framework.Framework) {
+	_ = f.K8sClient.Delete(ctx, s.nlbResourceStack.tcpr)
 	s.nlbResourceStack.Cleanup(ctx, f)
 }
 

--- a/test/e2e/gateway/nlb_instance_target.go
+++ b/test/e2e/gateway/nlb_instance_target.go
@@ -1,0 +1,220 @@
+package gateway
+
+import (
+	"context"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
+	"sigs.k8s.io/aws-load-balancer-controller/test/framework"
+	"sigs.k8s.io/aws-load-balancer-controller/test/framework/utils"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gwalpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+const (
+	appContainerPort        = 80
+	defaultNumReplicas      = 3
+	defaultName             = "instance-e2e"
+	defaultGatewayClassName = "gwclass-e2e"
+	defaultLbConfigName     = "lbconfig-e2e"
+)
+
+type NLBInstanceTestStack struct {
+	resourceStack *resourceStack
+}
+
+func (s *NLBInstanceTestStack) Deploy(ctx context.Context, f *framework.Framework, spec elbv2gw.LoadBalancerConfigurationSpec) error {
+	dp := s.buildDeploymentSpec(f.Options.TestImageRegistry)
+	svc := s.buildServiceSpec()
+	gwc := s.buildGatewayClassSpec()
+	gw := s.buildGatewaySpec()
+	lbc := s.buildLoadBalancerConfig(spec)
+	tcpr := s.buildTCPRoute()
+	s.resourceStack = NewResourceStack(dp, svc, gwc, gw, lbc, tcpr, "service-instance-e2e", false)
+
+	return s.resourceStack.Deploy(ctx, f)
+}
+
+func (s *NLBInstanceTestStack) UpdateServiceAnnotations(ctx context.Context, f *framework.Framework, svcAnnotations map[string]string) error {
+	return s.resourceStack.UpdateServiceAnnotations(ctx, f, svcAnnotations)
+}
+
+func (s *NLBInstanceTestStack) DeleteServiceAnnotations(ctx context.Context, f *framework.Framework, annotationKeys []string) error {
+	return s.resourceStack.DeleteServiceAnnotations(ctx, f, annotationKeys)
+}
+
+func (s *NLBInstanceTestStack) UpdateServiceTrafficPolicy(ctx context.Context, f *framework.Framework, trafficPolicy corev1.ServiceExternalTrafficPolicyType) error {
+	return s.resourceStack.UpdateServiceTrafficPolicy(ctx, f, trafficPolicy)
+}
+
+func (s *NLBInstanceTestStack) ScaleDeployment(ctx context.Context, f *framework.Framework, numReplicas int32) error {
+	return s.resourceStack.ScaleDeployment(ctx, f, numReplicas)
+}
+
+func (s *NLBInstanceTestStack) Cleanup(ctx context.Context, f *framework.Framework) error {
+	return s.resourceStack.Cleanup(ctx, f)
+}
+
+func (s *NLBInstanceTestStack) GetLoadBalancerIngressHostName() string {
+	return s.resourceStack.GetLoadBalancerIngressHostname()
+}
+
+func (s *NLBInstanceTestStack) GetWorkerNodes(ctx context.Context, f *framework.Framework) ([]corev1.Node, error) {
+	allNodes := &corev1.NodeList{}
+	err := f.K8sClient.List(ctx, allNodes)
+	if err != nil {
+		return nil, err
+	}
+	nodeList := []corev1.Node{}
+	for _, node := range allNodes.Items {
+		if _, notarget := node.Labels["node.kubernetes.io/exclude-from-external-load-balancers"]; !notarget {
+			nodeList = append(nodeList, node)
+		}
+	}
+	return nodeList, nil
+}
+
+func (s *NLBInstanceTestStack) ApplyNodeLabels(ctx context.Context, f *framework.Framework, node *corev1.Node, labels map[string]string) error {
+	f.Logger.Info("applying node labels", "node", k8s.NamespacedName(node))
+	oldNode := node.DeepCopy()
+	for key, value := range labels {
+		node.Labels[key] = value
+	}
+	if err := f.K8sClient.Patch(ctx, node, client.MergeFrom(oldNode)); err != nil {
+		f.Logger.Info("failed to update node", "node", k8s.NamespacedName(node))
+		return err
+	}
+	return nil
+}
+
+func (s *NLBInstanceTestStack) buildDeploymentSpec(testImageRegistry string) *appsv1.Deployment {
+	numReplicas := int32(defaultNumReplicas)
+	labels := map[string]string{
+		"app.kubernetes.io/name":     "multi-port",
+		"app.kubernetes.io/instance": defaultName,
+	}
+	dpImage := utils.GetDeploymentImage(testImageRegistry, utils.HelloImage)
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: defaultName,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &numReplicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:            "app",
+							ImagePullPolicy: corev1.PullAlways,
+							Image:           dpImage,
+							Ports: []corev1.ContainerPort{
+								{
+									ContainerPort: appContainerPort,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (s *NLBInstanceTestStack) buildServiceSpec() *corev1.Service {
+	labels := map[string]string{
+		"app.kubernetes.io/name":     "multi-port",
+		"app.kubernetes.io/instance": defaultName,
+	}
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: defaultName,
+		},
+		Spec: corev1.ServiceSpec{
+			Type:     corev1.ServiceTypeClusterIP,
+			Selector: labels,
+			Ports: []corev1.ServicePort{
+				{
+					Port:       80,
+					TargetPort: intstr.FromInt(80),
+					Protocol:   corev1.ProtocolTCP,
+				},
+			},
+		},
+	}
+	return svc
+}
+
+func (s *NLBInstanceTestStack) buildGatewayClassSpec() *gwv1.GatewayClass {
+	gwc := &gwv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: defaultGatewayClassName,
+		},
+		Spec: gwv1.GatewayClassSpec{
+			ControllerName: "gateway.k8s.aws/nlb",
+		},
+	}
+	return gwc
+}
+
+func (s *NLBInstanceTestStack) buildLoadBalancerConfig(spec elbv2gw.LoadBalancerConfigurationSpec) *elbv2gw.LoadBalancerConfiguration {
+	lbc := &elbv2gw.LoadBalancerConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: defaultLbConfigName,
+		},
+		Spec: spec,
+	}
+	return lbc
+}
+
+func (s *NLBInstanceTestStack) buildGatewaySpec() *gwv1.Gateway {
+	gw := &gwv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: defaultName,
+		},
+		Spec: gwv1.GatewaySpec{
+			GatewayClassName: defaultGatewayClassName,
+			Listeners: []gwv1.Listener{
+				{
+					Port:     80,
+					Protocol: gwv1.TCPProtocolType,
+				},
+			},
+			Infrastructure: &gwv1.GatewayInfrastructure{
+				ParametersRef: &gwv1.LocalParametersReference{
+					Group: "gateway.k8s.aws",
+					Kind:  "LoadBalancerConfiguration",
+					Name:  defaultLbConfigName,
+				},
+			},
+		},
+	}
+	return gw
+}
+
+func (s *NLBInstanceTestStack) buildTCPRoute() *gwalpha2.TCPRoute {
+	gw := &gwalpha2.TCPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: defaultName,
+		},
+		Spec: gwalpha2.TCPRouteSpec{
+			CommonRouteSpec: gwalpha2.CommonRouteSpec{
+				ParentRefs: []gwv1.ParentReference{
+					{
+						Name: defaultName,
+					},
+				},
+			},
+		},
+	}
+	return gw
+}

--- a/test/e2e/gateway/nlb_instance_target_test.go
+++ b/test/e2e/gateway/nlb_instance_target_test.go
@@ -1,0 +1,181 @@
+package gateway
+
+import (
+	"context"
+	"fmt"
+	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
+	"sigs.k8s.io/aws-load-balancer-controller/test/framework/verifier"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/aws-load-balancer-controller/test/framework/http"
+	"sigs.k8s.io/aws-load-balancer-controller/test/framework/utils"
+)
+
+var _ = Describe("test k8s service reconciled by the aws load balancer controller", func() {
+	var (
+		ctx     context.Context
+		stack   NLBInstanceTestStack
+		dnsName string
+		lbARN   string
+	)
+	BeforeEach(func() {
+		ctx = context.Background()
+		stack = NLBInstanceTestStack{}
+	})
+	AfterEach(func() {
+		err := stack.Cleanup(ctx, tf)
+		Expect(err).NotTo(HaveOccurred())
+	})
+	Context("with NLB instance target configuration", func() {
+		BeforeEach(func() {})
+		It("should provision internet-facing load balancer resources", func() {
+			interf := elbv2gw.LoadBalancerSchemeInternetFacing
+			lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
+				Scheme: &interf,
+			}
+			By("deploying stack", func() {
+				err := stack.Deploy(ctx, tf, lbcSpec)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("checking service status for lb dns name", func() {
+				dnsName = stack.GetLoadBalancerIngressHostName()
+				Expect(dnsName).ToNot(BeEmpty())
+			})
+
+			By("querying AWS loadbalancer from the dns name", func() {
+				var err error
+				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(lbARN).ToNot(BeEmpty())
+			})
+
+			By("verifying AWS loadbalancer resources", func() {
+				nodeList, err := stack.GetWorkerNodes(ctx, tf)
+				Expect(err).ToNot(HaveOccurred())
+				err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
+					Type:         "network",
+					Scheme:       "internet-facing",
+					TargetType:   "instance",
+					Listeners:    stack.resourceStack.getListenersPortMap(),
+					TargetGroups: stack.resourceStack.getTargetGroupNodePortMap(),
+					NumTargets:   len(nodeList),
+					TargetGroupHC: &verifier.TargetGroupHC{
+						Protocol:           "TCP",
+						Port:               "traffic-port",
+						Interval:           10,
+						Timeout:            10,
+						HealthyThreshold:   3,
+						UnhealthyThreshold: 3,
+					},
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("waiting for target group targets to be healthy", func() {
+				nodeList, err := stack.GetWorkerNodes(ctx, tf)
+				Expect(err).ToNot(HaveOccurred())
+				err = verifier.WaitUntilTargetsAreHealthy(ctx, tf, lbARN, len(nodeList))
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("waiting until DNS name is available", func() {
+				err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("sending http request to the lb", func() {
+				url := fmt.Sprintf("http://%v/any-path", dnsName)
+				err := tf.HTTPVerifier.VerifyURL(url, http.ResponseCodeMatches(200))
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("enabling cross zone load balancing", func() {
+				err := stack.UpdateServiceAnnotations(ctx, tf, map[string]string{
+					"service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled": "true",
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(func() bool {
+					return verifier.VerifyLoadBalancerAttributes(ctx, tf, lbARN, map[string]string{
+						"load_balancing.cross_zone.enabled": "true",
+					}) == nil
+				}, utils.PollTimeoutShort, utils.PollIntervalMedium).Should(BeTrue())
+			})
+
+			By("specifying load balancer tags", func() {
+				err := stack.UpdateServiceAnnotations(ctx, tf, map[string]string{
+					"service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags": "instance-mode=true, key1=value1",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(func() bool {
+					return verifier.VerifyLoadBalancerResourceTags(ctx, tf, lbARN, map[string]string{
+						"instance-mode":            "true",
+						"key1":                     "value1",
+						"elbv2.k8s.aws/cluster":    tf.Options.ClusterName,
+						"service.k8s.aws/stack":    stack.resourceStack.GetStackName(),
+						"service.k8s.aws/resource": "*",
+					}, nil)
+				}, utils.PollTimeoutShort, utils.PollIntervalMedium).Should(BeTrue())
+			})
+			By("modifying load balancer tags", func() {
+				err := stack.UpdateServiceAnnotations(ctx, tf, map[string]string{
+					"service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags": "instance-mode=true",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(func() bool {
+					return verifier.VerifyLoadBalancerResourceTags(ctx, tf, lbARN, map[string]string{
+						"instance-mode":            "true",
+						"elbv2.k8s.aws/cluster":    tf.Options.ClusterName,
+						"service.k8s.aws/stack":    stack.resourceStack.GetStackName(),
+						"service.k8s.aws/resource": "*",
+					}, map[string]string{
+						"key1": "value1",
+					})
+				}, utils.PollTimeoutShort, utils.PollIntervalMedium).Should(BeTrue())
+
+			})
+			By("modifying external traffic policy", func() {
+				err := stack.UpdateServiceTrafficPolicy(ctx, tf, corev1.ServiceExternalTrafficPolicyTypeLocal)
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(func() bool {
+					return verifier.GetTargetGroupHealthCheckProtocol(ctx, tf, lbARN) == "HTTP"
+				}, utils.PollTimeoutShort, utils.PollIntervalMedium).Should(BeTrue())
+				err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
+					Type:         "network",
+					Scheme:       "internet-facing",
+					TargetType:   "instance",
+					Listeners:    stack.resourceStack.getListenersPortMap(),
+					TargetGroups: stack.resourceStack.getTargetGroupNodePortMap(),
+					TargetGroupHC: &verifier.TargetGroupHC{
+						Protocol:           "HTTP",
+						Port:               stack.resourceStack.getHealthCheckNodePort(),
+						Path:               "/healthz",
+						Interval:           10,
+						Timeout:            6,
+						HealthyThreshold:   2,
+						UnhealthyThreshold: 2,
+					},
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+			// remove this once listener attributes are available in isolated region
+			if !strings.Contains(tf.Options.AWSRegion, "-iso-") {
+				By("modifying listener attributes", func() {
+					err := stack.UpdateServiceAnnotations(ctx, tf, map[string]string{
+						"service.beta.kubernetes.io/aws-load-balancer-listener-attributes.TCP-80": "tcp.idle_timeout.seconds=400",
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					lsARN := verifier.GetLoadBalancerListenerARN(ctx, tf, lbARN, "80")
+
+					Eventually(func() bool {
+						return verifier.VerifyListenerAttributes(ctx, tf, lsARN, map[string]string{
+							"tcp.idle_timeout.seconds": "400",
+						}) == nil
+					}, utils.PollTimeoutShort, utils.PollIntervalMedium).Should(BeTrue())
+				})
+			}
+		})
+	})
+})

--- a/test/e2e/gateway/nlb_instance_target_test.go
+++ b/test/e2e/gateway/nlb_instance_target_test.go
@@ -19,6 +19,9 @@ var _ = Describe("test nlb gateway reconciled by the aws load balancer controlle
 		lbARN   string
 	)
 	BeforeEach(func() {
+		if !tf.Options.EnableGatewayTests {
+			Skip("Skipping gateway tests")
+		}
 		ctx = context.Background()
 		stack = NLBInstanceTestStack{}
 	})

--- a/test/e2e/gateway/nlb_resource_stack.go
+++ b/test/e2e/gateway/nlb_resource_stack.go
@@ -1,0 +1,75 @@
+package gateway
+
+import (
+	"context"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
+	"sigs.k8s.io/aws-load-balancer-controller/test/framework"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gwalpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+func newNLBResourceStack(dp *appsv1.Deployment, svc *corev1.Service, gwc *gwv1.GatewayClass, gw *gwv1.Gateway, lbc *elbv2gw.LoadBalancerConfiguration, tcpr *gwalpha2.TCPRoute, baseName string, enablePodReadinessGate bool) *nlbResourceStack {
+
+	commonStack := newCommonResourceStack(dp, svc, gwc, gw, lbc, baseName, enablePodReadinessGate)
+	return &nlbResourceStack{
+		tcpr:        tcpr,
+		commonStack: commonStack,
+	}
+}
+
+// resourceStack containing the deployment and service resources
+type nlbResourceStack struct {
+	commonStack *commonResourceStack
+	tcpr        *gwalpha2.TCPRoute
+}
+
+func (s *nlbResourceStack) Deploy(ctx context.Context, f *framework.Framework) error {
+	return s.commonStack.Deploy(ctx, f, func(ctx context.Context, f *framework.Framework, namespace string) error {
+		s.tcpr.Namespace = namespace
+		return s.createTCPRoute(ctx, f)
+	})
+}
+
+func (s *nlbResourceStack) ScaleDeployment(ctx context.Context, f *framework.Framework, numReplicas int32) error {
+	return s.commonStack.ScaleDeployment(ctx, f, numReplicas)
+}
+
+func (s *nlbResourceStack) Cleanup(ctx context.Context, f *framework.Framework) {
+	s.commonStack.Cleanup(ctx, f)
+}
+
+func (s *nlbResourceStack) GetLoadBalancerIngressHostname() string {
+	return s.commonStack.GetLoadBalancerIngressHostname()
+}
+
+func (s *nlbResourceStack) GetStackName() string {
+	return s.commonStack.GetStackName()
+}
+
+func (s *nlbResourceStack) getListenersPortMap() map[string]string {
+	return s.commonStack.getListenersPortMap()
+}
+
+func (s *nlbResourceStack) getTargetGroupNodePortMap() map[string]string {
+	return s.commonStack.getTargetGroupNodePortMap()
+}
+
+func (s *nlbResourceStack) getHealthCheckNodePort() string {
+	return s.commonStack.getHealthCheckNodePort()
+}
+
+func (s *nlbResourceStack) waitUntilDeploymentReady(ctx context.Context, f *framework.Framework) error {
+	return s.commonStack.waitUntilDeploymentReady(ctx, f)
+}
+
+func (s *nlbResourceStack) createTCPRoute(ctx context.Context, f *framework.Framework) error {
+	f.Logger.Info("creating tcp route", "tcpr", k8s.NamespacedName(s.tcpr))
+	return f.K8sClient.Create(ctx, s.tcpr)
+}
+
+func (s *nlbResourceStack) deleteTCPRoute(ctx context.Context, f *framework.Framework) error {
+	return f.K8sClient.Delete(ctx, s.tcpr)
+}

--- a/test/e2e/gateway/resource_stack.go
+++ b/test/e2e/gateway/resource_stack.go
@@ -1,0 +1,349 @@
+package gateway
+
+import (
+	"context"
+	"fmt"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/algorithm"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
+	"sigs.k8s.io/aws-load-balancer-controller/test/framework"
+	"sigs.k8s.io/aws-load-balancer-controller/test/framework/utils"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gwalpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	"strconv"
+	"time"
+)
+
+func NewResourceStack(dp *appsv1.Deployment, svc *corev1.Service, gwc *gwv1.GatewayClass, gw *gwv1.Gateway, lbc *elbv2gw.LoadBalancerConfiguration, tcpr *gwalpha2.TCPRoute, baseName string, enablePodReadinessGate bool) *resourceStack {
+	return &resourceStack{
+		dp:                     dp,
+		svc:                    svc,
+		gwc:                    gwc,
+		gw:                     gw,
+		lbc:                    lbc,
+		tcpr:                   tcpr,
+		baseName:               baseName,
+		enablePodReadinessGate: enablePodReadinessGate,
+	}
+}
+
+// resourceStack containing the deployment and service resources
+type resourceStack struct {
+	// configurations
+	svc                    *corev1.Service
+	dp                     *appsv1.Deployment
+	gwc                    *gwv1.GatewayClass
+	gw                     *gwv1.Gateway
+	lbc                    *elbv2gw.LoadBalancerConfiguration
+	tcpr                   *gwalpha2.TCPRoute
+	ns                     *corev1.Namespace
+	baseName               string
+	enablePodReadinessGate bool
+
+	// runtime variables
+	createdDP  *appsv1.Deployment
+	createdSVC *corev1.Service
+	createdGW  *gwv1.Gateway
+}
+
+func (s *resourceStack) Deploy(ctx context.Context, f *framework.Framework) error {
+	if err := s.allocateNamespace(ctx, f); err != nil {
+		return err
+	}
+	s.dp.Namespace = s.ns.Name
+	s.svc.Namespace = s.ns.Name
+	s.gw.Namespace = s.ns.Name
+	s.lbc.Namespace = s.ns.Name
+	s.tcpr.Namespace = s.ns.Name
+
+	if err := s.createGatewayClass(ctx, f); err != nil {
+		return err
+	}
+	if err := s.createLoadBalancerConfig(ctx, f); err != nil {
+		return err
+	}
+	if err := s.createDeployment(ctx, f); err != nil {
+		return err
+	}
+	if err := s.createService(ctx, f); err != nil {
+		return err
+	}
+	if err := s.createGateway(ctx, f); err != nil {
+		return err
+	}
+	if err := s.createTCPRoute(ctx, f); err != nil {
+		return err
+	}
+	time.Sleep(7 * time.Minute)
+	if err := s.waitUntilDeploymentReady(ctx, f); err != nil {
+		return err
+	}
+
+	//if err := s.waitUntilServiceReady(ctx, f); err != nil {
+	//	return err
+	//}
+	return nil
+}
+
+func (s *resourceStack) UpdateServiceAnnotations(ctx context.Context, f *framework.Framework, svcAnnotations map[string]string) error {
+	if err := s.updateServiceAnnotations(ctx, f, svcAnnotations); err != nil {
+		return err
+	}
+	if err := s.waitUntilServiceReady(ctx, f); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *resourceStack) DeleteServiceAnnotations(ctx context.Context, f *framework.Framework, annotationKeys []string) error {
+	if err := s.removeServiceAnnotations(ctx, f, annotationKeys); err != nil {
+		return err
+	}
+	if err := s.waitUntilServiceReady(ctx, f); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *resourceStack) UpdateServiceTrafficPolicy(ctx context.Context, f *framework.Framework, trafficPolicy corev1.ServiceExternalTrafficPolicyType) error {
+	if err := s.updateServiceTrafficPolicy(ctx, f, trafficPolicy); err != nil {
+		return err
+	}
+	if err := s.waitUntilServiceReady(ctx, f); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *resourceStack) ScaleDeployment(ctx context.Context, f *framework.Framework, numReplicas int32) error {
+	f.Logger.Info("scaling deployment", "dp", k8s.NamespacedName(s.dp), "currentReplicas", s.dp.Spec.Replicas, "desiredReplicas", numReplicas)
+	oldDP := s.dp.DeepCopy()
+	s.dp.Spec.Replicas = &numReplicas
+	if err := f.K8sClient.Patch(ctx, s.dp, client.MergeFrom(oldDP)); err != nil {
+		f.Logger.Info("failed to update deployment", "dp", k8s.NamespacedName(s.dp))
+		return err
+	}
+	if err := s.waitUntilDeploymentReady(ctx, f); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *resourceStack) Cleanup(ctx context.Context, f *framework.Framework) error {
+	if err := s.deleteDeployment(ctx, f); err != nil {
+		return err
+	}
+	if err := s.deleteService(ctx, f); err != nil {
+		return err
+	}
+	if err := s.deleteNamespace(ctx, f); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *resourceStack) GetLoadBalancerIngressHostname() string {
+	return s.createdSVC.Status.LoadBalancer.Ingress[0].Hostname
+}
+
+func (s *resourceStack) GetStackName() string {
+	return fmt.Sprintf("%v/%v", s.ns.Name, s.svc.Name)
+}
+
+func (s *resourceStack) getListenersPortMap() map[string]string {
+	listenersMap := map[string]string{}
+	for _, port := range s.createdSVC.Spec.Ports {
+		listenersMap[strconv.Itoa(int(port.Port))] = string(port.Protocol)
+	}
+	return listenersMap
+}
+
+func (s *resourceStack) getTargetGroupNodePortMap() map[string]string {
+	tgPortProtocolMap := map[string]string{}
+	for _, port := range s.createdSVC.Spec.Ports {
+		tgPortProtocolMap[strconv.Itoa(int(port.NodePort))] = string(port.Protocol)
+	}
+	return tgPortProtocolMap
+}
+
+func (s *resourceStack) getHealthCheckNodePort() string {
+	return strconv.Itoa(int(s.svc.Spec.HealthCheckNodePort))
+}
+
+func (s *resourceStack) updateServiceTrafficPolicy(ctx context.Context, f *framework.Framework, trafficPolicy corev1.ServiceExternalTrafficPolicyType) error {
+	f.Logger.Info("updating service annotations", "svc", k8s.NamespacedName(s.svc))
+	oldSvc := s.svc.DeepCopy()
+	s.svc.Spec.ExternalTrafficPolicy = trafficPolicy
+	return s.updateService(ctx, f, oldSvc)
+}
+
+func (s *resourceStack) updateServiceAnnotations(ctx context.Context, f *framework.Framework, svcAnnotations map[string]string) error {
+	f.Logger.Info("updating service annotations", "svc", k8s.NamespacedName(s.svc))
+	oldSvc := s.svc.DeepCopy()
+	for key, value := range svcAnnotations {
+		s.svc.Annotations[key] = value
+	}
+	return s.updateService(ctx, f, oldSvc)
+}
+
+func (s *resourceStack) removeServiceAnnotations(ctx context.Context, f *framework.Framework, annotationKeys []string) error {
+	f.Logger.Info("removing service annotations", "svc", k8s.NamespacedName(s.svc))
+	oldSvc := s.svc.DeepCopy()
+	for _, key := range annotationKeys {
+		delete(s.svc.Annotations, key)
+	}
+	return s.updateService(ctx, f, oldSvc)
+}
+
+func (s *resourceStack) updateService(ctx context.Context, f *framework.Framework, oldSvc *corev1.Service) error {
+	f.Logger.Info("updating service", "svc", k8s.NamespacedName(s.svc))
+	if err := f.K8sClient.Patch(ctx, s.svc, client.MergeFrom(oldSvc)); err != nil {
+		f.Logger.Info("failed to update service", "svc", k8s.NamespacedName(s.svc))
+		return err
+	}
+	return nil
+}
+
+func (s *resourceStack) createDeployment(ctx context.Context, f *framework.Framework) error {
+	f.Logger.Info("creating deployment", "dp", k8s.NamespacedName(s.dp))
+	if err := f.K8sClient.Create(ctx, s.dp); err != nil {
+		f.Logger.Info("failed to create deployment")
+		return err
+	}
+	f.Logger.Info("created deployment", "dp", k8s.NamespacedName(s.dp))
+	return nil
+}
+
+func (s *resourceStack) waitUntilDeploymentReady(ctx context.Context, f *framework.Framework) error {
+	f.Logger.Info("waiting until deployment becomes ready", "dp", k8s.NamespacedName(s.dp))
+	observedDP, err := f.DPManager.WaitUntilDeploymentReady(ctx, s.dp)
+	if err != nil {
+		f.Logger.Info("failed waiting for deployment")
+		return err
+	}
+	f.Logger.Info("deployment is ready", "dp", k8s.NamespacedName(s.dp))
+	s.createdDP = observedDP
+	return nil
+}
+
+func (s *resourceStack) createService(ctx context.Context, f *framework.Framework) error {
+	f.Logger.Info("creating service", "svc", k8s.NamespacedName(s.svc))
+	return f.K8sClient.Create(ctx, s.svc)
+}
+
+func (s *resourceStack) createGatewayClass(ctx context.Context, f *framework.Framework) error {
+	f.Logger.Info("creating gateway class", "gwc", k8s.NamespacedName(s.gwc))
+	return f.K8sClient.Create(ctx, s.gwc)
+}
+
+func (s *resourceStack) createLoadBalancerConfig(ctx context.Context, f *framework.Framework) error {
+	f.Logger.Info("creating loadbalancer config", "lbc", k8s.NamespacedName(s.lbc))
+	return f.K8sClient.Create(ctx, s.lbc)
+}
+
+func (s *resourceStack) createGateway(ctx context.Context, f *framework.Framework) error {
+	f.Logger.Info("creating gateway", "gw", k8s.NamespacedName(s.gw))
+	return f.K8sClient.Create(ctx, s.gw)
+}
+
+func (s *resourceStack) createTCPRoute(ctx context.Context, f *framework.Framework) error {
+	f.Logger.Info("creating tcp route", "tcpr", k8s.NamespacedName(s.tcpr))
+	return f.K8sClient.Create(ctx, s.tcpr)
+}
+
+func (s *resourceStack) waitUntilServiceReady(ctx context.Context, f *framework.Framework) error {
+	f.Logger.Info("waiting until service becomes ready", "svc", k8s.NamespacedName(s.svc))
+	observedSVC, err := f.SVCManager.WaitUntilServiceActive(ctx, s.svc)
+	if err != nil {
+		f.Logger.Info("failed waiting for service")
+	}
+	s.createdSVC = observedSVC
+	return nil
+}
+
+func (s *resourceStack) waitUntilGatewayReady(ctx context.Context, f *framework.Framework) error {
+	observedGw := &gwv1.Gateway{}
+	err := wait.PollImmediateUntil(utils.PollIntervalShort, func() (bool, error) {
+		if err := f.K8sClient.Get(ctx, k8s.NamespacedName(s.gw), observedGw); err != nil {
+			return false, err
+		}
+		if observedGw.Status.Addresses != nil && len(observedGw.Status.Addresses) > 0 {
+			return true, nil
+		}
+		return false, nil
+	}, ctx.Done())
+	if err != nil {
+		return err
+	}
+	s.createdGW = observedGw
+	return nil
+}
+
+func (s *resourceStack) deleteDeployment(ctx context.Context, f *framework.Framework) error {
+	f.Logger.Info("deleting deployment", "dp", k8s.NamespacedName(s.dp))
+	if err := f.K8sClient.Delete(ctx, s.dp); err != nil {
+		f.Logger.Info("failed to delete deployment", "dp", k8s.NamespacedName(s.dp))
+		return err
+	}
+	if err := f.DPManager.WaitUntilDeploymentDeleted(ctx, s.dp); err != nil {
+		f.Logger.Info("failed to wait for deployment deletion", "dp", k8s.NamespacedName(s.dp))
+		return err
+	}
+	f.Logger.Info("deleted deployment", "dp", k8s.NamespacedName(s.dp))
+	return nil
+}
+
+func (s *resourceStack) deleteService(ctx context.Context, f *framework.Framework) error {
+	f.Logger.Info("deleting service", "svc", k8s.NamespacedName(s.svc))
+	if err := f.K8sClient.Delete(ctx, s.svc); err != nil {
+		f.Logger.Info("failed to delete service", "svc", k8s.NamespacedName(s.svc))
+		return err
+	}
+	if err := f.SVCManager.WaitUntilServiceDeleted(ctx, s.svc); err != nil {
+		f.Logger.Info("failed to wait for service deletion", "svc", k8s.NamespacedName(s.svc))
+		return err
+	}
+	f.Logger.Info("deleted service", "svc", k8s.NamespacedName(s.svc))
+	return nil
+}
+
+func (s *resourceStack) allocateNamespace(ctx context.Context, f *framework.Framework) error {
+	f.Logger.Info("allocating namespace")
+	ns, err := f.NSManager.AllocateNamespace(ctx, s.baseName)
+	if err != nil {
+		return err
+	}
+	s.ns = ns
+	f.Logger.Info("allocated namespace", "nsName", s.ns.Name)
+	if s.enablePodReadinessGate {
+		f.Logger.Info("label namespace for podReadinessGate injection", "nsName", s.ns.Name)
+		oldNS := s.ns.DeepCopy()
+		s.ns.Labels = algorithm.MergeStringMap(map[string]string{
+			"elbv2.k8s.aws/pod-readiness-gate-inject": "enabled",
+		}, s.ns.Labels)
+		err := f.K8sClient.Patch(ctx, ns, client.MergeFrom(oldNS))
+		if err != nil {
+			return err
+		}
+		f.Logger.Info("labeled namespace with podReadinessGate injection", "nsName", s.ns.Name)
+	}
+	return nil
+}
+
+func (s *resourceStack) deleteNamespace(ctx context.Context, tf *framework.Framework) error {
+	tf.Logger.Info("deleting namespace", "ns", k8s.NamespacedName(s.ns))
+	if err := tf.K8sClient.Delete(ctx, s.ns); err != nil {
+		tf.Logger.Info("failed to delete namespace", "ns", k8s.NamespacedName(s.ns))
+		return err
+	}
+	if err := tf.NSManager.WaitUntilNamespaceDeleted(ctx, s.ns); err != nil {
+		tf.Logger.Info("failed to wait for namespace deletion", "ns", k8s.NamespacedName(s.ns))
+		return err
+	}
+	tf.Logger.Info("deleted namespace", "ns", k8s.NamespacedName(s.ns))
+	return nil
+}

--- a/test/e2e/gateway/shared_resource_definitions.go
+++ b/test/e2e/gateway/shared_resource_definitions.go
@@ -98,7 +98,7 @@ func buildLoadBalancerConfig(spec elbv2gw.LoadBalancerConfigurationSpec) *elbv2g
 	return lbc
 }
 
-func buildGatewaySpec(gwc *gwv1.GatewayClass) *gwv1.Gateway {
+func buildBasicGatewaySpec(gwc *gwv1.GatewayClass, protocol gwv1.ProtocolType) *gwv1.Gateway {
 	gw := &gwv1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: defaultName,
@@ -109,7 +109,7 @@ func buildGatewaySpec(gwc *gwv1.GatewayClass) *gwv1.Gateway {
 				{
 					Name:     "test-listener",
 					Port:     80,
-					Protocol: gwv1.TCPProtocolType,
+					Protocol: protocol,
 				},
 			},
 			Infrastructure: &gwv1.GatewayInfrastructure{

--- a/test/e2e/gateway/shared_resource_definitions.go
+++ b/test/e2e/gateway/shared_resource_definitions.go
@@ -1,0 +1,189 @@
+package gateway
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
+	"sigs.k8s.io/aws-load-balancer-controller/test/framework/utils"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gwalpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	"strings"
+)
+
+func buildDeploymentSpec(testImageRegistry string) *appsv1.Deployment {
+	numReplicas := int32(defaultNumReplicas)
+	labels := map[string]string{
+		"app.kubernetes.io/name":     "multi-port",
+		"app.kubernetes.io/instance": defaultName,
+	}
+	dpImage := utils.GetDeploymentImage(testImageRegistry, utils.HelloImage)
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: defaultName,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &numReplicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:            "app",
+							ImagePullPolicy: corev1.PullAlways,
+							Image:           dpImage,
+							Ports: []corev1.ContainerPort{
+								{
+									ContainerPort: appContainerPort,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildServiceSpec() *corev1.Service {
+	labels := map[string]string{
+		"app.kubernetes.io/name":     "multi-port",
+		"app.kubernetes.io/instance": defaultName,
+	}
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: defaultName,
+		},
+		Spec: corev1.ServiceSpec{
+			Type:     corev1.ServiceTypeNodePort,
+			Selector: labels,
+			Ports: []corev1.ServicePort{
+				{
+					Port:       80,
+					TargetPort: intstr.FromInt(80),
+					Protocol:   corev1.ProtocolTCP,
+				},
+			},
+		},
+	}
+	return svc
+}
+
+func buildGatewayClassSpec(controllerName string) *gwv1.GatewayClass {
+	lbType := strings.Split(controllerName, "/")[1]
+	gwc := &gwv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: defaultGatewayClassName + "-" + lbType,
+		},
+		Spec: gwv1.GatewayClassSpec{
+			ControllerName: gwv1.GatewayController(controllerName),
+		},
+	}
+	return gwc
+}
+
+func buildLoadBalancerConfig(spec elbv2gw.LoadBalancerConfigurationSpec) *elbv2gw.LoadBalancerConfiguration {
+	lbc := &elbv2gw.LoadBalancerConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: defaultLbConfigName,
+		},
+		Spec: spec,
+	}
+	return lbc
+}
+
+func buildGatewaySpec(gwc *gwv1.GatewayClass) *gwv1.Gateway {
+	gw := &gwv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: defaultName,
+		},
+		Spec: gwv1.GatewaySpec{
+			GatewayClassName: gwv1.ObjectName(gwc.Name),
+			Listeners: []gwv1.Listener{
+				{
+					Name:     "test-listener",
+					Port:     80,
+					Protocol: gwv1.TCPProtocolType,
+				},
+			},
+			Infrastructure: &gwv1.GatewayInfrastructure{
+				ParametersRef: &gwv1.LocalParametersReference{
+					Group: "gateway.k8s.aws",
+					Kind:  "LoadBalancerConfiguration",
+					Name:  defaultLbConfigName,
+				},
+			},
+		},
+	}
+	return gw
+}
+
+func buildTCPRoute() *gwalpha2.TCPRoute {
+	port := gwalpha2.PortNumber(80)
+	tcpr := &gwalpha2.TCPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: defaultName,
+		},
+		Spec: gwalpha2.TCPRouteSpec{
+			CommonRouteSpec: gwalpha2.CommonRouteSpec{
+				ParentRefs: []gwv1.ParentReference{
+					{
+						Name: defaultName,
+					},
+				},
+			},
+			Rules: []gwalpha2.TCPRouteRule{
+				{
+					BackendRefs: []gwalpha2.BackendRef{
+						{
+							BackendObjectReference: gwalpha2.BackendObjectReference{
+								Name: defaultName,
+								Port: &port,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return tcpr
+}
+
+func buildHTTPRoute() *gwv1.HTTPRoute {
+	port := gwalpha2.PortNumber(80)
+	httpr := &gwv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: defaultName,
+		},
+		Spec: gwv1.HTTPRouteSpec{
+			CommonRouteSpec: gwalpha2.CommonRouteSpec{
+				ParentRefs: []gwv1.ParentReference{
+					{
+						Name: defaultName,
+					},
+				},
+			},
+			Rules: []gwv1.HTTPRouteRule{
+				{
+					BackendRefs: []gwv1.HTTPBackendRef{
+						{
+							BackendRef: gwv1.BackendRef{
+								BackendObjectReference: gwv1.BackendObjectReference{
+									Name: defaultName,
+									Port: &port,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return httpr
+}

--- a/test/e2e/ingress/ingress_suite_test.go
+++ b/test/e2e/ingress/ingress_suite_test.go
@@ -1,11 +1,12 @@
 package ingress
 
 import (
-	"testing"
-
+	"fmt"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	framework "sigs.k8s.io/aws-load-balancer-controller/test/framework"
+	"testing"
+	"time"
 )
 
 var tf *framework.Framework
@@ -16,7 +17,22 @@ func TestIngress(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
+
+	fmt.Println("before!")
 	var err error
+
+	defer func() {
+		fmt.Println("Hello!?")
+		if r := recover(); r != nil {
+			fmt.Println("Recovered in f", r)
+		}
+	}()
+
 	tf, err = framework.InitFramework()
+
+	fmt.Println("after!")
+
+	time.Sleep(10 * time.Second)
+
 	Expect(err).NotTo(HaveOccurred())
 })

--- a/test/e2e/ingress/ingress_suite_test.go
+++ b/test/e2e/ingress/ingress_suite_test.go
@@ -1,12 +1,10 @@
 package ingress
 
 import (
-	"fmt"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	framework "sigs.k8s.io/aws-load-balancer-controller/test/framework"
 	"testing"
-	"time"
 )
 
 var tf *framework.Framework
@@ -17,22 +15,9 @@ func TestIngress(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-
-	fmt.Println("before!")
 	var err error
 
-	defer func() {
-		fmt.Println("Hello!?")
-		if r := recover(); r != nil {
-			fmt.Println("Recovered in f", r)
-		}
-	}()
-
 	tf, err = framework.InitFramework()
-
-	fmt.Println("after!")
-
-	time.Sleep(10 * time.Second)
 
 	Expect(err).NotTo(HaveOccurred())
 })

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -7,6 +7,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
+	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/services"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/throttle"
@@ -18,6 +19,9 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework/utils"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gwalpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gwbeta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 type Framework struct {
@@ -50,6 +54,10 @@ func InitFramework() (*Framework, error) {
 	k8sSchema := runtime.NewScheme()
 	clientgoscheme.AddToScheme(k8sSchema)
 	elbv2api.AddToScheme(k8sSchema)
+	gwv1.AddToScheme(k8sSchema)
+	gwalpha2.AddToScheme(k8sSchema)
+	elbv2gw.AddToScheme(k8sSchema)
+	gwbeta1.AddToScheme(k8sSchema)
 
 	k8sClient, err := client.New(restCfg, client.Options{Scheme: k8sSchema})
 	if err != nil {

--- a/test/framework/options.go
+++ b/test/framework/options.go
@@ -25,10 +25,11 @@ type Options struct {
 	ControllerImage string
 
 	// Additional parameters for e2e tests
-	S3BucketName      string
-	CertificateARNs   string
-	IPFamily          string
-	TestImageRegistry string
+	S3BucketName       string
+	CertificateARNs    string
+	IPFamily           string
+	TestImageRegistry  string
+	EnableGatewayTests bool
 }
 
 func (options *Options) BindFlags() {
@@ -43,6 +44,8 @@ func (options *Options) BindFlags() {
 	flag.StringVar(&options.CertificateARNs, "certificate-arns", "", `Certificate ARNs to use for TLS listeners`)
 	flag.StringVar(&options.IPFamily, "ip-family", "IPv4", "the ip family used for the cluster, can be IPv4 or IPv6")
 	flag.StringVar(&options.TestImageRegistry, "test-image-registry", "617930562442.dkr.ecr.us-west-2.amazonaws.com", "the aws registry in test-infra-* accounts where e2e test images are stored")
+
+	flag.BoolVar(&options.EnableGatewayTests, "enable-gateway-tests", false, "enables gateway tests")
 }
 
 func (options *Options) Validate() error {


### PR DESCRIPTION
### Description

Adds a bare-bones integration test framework to run Gateway API integration tests. I refactored a bit of the existing test framework that already existed in the Services tests in order to be used in the Gateway tests and Service tests. For now, I only included two basic test cases, ALB routing to instance targets, and NLB routing to instance targets.

I need to implement the TargetGroup props logic in order to test more advanced configurations. Also, these tests use a couple arbitrary sleeps in order to synchronize state. Once this [PR](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4189) is merged then we can utilize the state of the Gateway in place of sleeps.


```
Ran 2 of 2 Specs in 1519.290 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 25m26.283073375s
```

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
