### PR TITLE
[feat gw-api]handle resolvedRef for route status update and update ho…

### DIFF
--- a/apis/gateway/v1beta1/targetgroupconfig_types.go
+++ b/apis/gateway/v1beta1/targetgroupconfig_types.go
@@ -129,7 +129,7 @@ const (
 	ProtocolTCP_UDP Protocol = "TCP_UDP"
 )
 
-// +kubebuilder:validation:Enum=http1;http2;grpc
+// +kubebuilder:validation:Enum=HTTP1;HTTP2;GRPC
 type ProtocolVersion string
 
 const (

--- a/config/crd/gateway/gateway-crds.yaml
+++ b/config/crd/gateway/gateway-crds.yaml
@@ -491,9 +491,9 @@ spec:
                     description: protocolVersion [HTTP/HTTPS protocol] The protocol
                       version. The possible values are GRPC , HTTP1 and HTTP2
                     enum:
-                    - http1
-                    - http2
-                    - grpc
+                    - HTTP1
+                    - HTTP2
+                    - GRPC
                     type: string
                   tags:
                     description: Tags defines list of Tags on target group.
@@ -694,9 +694,9 @@ spec:
                           description: protocolVersion [HTTP/HTTPS protocol] The protocol
                             version. The possible values are GRPC , HTTP1 and HTTP2
                           enum:
-                          - http1
-                          - http2
-                          - grpc
+                          - HTTP1
+                          - HTTP2
+                          - GRPC
                           type: string
                         tags:
                           description: Tags defines list of Tags on target group.

--- a/config/crd/gateway/gateway.k8s.aws_targetgroupconfigurations.yaml
+++ b/config/crd/gateway/gateway.k8s.aws_targetgroupconfigurations.yaml
@@ -186,9 +186,9 @@ spec:
                     description: protocolVersion [HTTP/HTTPS protocol] The protocol
                       version. The possible values are GRPC , HTTP1 and HTTP2
                     enum:
-                    - http1
-                    - http2
-                    - grpc
+                    - HTTP1
+                    - HTTP2
+                    - GRPC
                     type: string
                   tags:
                     description: Tags defines list of Tags on target group.
@@ -389,9 +389,9 @@ spec:
                           description: protocolVersion [HTTP/HTTPS protocol] The protocol
                             version. The possible values are GRPC , HTTP1 and HTTP2
                           enum:
-                          - http1
-                          - http2
-                          - grpc
+                          - HTTP1
+                          - HTTP2
+                          - GRPC
                           type: string
                         tags:
                           description: Tags defines list of Tags on target group.

--- a/pkg/gateway/model/utilities.go
+++ b/pkg/gateway/model/utilities.go
@@ -3,6 +3,7 @@ package model
 import (
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/gateway/routeutils"
 	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sort"
 	"strings"
 )
@@ -21,7 +22,22 @@ func isIPv6CIDR(cidr string) bool {
 	return strings.Contains(cidr, ":")
 }
 
+func getHighestPrecedenceHostname(hostnames []v1.Hostname) string {
+	if len(hostnames) == 0 {
+		return ""
+	}
+
+	highestHostname := hostnames[0]
+	for _, hostname := range hostnames {
+		if routeutils.GetHostnamePrecedenceOrder(string(hostname), string(highestHostname)) < 0 {
+			highestHostname = hostname
+		}
+	}
+	return string(highestHostname)
+}
+
 func sortRoutesByHostnamePrecedence(routes []routeutils.RouteDescriptor) {
+	// sort routes based on their highest precedence hostname
 	sort.SliceStable(routes, func(i, j int) bool {
 		hostnameOne := routes[i].GetHostnames()
 		hostnameTwo := routes[j].GetHostnames()
@@ -35,7 +51,11 @@ func sortRoutesByHostnamePrecedence(routes []routeutils.RouteDescriptor) {
 		if len(hostnameTwo) == 0 {
 			return true
 		}
-		precedence := routeutils.GetHostnamePrecedenceOrder(string(hostnameOne[0]), string(hostnameTwo[0]))
+
+		highestPrecedenceHostnameOne := getHighestPrecedenceHostname(hostnameOne)
+		highestPrecedenceHostnameTwo := getHighestPrecedenceHostname(hostnameTwo)
+
+		precedence := routeutils.GetHostnamePrecedenceOrder(highestPrecedenceHostnameOne, highestPrecedenceHostnameTwo)
 		if precedence != 0 {
 			return precedence < 0 // -1 means higher precedence
 		}

--- a/pkg/gateway/model/utilities_test.go
+++ b/pkg/gateway/model/utilities_test.go
@@ -111,6 +111,36 @@ func Test_SortRoutesByHostnamePrecedence(t *testing.T) {
 				&routeutils.MockRoute{Hostnames: []string{}},
 			},
 		},
+		{
+			name: "complex mixed hostnames with multiple hostnames in each port",
+			input: []routeutils.RouteDescriptor{
+				&routeutils.MockRoute{Hostnames: []string{"*.example.com", "test.details.example.com"}},
+				&routeutils.MockRoute{Hostnames: []string{}},
+				&routeutils.MockRoute{Hostnames: []string{"test.example.com"}},
+				&routeutils.MockRoute{Hostnames: []string{"another.example.com"}},
+			},
+			expected: []routeutils.RouteDescriptor{
+				&routeutils.MockRoute{Hostnames: []string{"*.example.com", "test.details.example.com"}}, // since test.details.example.com has the highest precedence order here
+				&routeutils.MockRoute{Hostnames: []string{"another.example.com"}},
+				&routeutils.MockRoute{Hostnames: []string{"test.example.com"}},
+				&routeutils.MockRoute{Hostnames: []string{}},
+			},
+		},
+		{
+			name: "shorter hostname with more dots should have higher precedence ",
+			input: []routeutils.RouteDescriptor{
+				&routeutils.MockRoute{Hostnames: []string{"another.example.com"}},
+				&routeutils.MockRoute{Hostnames: []string{"a.b.example.com"}},
+				&routeutils.MockRoute{Hostnames: []string{}},
+				&routeutils.MockRoute{Hostnames: []string{"*.example.com"}},
+			},
+			expected: []routeutils.RouteDescriptor{
+				&routeutils.MockRoute{Hostnames: []string{"a.b.example.com"}},
+				&routeutils.MockRoute{Hostnames: []string{"another.example.com"}},
+				&routeutils.MockRoute{Hostnames: []string{"*.example.com"}},
+				&routeutils.MockRoute{Hostnames: []string{}},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/gateway/routeutils/backend_test.go
+++ b/pkg/gateway/routeutils/backend_test.go
@@ -186,6 +186,7 @@ func TestCommonBackendLoader(t *testing.T) {
 				},
 			},
 			expectNoResult: true,
+			expectErr:      true,
 			storedService: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: namespaceToUse,

--- a/pkg/gateway/routeutils/listener_attachment_helper.go
+++ b/pkg/gateway/routeutils/listener_attachment_helper.go
@@ -148,7 +148,7 @@ func (attachmentHelper *listenerAttachmentHelperImpl) hostnameCheck(listener gwv
 	if err != nil {
 		attachmentHelper.logger.Error(err, "listener hostname is not valid", "listener", listener.Name, "hostname", *listener.Hostname)
 		initialErrorMessage := fmt.Sprintf("listener hostname %s is not valid (listener name %s)", listener.Name, *listener.Hostname)
-		return false, wrapError(errors.Errorf("%s", initialErrorMessage), gwv1.GatewayReasonListenersNotValid, gwv1.RouteReasonUnsupportedValue)
+		return false, wrapError(errors.Errorf("%s", initialErrorMessage), gwv1.GatewayReasonListenersNotValid, gwv1.RouteReasonUnsupportedValue, nil, nil)
 	}
 
 	if !isListenerHostnameValid {

--- a/pkg/gateway/routeutils/loader_error.go
+++ b/pkg/gateway/routeutils/loader_error.go
@@ -9,20 +9,32 @@ type LoaderError interface {
 	GetRawError() error
 	GetGatewayReason() gwv1.GatewayConditionReason
 	GetRouteReason() gwv1.RouteConditionReason
+	GetGatewayMessage() string
+	GetRouteMessage() string
 }
 
 type loaderErrorImpl struct {
+	underlyingErr            error // contains initial error message
 	resolvedGatewayCondition gwv1.GatewayConditionReason
 	resolvedRouteCondition   gwv1.RouteConditionReason
-	underlyingErr            error
+	resolvedGatewayMessage   *string
+	resolvedRouteMessage     *string
 }
 
-func wrapError(underlyingErr error, gatewayCondition gwv1.GatewayConditionReason, routeCondition gwv1.RouteConditionReason) LoaderError {
-	return &loaderErrorImpl{
+func wrapError(underlyingErr error, gatewayCondition gwv1.GatewayConditionReason, routeCondition gwv1.RouteConditionReason, resolvedGatewayMessage *string, resolvedRouteMessage *string) LoaderError {
+	e := &loaderErrorImpl{
 		underlyingErr:            underlyingErr,
 		resolvedGatewayCondition: gatewayCondition,
 		resolvedRouteCondition:   routeCondition,
 	}
+	if resolvedGatewayMessage != nil {
+		e.resolvedGatewayMessage = resolvedGatewayMessage
+	}
+
+	if resolvedRouteMessage != nil {
+		e.resolvedRouteMessage = resolvedRouteMessage
+	}
+	return e
 }
 
 func (e *loaderErrorImpl) GetRawError() error {
@@ -35,6 +47,22 @@ func (e *loaderErrorImpl) GetGatewayReason() gwv1.GatewayConditionReason {
 
 func (e *loaderErrorImpl) GetRouteReason() gwv1.RouteConditionReason {
 	return e.resolvedRouteCondition
+}
+
+// GetGatewayMessage original error message for gateway status update can be overridden by pass in resolvedGatewayMessage
+func (e *loaderErrorImpl) GetGatewayMessage() string {
+	if e.resolvedGatewayMessage != nil {
+		return *e.resolvedGatewayMessage
+	}
+	return e.underlyingErr.Error()
+}
+
+// GetRouteMessage original error message for route status update can be overridden by pass in resolvedRouteMessage
+func (e *loaderErrorImpl) GetRouteMessage() string {
+	if e.resolvedRouteMessage != nil {
+		return *e.resolvedRouteMessage
+	}
+	return e.underlyingErr.Error()
 }
 
 func (e *loaderErrorImpl) Error() string {

--- a/pkg/gateway/routeutils/namespace_selector.go
+++ b/pkg/gateway/routeutils/namespace_selector.go
@@ -35,7 +35,7 @@ func (n *namespaceSelectorImpl) getNamespacesFromSelector(context context.Contex
 
 	convertedSelector, err := metav1.LabelSelectorAsSelector(selector)
 	if err != nil {
-		return nil, wrapError(errors.Wrapf(err, "Unable to parse selector %s", selector), gwv1.GatewayReasonListenersNotValid, gwv1.RouteReasonUnsupportedValue)
+		return nil, wrapError(errors.Wrapf(err, "Unable to parse selector %s", selector), gwv1.GatewayReasonListenersNotValid, gwv1.RouteReasonUnsupportedValue, nil, nil)
 	}
 
 	err = n.k8sClient.List(context, &namespaceList, client.MatchingLabelsSelector{Selector: convertedSelector})

--- a/pkg/gateway/routeutils/utils.go
+++ b/pkg/gateway/routeutils/utils.go
@@ -152,6 +152,13 @@ func GetHostnamePrecedenceOrder(hostnameOne, hostnameTwo string) int {
 	} else if isHostnameOneWildcard && !isHostnameTwoWildcard {
 		return 1
 	} else {
+		dotsInHostnameOne := strings.Count(hostnameOne, ".")
+		dotsInHostnameTwo := strings.Count(hostnameTwo, ".")
+		if dotsInHostnameOne > dotsInHostnameTwo {
+			return -1
+		} else if dotsInHostnameOne < dotsInHostnameTwo {
+			return 1
+		}
 		if len(hostnameOne) > len(hostnameTwo) {
 			return -1
 		} else if len(hostnameOne) < len(hostnameTwo) {

--- a/pkg/gateway/routeutils/utils_test.go
+++ b/pkg/gateway/routeutils/utils_test.go
@@ -686,6 +686,20 @@ func TestGetHostnamePrecedenceOrder(t *testing.T) {
 			want:        -1,
 			description: "non-empty string should have higher precedence than empty",
 		},
+		{
+			name:        "one hostname has more dots",
+			hostnameOne: "*.example.com",
+			hostnameTwo: "*.t.exa.com",
+			want:        1,
+			description: "hostname with more dots should have higher precedence even if it has less character",
+		},
+		{
+			name:        "two hostnames have same number of dots, one has more characters",
+			hostnameOne: "*.t.example.com",
+			hostnameTwo: "*.t.exa.com",
+			want:        -1,
+			description: "hostname with more characters should have higher precedence order if they have same number of dots",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### Description
1. handle several unhandled reasons for ResolveRef false case in route status update 
	- "RefNotPermitted"
	- "InvalidKind"
	- "BackendNotFound"
	- "UnsupportedProtocol" -> this will be comparing protocol version with appProtocol. during testing, figured that we are validation protocol version value to be `supported values: "http1", "http2", "grpc"` which should be capitalized, so fixed it in CRD
2. modified logic for hostname precedence order 
- in function `sortRoutesByHostnamePrecedence`, with the original logic, it only compares first element in each list to sort them. but it should be find the highest precedence in each list first and then use highest precedence hostname to sort. 
- Also updated precedence order logic to count dot number, more dot means higher precedence, even though it might have shorter length
3. added more unit tests for route_reconciler.go, found that a lot are uncovered before

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested - some of the status update test result 
```
------
status:
  addresses:
  - type: Hostname
    value: internal-customized-alb-lb-name-1399439441.us-west-2.elb.amazonaws.com
  conditions:
  - lastTransitionTime: "2025-05-30T20:00:19Z"
    message: Backend Ref must be of kind 'Service'. Invalid data can be found in route
      (HTTPRoute, gateway-alb:http-app-1)
    observedGeneration: 16
    reason: ListenersNotValid
    status: "False"
    type: Accepted
  - lastTransitionTime: "2025-05-29T22:38:20Z"
    message: arn:aws:elasticloadbalancing:us-west-2:850920876970:loadbalancer/app/customized-alb-lb-name/7e7271c93476a8ed
    observedGeneration: 16
    reason: Programmed
    status: "True"
    type: Programmed
------
status:
  parents:
  - conditions:
    - lastTransitionTime: "2025-05-30T20:00:19Z"
      message: Backend Ref must be of kind 'Service' - test with route message override
      observedGeneration: 138
      reason: InvalidKind
      status: "False"
      type: Accepted
    - lastTransitionTime: "2025-05-30T20:00:19Z"
      message: Backend Ref must be of kind 'Service' - test with route message override
      observedGeneration: 138
      reason: InvalidKind
      status: "False"
      type: ResolvedRefs
    controllerName: gateway.k8s.aws/alb
    parentRef:
      group: gateway.networking.k8s.io
      kind: Gateway
      name: test-gw-alb
      port: 80
----------------
status:
  parents:
  - conditions:
    - lastTransitionTime: "2025-05-30T19:55:42Z"
      message: Service port appProtocol http is not compatible with target group protocolVersion
        GRPC
      observedGeneration: 137
      reason: UnsupportedProtocol
      status: "False"
      type: Accepted
    - lastTransitionTime: "2025-05-30T19:55:42Z"
      message: Service port appProtocol http is not compatible with target group protocolVersion
        GRPC
      observedGeneration: 137
      reason: UnsupportedProtocol
      status: "False"
      type: ResolvedRefs
    controllerName: gateway.k8s.aws/alb
    parentRef:
      group: gateway.networking.k8s.io
      kind: Gateway
      name: test-gw-alb
      port: 80
----------------
status:
  parents:
  - conditions:
    - lastTransitionTime: "2025-05-30T19:48:47Z"
      message: Service port appProtocol grpc is not compatible with target group protocolVersion
        HTTP1
      observedGeneration: 134
      reason: UnsupportedProtocol
      status: "False"
      type: Accepted
    - lastTransitionTime: "2025-05-30T19:48:47Z"
      message: Service port appProtocol grpc is not compatible with target group protocolVersion
        HTTP1
      observedGeneration: 134
      reason: UnsupportedProtocol
      status: "False"
      type: ResolvedRefs
    controllerName: gateway.k8s.aws/alb
    parentRef:
      group: gateway.networking.k8s.io
      kind: Gateway
      name: test-gw-alb
      port: 80
status:
  parents:
  - conditions:
    - lastTransitionTime: "2025-05-30T19:52:28Z"
      message: Backend Ref must be of kind 'Service'
      observedGeneration: 135
      reason: InvalidKind
      status: "False"
      type: Accepted
    - lastTransitionTime: "2025-05-30T19:52:28Z"
      message: Backend Ref must be of kind 'Service'
      observedGeneration: 135
      reason: InvalidKind
      status: "False"
      type: ResolvedRefs
    controllerName: gateway.k8s.aws/alb
    parentRef:
      group: gateway.networking.k8s.io
      kind: Gateway
      name: test-gw-alb
      port: 80

```
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [x] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:
 - refactored LoaderError, now by default it will return initial error message but if there is override by gateway message or route message (e.g. with wrapped detailed info) it will return the overridden message
