### PR TITLE
Update K8s version support

### DIFF
--- a/docs/deploy/installation.md
+++ b/docs/deploy/installation.md
@@ -14,7 +14,7 @@ The LBC is supported by AWS. Some clusters may be using the legacy "in-tree" fun
     You will no longer be able to provision new Classic Load Balancer (CLB) from your kubernetes service unless you disable this feature. Existing CLB will continue to work fine.
 
 ## Supported Kubernetes versions
-* AWS Load Balancer Controller v2.0.0~v2.1.3 requires Kubernetes 1.15+
+* AWS Load Balancer Controller v2.0.0~v2.1.3 requires Kubernetes 1.15-1.21
 * AWS Load Balancer Controller v2.2.0~v2.3.1 requires Kubernetes 1.16-1.21
 * AWS Load Balancer Controller v2.4.0+ requires Kubernetes 1.19+
 * AWS Load Balancer Controller v2.5.0+ requires Kubernetes 1.22+


### PR DESCRIPTION
### Issue

N/A

### Description

Update the version support docs so `v2.0.0~v2.1.3` ends support on `v1.21` of K8s. The current state of the docs indicate that these versions of the controller support K8s `v1.15+` which is incorrect as they rely on the `networking.k8s.io/v1beta1` API, which was removed in [K8s v1.22](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122). Below is a few log lines from my `v1.32` cluster confirming `v2.1.3` of the controller is using the removed API version

```
{"level":"info","ts":1752608955.1141255,"msg":"version","GitVersion":"v2.1.3","GitCommit":"c9d30f23960f12cd1e985e9b2cd3f077b9a8c93f","BuildDate":"2021-02-18T19:32:05+0000"}
{"level":"info","ts":1752608955.1508875,"logger":"controller-runtime.metrics","msg":"metrics server is starting to listen","addr":":8080"}
{"level":"error","ts":1752608955.1711683,"logger":"setup","msg":"unable to create controller","controller":"Ingress","error":"no matches for kind \"Ingress\" in version \"networking.k8s.io/v1beta1\""}
```

Further according to [this comment](https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2495#issuecomment-1032835564) on issue #2495 support for the GA version of this API wasn't added until `v2.4.0` of the controller and therefore this should have a similar end of support for `v1.21` of K8s like the `v2.2.0~v2.3.1` versions.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
