### PR TITLE
clear confusion around using ClusterIP service and Instance targets

### DIFF
--- a/pkg/gateway/model/model_build_target_group_test.go
+++ b/pkg/gateway/model/model_build_target_group_test.go
@@ -263,6 +263,41 @@ func Test_buildTargetGroupSpec(t *testing.T) {
 				Tags:                  make(map[string]string),
 			},
 		},
+		{
+			name:                     "wrong svc type for instance should produce an error",
+			tags:                     make(map[string]string),
+			lbType:                   elbv2model.LoadBalancerTypeNetwork,
+			disableRestrictedSGRules: false,
+			defaultTargetType:        string(elbv2model.TargetTypeInstance),
+			gateway: &gwv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "my-gw-ns",
+					Name:      "my-gw",
+				},
+			},
+			route: &routeutils.MockRoute{
+				Kind:      routeutils.TCPRouteKind,
+				Name:      "my-route",
+				Namespace: "my-route-ns",
+			},
+			backend: routeutils.Backend{
+				Service: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "my-svc-ns",
+						Name:      "my-svc",
+					},
+				},
+				ServicePort: &corev1.ServicePort{
+					Protocol: corev1.ProtocolTCP,
+					Port:     80,
+					TargetPort: intstr.IntOrString{
+						IntVal: 80,
+						Type:   intstr.Int,
+					},
+				},
+			},
+			expectErr: true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1207,7 +1242,7 @@ func Test_buildTargetGroupPort(t *testing.T) {
 			name:       "instance - no node port",
 			svcPort:    corev1.ServicePort{},
 			targetType: elbv2model.TargetTypeInstance,
-			expected:   1,
+			expected:   0,
 		},
 		{
 			name: "ip",

--- a/pkg/ingress/model_build_target_group.go
+++ b/pkg/ingress/model_build_target_group.go
@@ -181,6 +181,14 @@ func (t *defaultModelBuildTask) buildTargetGroupSpec(ctx context.Context,
 	}
 	tgPort := t.buildTargetGroupPort(ctx, targetType, svcPort)
 	name := t.buildTargetGroupName(ctx, k8s.NamespacedName(ing.Ing), svc, port, tgPort, targetType, tgProtocol, tgProtocolVersion)
+
+	if tgPort == 0 {
+		if targetType == elbv2model.TargetTypeIP {
+			return elbv2model.TargetGroupSpec{}, errors.Errorf("TargetGroup port is empty. Are you using the correct service type?")
+		}
+		return elbv2model.TargetGroupSpec{}, errors.Errorf("TargetGroup port is empty. When using Instance targets, your service be must of type 'NodePort' or 'LoadBalancer'")
+	}
+
 	return elbv2model.TargetGroupSpec{
 		Name:                  name,
 		TargetType:            targetType,

--- a/pkg/service/model_build_target_group.go
+++ b/pkg/service/model_build_target_group.go
@@ -72,6 +72,14 @@ func (t *defaultModelBuildTask) buildTargetGroupSpec(ctx context.Context, tgProt
 	if err != nil {
 		return elbv2model.TargetGroupSpec{}, err
 	}
+
+	if targetPort == 0 {
+		if targetType == elbv2model.TargetTypeIP {
+			return elbv2model.TargetGroupSpec{}, errors.Errorf("TargetGroup port is empty. Are you using the correct service type?")
+		}
+		return elbv2model.TargetGroupSpec{}, errors.Errorf("TargetGroup port is empty. When using Instance targets, your service be must of type 'NodePort' or 'LoadBalancer'")
+	}
+
 	return elbv2model.TargetGroupSpec{
 		Name:                  tgName,
 		TargetType:            targetType,


### PR DESCRIPTION
### Issue

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4238

### Description

Presently, the error returned when using the wrong service type and instance targets is very unclear. In our documentation we state that you MUST use 'Loadbalancer' or 'NodePort' typed services however the error message returned by the controller does not make it obvious.


Manual testing:
```
{"level":"error","ts":"2025-06-24T18:30:37Z","msg":"Reconciler error","controller":"ingress","object":{"name":"echoserver","namespace":"echoserver2"},"namespace":"echoserver2","name":"echoserver","reconcileID":"0a027cdf-11ac-44e1-bd73-8bbc419e732c","error":"ingress: echoserver2/echoserver: TargetGroup port is empty. When using Instance targets, your service be must of type 'NodePort' or 'LoadBalancer'"}
```

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
