### PR TITLE
[feat gw-api]bugfix and prevent backward generation route status update

### DIFF
--- a/controllers/gateway/eventhandlers/grpc_route_events.go
+++ b/controllers/gateway/eventhandlers/grpc_route_events.go
@@ -58,7 +58,7 @@ func (h *enqueueRequestsForGRPCRouteEvent) Generic(ctx context.Context, e event.
 }
 
 func (h *enqueueRequestsForGRPCRouteEvent) enqueueImpactedGateways(ctx context.Context, route *gatewayv1.GRPCRoute, queue workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	gateways, err := GetImpactedGatewaysFromParentRefs(ctx, h.k8sClient, route.Spec.ParentRefs, route.Namespace, constants.ALBGatewayController)
+	gateways, err := GetImpactedGatewaysFromParentRefs(ctx, h.k8sClient, route.Spec.ParentRefs, route.Status.Parents, route.Namespace, constants.ALBGatewayController)
 	if err != nil {
 		h.logger.V(1).Info("ignoring unknown gateways referred by", "grpcroute", route.Name, "error", err)
 	}

--- a/controllers/gateway/eventhandlers/http_route_events.go
+++ b/controllers/gateway/eventhandlers/http_route_events.go
@@ -58,7 +58,7 @@ func (h *enqueueRequestsForHTTPRouteEvent) Generic(ctx context.Context, e event.
 }
 
 func (h *enqueueRequestsForHTTPRouteEvent) enqueueImpactedGateways(ctx context.Context, route *gatewayv1.HTTPRoute, queue workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	gateways, err := GetImpactedGatewaysFromParentRefs(ctx, h.k8sClient, route.Spec.ParentRefs, route.Namespace, constants.ALBGatewayController)
+	gateways, err := GetImpactedGatewaysFromParentRefs(ctx, h.k8sClient, route.Spec.ParentRefs, route.Status.Parents, route.Namespace, constants.ALBGatewayController)
 	if err != nil {
 		h.logger.V(1).Info("ignoring unknown gateways referred by", "httproute", route.Name, "error", err)
 	}

--- a/controllers/gateway/eventhandlers/tcp_route_events.go
+++ b/controllers/gateway/eventhandlers/tcp_route_events.go
@@ -58,7 +58,7 @@ func (h *enqueueRequestsForTCPRouteEvent) Generic(ctx context.Context, e event.T
 }
 
 func (h *enqueueRequestsForTCPRouteEvent) enqueueImpactedGateways(ctx context.Context, route *gwalpha2.TCPRoute, queue workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	gateways, err := GetImpactedGatewaysFromParentRefs(ctx, h.k8sClient, route.Spec.ParentRefs, route.Namespace, constants.NLBGatewayController)
+	gateways, err := GetImpactedGatewaysFromParentRefs(ctx, h.k8sClient, route.Spec.ParentRefs, route.Status.Parents, route.Namespace, constants.NLBGatewayController)
 	if err != nil {
 		h.logger.V(1).Info("ignoring unknown gateways referred by", "tcproute", route.Name, "error", err)
 	}

--- a/controllers/gateway/eventhandlers/tls_route_events.go
+++ b/controllers/gateway/eventhandlers/tls_route_events.go
@@ -58,7 +58,7 @@ func (h *enqueueRequestsForTLSRouteEvent) Generic(ctx context.Context, e event.T
 }
 
 func (h *enqueueRequestsForTLSRouteEvent) enqueueImpactedGateways(ctx context.Context, route *gwalpha2.TLSRoute, queue workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	gateways, err := GetImpactedGatewaysFromParentRefs(ctx, h.k8sClient, route.Spec.ParentRefs, route.Namespace, constants.NLBGatewayController)
+	gateways, err := GetImpactedGatewaysFromParentRefs(ctx, h.k8sClient, route.Spec.ParentRefs, route.Status.Parents, route.Namespace, constants.NLBGatewayController)
 	if err != nil {
 		h.logger.V(1).Info("ignoring unknown gateways referred by", "tlsroute", route.Name, "error", err)
 	}

--- a/controllers/gateway/eventhandlers/udp_route_events.go
+++ b/controllers/gateway/eventhandlers/udp_route_events.go
@@ -58,7 +58,7 @@ func (h *enqueueRequestsForUDPRouteEvent) Generic(ctx context.Context, e event.T
 }
 
 func (h *enqueueRequestsForUDPRouteEvent) enqueueImpactedGateways(ctx context.Context, route *gwalpha2.UDPRoute, queue workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	gateways, err := GetImpactedGatewaysFromParentRefs(ctx, h.k8sClient, route.Spec.ParentRefs, route.Namespace, constants.NLBGatewayController)
+	gateways, err := GetImpactedGatewaysFromParentRefs(ctx, h.k8sClient, route.Spec.ParentRefs, route.Status.Parents, route.Namespace, constants.NLBGatewayController)
 	if err != nil {
 		h.logger.V(1).Info("ignoring unknown gateways referred by", "udproute", route.Name, "error", err)
 	}

--- a/pkg/gateway/routeutils/descriptor.go
+++ b/pkg/gateway/routeutils/descriptor.go
@@ -17,6 +17,7 @@ type routeMetadataDescriptor interface {
 	GetParentRefs() []gwv1.ParentReference
 	GetRawRoute() interface{}
 	GetBackendRefs() []gwv1.BackendRef
+	GetRouteGeneration() int64
 }
 
 // preLoadRouteDescriptor this object is used to represent a route description that has not loaded its child data (services, tg config)

--- a/pkg/gateway/routeutils/grpc.go
+++ b/pkg/gateway/routeutils/grpc.go
@@ -111,6 +111,10 @@ func (grpcRoute *grpcRouteDescription) GetBackendRefs() []gwv1.BackendRef {
 	return backendRefs
 }
 
+func (grpcRoute *grpcRouteDescription) GetRouteGeneration() int64 {
+	return grpcRoute.route.Generation
+}
+
 var _ RouteDescriptor = &grpcRouteDescription{}
 
 // Can we use an indexer here to query more efficiently?

--- a/pkg/gateway/routeutils/http.go
+++ b/pkg/gateway/routeutils/http.go
@@ -87,6 +87,10 @@ func (httpRoute *httpRouteDescription) GetRouteKind() RouteKind {
 	return HTTPRouteKind
 }
 
+func (httpRoute *httpRouteDescription) GetRouteGeneration() int64 {
+	return httpRoute.route.Generation
+}
+
 func (httpRoute *httpRouteDescription) GetRouteNamespacedName() types.NamespacedName {
 	return k8s.NamespacedName(httpRoute.route)
 }

--- a/pkg/gateway/routeutils/listener_attachment_helper.go
+++ b/pkg/gateway/routeutils/listener_attachment_helper.go
@@ -41,7 +41,7 @@ func (attachmentHelper *listenerAttachmentHelperImpl) listenerAllowsAttachment(c
 	}
 	if !namespaceOK {
 		deferredRouteReconciler.Enqueue(
-			GenerateRouteData(false, true, string(gwv1.RouteReasonNotAllowedByListeners), RouteStatusInfoRejectedMessageNamespaceNotMatch, route, gw),
+			GenerateRouteData(false, true, string(gwv1.RouteReasonNotAllowedByListeners), RouteStatusInfoRejectedMessageNamespaceNotMatch, route.GetRouteNamespacedName(), route.GetRouteKind(), route.GetRouteGeneration(), gw),
 		)
 
 		return false, nil
@@ -51,7 +51,7 @@ func (attachmentHelper *listenerAttachmentHelperImpl) listenerAllowsAttachment(c
 	kindOK := attachmentHelper.kindCheck(listener, route)
 	if !kindOK {
 		deferredRouteReconciler.Enqueue(
-			GenerateRouteData(false, true, string(gwv1.RouteReasonNotAllowedByListeners), RouteStatusInfoRejectedMessageKindNotMatch, route, gw),
+			GenerateRouteData(false, true, string(gwv1.RouteReasonNotAllowedByListeners), RouteStatusInfoRejectedMessageKindNotMatch, route.GetRouteNamespacedName(), route.GetRouteKind(), route.GetRouteGeneration(), gw),
 		)
 		return false, nil
 	}
@@ -65,7 +65,7 @@ func (attachmentHelper *listenerAttachmentHelperImpl) listenerAllowsAttachment(c
 		if !hostnameOK {
 			// hostname is not ok, print out gwName and gwNamespace test-gw-alb gateway-alb
 			deferredRouteReconciler.Enqueue(
-				GenerateRouteData(false, true, string(gwv1.RouteReasonNoMatchingListenerHostname), RouteStatusInfoRejectedMessageNoMatchingHostname, route, gw),
+				GenerateRouteData(false, true, string(gwv1.RouteReasonNoMatchingListenerHostname), RouteStatusInfoRejectedMessageNoMatchingHostname, route.GetRouteNamespacedName(), route.GetRouteKind(), route.GetRouteGeneration(), gw),
 			)
 			return false, nil
 		}

--- a/pkg/gateway/routeutils/loader_test.go
+++ b/pkg/gateway/routeutils/loader_test.go
@@ -27,6 +27,7 @@ var _ RouteDescriptor = &mockRoute{}
 type mockRoute struct {
 	namespacedName types.NamespacedName
 	routeKind      RouteKind
+	generation     int64
 }
 
 func (m *mockRoute) loadAttachedRules(context context.Context, k8sClient client.Client) (RouteDescriptor, error) {
@@ -54,6 +55,10 @@ func (m *mockRoute) GetParentRefs() []gwv1.ParentReference {
 func (m *mockRoute) GetBackendRefs() []gwv1.BackendRef {
 	//TODO implement me
 	panic("implement me")
+}
+
+func (m *mockRoute) GetRouteGeneration() int64 {
+	return m.generation
 }
 
 func (m *mockRoute) GetRawRoute() interface{} {

--- a/pkg/gateway/routeutils/mock_route.go
+++ b/pkg/gateway/routeutils/mock_route.go
@@ -51,4 +51,8 @@ func (m *MockRoute) GetAttachedRules() []RouteRule {
 	panic("implement me")
 }
 
+func (m *MockRoute) GetRouteGeneration() int64 {
+	panic("implement me")
+}
+
 var _ RouteDescriptor = &MockRoute{}

--- a/pkg/gateway/routeutils/route_reconciler_utils.go
+++ b/pkg/gateway/routeutils/route_reconciler_utils.go
@@ -1,12 +1,15 @@
 package routeutils
 
-import gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+import (
+	"k8s.io/apimachinery/pkg/types"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
 
 // This file contains utils used for gateway api route reconciler
 
 // RouteData
 // RouteStatusInfo: contains status condition info
-// RouteMetadata: contains route metadata: name, namespace and kind
+// RouteMetadata: contains route metadata: name, namespace, kind and generation
 // ParentRefGateway: contains gateway information, each routeStatusInfo should have a correlated parentRefGateway
 type RouteData struct {
 	RouteStatusInfo  RouteStatusInfo
@@ -22,9 +25,10 @@ type RouteStatusInfo struct {
 }
 
 type RouteMetadata struct {
-	RouteName      string
-	RouteNamespace string
-	RouteKind      string
+	RouteName       string
+	RouteNamespace  string
+	RouteKind       string
+	RouteGeneration int64
 }
 
 type ParentRefGateway struct {
@@ -47,7 +51,7 @@ const (
 	RouteStatusInfoRejectedParentRefNotExist         = "ParentRefDoesNotExist"
 )
 
-func GenerateRouteData(accepted bool, resolvedRefs bool, reason string, message string, route preLoadRouteDescriptor, gw gwv1.Gateway) RouteData {
+func GenerateRouteData(accepted bool, resolvedRefs bool, reason string, message string, routeNamespaceName types.NamespacedName, routeKind RouteKind, routeGeneration int64, gw gwv1.Gateway) RouteData {
 	return RouteData{
 		RouteStatusInfo: RouteStatusInfo{
 			Accepted:     accepted,
@@ -56,9 +60,10 @@ func GenerateRouteData(accepted bool, resolvedRefs bool, reason string, message 
 			Message:      message,
 		},
 		RouteMetadata: RouteMetadata{
-			RouteName:      route.GetRouteNamespacedName().Name,
-			RouteNamespace: route.GetRouteNamespacedName().Namespace,
-			RouteKind:      string(route.GetRouteKind()),
+			RouteName:       routeNamespaceName.Name,
+			RouteNamespace:  routeNamespaceName.Namespace,
+			RouteKind:       string(routeKind),
+			RouteGeneration: routeGeneration,
 		},
 		ParentRefGateway: ParentRefGateway{
 			Name:      gw.Name,

--- a/pkg/gateway/routeutils/tcp.go
+++ b/pkg/gateway/routeutils/tcp.go
@@ -111,6 +111,10 @@ func (tcpRoute *tcpRouteDescription) GetBackendRefs() []gwv1.BackendRef {
 	return backendRefs
 }
 
+func (tcpRoute *tcpRouteDescription) GetRouteGeneration() int64 {
+	return tcpRoute.route.Generation
+}
+
 var _ RouteDescriptor = &tcpRouteDescription{}
 
 // Can we use an indexer here to query more efficiently?

--- a/pkg/gateway/routeutils/tls.go
+++ b/pkg/gateway/routeutils/tls.go
@@ -90,6 +90,10 @@ func (tlsRoute *tlsRouteDescription) GetRouteKind() RouteKind {
 	return TLSRouteKind
 }
 
+func (tlsRoute *tlsRouteDescription) GetRouteGeneration() int64 {
+	return tlsRoute.route.Generation
+}
+
 func convertTLSRoute(r gwalpha2.TLSRoute) *tlsRouteDescription {
 	return &tlsRouteDescription{route: &r, backendLoader: commonBackendLoader}
 }

--- a/pkg/gateway/routeutils/udp.go
+++ b/pkg/gateway/routeutils/udp.go
@@ -89,6 +89,10 @@ func (udpRoute *udpRouteDescription) GetRouteKind() RouteKind {
 	return UDPRouteKind
 }
 
+func (udpRoute *udpRouteDescription) GetRouteGeneration() int64 {
+	return udpRoute.route.Generation
+}
+
 func convertUDPRoute(r gwalpha2.UDPRoute) *udpRouteDescription {
 	return &udpRouteDescription{route: &r, backendLoader: commonBackendLoader}
 }

--- a/pkg/gateway/routeutils/utils_test.go
+++ b/pkg/gateway/routeutils/utils_test.go
@@ -59,6 +59,11 @@ func (m mockPreLoadRouteDescriptor) GetBackendRefs() []gwv1.BackendRef {
 	return m.backendRefs
 }
 
+func (m mockPreLoadRouteDescriptor) GetRouteGeneration() int64 {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (m mockPreLoadRouteDescriptor) loadAttachedRules(context context.Context, k8sClient client.Client) (RouteDescriptor, error) {
 	//TODO implement me
 	panic("implement me")


### PR DESCRIPTION
### Description
1. fix for getting impacted gateway for route update, current setup only takes new parentRef from route, which left previous parentRefs do not have gateway reconcile triggered-> modified GetImpactedGatewaysFromParentRefs for this
2. added additional check in route reconciler so status won't be updated if the new generation is less than current route generation -> introduced GetRouteGeneration for this

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
   - tested No.1 by printing out impacted gateways for following case: originally have GW1 and GW2 in parentRef, then update it to GW3. with the new change, GW1, GW2 and GW3 are considered as impacted.
   - tested No.2 by hardcoding routeGeneration from generateRouteData to be 1, thus nothing is updated since 1 is less than current generation
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
