### PR TITLE
[feat gw-api]implement finalizer

### DIFF
--- a/controllers/gateway/eventhandlers/gateway_events.go
+++ b/controllers/gateway/eventhandlers/gateway_events.go
@@ -54,7 +54,7 @@ func (h *enqueueRequestsForGatewayEvent) Delete(ctx context.Context, e event.Typ
 
 func (h *enqueueRequestsForGatewayEvent) Generic(ctx context.Context, e event.TypedGenericEvent[*gwv1.Gateway], queue workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 	gw := e.Object
-	h.logger.V(1).Info("enqueue gateway delete event", "gateway", k8s.NamespacedName(gw))
+	h.logger.V(1).Info("enqueue gateway generic event", "gateway", k8s.NamespacedName(gw))
 	h.enqueueImpactedGateway(ctx, gw, queue)
 }
 

--- a/controllers/gateway/eventhandlers/service_events.go
+++ b/controllers/gateway/eventhandlers/service_events.go
@@ -65,6 +65,9 @@ func (h *enqueueRequestsForServiceEvent) Update(ctx context.Context, e event.Typ
 func (h *enqueueRequestsForServiceEvent) Delete(ctx context.Context, e event.TypedDeleteEvent[*corev1.Service], queue workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 	svc := e.Object
 	h.logger.V(1).Info("enqueue service delete event", "service", svc.Name)
+	// remove target group configuration finalizer when service is deleted
+	RemoveTargetGroupConfigurationFinalizer(ctx, svc, h.k8sClient, h.logger, h.eventRecorder)
+
 	h.enqueueImpactedRoutes(ctx, svc)
 }
 

--- a/controllers/gateway/eventhandlers/utils.go
+++ b/controllers/gateway/eventhandlers/utils.go
@@ -3,10 +3,16 @@ package eventhandlers
 import (
 	"context"
 	"fmt"
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/record"
 	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/gateway/constants"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/gateway/routeutils"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/shared_constants"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
@@ -153,4 +159,26 @@ func removeDuplicateParentRefs(parentRefs []gwv1.ParentReference, resourceNamesp
 		}
 	}
 	return result
+}
+
+// RemoveTargetGroupConfigurationFinalizer removes target group configuration finalizer when service is deleted
+func RemoveTargetGroupConfigurationFinalizer(ctx context.Context, svc *corev1.Service, k8sClient client.Client, logger logr.Logger, recorder record.EventRecorder) {
+	tgConfig, err := routeutils.LookUpTargetGroupConfiguration(ctx, k8sClient, k8s.NamespacedName(svc))
+	if err != nil {
+		logger.Error(err, "failed to look up target group configuration", "service", svc.Name)
+		return
+	}
+	if tgConfig == nil {
+		logger.V(1).Info("TargetGroupConfigurationNotFound, ignoring remove finalizer.", "TargetGroupConfiguration", svc.Name)
+		return
+	}
+
+	tgFinalizer := shared_constants.TargetGroupConfigurationFinalizer
+	if k8s.HasFinalizer(tgConfig, tgFinalizer) {
+		finalizerManager := k8s.NewDefaultFinalizerManager(k8sClient, logr.Discard())
+		if err := finalizerManager.RemoveFinalizers(ctx, tgConfig, tgFinalizer); err != nil {
+			recorder.Event(tgConfig, corev1.EventTypeWarning, k8s.TargetGroupBindingEventReasonFailedRemoveFinalizer, fmt.Sprintf("Failed to remove target group configuration finalizer due to %v", err))
+		}
+		logger.V(1).Info("Successfully removed target group configuration finalizer.", "TargetGroupConfiguration", tgConfig.Name)
+	}
 }

--- a/controllers/gateway/utils.go
+++ b/controllers/gateway/utils.go
@@ -6,8 +6,13 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
+	"sigs.k8s.io/aws-load-balancer-controller/controllers/gateway/eventhandlers"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/gateway/constants"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/gateway/routeutils"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/shared_constants"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sort"
@@ -179,4 +184,87 @@ func generateRouteList(listenerRoutes map[int32][]routeutils.RouteDescriptor) st
 	sort.Strings(allRoutes)
 
 	return strings.Join(allRoutes, ",")
+}
+
+// AddLoadBalancerConfigurationFinalizers add finalizer to load balancer configuration when it is in use by gateway or gatewayClass
+func AddLoadBalancerConfigurationFinalizers(ctx context.Context, gw *gwv1.Gateway, gwClass *gwv1.GatewayClass, k8sClient client.Client, manager k8s.FinalizerManager, controllerName string) error {
+	// add finalizer to lbConfig referred by gatewayClass
+	if gwClass.Spec.ParametersRef != nil && string(gwClass.Spec.ParametersRef.Kind) == constants.LoadBalancerConfiguration {
+		lbConfig := &elbv2gw.LoadBalancerConfiguration{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{
+			Namespace: string(*gwClass.Spec.ParametersRef.Namespace),
+			Name:      gwClass.Spec.ParametersRef.Name,
+		}, lbConfig); err != nil {
+			return client.IgnoreNotFound(err)
+		}
+		if err := manager.AddFinalizers(ctx, lbConfig, shared_constants.LoadBalancerConfigurationFinalizer); err != nil {
+			return err
+		}
+	}
+
+	// add finalizer to lbConfig referred by gateway
+	if gw.Spec.Infrastructure != nil && gw.Spec.Infrastructure.ParametersRef != nil && string(gw.Spec.Infrastructure.ParametersRef.Kind) == constants.LoadBalancerConfiguration {
+		lbConfig := &elbv2gw.LoadBalancerConfiguration{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{
+			Namespace: gw.Namespace,
+			Name:      gw.Spec.Infrastructure.ParametersRef.Name,
+		}, lbConfig); err != nil {
+			return client.IgnoreNotFound(err)
+		}
+		if err := manager.AddFinalizers(ctx, lbConfig, shared_constants.LoadBalancerConfigurationFinalizer); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func RemoveLoadBalancerConfigurationFinalizers(ctx context.Context, gw *gwv1.Gateway, gwClass *gwv1.GatewayClass, k8sClient client.Client, manager k8s.FinalizerManager, controllerName string) error {
+	// remove finalizer from lbConfig - gatewayClass
+	if gwClass.Spec.ParametersRef != nil && string(gwClass.Spec.ParametersRef.Kind) == constants.LoadBalancerConfiguration {
+		lbConfig := &elbv2gw.LoadBalancerConfiguration{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{
+			Namespace: string(*gwClass.Spec.ParametersRef.Namespace),
+			Name:      gwClass.Spec.ParametersRef.Name,
+		}, lbConfig); err != nil {
+			return client.IgnoreNotFound(err)
+		}
+		// remove finalizer if it exists and it not in use
+		if k8s.HasFinalizer(lbConfig, shared_constants.LoadBalancerConfigurationFinalizer) && !isLBConfigInUse(ctx, lbConfig, gw, gwClass, k8sClient, controllerName) {
+			if err := manager.RemoveFinalizers(ctx, lbConfig, shared_constants.LoadBalancerConfigurationFinalizer); err != nil {
+				return err
+			}
+		}
+	}
+
+	// remove finalizer from lbConfig - gateway
+	if gw.Spec.Infrastructure != nil && gw.Spec.Infrastructure.ParametersRef != nil && string(gw.Spec.Infrastructure.ParametersRef.Kind) == constants.LoadBalancerConfiguration {
+		lbConfig := &elbv2gw.LoadBalancerConfiguration{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{
+			Namespace: gw.Namespace,
+			Name:      gw.Spec.Infrastructure.ParametersRef.Name,
+		}, lbConfig); err != nil {
+			return client.IgnoreNotFound(err)
+		}
+		// remove finalizer if it exists and it is not in use
+		if k8s.HasFinalizer(lbConfig, shared_constants.LoadBalancerConfigurationFinalizer) && !isLBConfigInUse(ctx, lbConfig, gw, gwClass, k8sClient, controllerName) {
+			if err := manager.RemoveFinalizers(ctx, lbConfig, shared_constants.LoadBalancerConfigurationFinalizer); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func isLBConfigInUse(ctx context.Context, lbConfig *elbv2gw.LoadBalancerConfiguration, gw *gwv1.Gateway, gwClass *gwv1.GatewayClass, k8sClient client.Client, controllerName string) bool {
+	// check if lbConfig is referred by any other gateway
+	gwsUsingLBConfig := eventhandlers.GetImpactedGatewaysFromLbConfig(ctx, k8sClient, lbConfig, controllerName)
+	for _, gwUsingLBConfig := range gwsUsingLBConfig {
+		if gwUsingLBConfig.Name != gw.Name || gwUsingLBConfig.Namespace != gw.Namespace {
+			return true
+		}
+	}
+
+	// check if lbConfig is referred by any other gatewayClass
+	gwClassesUsingLBConfig := eventhandlers.GetImpactedGatewayClassesFromLbConfig(ctx, k8sClient, lbConfig, sets.New(controllerName))
+	return len(gwClassesUsingLBConfig) > 0
 }

--- a/controllers/gateway/utils_test.go
+++ b/controllers/gateway/utils_test.go
@@ -4,13 +4,19 @@ import (
 	"context"
 	"fmt"
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
+	mock_client "sigs.k8s.io/aws-load-balancer-controller/mocks/controller-runtime/client"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/gateway/constants"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/gateway/routeutils"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/shared_constants"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/testutils"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 	"strconv"
 	"testing"
@@ -866,6 +872,319 @@ func Test_generateRouteList(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			res := generateRouteList(tc.routes)
 			assert.Equal(t, tc.expected, res)
+		})
+	}
+}
+
+func Test_AddLoadBalancerConfigurationFinalizers(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	k8sClient := mock_client.NewMockClient(ctrl)
+	k8sFinalizerManager := k8s.NewMockFinalizerManager(ctrl)
+	defaultNamespace := gwv1.Namespace("test-ns")
+	testNamespace := "test-ns"
+	testName := "test-name"
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name         string
+		gateway      *gwv1.Gateway
+		gatewayClass *gwv1.GatewayClass
+		setupMocks   func()
+		wantErr      bool
+	}{
+		{
+			name: "gateway and gatewayClass have no LB config",
+			gateway: &gwv1.Gateway{
+				Spec: gwv1.GatewaySpec{},
+			},
+			gatewayClass: &gwv1.GatewayClass{
+				Spec: gwv1.GatewayClassSpec{},
+			},
+			setupMocks: func() {},
+			wantErr:    false,
+		},
+		{
+			name:    "gatewayClass has LB config",
+			gateway: &gwv1.Gateway{},
+			gatewayClass: &gwv1.GatewayClass{
+				Spec: gwv1.GatewayClassSpec{
+					ParametersRef: &gwv1.ParametersReference{
+						Kind:      gwv1.Kind(constants.LoadBalancerConfiguration),
+						Name:      testName,
+						Namespace: &defaultNamespace,
+					},
+				},
+			},
+			setupMocks: func() {
+				lbConfig := &elbv2gw.LoadBalancerConfiguration{}
+				k8sClient.EXPECT().Get(ctx, types.NamespacedName{
+					Namespace: testNamespace,
+					Name:      testName,
+				}, lbConfig).Return(nil)
+				k8sFinalizerManager.EXPECT().AddFinalizers(ctx, lbConfig,
+					shared_constants.LoadBalancerConfigurationFinalizer).Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "gateway has LB config",
+			gateway: &gwv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNamespace,
+				},
+				Spec: gwv1.GatewaySpec{
+					Infrastructure: &gwv1.GatewayInfrastructure{
+						ParametersRef: &gwv1.LocalParametersReference{
+							Kind: gwv1.Kind(constants.LoadBalancerConfiguration),
+							Name: testName,
+						},
+					},
+				},
+			},
+			gatewayClass: &gwv1.GatewayClass{},
+			setupMocks: func() {
+				lbConfig := &elbv2gw.LoadBalancerConfiguration{}
+				k8sClient.EXPECT().Get(ctx, types.NamespacedName{
+					Namespace: testNamespace,
+					Name:      testName,
+				}, lbConfig).Return(nil)
+				k8sFinalizerManager.EXPECT().AddFinalizers(ctx, lbConfig,
+					shared_constants.LoadBalancerConfigurationFinalizer).Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name:    "failed in adding finalizer",
+			gateway: &gwv1.Gateway{},
+			gatewayClass: &gwv1.GatewayClass{
+				Spec: gwv1.GatewayClassSpec{
+					ParametersRef: &gwv1.ParametersReference{
+						Kind:      gwv1.Kind(constants.LoadBalancerConfiguration),
+						Name:      testName,
+						Namespace: &defaultNamespace,
+					},
+				},
+			},
+			setupMocks: func() {
+				lbConfig := &elbv2gw.LoadBalancerConfiguration{}
+				k8sClient.EXPECT().Get(ctx, types.NamespacedName{
+					Namespace: testNamespace,
+					Name:      testName,
+				}, lbConfig).Return(nil)
+				k8sFinalizerManager.EXPECT().AddFinalizers(ctx, lbConfig,
+					shared_constants.LoadBalancerConfigurationFinalizer).Return(fmt.Errorf("test error"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setupMocks()
+			err := AddLoadBalancerConfigurationFinalizers(ctx, tt.gateway, tt.gatewayClass, k8sClient, k8sFinalizerManager, "controllerName")
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_RemoveLoadBalancerConfigurationFinalizers(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	k8sClient := mock_client.NewMockClient(ctrl)
+	k8sFinalizerManager := k8s.NewMockFinalizerManager(ctrl)
+	ctx := context.Background()
+	controllerName := "test-controller"
+	testGwName := "test-gw"
+	testNamespace := "test-ns"
+	testLbConfigName := "test-lb-config"
+
+	tests := []struct {
+		name         string
+		gateway      *gwv1.Gateway
+		gatewayClass *gwv1.GatewayClass
+		setupMocks   func()
+		wantErr      bool
+	}{
+		{
+			name: "remove finalizer from gateway LB config",
+			gateway: &gwv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testGwName,
+					Namespace: testNamespace,
+				},
+				Spec: gwv1.GatewaySpec{
+					Infrastructure: &gwv1.GatewayInfrastructure{
+						ParametersRef: &gwv1.LocalParametersReference{
+							Kind: gwv1.Kind(constants.LoadBalancerConfiguration),
+							Name: testLbConfigName,
+						},
+					},
+				},
+			},
+			gatewayClass: &gwv1.GatewayClass{},
+			setupMocks: func() {
+				k8sClient.EXPECT().
+					Get(ctx, types.NamespacedName{
+						Namespace: testNamespace,
+						Name:      testLbConfigName,
+					}, gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ types.NamespacedName, obj *elbv2gw.LoadBalancerConfiguration, _ ...client.GetOption) error {
+						obj.Finalizers = []string{shared_constants.LoadBalancerConfigurationFinalizer}
+						return nil
+					})
+
+				k8sClient.EXPECT().
+					List(ctx, &gwv1.GatewayList{}, gomock.Any()).
+					Return(nil)
+				k8sClient.EXPECT().
+					List(ctx, &gwv1.GatewayClassList{}, gomock.Any()).
+					Return(nil)
+
+				k8sFinalizerManager.EXPECT().
+					RemoveFinalizers(ctx, gomock.Any(), shared_constants.LoadBalancerConfigurationFinalizer).
+					Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "failed in remove finalizer",
+			gateway: &gwv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testGwName,
+					Namespace: testNamespace,
+				},
+				Spec: gwv1.GatewaySpec{
+					Infrastructure: &gwv1.GatewayInfrastructure{
+						ParametersRef: &gwv1.LocalParametersReference{
+							Kind: gwv1.Kind(constants.LoadBalancerConfiguration),
+							Name: testLbConfigName,
+						},
+					},
+				},
+			},
+			gatewayClass: &gwv1.GatewayClass{},
+			setupMocks: func() {
+				k8sClient.EXPECT().
+					Get(ctx, gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ types.NamespacedName, obj *elbv2gw.LoadBalancerConfiguration, _ ...client.GetOption) error {
+						obj.Finalizers = []string{shared_constants.LoadBalancerConfigurationFinalizer}
+						return nil
+					})
+
+				k8sClient.EXPECT().
+					List(ctx, &gwv1.GatewayList{}, gomock.Any()).
+					Return(nil)
+				k8sClient.EXPECT().
+					List(ctx, &gwv1.GatewayClassList{}, gomock.Any()).
+					Return(nil)
+
+				k8sFinalizerManager.EXPECT().
+					RemoveFinalizers(ctx, gomock.Any(), shared_constants.LoadBalancerConfigurationFinalizer).
+					Return(fmt.Errorf("failed to remove finalizer"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setupMocks()
+			err := RemoveLoadBalancerConfigurationFinalizers(ctx, tt.gateway, tt.gatewayClass, k8sClient, k8sFinalizerManager, controllerName)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+
+}
+
+func Test_isLBConfigInUse(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	k8sClient := mock_client.NewMockClient(ctrl)
+	ctx := context.Background()
+	controllerName := "test-controller"
+	testNamespace := "test-ns"
+
+	tests := []struct {
+		name         string
+		lbConfig     *elbv2gw.LoadBalancerConfiguration
+		gateway      *gwv1.Gateway
+		gatewayClass *gwv1.GatewayClass
+		setupMocks   func()
+		want         bool
+	}{
+		{
+			name: "LB config not in use",
+			lbConfig: &elbv2gw.LoadBalancerConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-config",
+					Namespace: testNamespace,
+				},
+			},
+			gateway: &gwv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-gw",
+					Namespace: testNamespace,
+				},
+			},
+			gatewayClass: &gwv1.GatewayClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gwclass",
+				},
+			},
+			setupMocks: func() {
+				k8sClient.EXPECT().
+					Get(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil).AnyTimes()
+
+				k8sClient.EXPECT().
+					List(gomock.Any(), &gwv1.GatewayList{}, gomock.Any()).
+					DoAndReturn(func(_ context.Context, list *gwv1.GatewayList, _ ...client.ListOption) error {
+						list.Items = []gwv1.Gateway{
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      "test-gw",
+									Namespace: testNamespace,
+								},
+							},
+						}
+						return nil
+					}).AnyTimes()
+
+				k8sClient.EXPECT().
+					List(gomock.Any(), &gwv1.GatewayClassList{}, gomock.Any()).
+					DoAndReturn(func(_ context.Context, list *gwv1.GatewayClassList, _ ...client.ListOption) error {
+						list.Items = []gwv1.GatewayClass{
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: "test-gwclass",
+								},
+							},
+						}
+						return nil
+					}).AnyTimes()
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setupMocks()
+			got := isLBConfigInUse(ctx, tt.lbConfig, tt.gateway, tt.gatewayClass, k8sClient, controllerName)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/gateway/routeutils/backend.go
+++ b/pkg/gateway/routeutils/backend.go
@@ -3,11 +3,13 @@ package routeutils
 import (
 	"context"
 	"fmt"
+	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/shared_constants"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwbeta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -102,11 +104,17 @@ func commonBackendLoader(ctx context.Context, k8sClient client.Client, typeSpeci
 		}
 	}
 
-	tgConfig, err := lookUpTargetGroupConfiguration(ctx, k8sClient, k8s.NamespacedName(svc))
+	tgConfig, err := LookUpTargetGroupConfiguration(ctx, k8sClient, k8s.NamespacedName(svc))
 
 	if err != nil {
 		// As of right now, this error can only be thrown because of a k8s api error hence no status update.
 		return nil, errors.Wrap(err, fmt.Sprintf("Unable to fetch tg config object"))
+	}
+	// add TGConfig finalizer
+	if tgConfig != nil {
+		if err := addTargetGroupConfigurationFinalizer(ctx, k8sClient, tgConfig); err != nil {
+			return nil, errors.Wrap(err, fmt.Sprintf("Unable to add finalizer to tg config object"))
+		}
 	}
 
 	if servicePort == nil {
@@ -164,9 +172,9 @@ func commonBackendLoader(ctx context.Context, k8sClient client.Client, typeSpeci
 	}, nil
 }
 
-// lookUpTargetGroupConfiguration given a service, lookup the target group configuration associated with the service.
+// LookUpTargetGroupConfiguration given a service, lookup the target group configuration associated with the service.
 // recall that target group configuration always lives within the same namespace as the service.
-func lookUpTargetGroupConfiguration(ctx context.Context, k8sClient client.Client, serviceMetadata types.NamespacedName) (*elbv2gw.TargetGroupConfiguration, error) {
+func LookUpTargetGroupConfiguration(ctx context.Context, k8sClient client.Client, serviceMetadata types.NamespacedName) (*elbv2gw.TargetGroupConfiguration, error) {
 	tgConfigList := &elbv2gw.TargetGroupConfigurationList{}
 
 	// TODO - Add index
@@ -226,4 +234,16 @@ func referenceGrantCheck(ctx context.Context, k8sClient client.Client, svcIdenti
 	}
 
 	return false, nil
+}
+
+// Implements helper function to add finalizer for target group configuration
+func addTargetGroupConfigurationFinalizer(ctx context.Context, k8sClient client.Client, tgConfig *elbv2gw.TargetGroupConfiguration) error {
+	finalizer := shared_constants.TargetGroupConfigurationFinalizer
+	// check if finalizer already exist
+	if k8s.HasFinalizer(tgConfig, finalizer) {
+		return nil
+	}
+	finalizerManager := k8s.NewDefaultFinalizerManager(k8sClient, logr.Discard())
+
+	return finalizerManager.AddFinalizers(ctx, tgConfig, finalizer)
 }

--- a/pkg/gateway/routeutils/backend_test.go
+++ b/pkg/gateway/routeutils/backend_test.go
@@ -528,7 +528,7 @@ func Test_lookUpTargetGroupConfiguration(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
-			result, err := lookUpTargetGroupConfiguration(context.Background(), k8sClient, tc.serviceMetadata)
+			result, err := LookUpTargetGroupConfiguration(context.Background(), k8sClient, tc.serviceMetadata)
 
 			if tc.expectErr {
 				assert.Error(t, err)

--- a/pkg/k8s/events.go
+++ b/pkg/k8s/events.go
@@ -37,4 +37,12 @@ const (
 	GatewayEventReasonSuccessfullyReconciled         = "SuccessfullyReconciled"
 	GatewayEventReasonFailedDeployModel              = "FailedDeployModel"
 	GatewayEventReasonFailedBuildModel               = "FailedBuildModel"
+
+	// Target Group Configuration events
+	TargetGroupConfigurationEventReasonFailedAddFinalizer    = "FailedAddFinalizer"
+	TargetGroupConfigurationEventReasonFailedRemoveFinalizer = "FailedRemoveFinalizer"
+
+	// Load Balancer Configuration events
+	LoadBalancerConfigurationEventReasonFailedAddFinalizer    = "FailedAddFinalizer"
+	LoadBalancerConfigurationEventReasonFailedRemoveFinalizer = "FailedRemoveFinalizer"
 )

--- a/pkg/shared_constants/finalizers.go
+++ b/pkg/shared_constants/finalizers.go
@@ -15,4 +15,10 @@ const (
 
 	// ALBGatewayFinalizer the finalizer we attach to an ALB Gateway resource
 	ALBGatewayFinalizer = "gateway.k8s.aws/alb"
+
+	// TargetGroupConfigurationFinalizer the finalizer we attach to a target group configuration resource
+	TargetGroupConfigurationFinalizer = "gateway.k8s.aws/targetgroupconfigurations"
+
+	// LoadBalancerConfigurationFinalizer the finalizer we attach to a load balancer configuration resource
+	LoadBalancerConfigurationFinalizer = "gateway.k8s.aws/loadbalancerconfigurations"
 )


### PR DESCRIPTION
### Description
- implement finalizer for target group configuration and load balancer configuration 
- LBConfig finalizer will be added during reconcileUpdate and removed during reconcileDelete, it will check both gateway and gatewayClass 
- TargetGroupConfig will be added in backend loader and removed when service is deleted

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
========== test targetgroupconfiguration =======
targetgroupconfiguration will be removed when service is deleted 
Test process: 
1. targetgroupconfiguration refers to a service
2. http route added this service to trigger reconcile
2. delete service -> finalizer should be deleted
Result 
```
sic-test-alb % k describe targetgroupconfiguration targetgroupconfiguration-sample -n gateway-alb
Name:         targetgroupconfiguration-sample
Namespace:    gateway-alb
Labels:       <none>
Annotations:  <none>
API Version:  gateway.k8s.aws/v1beta1
Kind:         TargetGroupConfiguration
Metadata:
  Creation Timestamp:  2025-05-30T01:11:34Z
  Finalizers:
    gateway.k8s.aws/targetgroupconfigurations
  Generation:        5
  Resource Version:  21594197
  UID:               582df46b-2d0a-4a41-b23f-ffc42e07bdd0
Spec:
  Default Configuration:
    Health Check Config:
      Health Check Interval:      30
      Health Check Path:          /health
      Health Check Protocol:      http
      Health Check Timeout:       5
      Healthy Threshold Count:    2
      Unhealthy Threshold Count:  2
    Protocol:                     HTTP
    Protocol Version:             HTTP1
    Target Type:                  ip
  Target Reference:
    Group:
    Kind:   Service
    Name:   echoserver2
Events:     <none>
```
Load balancer Configuration result 
```
k describe loadbalancerconfiguration test-gw-alb-lb-config-1 -n gateway-alb
Name:         test-gw-alb-lb-config-1
Namespace:    gateway-alb
Labels:       <none>
Annotations:  <none>
API Version:  gateway.k8s.aws/v1beta1
Kind:         LoadBalancerConfiguration
Metadata:
  Creation Timestamp:  2025-06-03T20:48:36Z
  Finalizers:
    gateway.k8s.aws/loadbalancerconfigurations
  Generation:        1
  Resource Version:  21606856
  UID:               b2e9ef38-c25d-4625-817d-4f5aa4892990
Spec:
  Load Balancer Name:  customized-alb-lb-name-1
Events:                <none>
$ k delete gateway test-gw-alb -n gateway-alb
gateway.gateway.networking.k8s.io "test-gw-alb" deleted
$ k describe loadbalancerconfiguration test-gw-alb-lb-config-1 -n gateway-alb
Name:         test-gw-alb-lb-config-1
Namespace:    gateway-alb
Labels:       <none>
Annotations:  <none>
API Version:  gateway.k8s.aws/v1beta1
Kind:         LoadBalancerConfiguration
Metadata:
  Creation Timestamp:  2025-06-03T20:48:36Z
  Generation:          1
  Resource Version:    21692623
  UID:                 b2e9ef38-c25d-4625-817d-4f5aa4892990
Spec:
  Load Balancer Name:  customized-alb-lb-name-1
Events:                <none>
```

- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
