### PR TITLE
fix: Failing tests in ipv6 cluster

### DIFF
--- a/pkg/ingress/model_build_frontend_nlb.go
+++ b/pkg/ingress/model_build_frontend_nlb.go
@@ -5,8 +5,9 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"sigs.k8s.io/aws-load-balancer-controller/pkg/shared_constants"
 	"strconv"
+
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/shared_constants"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
@@ -690,7 +691,7 @@ func (t *defaultModelBuildTask) buildFrontendNlbTargetGroupSpec(ctx context.Cont
 		TargetType:        elbv2model.TargetTypeALB,
 		Port:              awssdk.Int32(port),
 		Protocol:          tgProtocol,
-		IPAddressType:     elbv2model.TargetGroupIPAddressType(t.loadBalancer.Spec.IPAddressType),
+		IPAddressType:     elbv2model.TargetGroupIPAddressTypeIPv4,
 		HealthCheckConfig: healthCheckConfig,
 	}, nil
 }

--- a/test/e2e/ingress/vanilla_ingress_test.go
+++ b/test/e2e/ingress/vanilla_ingress_test.go
@@ -851,6 +851,11 @@ var _ = Describe("vanilla ingress tests", func() {
 				"alb.ingress.kubernetes.io/frontend-nlb-scheme":           "internet-facing",
 			}
 
+			if tf.Options.IPFamily == "IPv6" {
+				annotation["alb.ingress.kubernetes.io/ip-address-type"] = "dualstack"
+				annotation["alb.ingress.kubernetes.io/target-type"] = "ip"
+			}
+
 			ing := ingBuilder.
 				AddHTTPRoute("", networking.HTTPIngressPath{Path: "/path", PathType: &exact, Backend: ingBackend}).
 				WithAnnotations(annotation).Build(sandboxNS.Name, "ing")


### PR DESCRIPTION
### Issue

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4209

### Description

Making a change to always create IPv4 target group for NLB as the communication between an NLB and ALB only happens over IPv4 even though you can configure dualstack scheme for your ALB

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
