### PR TITLE
feat: allow targetGroupName instead of targetGroupARN in forward action ingress annotations

### DIFF
--- a/pkg/ingress/enhanced_backend_builder.go
+++ b/pkg/ingress/enhanced_backend_builder.go
@@ -208,13 +208,14 @@ func (b *defaultEnhancedBackendBuilder) buildActionViaServiceAndServicePort(_ co
 // normalizeSimplifiedSchemaForwardAction will normalize to the advanced schema for forward action to share common processing logic.
 // we support a simplified schema in action annotation when configure forward to a single TargetGroup.
 func (b *defaultEnhancedBackendBuilder) normalizeSimplifiedSchemaForwardAction(_ context.Context, action *Action) {
-	if action.Type == ActionTypeForward && action.TargetGroupARN != nil {
+	if action.Type == ActionTypeForward && (action.TargetGroupARN != nil || action.TargetGroupName != nil) {
 		*action = Action{
 			Type: ActionTypeForward,
 			ForwardConfig: &ForwardActionConfig{
 				TargetGroups: []TargetGroupTuple{
 					{
-						TargetGroupARN: action.TargetGroupARN,
+						TargetGroupARN:  action.TargetGroupARN,
+						TargetGroupName: action.TargetGroupName,
 					},
 				},
 			},

--- a/pkg/ingress/enhanced_backend_builder_test.go
+++ b/pkg/ingress/enhanced_backend_builder_test.go
@@ -1049,10 +1049,29 @@ func Test_defaultEnhancedBackendBuilder_buildActionViaAnnotation(t *testing.T) {
 			},
 		},
 		{
+			name: "forward action - simplified schema with target group name",
+			args: args{
+				ingAnnotation: map[string]string{
+					"alb.ingress.kubernetes.io/actions.forward-single-tg": `{"type":"forward","targetGroupName": "tg-name"}`,
+				},
+				svcName: "forward-single-tg",
+			},
+			want: Action{
+				Type: ActionTypeForward,
+				ForwardConfig: &ForwardActionConfig{
+					TargetGroups: []TargetGroupTuple{
+						{
+							TargetGroupName: awssdk.String("tg-name"),
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "forward action - advanced schema",
 			args: args{
 				ingAnnotation: map[string]string{
-					"alb.ingress.kubernetes.io/actions.forward-multiple-tg": `{"type":"forward","forwardConfig":{"targetGroups":[{"serviceName":"service-1","servicePort":"http","weight":20},{"serviceName":"service-2","servicePort":80,"weight":20},{"targetGroupARN":"tg-arn","weight":60}],"targetGroupStickinessConfig":{"enabled":true,"durationSeconds":200}}}`,
+					"alb.ingress.kubernetes.io/actions.forward-multiple-tg": `{"type":"forward","forwardConfig":{"targetGroups":[{"serviceName":"service-1","servicePort":"http","weight":20},{"serviceName":"service-2","servicePort":80,"weight":20},{"targetGroupARN":"tg-arn","weight":60},{"targetGroupName":"tg-name","weight":80}],"targetGroupStickinessConfig":{"enabled":true,"durationSeconds":200}}}`,
 				},
 				svcName: "forward-multiple-tg",
 			},
@@ -1073,6 +1092,10 @@ func Test_defaultEnhancedBackendBuilder_buildActionViaAnnotation(t *testing.T) {
 						{
 							TargetGroupARN: awssdk.String("tg-arn"),
 							Weight:         awssdk.Int32(60),
+						},
+						{
+							TargetGroupName: awssdk.String("tg-name"),
+							Weight:          awssdk.Int32(80),
 						},
 					},
 					TargetGroupStickinessConfig: &TargetGroupStickinessConfig{

--- a/pkg/ingress/model_build_actions.go
+++ b/pkg/ingress/model_build_actions.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"fmt"
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	elbv2sdk "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/services"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/core"
 	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
 	"strings"
@@ -105,6 +108,12 @@ func (t *defaultModelBuildTask) buildForwardAction(ctx context.Context, ing Clas
 		var tgARN core.StringToken
 		if tgt.TargetGroupARN != nil {
 			tgARN = core.LiteralStringToken(*tgt.TargetGroupARN)
+		} else if tgt.TargetGroupName != nil {
+			tgObj, err := getTargetGroupsByNameFromAWS(ctx, t.elbv2Client, tgt)
+			if err != nil {
+				return elbv2model.Action{}, fmt.Errorf("searching TargetGroup with name %s: %w", *tgt.TargetGroupName, err)
+			}
+			tgARN = core.LiteralStringToken(*tgObj.TargetGroupArn)
 		} else {
 			svcKey := types.NamespacedName{
 				Namespace: ing.Ing.Namespace,
@@ -225,4 +234,20 @@ func (t *defaultModelBuildTask) buildSSLRedirectAction(_ context.Context, sslRed
 			StatusCode: sslRedirectConfig.StatusCode,
 		},
 	}
+}
+
+// getTargetGroupsByNameFromAWS returns the AWS target group corresponding to the name
+func getTargetGroupsByNameFromAWS(ctx context.Context, elbv2Client services.ELBV2, tgt TargetGroupTuple) (*elbv2types.TargetGroup, error) {
+	req := &elbv2sdk.DescribeTargetGroupsInput{
+		Names: []string{*tgt.TargetGroupName},
+	}
+
+	tgList, err := elbv2Client.DescribeTargetGroupsAsList(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if len(tgList) != 1 {
+		return nil, errors.Errorf("expecting a single targetGroup with query [%s] but got %v", *tgt.TargetGroupName, len(tgList))
+	}
+	return &tgList[0], nil
 }


### PR DESCRIPTION
### Issue

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4280

### Description

Allow targetGroupName instead of targetGroupARN in forward action ingress annotations

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
