### PR TITLE
[feat gw-api] implement grpcroute match

### DIFF
--- a/pkg/gateway/model/model_build_listener.go
+++ b/pkg/gateway/model/model_build_listener.go
@@ -188,18 +188,19 @@ func (l listenerBuilderImpl) buildListenerRules(stack core.Stack, ls *elbv2model
 
 	var albRules []elbv2model.Rule
 	for _, ruleWithPrecedence := range rulesWithPrecedenceOrder {
-		route := ruleWithPrecedence.RouteDescriptor
-		rule := ruleWithPrecedence.Rule
+		route := ruleWithPrecedence.CommonRulePrecedence.RouteDescriptor
+		rule := ruleWithPrecedence.CommonRulePrecedence.Rule
 
 		var conditionsList []elbv2model.RuleCondition
 		var err error
 		switch route.GetRouteKind() {
 		case routeutils.HTTPRouteKind:
 			conditionsList, err = routeutils.BuildHttpRuleConditions(ruleWithPrecedence)
-			if err != nil {
-				return err
-			}
-			// TODO: add case for GRPC
+		case routeutils.GRPCRouteKind:
+			conditionsList, err = routeutils.BuildGrpcRuleConditions(ruleWithPrecedence)
+		}
+		if err != nil {
+			return err
 		}
 		tags, tagsErr := l.tagHelper.getGatewayTags(lbCfg)
 		if tagsErr != nil {

--- a/pkg/gateway/model/model_build_target_group.go
+++ b/pkg/gateway/model/model_build_target_group.go
@@ -288,7 +288,7 @@ func (builder *targetGroupBuilderImpl) buildTargetGroupSpec(gw *gwv1.Gateway, ro
 		if targetType == elbv2model.TargetTypeIP {
 			return elbv2model.TargetGroupSpec{}, errors.Errorf("TargetGroup port is empty. Are you using the correct service type?")
 		}
-		return elbv2model.TargetGroupSpec{}, errors.Errorf("TargetGroup port is empty. When using Instance targets, your service be must of type 'NodePort' or 'LoadBalancer'")
+		return elbv2model.TargetGroupSpec{}, errors.Errorf("TargetGroup port is empty. When using Instance targets, your service must be of type 'NodePort' or 'LoadBalancer'")
 	}
 	return elbv2model.TargetGroupSpec{
 		Name:                  name,

--- a/pkg/gateway/routeutils/constants.go
+++ b/pkg/gateway/routeutils/constants.go
@@ -32,5 +32,5 @@ var defaultProtocolToRouteKindMap = map[gwv1.ProtocolType][]RouteKind{
 	gwv1.UDPProtocolType:   {UDPRouteKind},
 	gwv1.TLSProtocolType:   {TLSRouteKind, TCPRouteKind},
 	gwv1.HTTPProtocolType:  {HTTPRouteKind},
-	gwv1.HTTPSProtocolType: {HTTPRouteKind},
+	gwv1.HTTPSProtocolType: {HTTPRouteKind, GRPCRouteKind},
 }

--- a/pkg/gateway/routeutils/route_rule_condition.go
+++ b/pkg/gateway/routeutils/route_rule_condition.go
@@ -11,7 +11,7 @@ import (
 // BuildHttpRuleConditions each match will be mapped to a ruleCondition, conditions within same match will be ANDed
 func BuildHttpRuleConditions(rule RulePrecedence) ([]elbv2model.RuleCondition, error) {
 	match := rule.HTTPMatch
-	hostnamesStringList := rule.Hostnames
+	hostnamesStringList := rule.CommonRulePrecedence.Hostnames
 	var conditions []elbv2model.RuleCondition
 	if hostnamesStringList != nil && len(hostnamesStringList) > 0 {
 		conditions = append(conditions, elbv2model.RuleCondition{
@@ -141,10 +141,98 @@ func buildHttpMethodCondition(method *gwv1.HTTPMethod) []elbv2model.RuleConditio
 	}
 }
 
-// TODO: implement it for GRPCRoute
-func buildGrpcRouteRuleConditions(matches RouteRule) ([][]elbv2model.RuleCondition, error) {
-	var conditions [][]elbv2model.RuleCondition
+func BuildGrpcRuleConditions(rule RulePrecedence) ([]elbv2model.RuleCondition, error) {
+	// handle host header
+	hostnamesStringList := rule.CommonRulePrecedence.Hostnames
+	var conditions []elbv2model.RuleCondition
+	if hostnamesStringList != nil && len(hostnamesStringList) > 0 {
+		conditions = append(conditions, elbv2model.RuleCondition{
+			Field: elbv2model.RuleConditionFieldHostHeader,
+			HostHeaderConfig: &elbv2model.HostHeaderConditionConfig{
+				Values: hostnamesStringList,
+			},
+		})
+	}
+
+	match := rule.GRPCMatch
+
+	if match == nil {
+		// If Method field is not specified, all services and methods will match.
+		conditions = append(conditions, elbv2model.RuleCondition{
+			Field: elbv2model.RuleConditionFieldPathPattern,
+			PathPatternConfig: &elbv2model.PathPatternConditionConfig{
+				Values: []string{"/*"},
+			},
+		})
+		return conditions, nil
+	}
+
+	// handle method match
+	if match.Method == nil {
+		conditions = append(conditions, elbv2model.RuleCondition{
+			Field: elbv2model.RuleConditionFieldPathPattern,
+			PathPatternConfig: &elbv2model.PathPatternConditionConfig{
+				Values: []string{"/*"},
+			},
+		})
+	} else {
+		methodCondition, err := buildGrpcMethodCondition(match.Method)
+		if err != nil {
+			return nil, err
+		}
+		conditions = append(conditions, methodCondition...)
+	}
+
+	// handle header match
+	if match.Headers != nil && len(match.Headers) > 0 {
+		headerConditions := buildGrpcHeaderCondition(match.Headers)
+		conditions = append(conditions, headerConditions...)
+	}
+
 	return conditions, nil
+}
+
+func buildGrpcHeaderCondition(headers []gwv1.GRPCHeaderMatch) []elbv2model.RuleCondition {
+	var conditions []elbv2model.RuleCondition
+	for _, header := range headers {
+		headerCondition := []elbv2model.RuleCondition{
+			{
+				Field: elbv2model.RuleConditionFieldHTTPHeader,
+				HTTPHeaderConfig: &elbv2model.HTTPHeaderConditionConfig{
+					HTTPHeaderName: string(header.Name),
+					// for a given HTTPHeaderName, ALB rule can accept a list of values. However, gateway route headers only accept one value per name, and name cannot duplicate.
+					Values: []string{header.Value},
+				},
+			},
+		}
+		conditions = append(conditions, headerCondition...)
+	}
+	return conditions
+}
+
+// buildGrpcMethodCondition - we handle regex and exact type in same way since regex is taken as-is
+// Exact method type will not accept wildcards - this is checked by kubebuilder validation
+// Regular expression method type only works with wildcard * and ? for now
+func buildGrpcMethodCondition(method *gwv1.GRPCMethodMatch) ([]elbv2model.RuleCondition, error) {
+	var pathValue string
+	if method.Service != nil && method.Method != nil {
+		pathValue = fmt.Sprintf("/%s/%s", *method.Service, *method.Method)
+	} else if method.Service != nil {
+		pathValue = fmt.Sprintf("/%s/*", *method.Service)
+	} else if method.Method != nil {
+		pathValue = fmt.Sprintf("/*/%s", *method.Method)
+	} else {
+		return nil, errors.Errorf("Invalid grpc method match: %v", method)
+	}
+
+	return []elbv2model.RuleCondition{
+		{
+			Field: elbv2model.RuleConditionFieldPathPattern,
+			PathPatternConfig: &elbv2model.PathPatternConditionConfig{
+				Values: []string{pathValue},
+			},
+		},
+	}, nil
 }
 
 // BuildHttpRuleActionsBasedOnFilter only request redirect is supported, header modification is limited due to ALB support level.

--- a/pkg/gateway/routeutils/route_rule_condition_test.go
+++ b/pkg/gateway/routeutils/route_rule_condition_test.go
@@ -9,10 +9,138 @@ import (
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
+var (
+	headerName    = "testHeader"
+	headerValue   = "testValue"
+	queryName     = "testQuery"
+	queryValue    = "testValue"
+	hostname      = "example.com"
+	service       = "testService"
+	method        = "testMethod"
+	testKey       = "testKey"
+	testValue     = "testValue"
+	testKeyTwo    = "testKeyTwo"
+	testValueTwo  = "testValueTwo"
+	prefixType    = gwv1.PathMatchPathPrefix
+	exactType     = gwv1.PathMatchExact
+	regexType     = gwv1.PathMatchRegularExpression
+	grpcExactType = gwv1.GRPCMethodMatchExact
+	grpcRegexType = gwv1.GRPCMethodMatchRegularExpression
+)
+
+func Test_BuildHttpRuleConditions(t *testing.T) {
+	pathValue := "/test"
+	defaultPathValue := "/"
+	methodValue := gwv1.HTTPMethodGet
+
+	tests := []struct {
+		name    string
+		rule    RulePrecedence
+		want    []elbv2model.RuleCondition
+		wantErr bool
+	}{
+		{
+			name: "match with all fields provided",
+			rule: RulePrecedence{
+				CommonRulePrecedence: CommonRulePrecedence{
+					Hostnames: []string{hostname},
+				},
+				HTTPMatch: &gwv1.HTTPRouteMatch{
+					Path: &gwv1.HTTPPathMatch{
+						Type:  &exactType,
+						Value: &pathValue,
+					},
+					Method: &methodValue,
+					Headers: []gwv1.HTTPHeaderMatch{
+						{
+							Name:  gwv1.HTTPHeaderName(headerName),
+							Value: headerValue,
+						},
+					},
+					QueryParams: []gwv1.HTTPQueryParamMatch{
+						{
+							Name:  gwv1.HTTPHeaderName(queryName),
+							Value: queryValue,
+						},
+					},
+				},
+			},
+			want: []elbv2model.RuleCondition{
+				{
+					Field: elbv2model.RuleConditionFieldHostHeader,
+					HostHeaderConfig: &elbv2model.HostHeaderConditionConfig{
+						Values: []string{hostname},
+					},
+				},
+				{
+					Field: elbv2model.RuleConditionFieldPathPattern,
+					PathPatternConfig: &elbv2model.PathPatternConditionConfig{
+						Values: []string{pathValue},
+					},
+				},
+				{
+					Field: elbv2model.RuleConditionFieldHTTPHeader,
+					HTTPHeaderConfig: &elbv2model.HTTPHeaderConditionConfig{
+						HTTPHeaderName: headerName,
+						Values:         []string{headerValue},
+					},
+				},
+				{
+					Field: elbv2model.RuleConditionFieldQueryString,
+					QueryStringConfig: &elbv2model.QueryStringConditionConfig{
+						Values: []elbv2model.QueryStringKeyValuePair{
+							{
+								Key:   &queryName,
+								Value: queryValue,
+							},
+						},
+					},
+				},
+				{
+					Field: elbv2model.RuleConditionFieldHTTPRequestMethod,
+					HTTPRequestMethodConfig: &elbv2model.HTTPRequestMethodConditionConfig{
+						Values: []string{string(methodValue)},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "with default Type Prefix and default value /",
+			rule: RulePrecedence{
+				HTTPMatch: &gwv1.HTTPRouteMatch{
+					Path: &gwv1.HTTPPathMatch{
+						Type:  &prefixType,
+						Value: &defaultPathValue,
+					},
+				},
+			},
+			want: []elbv2model.RuleCondition{
+				{
+					Field: elbv2model.RuleConditionFieldPathPattern,
+					PathPatternConfig: &elbv2model.PathPatternConditionConfig{
+						Values: []string{"/*"},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := BuildHttpRuleConditions(tt.rule)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
 func Test_buildHttpPathCondition(t *testing.T) {
-	prefixType := gwv1.PathMatchPathPrefix
-	exactType := gwv1.PathMatchExact
-	regexType := gwv1.PathMatchRegularExpression
 	pathValue := "/prefix"
 	pathValueWithWildcard := "/prefix*"
 	regexPathValue := "/v+?/*"
@@ -103,10 +231,6 @@ func Test_buildHttpPathCondition(t *testing.T) {
 }
 
 func Test_buildHttpHeaderCondition(t *testing.T) {
-	testKey := "testKey"
-	testValue := "testValue"
-	testKeyTwo := "testKeyTwo"
-	testValueTwo := "testValueTwo"
 	tests := []struct {
 		name        string
 		headerMatch []gwv1.HTTPHeaderMatch
@@ -170,10 +294,6 @@ func Test_buildHttpHeaderCondition(t *testing.T) {
 }
 
 func Test_buildHttpQueryParamCondition(t *testing.T) {
-	testKey := "testKey"
-	testValue := "testValue"
-	testKeyTwo := "testKeyTwo"
-	testValueTwo := "testValueTwo"
 	tests := []struct {
 		name        string
 		queryParams []gwv1.HTTPQueryParamMatch
@@ -283,7 +403,7 @@ func Test_buildHttpRedirectAction(t *testing.T) {
 	scheme := "https"
 	expectedScheme := "HTTPS"
 	invalidScheme := "invalid"
-	hostname := "example.com"
+
 	port := int32(80)
 	portString := "80"
 	statusCode := 301
@@ -436,6 +556,306 @@ func Test_BuildHttpRuleActionsBasedOnFilter(t *testing.T) {
 				assert.Nil(t, actions)
 			} else {
 				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_BuildGrpcRuleConditions(t *testing.T) {
+	tests := []struct {
+		name    string
+		rule    RulePrecedence
+		want    []elbv2model.RuleCondition
+		wantErr bool
+	}{
+		{
+			name: "input has both method and headers",
+			rule: RulePrecedence{
+				CommonRulePrecedence: CommonRulePrecedence{
+					Hostnames: []string{hostname},
+				},
+				GRPCMatch: &gwv1.GRPCRouteMatch{
+					Method: &gwv1.GRPCMethodMatch{
+						Type:    &grpcExactType,
+						Service: &service,
+						Method:  &method,
+					},
+					Headers: []gwv1.GRPCHeaderMatch{
+						{
+							Name:  gwv1.GRPCHeaderName(headerName),
+							Value: headerValue,
+						},
+					},
+				},
+			},
+			want: []elbv2model.RuleCondition{
+				{
+					Field: elbv2model.RuleConditionFieldHostHeader,
+					HostHeaderConfig: &elbv2model.HostHeaderConditionConfig{
+						Values: []string{hostname},
+					},
+				},
+				{
+					Field: elbv2model.RuleConditionFieldPathPattern,
+					PathPatternConfig: &elbv2model.PathPatternConditionConfig{
+						Values: []string{"/" + service + "/" + method},
+					},
+				},
+				{
+					Field: elbv2model.RuleConditionFieldHTTPHeader,
+					HTTPHeaderConfig: &elbv2model.HTTPHeaderConditionConfig{
+						HTTPHeaderName: headerName,
+						Values:         []string{headerValue},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "input with method is nil",
+			rule: RulePrecedence{
+				CommonRulePrecedence: CommonRulePrecedence{
+					Hostnames: []string{hostname},
+				},
+				GRPCMatch: &gwv1.GRPCRouteMatch{},
+			},
+			want: []elbv2model.RuleCondition{
+				{
+					Field: elbv2model.RuleConditionFieldHostHeader,
+					HostHeaderConfig: &elbv2model.HostHeaderConditionConfig{
+						Values: []string{hostname},
+					},
+				},
+				{
+					Field: elbv2model.RuleConditionFieldPathPattern,
+					PathPatternConfig: &elbv2model.PathPatternConditionConfig{
+						Values: []string{"/*"},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "input with match is nil",
+			rule: RulePrecedence{
+				CommonRulePrecedence: CommonRulePrecedence{
+					Hostnames: []string{hostname},
+				},
+			},
+			want: []elbv2model.RuleCondition{
+				{
+					Field: elbv2model.RuleConditionFieldHostHeader,
+					HostHeaderConfig: &elbv2model.HostHeaderConditionConfig{
+						Values: []string{hostname},
+					},
+				},
+				{
+					Field: elbv2model.RuleConditionFieldPathPattern,
+					PathPatternConfig: &elbv2model.PathPatternConditionConfig{
+						Values: []string{"/*"},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := BuildGrpcRuleConditions(tt.rule)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func Test_buildGrpcHeaderCondition(t *testing.T) {
+	tests := []struct {
+		name        string
+		headerMatch []gwv1.GRPCHeaderMatch
+		want        []elbv2model.RuleCondition
+	}{
+		{
+			name: "single header match",
+			headerMatch: []gwv1.GRPCHeaderMatch{
+				{
+					Name:  gwv1.GRPCHeaderName(testKey),
+					Value: testValue,
+				},
+			},
+			want: []elbv2model.RuleCondition{
+				{
+					Field: elbv2model.RuleConditionFieldHTTPHeader,
+					HTTPHeaderConfig: &elbv2model.HTTPHeaderConditionConfig{
+						HTTPHeaderName: testKey,
+						Values:         []string{testValue},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple header match",
+			headerMatch: []gwv1.GRPCHeaderMatch{
+				{
+					Name:  gwv1.GRPCHeaderName(testKey),
+					Value: testValue,
+				},
+				{
+					Name:  gwv1.GRPCHeaderName(testKeyTwo),
+					Value: testValueTwo,
+				},
+			},
+			want: []elbv2model.RuleCondition{
+				{
+					Field: elbv2model.RuleConditionFieldHTTPHeader,
+					HTTPHeaderConfig: &elbv2model.HTTPHeaderConditionConfig{
+						HTTPHeaderName: testKey,
+						Values:         []string{testValue},
+					},
+				},
+				{
+					Field: elbv2model.RuleConditionFieldHTTPHeader,
+					HTTPHeaderConfig: &elbv2model.HTTPHeaderConditionConfig{
+						HTTPHeaderName: testKeyTwo,
+						Values:         []string{testValueTwo},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildGrpcHeaderCondition(tt.headerMatch)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_buildGrpcMethodCondition(t *testing.T) {
+
+	pathWithBoth := "/" + service + "/" + method
+	pathWithService := "/" + service + "/*"
+	pathWithMethod := "/*/" + method
+
+	regexService := "testService*"
+	regexMethod := "testMethod?"
+	regexPathWithBoth := "/" + regexService + "/" + regexMethod
+	regexPathWithService := "/" + regexService + "/*"
+	regexPathWithMethod := "/*/" + regexMethod
+
+	tests := []struct {
+		name    string
+		method  *gwv1.GRPCMethodMatch
+		want    []elbv2model.RuleCondition
+		wantErr bool
+	}{
+		{
+			name: "exact match with both service and method",
+			method: &gwv1.GRPCMethodMatch{
+				Type:    &grpcExactType,
+				Service: &service,
+				Method:  &method,
+			},
+			want: []elbv2model.RuleCondition{
+				{
+					Field: elbv2model.RuleConditionFieldPathPattern,
+					PathPatternConfig: &elbv2model.PathPatternConditionConfig{
+						Values: []string{pathWithBoth},
+					},
+				},
+			},
+		},
+		{
+			name: "exact match with only service",
+			method: &gwv1.GRPCMethodMatch{
+				Type:    &grpcExactType,
+				Service: &service,
+			},
+			want: []elbv2model.RuleCondition{
+				{
+					Field: elbv2model.RuleConditionFieldPathPattern,
+					PathPatternConfig: &elbv2model.PathPatternConditionConfig{
+						Values: []string{pathWithService},
+					},
+				},
+			},
+		},
+		{
+			name: "exact match with only method",
+			method: &gwv1.GRPCMethodMatch{
+				Type:   &grpcExactType,
+				Method: &method,
+			},
+			want: []elbv2model.RuleCondition{
+				{
+					Field: elbv2model.RuleConditionFieldPathPattern,
+					PathPatternConfig: &elbv2model.PathPatternConditionConfig{
+						Values: []string{pathWithMethod},
+					},
+				},
+			},
+		},
+		{
+			name: "regex match with both service and method",
+			method: &gwv1.GRPCMethodMatch{
+				Type:    &grpcRegexType,
+				Service: &regexService,
+				Method:  &regexMethod,
+			},
+			want: []elbv2model.RuleCondition{
+				{
+					Field: elbv2model.RuleConditionFieldPathPattern,
+					PathPatternConfig: &elbv2model.PathPatternConditionConfig{
+						Values: []string{regexPathWithBoth},
+					},
+				},
+			},
+		},
+		{
+			name: "regex match with only service",
+			method: &gwv1.GRPCMethodMatch{
+				Type:    &grpcRegexType,
+				Service: &regexService,
+			},
+			want: []elbv2model.RuleCondition{
+				{
+					Field: elbv2model.RuleConditionFieldPathPattern,
+					PathPatternConfig: &elbv2model.PathPatternConditionConfig{
+						Values: []string{regexPathWithService},
+					},
+				},
+			},
+		},
+		{
+			name: "regex match with only method",
+			method: &gwv1.GRPCMethodMatch{
+				Type:   &grpcRegexType,
+				Method: &regexMethod,
+			},
+			want: []elbv2model.RuleCondition{
+				{
+					Field: elbv2model.RuleConditionFieldPathPattern,
+					PathPatternConfig: &elbv2model.PathPatternConditionConfig{
+						Values: []string{regexPathWithMethod},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildGrpcMethodCondition(tt.method)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
 			}
 		})
 	}

--- a/pkg/gateway/routeutils/route_rule_precedence_test.go
+++ b/pkg/gateway/routeutils/route_rule_precedence_test.go
@@ -6,7 +6,113 @@ import (
 	"time"
 )
 
-func Test_comparePrecedence(t *testing.T) {
+var (
+	defaultHostname = []string{"example.com"}
+)
+
+func Test_compareHttpRulePrecedence(t *testing.T) {
+	tests := []struct {
+		name    string
+		ruleOne RulePrecedence
+		ruleTwo RulePrecedence
+		want    bool
+		reason  string
+	}{
+		{
+			name: "hostname - exact vs wildcard",
+			ruleOne: RulePrecedence{
+				CommonRulePrecedence: CommonRulePrecedence{
+					Hostnames: []string{"api.example.com"},
+				},
+			},
+			ruleTwo: RulePrecedence{
+				CommonRulePrecedence: CommonRulePrecedence{
+					Hostnames: []string{"*.example.com"},
+				},
+			},
+			want:   true,
+			reason: "exact hostname has higher precedence than wildcard",
+		},
+		{
+			name: "path type - exact vs prefix",
+			ruleOne: RulePrecedence{
+				CommonRulePrecedence: CommonRulePrecedence{
+					Hostnames: defaultHostname,
+				},
+				HttpSpecificRulePrecedenceFactor: &HttpSpecificRulePrecedenceFactor{
+					PathType: 3,
+				},
+			},
+			ruleTwo: RulePrecedence{
+				CommonRulePrecedence: CommonRulePrecedence{
+					Hostnames: defaultHostname,
+				},
+				HttpSpecificRulePrecedenceFactor: &HttpSpecificRulePrecedenceFactor{
+					PathType: 1,
+				},
+			},
+			want:   true,
+			reason: "exact path has higher precedence than prefix",
+		},
+		{
+			name: "path length precedence",
+			ruleOne: RulePrecedence{
+				CommonRulePrecedence: CommonRulePrecedence{
+					Hostnames: defaultHostname,
+				},
+				HttpSpecificRulePrecedenceFactor: &HttpSpecificRulePrecedenceFactor{
+					PathType:   1,
+					PathLength: 10,
+				},
+			},
+			ruleTwo: RulePrecedence{
+				CommonRulePrecedence: CommonRulePrecedence{
+					Hostnames: defaultHostname,
+				},
+				HttpSpecificRulePrecedenceFactor: &HttpSpecificRulePrecedenceFactor{
+					PathType:   1,
+					PathLength: 5,
+				},
+			},
+			want:   true,
+			reason: "longer path has higher precedence",
+		},
+		{
+			name: "http route method precedence",
+			ruleOne: RulePrecedence{
+				CommonRulePrecedence: CommonRulePrecedence{
+					Hostnames: defaultHostname,
+				},
+				HttpSpecificRulePrecedenceFactor: &HttpSpecificRulePrecedenceFactor{
+					PathType:   1,
+					PathLength: 5,
+					HasMethod:  true,
+				},
+			},
+			ruleTwo: RulePrecedence{
+				CommonRulePrecedence: CommonRulePrecedence{
+					Hostnames: defaultHostname,
+				},
+				HttpSpecificRulePrecedenceFactor: &HttpSpecificRulePrecedenceFactor{
+					PathType:   1,
+					PathLength: 5,
+					HasMethod:  false,
+				},
+			},
+			want:   true,
+			reason: "rule with method has higher precedence",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := compareHttpRulePrecedence(tt.ruleOne, tt.ruleTwo)
+			assert.Equal(t, tt.want, got, tt.reason)
+		})
+	}
+}
+
+func Test_compareGrpcRulePrecedence(t *testing.T) {
 	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 	earlier := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 
@@ -20,97 +126,135 @@ func Test_comparePrecedence(t *testing.T) {
 		{
 			name: "hostname - exact vs wildcard",
 			ruleOne: RulePrecedence{
-				Hostnames: []string{"api.example.com"},
+				CommonRulePrecedence: CommonRulePrecedence{
+					Hostnames: []string{"api.example.com"},
+				},
 			},
 			ruleTwo: RulePrecedence{
-				Hostnames: []string{"*.example.com"},
+				CommonRulePrecedence: CommonRulePrecedence{
+					Hostnames: []string{"*.example.com"},
+				},
 			},
 			want:   true,
 			reason: "exact hostname has higher precedence than wildcard",
 		},
 		{
-			name: "path type - exact vs prefix",
+			name: "grpc route service precedence",
 			ruleOne: RulePrecedence{
-				Hostnames: []string{"example.com"},
-				PathType:  3, // exact
+				CommonRulePrecedence: CommonRulePrecedence{
+					Hostnames: defaultHostname,
+				},
+				GrpcSpecificRulePrecedenceFactor: &GrpcSpecificRulePrecedenceFactor{
+					PathType:      1,
+					ServiceLength: 10,
+				},
 			},
 			ruleTwo: RulePrecedence{
-				Hostnames: []string{"example.com"},
-				PathType:  1, // prefix
+				CommonRulePrecedence: CommonRulePrecedence{
+					Hostnames: defaultHostname,
+				},
+				GrpcSpecificRulePrecedenceFactor: &GrpcSpecificRulePrecedenceFactor{
+					PathType:      1,
+					ServiceLength: 5,
+				},
 			},
 			want:   true,
-			reason: "exact path has higher precedence than prefix",
+			reason: "rule with longer service length has higher precedence",
 		},
 		{
-			name: "path length precedence",
+			name: "grpc header count precedence",
 			ruleOne: RulePrecedence{
-				Hostnames:  []string{"example.com"},
-				PathType:   1,
-				PathLength: 10,
+				CommonRulePrecedence: CommonRulePrecedence{
+					Hostnames: defaultHostname,
+				},
+				GrpcSpecificRulePrecedenceFactor: &GrpcSpecificRulePrecedenceFactor{
+					PathType:    1,
+					HeaderCount: 10,
+				},
 			},
 			ruleTwo: RulePrecedence{
-				Hostnames:  []string{"example.com"},
-				PathType:   1,
-				PathLength: 5,
-			},
-			want:   true,
-			reason: "longer path has higher precedence",
-		},
-		{
-			name: "method precedence",
-			ruleOne: RulePrecedence{
-				Hostnames:  []string{"example.com"},
-				PathType:   1,
-				PathLength: 5,
-				HasMethod:  true,
-			},
-			ruleTwo: RulePrecedence{
-				Hostnames:  []string{"example.com"},
-				PathType:   1,
-				PathLength: 5,
-				HasMethod:  false,
-			},
-			want:   true,
-			reason: "rule with method has higher precedence",
-		},
-		{
-			name: "header count precedence",
-			ruleOne: RulePrecedence{
-				Hostnames:   []string{"example.com"},
-				PathType:    1,
-				PathLength:  5,
-				HasMethod:   false,
-				HeaderCount: 3,
-			},
-			ruleTwo: RulePrecedence{
-				Hostnames:   []string{"example.com"},
-				PathType:    1,
-				PathLength:  5,
-				HasMethod:   false,
-				HeaderCount: 1,
+				CommonRulePrecedence: CommonRulePrecedence{
+					Hostnames: defaultHostname,
+				},
+				GrpcSpecificRulePrecedenceFactor: &GrpcSpecificRulePrecedenceFactor{
+					PathType:    1,
+					HeaderCount: 5,
+				},
 			},
 			want:   true,
 			reason: "more headers has higher precedence",
 		},
 		{
-			name: "creation timestamp precedence",
+			name: "grpc method precedence",
 			ruleOne: RulePrecedence{
-				Hostnames:            []string{"example.com"},
-				PathType:             1,
-				PathLength:           5,
-				HasMethod:            false,
-				HeaderCount:          1,
-				QueryParamCount:      0,
-				RouteCreateTimestamp: earlier,
+				CommonRulePrecedence: CommonRulePrecedence{
+					Hostnames: defaultHostname,
+				},
+				GrpcSpecificRulePrecedenceFactor: &GrpcSpecificRulePrecedenceFactor{
+					PathType:     1,
+					MethodLength: 10,
+				},
 			},
 			ruleTwo: RulePrecedence{
-				Hostnames:            []string{"example.com"},
-				PathType:             1,
-				PathLength:           5,
-				HasMethod:            false,
-				HeaderCount:          1,
-				QueryParamCount:      0,
-				RouteCreateTimestamp: now,
+				CommonRulePrecedence: CommonRulePrecedence{
+					Hostnames: defaultHostname,
+				},
+				GrpcSpecificRulePrecedenceFactor: &GrpcSpecificRulePrecedenceFactor{
+					PathType:     1,
+					MethodLength: 5,
+				},
+			},
+			want:   true,
+			reason: "rules with longer method length has higher precedence",
+		},
+		{
+			name: "grpc service precedence over method",
+			ruleOne: RulePrecedence{
+				CommonRulePrecedence: CommonRulePrecedence{
+					Hostnames: defaultHostname,
+				},
+				GrpcSpecificRulePrecedenceFactor: &GrpcSpecificRulePrecedenceFactor{
+					PathType:      1,
+					ServiceLength: 5,
+				},
+			},
+			ruleTwo: RulePrecedence{
+				CommonRulePrecedence: CommonRulePrecedence{
+					Hostnames: defaultHostname,
+				},
+				GrpcSpecificRulePrecedenceFactor: &GrpcSpecificRulePrecedenceFactor{
+					PathType:     1,
+					MethodLength: 10,
+				},
+			},
+			want:   true,
+			reason: "rules with service has higher precedence than method",
+		},
+		{
+			name: "creation timestamp precedence",
+			ruleOne: RulePrecedence{
+				CommonRulePrecedence: CommonRulePrecedence{
+					Hostnames:            defaultHostname,
+					RouteCreateTimestamp: earlier,
+				},
+				GrpcSpecificRulePrecedenceFactor: &GrpcSpecificRulePrecedenceFactor{
+					PathType:      1,
+					ServiceLength: 10,
+					MethodLength:  10,
+					HeaderCount:   10,
+				},
+			},
+			ruleTwo: RulePrecedence{
+				CommonRulePrecedence: CommonRulePrecedence{
+					Hostnames:            defaultHostname,
+					RouteCreateTimestamp: now,
+				},
+				GrpcSpecificRulePrecedenceFactor: &GrpcSpecificRulePrecedenceFactor{
+					PathType:      1,
+					ServiceLength: 10,
+					MethodLength:  10,
+					HeaderCount:   10,
+				},
 			},
 			want:   true,
 			reason: "earlier creation time has higher precedence",
@@ -118,26 +262,28 @@ func Test_comparePrecedence(t *testing.T) {
 		{
 			name: "rule index precedence",
 			ruleOne: RulePrecedence{
-				Hostnames:            []string{"example.com"},
-				PathType:             1,
-				PathLength:           5,
-				HasMethod:            false,
-				HeaderCount:          1,
-				QueryParamCount:      0,
-				RouteCreateTimestamp: now,
-				RouteNamespacedName:  "default/route-a",
-				RuleIndexInRoute:     0,
+				CommonRulePrecedence: CommonRulePrecedence{
+					Hostnames:        defaultHostname,
+					RuleIndexInRoute: 1,
+				},
+				GrpcSpecificRulePrecedenceFactor: &GrpcSpecificRulePrecedenceFactor{
+					PathType:      1,
+					ServiceLength: 10,
+					MethodLength:  10,
+					HeaderCount:   10,
+				},
 			},
 			ruleTwo: RulePrecedence{
-				Hostnames:            []string{"example.com"},
-				PathType:             1,
-				PathLength:           5,
-				HasMethod:            false,
-				HeaderCount:          1,
-				QueryParamCount:      0,
-				RouteCreateTimestamp: now,
-				RouteNamespacedName:  "default/route-a",
-				RuleIndexInRoute:     1,
+				CommonRulePrecedence: CommonRulePrecedence{
+					Hostnames:        defaultHostname,
+					RuleIndexInRoute: 3,
+				},
+				GrpcSpecificRulePrecedenceFactor: &GrpcSpecificRulePrecedenceFactor{
+					PathType:      1,
+					ServiceLength: 10,
+					MethodLength:  10,
+					HeaderCount:   10,
+				},
 			},
 			want:   true,
 			reason: "lower rule index has higher precedence",
@@ -146,7 +292,7 @@ func Test_comparePrecedence(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := comparePrecedence(tt.ruleOne, tt.ruleTwo)
+			got := compareGrpcRulePrecedence(tt.ruleOne, tt.ruleTwo)
 			assert.Equal(t, tt.want, got, tt.reason)
 		})
 	}


### PR DESCRIPTION
### Description
- implement grpcroute match 
- refactor code in rule precedence file, the big changes are 
   - grpcroute and httproute has independent compare precedence logic 
   - the sort logic will take all routes from same port but it will sort grpcroute and httproute independently, and append them together. based on current logic, rules from httproute will be appended first since they tend to be more specific, but we might plan to have it configurable by user later. This is to handle the case when both  grpcroute and httproute attached to same port, and for old logic, if will try to compare a rule from grpcroute and a rule from httproute, which does not make sense since they are different. Also, because the only time both can be attached is when hostname does not overlap, so they will never have same routing rule. we just need to keep the relative priority within each route to be correct.

- change priority of prefix and regex for easy of comparison, before it is exact > regex > prefix, now it is exact > prefix > regex (align with ingress)
- did not add e2e test yet, did manual testing and run some existing e2e test 

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
tested with 2 yaml files below
```
  rules:
    - matches:
        - method:
            # provide only method
            method: User
        - headers:
            # no method provided, will be treated as /*
            - name: test-header-4
              value: test-value-4
      backendRefs:
        - name: echoserver3
          port: 80
    - matches:
        - method:
            # provide both service and method
            service: com.example
            method: Login
          headers:
            - name: test-header-1
              value: test-value-1
            - name: test-header-2
              value: test-value-2
        - method:
            # provide only service
            service: second.com
          headers:
            - name: test-header-3
              value: test-value-3
-----------------------------------
  rules:
    - matches:
        - method:
            # provide only method
            type: RegularExpression
            method: User*
          headers:
            - name: test-header-5
              value: test-value-5
        - method:
            # provide only service
            type: RegularExpression
            service: service?
          headers:
            - name: test-header-6
              value: test-value-6
```
result:
<img width="495" height="770" alt="Screenshot 2025-07-24 at 11 04 26 AM" src="https://github.com/user-attachments/assets/5c639c81-00a0-4004-9a89-960947dc3d29" />


- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
