### PR TITLE
[feat gw-api] backfill E2E tests

### DIFF
--- a/test/e2e/gateway/alb_instance_target_test.go
+++ b/test/e2e/gateway/alb_instance_target_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"fmt"
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	"github.com/gavv/httpexpect/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
+	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework/http"
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework/utils"
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework/verifier"
@@ -32,12 +35,14 @@ var _ = Describe("test k8s alb gateway using instance targets reconciled by the 
 	AfterEach(func() {
 		stack.Cleanup(ctx, tf)
 	})
+
 	Context("with ALB instance target configuration with basic HTTPRoute", func() {
 		BeforeEach(func() {})
 		It("should provision internet-facing load balancer resources", func() {
 			interf := elbv2gw.LoadBalancerSchemeInternetFacing
 			lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
-				Scheme: &interf,
+				Scheme:                 &interf,
+				ListenerConfigurations: listenerConfigurationForHeaderModification,
 			}
 			tgSpec := elbv2gw.TargetGroupConfigurationSpec{}
 			gwListeners := []gwv1.Listener{
@@ -47,7 +52,8 @@ var _ = Describe("test k8s alb gateway using instance targets reconciled by the 
 					Protocol: gwv1.HTTPProtocolType,
 				},
 			}
-			httpr := buildHTTPRoute([]string{})
+			httpr := buildHTTPRoute([]string{}, []gwv1.HTTPRouteRule{})
+
 			By("deploying stack", func() {
 				err := stack.Deploy(ctx, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec)
 				Expect(err).NotTo(HaveOccurred())
@@ -63,6 +69,15 @@ var _ = Describe("test k8s alb gateway using instance targets reconciled by the 
 				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(lbARN).ToNot(BeEmpty())
+			})
+
+			By("verifying listener attributes header modification is applied", func() {
+				lsARN := verifier.GetLoadBalancerListenerARN(ctx, tf, lbARN, "80")
+				err := verifier.VerifyListenerAttributes(ctx, tf, lsARN, map[string]string{
+					headerModificationServerEnabled: "true",
+					headerModificationMaxAge:        headerModificationMaxAgeValue,
+				})
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			tgMap := map[string][]string{
@@ -107,6 +122,270 @@ var _ = Describe("test k8s alb gateway using instance targets reconciled by the 
 		})
 	})
 
+	Context("with ALB instance target configuration with HTTPRoute specified matches", func() {
+		BeforeEach(func() {})
+		It("should provision internet-facing load balancer resources", func() {
+			interf := elbv2gw.LoadBalancerSchemeInternetFacing
+			lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
+				Scheme: &interf,
+			}
+			tgSpec := elbv2gw.TargetGroupConfigurationSpec{}
+			gwListeners := []gwv1.Listener{
+				{
+					Name:     "test-listener",
+					Port:     80,
+					Protocol: gwv1.HTTPProtocolType,
+				},
+			}
+			httpr := buildHTTPRoute([]string{}, httpRouteRuleWithMatchesAndTargetGroupWeights)
+
+			By("deploying stack", func() {
+				err := stack.Deploy(ctx, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("checking gateway status for lb dns name", func() {
+				dnsName = stack.GetLoadBalancerIngressHostName()
+				Expect(dnsName).ToNot(BeEmpty())
+			})
+
+			By("querying AWS loadbalancer from the dns name", func() {
+				var err error
+				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(lbARN).ToNot(BeEmpty())
+			})
+
+			tgMap := map[string][]string{
+				strconv.Itoa(int(stack.albResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort)): {"HTTP"},
+			}
+
+			By("verifying AWS loadbalancer resources", func() {
+				nodeList, err := stack.GetWorkerNodes(ctx, tf)
+				Expect(err).ToNot(HaveOccurred())
+				err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
+					Type:          "application",
+					Scheme:        "internet-facing",
+					TargetType:    "instance",
+					Listeners:     stack.albResourceStack.getListenersPortMap(),
+					TargetGroups:  tgMap,
+					NumTargets:    len(nodeList),
+					TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("verifying HTTP load balancer listener", func() {
+				err := verifier.VerifyLoadBalancerListener(ctx, tf, lbARN, int32(gwListeners[0].Port), &verifier.ListenerExpectation{
+					ProtocolPort: "HTTP:80",
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("verifying listener rules", func() {
+				err := verifier.VerifyLoadBalancerListenerRules(ctx, tf, lbARN, int32(gwListeners[0].Port), []verifier.ListenerRuleExpectation{
+					{
+						Conditions: []elbv2types.RuleCondition{
+							{
+								Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
+								PathPatternConfig: &elbv2types.PathPatternConditionConfig{
+									Values: []string{testPathString},
+								},
+							},
+						},
+						Actions: []elbv2types.Action{
+							{
+								Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
+								ForwardConfig: &elbv2types.ForwardActionConfig{
+									TargetGroups: []elbv2types.TargetGroupTuple{
+										{
+											TargetGroupArn: awssdk.String(testTargetGroupArn),
+											Weight:         awssdk.Int32(50),
+										},
+									},
+								},
+							},
+						},
+						Priority: 1,
+					},
+					{
+						Conditions: []elbv2types.RuleCondition{
+							{
+								Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
+								PathPatternConfig: &elbv2types.PathPatternConditionConfig{
+									Values: []string{testPathString, fmt.Sprintf("%s/*", testPathString)},
+								},
+							},
+							{
+								Field: awssdk.String(string(elbv2model.RuleConditionFieldHTTPRequestMethod)),
+								HttpRequestMethodConfig: &elbv2types.HttpRequestMethodConditionConfig{
+									Values: []string{
+										"GET",
+									},
+								},
+							},
+							{
+								Field: awssdk.String(string(elbv2model.RuleConditionFieldHTTPHeader)),
+								HttpHeaderConfig: &elbv2types.HttpHeaderConditionConfig{
+									HttpHeaderName: awssdk.String(testHttpHeaderNameOne),
+									Values: []string{
+										testHttpHeaderValueOne,
+									},
+								},
+							},
+							{
+								Field: awssdk.String(string(elbv2model.RuleConditionFieldHTTPHeader)),
+								HttpHeaderConfig: &elbv2types.HttpHeaderConditionConfig{
+									HttpHeaderName: awssdk.String(testHttpHeaderNameTwo),
+									Values: []string{
+										testHttpHeaderValueTwo,
+									},
+								},
+							},
+						},
+						Actions: []elbv2types.Action{
+							{
+								Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
+								ForwardConfig: &elbv2types.ForwardActionConfig{
+									TargetGroups: []elbv2types.TargetGroupTuple{
+										{
+											TargetGroupArn: awssdk.String(testTargetGroupArn),
+											Weight:         awssdk.Int32(30),
+										},
+									},
+								},
+							},
+						},
+						Priority: 2,
+					},
+					{
+						Conditions: []elbv2types.RuleCondition{
+							{
+								Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
+								PathPatternConfig: &elbv2types.PathPatternConditionConfig{
+									Values: []string{testPathString, fmt.Sprintf("%s/*", testPathString)},
+								},
+							},
+							{
+								Field: awssdk.String(string(elbv2model.RuleConditionFieldQueryString)),
+								QueryStringConfig: &elbv2types.QueryStringConditionConfig{
+									Values: []elbv2types.QueryStringKeyValuePair{
+										{
+											Key:   awssdk.String(testQueryStringKeyOne),
+											Value: awssdk.String(testQueryStringValueOne),
+										},
+									},
+								},
+							},
+							{
+								Field: awssdk.String(string(elbv2model.RuleConditionFieldQueryString)),
+								QueryStringConfig: &elbv2types.QueryStringConditionConfig{
+									Values: []elbv2types.QueryStringKeyValuePair{
+										{
+											Key:   awssdk.String(testQueryStringKeyTwo),
+											Value: awssdk.String(testQueryStringValueTwo),
+										},
+									},
+								},
+							},
+						},
+						Actions: []elbv2types.Action{
+							{
+								Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
+								ForwardConfig: &elbv2types.ForwardActionConfig{
+									TargetGroups: []elbv2types.TargetGroupTuple{
+										{
+											TargetGroupArn: awssdk.String(testTargetGroupArn),
+											Weight:         awssdk.Int32(30),
+										},
+									},
+								},
+							},
+						},
+						Priority: 3,
+					},
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("waiting for target group targets to be healthy", func() {
+				nodeList, err := stack.GetWorkerNodes(ctx, tf)
+				Expect(err).ToNot(HaveOccurred())
+				err = verifier.WaitUntilTargetsAreHealthy(ctx, tf, lbARN, len(nodeList))
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("waiting until DNS name is available", func() {
+				err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("sending http request to the lb", func() {
+				url := fmt.Sprintf("http://%v%s", dnsName, testPathString)
+				err := tf.HTTPVerifier.VerifyURL(url, http.ResponseCodeMatches(200))
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
+
+	Context("with ALB instance target configuration with HTTPRoute specified filter", func() {
+		BeforeEach(func() {})
+		It("should provision internet-facing load balancer resources", func() {
+			interf := elbv2gw.LoadBalancerSchemeInternetFacing
+			lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
+				Scheme: &interf,
+			}
+			tgSpec := elbv2gw.TargetGroupConfigurationSpec{}
+			gwListeners := []gwv1.Listener{
+				{
+					Name:     "test-listener",
+					Port:     80,
+					Protocol: gwv1.HTTPProtocolType,
+				},
+			}
+			httpr := buildHTTPRoute([]string{}, httpRouteRuleWithMatchesAndFilters)
+
+			By("deploying stack", func() {
+				err := stack.Deploy(ctx, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("checking gateway status for lb dns name", func() {
+				dnsName = stack.GetLoadBalancerIngressHostName()
+				Expect(dnsName).ToNot(BeEmpty())
+			})
+
+			By("querying AWS loadbalancer from the dns name", func() {
+				var err error
+				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(lbARN).ToNot(BeEmpty())
+			})
+
+			By("waiting until DNS name is available", func() {
+				err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("testing redirect with ReplaceFullPath", func() {
+				httpExp := httpexpect.New(tf.LoggerReporter, fmt.Sprintf("http://%v", dnsName))
+				httpExp.GET("/old-path").WithRedirectPolicy(httpexpect.DontFollowRedirects).Expect().
+					Status(301).
+					Header("Location").Equal("https://example.com:80/new-path")
+			})
+
+			By("testing redirect with ReplacePrefixMatch", func() {
+				httpExp := httpexpect.New(tf.LoggerReporter, fmt.Sprintf("http://%v", dnsName))
+				httpExp.GET("/api/v1/users").WithRedirectPolicy(httpexpect.DontFollowRedirects).Expect().
+					Status(302).
+					Header("Location").Equal("https://api.example.com:80/v2/*")
+			})
+
+			By("testing redirect with scheme and port change", func() {
+				httpExp := httpexpect.New(tf.LoggerReporter, fmt.Sprintf("http://%v", dnsName))
+				httpExp.GET("/secure").WithRedirectPolicy(httpexpect.DontFollowRedirects).Expect().
+					Status(302).
+					Header("Location").Equal("https://secure.example.com:8443/secure")
+			})
+		})
+	})
+
 	Context("with ALB instance target configuration with secure HTTPRoute", func() {
 		BeforeEach(func() {})
 		It("should provision internet-facing load balancer resources", func() {
@@ -133,7 +412,7 @@ var _ = Describe("test k8s alb gateway using instance targets reconciled by the 
 					Hostname: (*gwv1.Hostname)(awssdk.String(testHostname)),
 				},
 			}
-			httpr := buildHTTPRoute([]string{testHostname})
+			httpr := buildHTTPRoute([]string{testHostname}, []gwv1.HTTPRouteRule{})
 			By("deploying stack", func() {
 				err := stack.Deploy(ctx, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec)
 				Expect(err).NotTo(HaveOccurred())
@@ -230,7 +509,7 @@ var _ = Describe("test k8s alb gateway using instance targets reconciled by the 
 					Hostname: (*gwv1.Hostname)(awssdk.String(testHostname)),
 				},
 			}
-			httpr := buildHTTPRoute([]string{testHostname})
+			httpr := buildHTTPRoute([]string{testHostname}, []gwv1.HTTPRouteRule{})
 			By("deploying stack", func() {
 				err := stack.Deploy(ctx, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec)
 				Expect(err).NotTo(HaveOccurred())
@@ -339,7 +618,7 @@ var _ = Describe("test k8s alb gateway using instance targets reconciled by the 
 					Hostname: (*gwv1.Hostname)(awssdk.String(testHostname)),
 				},
 			}
-			httpr := buildHTTPRoute([]string{testHostname})
+			httpr := buildHTTPRoute([]string{testHostname}, []gwv1.HTTPRouteRule{})
 
 			By("deploying stack", func() {
 				err := stack.Deploy(ctx, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec)

--- a/test/e2e/gateway/alb_ip_target_test.go
+++ b/test/e2e/gateway/alb_ip_target_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"fmt"
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	"github.com/gavv/httpexpect/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
+	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework/http"
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework/utils"
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework/verifier"
@@ -36,7 +39,8 @@ var _ = Describe("test k8s alb gateway using ip targets reconciled by the aws lo
 		It("should provision internet-facing load balancer resources", func() {
 			interf := elbv2gw.LoadBalancerSchemeInternetFacing
 			lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
-				Scheme: &interf,
+				Scheme:                 &interf,
+				ListenerConfigurations: listenerConfigurationForHeaderModification,
 			}
 			ipTargetType := elbv2gw.TargetTypeIP
 			tgSpec := elbv2gw.TargetGroupConfigurationSpec{
@@ -51,7 +55,7 @@ var _ = Describe("test k8s alb gateway using ip targets reconciled by the aws lo
 					Protocol: gwv1.HTTPProtocolType,
 				},
 			}
-			httpr := buildHTTPRoute([]string{})
+			httpr := buildHTTPRoute([]string{}, []gwv1.HTTPRouteRule{})
 			By("deploying stack", func() {
 				err := stack.Deploy(ctx, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec)
 				Expect(err).NotTo(HaveOccurred())
@@ -67,6 +71,15 @@ var _ = Describe("test k8s alb gateway using ip targets reconciled by the aws lo
 				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(lbARN).ToNot(BeEmpty())
+			})
+
+			By("verifying listener attributes header modification is applied", func() {
+				lsARN := verifier.GetLoadBalancerListenerARN(ctx, tf, lbARN, "80")
+				err := verifier.VerifyListenerAttributes(ctx, tf, lsARN, map[string]string{
+					headerModificationServerEnabled: "true",
+					headerModificationMaxAge:        headerModificationMaxAgeValue,
+				})
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			tgMap := map[string][]string{
@@ -99,6 +112,280 @@ var _ = Describe("test k8s alb gateway using ip targets reconciled by the aws lo
 				url := fmt.Sprintf("http://%v/any-path", dnsName)
 				err := tf.HTTPVerifier.VerifyURL(url, http.ResponseCodeMatches(200))
 				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
+
+	Context("with ALB ip target configuration with HTTPRoute specified matches", func() {
+		BeforeEach(func() {})
+		It("should provision internet-facing load balancer resources", func() {
+			interf := elbv2gw.LoadBalancerSchemeInternetFacing
+			lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
+				Scheme: &interf,
+			}
+			ipTargetType := elbv2gw.TargetTypeIP
+			tgSpec := elbv2gw.TargetGroupConfigurationSpec{
+				DefaultConfiguration: elbv2gw.TargetGroupProps{
+					TargetType: &ipTargetType,
+				},
+			}
+			gwListeners := []gwv1.Listener{
+				{
+					Name:     "test-listener",
+					Port:     80,
+					Protocol: gwv1.HTTPProtocolType,
+				},
+			}
+			
+			httpr := buildHTTPRoute([]string{}, httpRouteRuleWithMatchesAndTargetGroupWeights)
+			By("deploying stack", func() {
+				err := stack.Deploy(ctx, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("checking gateway status for lb dns name", func() {
+				dnsName = stack.GetLoadBalancerIngressHostName()
+				Expect(dnsName).ToNot(BeEmpty())
+			})
+
+			By("querying AWS loadbalancer from the dns name", func() {
+				var err error
+				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(lbARN).ToNot(BeEmpty())
+			})
+
+			tgMap := map[string][]string{
+				"80": {"HTTP"},
+			}
+
+			targetNumber := int(*stack.albResourceStack.commonStack.dps[0].Spec.Replicas)
+
+			By("verifying AWS loadbalancer resources", func() {
+				err := verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
+					Type:          "application",
+					Scheme:        "internet-facing",
+					TargetType:    "ip", // IP target type
+					Listeners:     stack.albResourceStack.getListenersPortMap(),
+					TargetGroups:  tgMap,
+					NumTargets:    targetNumber,
+					TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("verifying HTTP load balancer listener", func() {
+				err := verifier.VerifyLoadBalancerListener(ctx, tf, lbARN, int32(gwListeners[0].Port), &verifier.ListenerExpectation{
+					ProtocolPort: "HTTP:80",
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("verifying listener rules", func() {
+				err := verifier.VerifyLoadBalancerListenerRules(ctx, tf, lbARN, int32(gwListeners[0].Port), []verifier.ListenerRuleExpectation{
+					{
+						Conditions: []elbv2types.RuleCondition{
+							{
+								Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
+								PathPatternConfig: &elbv2types.PathPatternConditionConfig{
+									Values: []string{testPathString},
+								},
+							},
+						},
+						Actions: []elbv2types.Action{
+							{
+								Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
+								ForwardConfig: &elbv2types.ForwardActionConfig{
+									TargetGroups: []elbv2types.TargetGroupTuple{
+										{
+											TargetGroupArn: awssdk.String(testTargetGroupArn),
+											Weight:         awssdk.Int32(50),
+										},
+									},
+								},
+							},
+						},
+						Priority: 1,
+					},
+					{
+						Conditions: []elbv2types.RuleCondition{
+							{
+								Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
+								PathPatternConfig: &elbv2types.PathPatternConditionConfig{
+									Values: []string{testPathString, fmt.Sprintf("%s/*", testPathString)},
+								},
+							},
+							{
+								Field: awssdk.String(string(elbv2model.RuleConditionFieldHTTPRequestMethod)),
+								HttpRequestMethodConfig: &elbv2types.HttpRequestMethodConditionConfig{
+									Values: []string{
+										"GET",
+									},
+								},
+							},
+							{
+								Field: awssdk.String(string(elbv2model.RuleConditionFieldHTTPHeader)),
+								HttpHeaderConfig: &elbv2types.HttpHeaderConditionConfig{
+									HttpHeaderName: awssdk.String(testHttpHeaderNameOne),
+									Values: []string{
+										testHttpHeaderValueOne,
+									},
+								},
+							},
+							{
+								Field: awssdk.String(string(elbv2model.RuleConditionFieldHTTPHeader)),
+								HttpHeaderConfig: &elbv2types.HttpHeaderConditionConfig{
+									HttpHeaderName: awssdk.String(testHttpHeaderNameTwo),
+									Values: []string{
+										testHttpHeaderValueTwo,
+									},
+								},
+							},
+						},
+						Actions: []elbv2types.Action{
+							{
+								Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
+								ForwardConfig: &elbv2types.ForwardActionConfig{
+									TargetGroups: []elbv2types.TargetGroupTuple{
+										{
+											TargetGroupArn: awssdk.String(testTargetGroupArn),
+											Weight:         awssdk.Int32(30),
+										},
+									},
+								},
+							},
+						},
+						Priority: 2,
+					},
+					{
+						Conditions: []elbv2types.RuleCondition{
+							{
+								Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
+								PathPatternConfig: &elbv2types.PathPatternConditionConfig{
+									Values: []string{testPathString, fmt.Sprintf("%s/*", testPathString)},
+								},
+							},
+							{
+								Field: awssdk.String(string(elbv2model.RuleConditionFieldQueryString)),
+								QueryStringConfig: &elbv2types.QueryStringConditionConfig{
+									Values: []elbv2types.QueryStringKeyValuePair{
+										{
+											Key:   awssdk.String(testQueryStringKeyOne),
+											Value: awssdk.String(testQueryStringValueOne),
+										},
+									},
+								},
+							},
+							{
+								Field: awssdk.String(string(elbv2model.RuleConditionFieldQueryString)),
+								QueryStringConfig: &elbv2types.QueryStringConditionConfig{
+									Values: []elbv2types.QueryStringKeyValuePair{
+										{
+											Key:   awssdk.String(testQueryStringKeyTwo),
+											Value: awssdk.String(testQueryStringValueTwo),
+										},
+									},
+								},
+							},
+						},
+						Actions: []elbv2types.Action{
+							{
+								Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
+								ForwardConfig: &elbv2types.ForwardActionConfig{
+									TargetGroups: []elbv2types.TargetGroupTuple{
+										{
+											TargetGroupArn: awssdk.String(testTargetGroupArn),
+											Weight:         awssdk.Int32(30),
+										},
+									},
+								},
+							},
+						},
+						Priority: 3,
+					},
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("waiting for target group targets to be healthy", func() {
+				err := verifier.WaitUntilTargetsAreHealthy(ctx, tf, lbARN, targetNumber)
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("waiting until DNS name is available", func() {
+				err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("sending http request to the lb", func() {
+				url := fmt.Sprintf("http://%v%s", dnsName, testPathString)
+				err := tf.HTTPVerifier.VerifyURL(url, http.ResponseCodeMatches(200))
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
+
+	Context("with ALB ip target configuration with HTTPRoute specified filter", func() {
+		BeforeEach(func() {})
+		It("should redirect requests correctly", func() {
+			interf := elbv2gw.LoadBalancerSchemeInternetFacing
+			lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
+				Scheme: &interf,
+			}
+			ipTargetType := elbv2gw.TargetTypeIP
+			tgSpec := elbv2gw.TargetGroupConfigurationSpec{
+				DefaultConfiguration: elbv2gw.TargetGroupProps{
+					TargetType: &ipTargetType,
+				},
+			}
+			gwListeners := []gwv1.Listener{
+				{
+					Name:     "test-listener",
+					Port:     80,
+					Protocol: gwv1.HTTPProtocolType,
+				},
+			}
+			httpr := buildHTTPRoute([]string{}, httpRouteRuleWithMatchesAndFilters)
+
+			By("deploying stack", func() {
+				err := stack.Deploy(ctx, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("checking gateway status for lb dns name", func() {
+				dnsName = stack.GetLoadBalancerIngressHostName()
+				Expect(dnsName).ToNot(BeEmpty())
+			})
+
+			By("querying AWS loadbalancer from the dns name", func() {
+				var err error
+				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(lbARN).ToNot(BeEmpty())
+			})
+
+			By("waiting until DNS name is available", func() {
+				err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("testing redirect with ReplaceFullPath", func() {
+				httpExp := httpexpect.New(tf.LoggerReporter, fmt.Sprintf("http://%v", dnsName))
+				httpExp.GET("/old-path").WithRedirectPolicy(httpexpect.DontFollowRedirects).Expect().
+					Status(301).
+					Header("Location").Equal("https://example.com:80/new-path")
+			})
+
+			By("testing redirect with ReplacePrefixMatch", func() {
+				httpExp := httpexpect.New(tf.LoggerReporter, fmt.Sprintf("http://%v", dnsName))
+				httpExp.GET("/api/v1/users").WithRedirectPolicy(httpexpect.DontFollowRedirects).Expect().
+					Status(302).
+					Header("Location").Equal("https://api.example.com:80/v2/*")
+			})
+
+			By("testing redirect with scheme and port change", func() {
+				httpExp := httpexpect.New(tf.LoggerReporter, fmt.Sprintf("http://%v", dnsName))
+				httpExp.GET("/secure").WithRedirectPolicy(httpexpect.DontFollowRedirects).Expect().
+					Status(302).
+					Header("Location").Equal("https://secure.example.com:8443/secure")
 			})
 		})
 	})
@@ -140,7 +427,7 @@ var _ = Describe("test k8s alb gateway using ip targets reconciled by the aws lo
 				},
 			}
 
-			httpr := buildHTTPRoute([]string{testHostname})
+			httpr := buildHTTPRoute([]string{testHostname}, []gwv1.HTTPRouteRule{})
 
 			By("deploying stack", func() {
 				err := stack.Deploy(ctx, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec)
@@ -249,7 +536,7 @@ var _ = Describe("test k8s alb gateway using ip targets reconciled by the aws lo
 				},
 			}
 
-			httpr := buildHTTPRoute([]string{testHostname})
+			httpr := buildHTTPRoute([]string{testHostname}, []gwv1.HTTPRouteRule{})
 
 			By("deploying stack", func() {
 				err := stack.Deploy(ctx, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec)
@@ -369,7 +656,7 @@ var _ = Describe("test k8s alb gateway using ip targets reconciled by the aws lo
 				},
 			}
 
-			httpr := buildHTTPRoute([]string{})
+			httpr := buildHTTPRoute([]string{}, []gwv1.HTTPRouteRule{})
 
 			By("deploying stack", func() {
 				err := stack.Deploy(ctx, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec)

--- a/test/e2e/gateway/consts.go
+++ b/test/e2e/gateway/consts.go
@@ -1,6 +1,12 @@
 package gateway
 
-import "sigs.k8s.io/aws-load-balancer-controller/test/framework/verifier"
+import (
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
+	"sigs.k8s.io/aws-load-balancer-controller/test/framework/verifier"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gwalpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
 
 const (
 	appContainerPort        = 80
@@ -13,6 +19,20 @@ const (
 	defaultTgConfigName     = "tgconfig-e2e"
 	udpDefaultTgConfigName  = defaultTgConfigName + "-udp"
 	testHostname            = "*.elb.us-west-2.amazonaws.com"
+	// constants used in ALB http route matches and filters tests
+	headerModificationServerEnabled = "routing.http.response.server.enabled"
+	headerModificationMaxAge        = "routing.http.response.access_control_max_age.header_value"
+	headerModificationMaxAgeValue   = "30"
+	testPathString                  = "/test-path"
+	testHttpHeaderNameOne           = "X-Test-Header-One"
+	testHttpHeaderValueOne          = "test-header-value-One"
+	testHttpHeaderNameTwo           = "X-Test-Header-Two"
+	testHttpHeaderValueTwo          = "test-header-value-Two"
+	testTargetGroupArn              = "arn:randomArn"
+	testQueryStringKeyOne           = "queryKeyOne"
+	testQueryStringValueOne         = "queryValueOne"
+	testQueryStringKeyTwo           = "queryKeyTwo"
+	testQueryStringValueTwo         = "queryValueTwo"
 )
 
 // Common settings for ALB target group health checks
@@ -24,4 +44,197 @@ var DEFAULT_ALB_TARGET_GROUP_HC = &verifier.TargetGroupHC{
 	Timeout:            5,
 	HealthyThreshold:   3,
 	UnhealthyThreshold: 3,
+}
+
+var listenerConfigurationForHeaderModification = &[]elbv2gw.ListenerConfiguration{
+	{
+		ProtocolPort: "HTTP:80",
+		ListenerAttributes: []elbv2gw.ListenerAttribute{
+			{
+				Key:   headerModificationServerEnabled,
+				Value: "true",
+			},
+			{
+				Key:   headerModificationMaxAge,
+				Value: headerModificationMaxAgeValue,
+			},
+		},
+	},
+}
+
+var defaultPort = gwalpha2.PortNumber(80)
+var DefaultHttpRouteRuleBackendRefs = []gwv1.HTTPBackendRef{
+	{
+		BackendRef: gwv1.BackendRef{
+			BackendObjectReference: gwv1.BackendObjectReference{
+				Name: defaultName,
+				Port: &defaultPort,
+			},
+		},
+	},
+}
+
+var portNew = gwalpha2.PortNumber(8443)
+var httpRouteRuleWithMatchesAndFilters = []gwv1.HTTPRouteRule{
+	{
+		Matches: []gwv1.HTTPRouteMatch{
+			{
+				Path: &gwv1.HTTPPathMatch{
+					Type:  &[]gwv1.PathMatchType{gwv1.PathMatchExact}[0],
+					Value: awssdk.String("/old-path"),
+				},
+			},
+		},
+		Filters: []gwv1.HTTPRouteFilter{
+			{
+				Type: gwv1.HTTPRouteFilterRequestRedirect,
+				RequestRedirect: &gwv1.HTTPRequestRedirectFilter{
+					Scheme:   awssdk.String("https"),
+					Hostname: (*gwv1.PreciseHostname)(awssdk.String("example.com")),
+					Path: &gwv1.HTTPPathModifier{
+						Type:            gwv1.FullPathHTTPPathModifier,
+						ReplaceFullPath: awssdk.String("/new-path"),
+					},
+					StatusCode: awssdk.Int(301),
+					Port:       &defaultPort,
+				},
+			},
+		},
+	},
+	{
+		Matches: []gwv1.HTTPRouteMatch{
+			{
+				Path: &gwv1.HTTPPathMatch{
+					Type:  &[]gwv1.PathMatchType{gwv1.PathMatchPathPrefix}[0],
+					Value: awssdk.String("/api"),
+				},
+			},
+		},
+		Filters: []gwv1.HTTPRouteFilter{
+			{
+				Type: gwv1.HTTPRouteFilterRequestRedirect,
+				RequestRedirect: &gwv1.HTTPRequestRedirectFilter{
+					Scheme:   awssdk.String("https"),
+					Hostname: (*gwv1.PreciseHostname)(awssdk.String("api.example.com")),
+					Path: &gwv1.HTTPPathModifier{
+						Type:               gwv1.PrefixMatchHTTPPathModifier,
+						ReplacePrefixMatch: awssdk.String("/v2"),
+					},
+					StatusCode: awssdk.Int(302),
+					Port:       &defaultPort,
+				},
+			},
+		},
+	},
+	{
+		Matches: []gwv1.HTTPRouteMatch{
+			{
+				Path: &gwv1.HTTPPathMatch{
+					Type:  &[]gwv1.PathMatchType{gwv1.PathMatchExact}[0],
+					Value: awssdk.String("/secure"),
+				},
+			},
+		},
+		Filters: []gwv1.HTTPRouteFilter{
+			{
+				Type: gwv1.HTTPRouteFilterRequestRedirect,
+				RequestRedirect: &gwv1.HTTPRequestRedirectFilter{
+					Scheme:     awssdk.String("https"),
+					Hostname:   (*gwv1.PreciseHostname)(awssdk.String("secure.example.com")),
+					Port:       &portNew,
+					StatusCode: awssdk.Int(302),
+				},
+			},
+		},
+	},
+}
+
+var httpRouteRuleWithMatchesAndTargetGroupWeights = []gwv1.HTTPRouteRule{
+	// rule 1
+	{
+		Matches: []gwv1.HTTPRouteMatch{
+			{
+				Path: &gwv1.HTTPPathMatch{
+					Type:  &[]gwv1.PathMatchType{gwv1.PathMatchExact}[0],
+					Value: awssdk.String(testPathString),
+				},
+			},
+		},
+		BackendRefs: []gwv1.HTTPBackendRef{
+			{
+				BackendRef: gwv1.BackendRef{
+					BackendObjectReference: gwv1.BackendObjectReference{
+						Name: defaultName,
+						Port: &defaultPort,
+					},
+					Weight: awssdk.Int32(50),
+				},
+			},
+		},
+	},
+	// rule 2
+	{
+		Matches: []gwv1.HTTPRouteMatch{
+			{
+				Path: &gwv1.HTTPPathMatch{
+					Type:  &[]gwv1.PathMatchType{gwv1.PathMatchPathPrefix}[0],
+					Value: awssdk.String(testPathString),
+				},
+				QueryParams: []gwv1.HTTPQueryParamMatch{
+					{
+						Name:  testQueryStringKeyOne,
+						Value: testQueryStringValueOne,
+					},
+					{
+						Name:  testQueryStringKeyTwo,
+						Value: testQueryStringValueTwo,
+					},
+				},
+			},
+		},
+		BackendRefs: []gwv1.HTTPBackendRef{
+			{
+				BackendRef: gwv1.BackendRef{
+					BackendObjectReference: gwv1.BackendObjectReference{
+						Name: defaultName,
+						Port: &defaultPort,
+					},
+					Weight: awssdk.Int32(30),
+				},
+			},
+		},
+	},
+	// rule 3
+	{
+		Matches: []gwv1.HTTPRouteMatch{
+			{
+				Path: &gwv1.HTTPPathMatch{
+					Type:  &[]gwv1.PathMatchType{gwv1.PathMatchPathPrefix}[0],
+					Value: awssdk.String(testPathString),
+				},
+				Headers: []gwv1.HTTPHeaderMatch{
+					{
+						Name:  testHttpHeaderNameOne,
+						Value: testHttpHeaderValueOne,
+					},
+					{
+						Name:  testHttpHeaderNameTwo,
+						Value: testHttpHeaderValueTwo,
+					},
+				},
+				Method: &[]gwv1.HTTPMethod{gwv1.HTTPMethodGet}[0],
+			},
+		},
+		BackendRefs: []gwv1.HTTPBackendRef{
+			{
+				BackendRef: gwv1.BackendRef{
+					BackendObjectReference: gwv1.BackendObjectReference{
+						Name: defaultName,
+						Port: &defaultPort,
+					},
+					Weight: awssdk.Int32(30),
+				},
+			},
+		},
+	},
 }

--- a/test/e2e/gateway/shared_resource_definitions.go
+++ b/test/e2e/gateway/shared_resource_definitions.go
@@ -308,8 +308,7 @@ func buildTLSRoute() *gwalpha2.TLSRoute {
 
 */
 
-func buildHTTPRoute(hostnames []string) *gwv1.HTTPRoute {
-	port := gwalpha2.PortNumber(80)
+func buildHTTPRoute(hostnames []string, rules []gwv1.HTTPRouteRule) *gwv1.HTTPRoute {
 	routeName := fmt.Sprintf("%v-%v", defaultName, utils.RandomDNS1123Label(6))
 	httpr := &gwv1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
@@ -323,20 +322,6 @@ func buildHTTPRoute(hostnames []string) *gwv1.HTTPRoute {
 					},
 				},
 			},
-			Rules: []gwv1.HTTPRouteRule{
-				{
-					BackendRefs: []gwv1.HTTPBackendRef{
-						{
-							BackendRef: gwv1.BackendRef{
-								BackendObjectReference: gwv1.BackendObjectReference{
-									Name: defaultName,
-									Port: &port,
-								},
-							},
-						},
-					},
-				},
-			},
 		},
 	}
 	routeHostnames := make([]gwv1.Hostname, 0, len(hostnames))
@@ -344,5 +329,14 @@ func buildHTTPRoute(hostnames []string) *gwv1.HTTPRoute {
 		routeHostnames = append(routeHostnames, gwv1.Hostname(hostname))
 	}
 	httpr.Spec.Hostnames = routeHostnames
+	if len(rules) > 0 {
+		httpr.Spec.Rules = rules
+	} else {
+		httpr.Spec.Rules = []gwv1.HTTPRouteRule{
+			{
+				BackendRefs: DefaultHttpRouteRuleBackendRefs,
+			},
+		}
+	}
 	return httpr
 }


### PR DESCRIPTION
### Description
- backfil E2E test for httproute match and filter feature, mostly added verifier for rule in E2E test
- added some unit tests
- added exception for other header modification since we only support redirect 
- added function for building target stickiness (this will be used later)
- fixed some minor issues i saw during implementation

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
```
ginkgo -v -r test/e2e/gateway --  --kubeconfig=$KUBECONFIG --cluster-name=xxx --aws-region=xx --aws-vpc-id=vpc-xx --enable-gateway-tests -ginkgo.focus="test k8s alb gateway using instance targets reconciled by the aws load balancer controller|test k8s alb gateway using ip targets reconciled by the aws load balancer controller"

with result: 
------------------------------
SS

Ran 6 of 14 Specs in 1825.423 seconds
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 8 Skipped
PASS
```
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [x] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
