### PR TITLE
[feat gw-api]implement hostname uniqueness for httproute and grpcrout…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -80,7 +80,7 @@ require (
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/cli v25.0.1+incompatible // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
-	github.com/docker/docker v25.0.6+incompatible // indirect
+	github.com/docker/docker v27.1.1+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.7.0 // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect
@@ -173,7 +173,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.33.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.39.0 // indirect
-	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/oauth2 v0.27.0 // indirect
 	golang.org/x/sync v0.15.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -133,6 +133,8 @@ github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBi
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v25.0.6+incompatible h1:5cPwbwriIcsua2REJe8HqQV+6WlWc1byg2QSXzBxBGg=
 github.com/docker/docker v25.0.6+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v27.1.1+incompatible h1:hO/M4MtV36kzKldqnA37IWhebRA+LnqqcqDja6kVaKY=
+github.com/docker/docker v27.1.1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.7.0 h1:xtCHsjxogADNZcdv1pKUHXryefjlVRqWqIhk/uXJp0A=
 github.com/docker/docker-credential-helpers v0.7.0/go.mod h1:rETQfLdHNT3foU5kuNkFR1R1V12OJRRO5lzt2D1b5X0=
 github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c=
@@ -147,8 +149,6 @@ github.com/emicklei/go-restful/v3 v3.12.0 h1:y2DdzBAURM29NFF94q6RaY4vjIH1rtwDapw
 github.com/emicklei/go-restful/v3 v3.12.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/evanphx/json-patch v5.9.0+incompatible h1:fBXyNpNMuTTDdquAq/uisOr2lShz4oaXpDTX2bLe7ls=
 github.com/evanphx/json-patch v5.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
-github.com/evanphx/json-patch/v5 v5.9.0 h1:kcBlZQbplgElYIlo/n1hJbls2z/1awpXxpRi0/FOJfg=
-github.com/evanphx/json-patch/v5 v5.9.0/go.mod h1:VNkHZ/282BpEyt/tObQO8s5CMPmYYq14uClGH4abBuQ=
 github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f h1:Wl78ApPPB2Wvf/TIe2xdyJxTlb6obmF18d8QdkxNDu4=
@@ -504,8 +504,6 @@ golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.39.0 h1:SHs+kF4LP+f+p14esP5jAoDpHU8Gu/v9lFRK6IT5imM=
 golang.org/x/crypto v0.39.0/go.mod h1:L+Xg3Wf6HoL4Bn4238Z6ft6KfEpN0tJGo53AAPC632U=
-golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 h1:2dVuKD2vS7b0QIHQbpyTISPd0LeHDbnYEryqj5Q1ug8=
-golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56/go.mod h1:M4RDyNAINzryxdtnbRXRL/OHtkFuWGRjvuhBJpk2IlY=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
@@ -655,8 +653,6 @@ moul.io/http2curl/v2 v2.3.0 h1:9r3JfDzWPcbIklMOs2TnIFzDYvfAZvjeavG6EzP7jYs=
 moul.io/http2curl/v2 v2.3.0/go.mod h1:RW4hyBjTWSYDOxapodpNEtX0g5Eb16sxklBqmd2RHcE=
 oras.land/oras-go v1.2.5 h1:XpYuAwAb0DfQsunIyMfeET92emK8km3W4yEzZvUbsTo=
 oras.land/oras-go v1.2.5/go.mod h1:PuAwRShRZCsZb7g8Ar3jKKQR/2A/qN+pkYxIOd/FAoo=
-sigs.k8s.io/controller-runtime v0.19.3 h1:XO2GvC9OPftRst6xWCpTgBZO04S2cbp0Qqkj8bX1sPw=
-sigs.k8s.io/controller-runtime v0.19.3/go.mod h1:j4j87DqtsThvwTv5/Tc5NFRyyF/RF0ip4+62tbTSIUM=
 sigs.k8s.io/controller-runtime v0.21.0 h1:CYfjpEuicjUecRk+KAeyYh+ouUBn4llGyDYytIGcJS8=
 sigs.k8s.io/controller-runtime v0.21.0/go.mod h1:OSg14+F65eWqIu4DceX7k/+QRAbTTvxeQSNSOQpukWM=
 sigs.k8s.io/gateway-api v1.2.0 h1:LrToiFwtqKTKZcZtoQPTuo3FxhrrhTgzQG0Te+YGSo8=

--- a/pkg/gateway/routeutils/listener_attachment_helper.go
+++ b/pkg/gateway/routeutils/listener_attachment_helper.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -13,7 +14,7 @@ import (
 // listenerAttachmentHelper is an internal utility interface that can be used to determine if a listener will allow
 // a route to attach to it.
 type listenerAttachmentHelper interface {
-	listenerAllowsAttachment(ctx context.Context, gw gwv1.Gateway, listener gwv1.Listener, route preLoadRouteDescriptor, deferredRouteReconciler RouteReconciler) (bool, error)
+	listenerAllowsAttachment(ctx context.Context, gw gwv1.Gateway, listener gwv1.Listener, route preLoadRouteDescriptor, deferredRouteReconciler RouteReconciler, hostnamesFromHttpRoutes map[types.NamespacedName][]gwv1.Hostname, hostnamesFromGrpcRoutes map[types.NamespacedName][]gwv1.Hostname) (bool, error)
 }
 
 var _ listenerAttachmentHelper = &listenerAttachmentHelperImpl{}
@@ -33,7 +34,7 @@ func newListenerAttachmentHelper(k8sClient client.Client, logger logr.Logger) li
 
 // listenerAllowsAttachment utility method to determine if a listener will allow a route to connect using
 // Gateway API rules to determine compatibility between lister and route.
-func (attachmentHelper *listenerAttachmentHelperImpl) listenerAllowsAttachment(ctx context.Context, gw gwv1.Gateway, listener gwv1.Listener, route preLoadRouteDescriptor, deferredRouteReconciler RouteReconciler) (bool, error) {
+func (attachmentHelper *listenerAttachmentHelperImpl) listenerAllowsAttachment(ctx context.Context, gw gwv1.Gateway, listener gwv1.Listener, route preLoadRouteDescriptor, deferredRouteReconciler RouteReconciler, hostnamesFromHttpRoutes map[types.NamespacedName][]gwv1.Hostname, hostnamesFromGrpcRoutes map[types.NamespacedName][]gwv1.Hostname) (bool, error) {
 	// check namespace
 	namespaceOK, err := attachmentHelper.namespaceCheck(ctx, gw, listener, route)
 	if err != nil {
@@ -63,9 +64,20 @@ func (attachmentHelper *listenerAttachmentHelperImpl) listenerAllowsAttachment(c
 			return false, err
 		}
 		if !hostnameOK {
-			// hostname is not ok, print out gwName and gwNamespace test-gw-alb gateway-alb
 			deferredRouteReconciler.Enqueue(
 				GenerateRouteData(false, true, string(gwv1.RouteReasonNoMatchingListenerHostname), RouteStatusInfoRejectedMessageNoMatchingHostname, route.GetRouteNamespacedName(), route.GetRouteKind(), route.GetRouteGeneration(), gw),
+			)
+			return false, nil
+		}
+	}
+
+	// check cross serving hostname uniqueness
+	if route.GetRouteKind() == HTTPRouteKind || route.GetRouteKind() == GRPCRouteKind {
+		hostnameUniquenessOK, conflictRoute := attachmentHelper.crossServingHostnameUniquenessCheck(route, hostnamesFromHttpRoutes, hostnamesFromGrpcRoutes)
+		if !hostnameUniquenessOK {
+			message := fmt.Sprintf("HTTPRoute and GRPCRoute have overlap hostname, attachment is rejected. Conflict route: %s", conflictRoute)
+			deferredRouteReconciler.Enqueue(
+				GenerateRouteData(false, true, string(gwv1.RouteReasonNotAllowedByListeners), message, route.GetRouteNamespacedName(), route.GetRouteKind(), route.GetRouteGeneration(), gw),
 			)
 			return false, nil
 		}
@@ -198,4 +210,35 @@ func (attachmentHelper *listenerAttachmentHelperImpl) hostnameCheck(listener gwv
 		}
 	}
 	return false, nil
+}
+
+func (attachmentHelper *listenerAttachmentHelperImpl) crossServingHostnameUniquenessCheck(route preLoadRouteDescriptor, hostnamesFromHttpRoutes map[types.NamespacedName][]gwv1.Hostname, hostnamesFromGrpcRoutes map[types.NamespacedName][]gwv1.Hostname) (bool, string) {
+	namespacedName := route.GetRouteNamespacedName()
+	hostnames := route.GetHostnames()
+	routeKind := route.GetRouteKind()
+	var conflictMap map[types.NamespacedName][]gwv1.Hostname
+
+	switch routeKind {
+	case GRPCRouteKind:
+		hostnamesFromGrpcRoutes[namespacedName] = hostnames
+		if len(hostnamesFromHttpRoutes) > 0 {
+			conflictMap = hostnamesFromHttpRoutes
+		}
+	case HTTPRouteKind:
+		hostnamesFromHttpRoutes[namespacedName] = hostnames
+		if len(hostnamesFromGrpcRoutes) > 0 {
+			conflictMap = hostnamesFromGrpcRoutes
+		}
+	}
+
+	for _, hostname := range hostnames {
+		for conflictNamespacedName, conflictHostnames := range conflictMap {
+			for _, conflictHostname := range conflictHostnames {
+				if isHostnameCompatible(string(hostname), string(conflictHostname)) {
+					return false, conflictNamespacedName.String()
+				}
+			}
+		}
+	}
+	return true, ""
 }

--- a/pkg/gateway/routeutils/listener_attachment_helper_test.go
+++ b/pkg/gateway/routeutils/listener_attachment_helper_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 	"testing"
@@ -69,10 +70,12 @@ func Test_listenerAllowsAttachment(t *testing.T) {
 			attachmentHelper := listenerAttachmentHelperImpl{
 				logger: logr.Discard(),
 			}
+			hostnameFromHttpRoute := map[types.NamespacedName][]gwv1.Hostname{}
+			hostnameFromGrpcRoute := map[types.NamespacedName][]gwv1.Hostname{}
 			mockReconciler := NewMockRouteReconciler()
 			result, err := attachmentHelper.listenerAllowsAttachment(context.Background(), gw, gwv1.Listener{
 				Protocol: tc.listenerProtocol,
-			}, route, mockReconciler)
+			}, route, mockReconciler, hostnameFromHttpRoute, hostnameFromGrpcRoute)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expected, result)
 		})
@@ -406,6 +409,202 @@ func Test_kindCheck(t *testing.T) {
 				logger: logr.Discard(),
 			}
 			assert.Equal(t, tc.expectedResult, attachmentHelper.kindCheck(tc.listener, tc.route))
+		})
+	}
+}
+
+func Test_hostnameCheck(t *testing.T) {
+	validHostname := gwv1.Hostname("example.com")
+	invalidHostname := gwv1.Hostname("invalid..hostname")
+	invalidHostnameTwo := gwv1.Hostname("another..invalid")
+
+	tests := []struct {
+		name           string
+		listener       gwv1.Listener
+		route          preLoadRouteDescriptor
+		expectedResult bool
+		expectedError  bool
+	}{
+		{
+			name: "listener has no hostname - should pass",
+			listener: gwv1.Listener{
+				Hostname: nil,
+			},
+			route: &mockRoute{
+				hostnames: []gwv1.Hostname{"example.com"},
+			},
+			expectedResult: true,
+			expectedError:  false,
+		},
+		{
+			name: "route has no hostnames - should pass",
+			listener: gwv1.Listener{
+				Hostname: &validHostname,
+			},
+			route: &mockRoute{
+				hostnames: []gwv1.Hostname{},
+			},
+			expectedResult: true,
+			expectedError:  false,
+		},
+		{
+			name: "listener hostname invalid - should fail",
+			listener: gwv1.Listener{
+				Hostname: &invalidHostname,
+			},
+			route: &mockRoute{
+				hostnames: []gwv1.Hostname{"example.com"},
+			},
+			expectedResult: false,
+			expectedError:  true,
+		},
+		{
+			name: "compatible hostnames - should pass",
+			listener: gwv1.Listener{
+				Hostname: &validHostname,
+			},
+			route: &mockRoute{
+				hostnames: []gwv1.Hostname{"example.com"},
+			},
+			expectedResult: true,
+			expectedError:  false,
+		},
+		{
+			name: "incompatible hostnames - should fail",
+			listener: gwv1.Listener{
+				Hostname: &validHostname,
+			},
+			route: &mockRoute{
+				hostnames: []gwv1.Hostname{"example.test.com"},
+			},
+			expectedResult: false,
+			expectedError:  false,
+		},
+		{
+			name: "route has invalid hostname but valid one matches - should pass",
+			listener: gwv1.Listener{
+				Hostname: &validHostname,
+			},
+			route: &mockRoute{
+				hostnames: []gwv1.Hostname{invalidHostname, "example.com"},
+			},
+			expectedResult: true,
+			expectedError:  false,
+		},
+		{
+			name: "route has only invalid hostnames - should fail",
+			listener: gwv1.Listener{
+				Hostname: &validHostname,
+			},
+			route: &mockRoute{
+				hostnames: []gwv1.Hostname{invalidHostname, invalidHostnameTwo},
+			},
+			expectedResult: false,
+			expectedError:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			helper := &listenerAttachmentHelperImpl{
+				logger: logr.Discard(),
+			}
+
+			result, err := helper.hostnameCheck(tt.listener, tt.route)
+
+			assert.Equal(t, tt.expectedResult, result)
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_crossServingHostnameUniquenessCheck(t *testing.T) {
+	hostnames := []gwv1.Hostname{"example.com"}
+	namespace := "test-namespace"
+	httpRouteName := "http-route-name"
+	grpcRouteName := "grpc-route-name"
+	tests := []struct {
+		name                    string
+		route                   preLoadRouteDescriptor
+		hostnamesFromHttpRoutes map[types.NamespacedName][]gwv1.Hostname
+		hostnamesFromGrpcRoutes map[types.NamespacedName][]gwv1.Hostname
+		expected                bool
+	}{
+		{
+			name: "GRPC route only - should pass",
+			route: &mockRoute{
+				routeKind:      GRPCRouteKind,
+				hostnames:      hostnames,
+				namespacedName: types.NamespacedName{Name: grpcRouteName, Namespace: namespace},
+			},
+			hostnamesFromHttpRoutes: map[types.NamespacedName][]gwv1.Hostname{},
+			hostnamesFromGrpcRoutes: map[types.NamespacedName][]gwv1.Hostname{},
+			expected:                true,
+		},
+		{
+			name: "HTTP route only - should pass",
+			route: &mockRoute{
+				routeKind:      HTTPRouteKind,
+				hostnames:      hostnames,
+				namespacedName: types.NamespacedName{Name: httpRouteName, Namespace: namespace},
+			},
+			hostnamesFromHttpRoutes: map[types.NamespacedName][]gwv1.Hostname{},
+			hostnamesFromGrpcRoutes: map[types.NamespacedName][]gwv1.Hostname{},
+			expected:                true,
+		},
+		{
+			name: "GRPC route with overlapping HTTP route hostname - should fail",
+			route: &mockRoute{
+				routeKind:      GRPCRouteKind,
+				hostnames:      hostnames,
+				namespacedName: types.NamespacedName{Name: grpcRouteName, Namespace: namespace},
+			},
+			hostnamesFromHttpRoutes: map[types.NamespacedName][]gwv1.Hostname{
+				{Name: httpRouteName, Namespace: namespace}: hostnames,
+			},
+			hostnamesFromGrpcRoutes: map[types.NamespacedName][]gwv1.Hostname{},
+			expected:                false,
+		},
+		{
+			name: "HTTP route with overlapping GRPC route hostname - should fail",
+			route: &mockRoute{
+				routeKind:      HTTPRouteKind,
+				hostnames:      hostnames,
+				namespacedName: types.NamespacedName{Name: httpRouteName, Namespace: namespace},
+			},
+			hostnamesFromHttpRoutes: map[types.NamespacedName][]gwv1.Hostname{},
+			hostnamesFromGrpcRoutes: map[types.NamespacedName][]gwv1.Hostname{
+				{Name: grpcRouteName, Namespace: namespace}: hostnames,
+			},
+			expected: false,
+		},
+		{
+			name: "GRPC route with non-overlapping HTTP route hostname - should pass",
+			route: &mockRoute{
+				routeKind:      GRPCRouteKind,
+				hostnames:      []gwv1.Hostname{"grpc.example.com"},
+				namespacedName: types.NamespacedName{Name: grpcRouteName, Namespace: namespace},
+			},
+			hostnamesFromHttpRoutes: map[types.NamespacedName][]gwv1.Hostname{
+				{Name: httpRouteName, Namespace: namespace}: {"http.example.com"},
+			},
+			hostnamesFromGrpcRoutes: map[types.NamespacedName][]gwv1.Hostname{},
+			expected:                true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			helper := &listenerAttachmentHelperImpl{
+				logger: logr.Discard(),
+			}
+
+			result, _ := helper.crossServingHostnameUniquenessCheck(tt.route, tt.hostnamesFromHttpRoutes, tt.hostnamesFromGrpcRoutes)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/pkg/gateway/routeutils/loader_test.go
+++ b/pkg/gateway/routeutils/loader_test.go
@@ -29,6 +29,7 @@ type mockRoute struct {
 	namespacedName types.NamespacedName
 	routeKind      RouteKind
 	generation     int64
+	hostnames      []gwv1.Hostname
 }
 
 func (m *mockRoute) loadAttachedRules(context context.Context, k8sClient client.Client) (RouteDescriptor, []routeLoadError) {
@@ -44,8 +45,7 @@ func (m *mockRoute) GetRouteKind() RouteKind {
 }
 
 func (m *mockRoute) GetHostnames() []gwv1.Hostname {
-	//TODO implement me
-	panic("implement me")
+	return m.hostnames
 }
 
 func (m *mockRoute) GetParentRefs() []gwv1.ParentReference {

--- a/pkg/gateway/routeutils/route_listener_mapper_test.go
+++ b/pkg/gateway/routeutils/route_listener_mapper_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 	"testing"
 )
@@ -19,7 +20,7 @@ func makeListenerAttachmentMapKey(listener gwv1.Listener, route preLoadRouteDesc
 	return fmt.Sprintf("%s-%d-%s-%s", listener.Name, listener.Port, nsn.Name, nsn.Namespace)
 }
 
-func (m *mockListenerAttachmentHelper) listenerAllowsAttachment(ctx context.Context, gw gwv1.Gateway, listener gwv1.Listener, route preLoadRouteDescriptor, routeReconciler RouteReconciler) (bool, error) {
+func (m *mockListenerAttachmentHelper) listenerAllowsAttachment(ctx context.Context, gw gwv1.Gateway, listener gwv1.Listener, route preLoadRouteDescriptor, routeReconciler RouteReconciler, hostnamesFromHttpRoutes map[types.NamespacedName][]gwv1.Hostname, hostnamesFromGrpcRoutes map[types.NamespacedName][]gwv1.Hostname) (bool, error) {
 	k := makeListenerAttachmentMapKey(listener, route)
 	return m.attachmentMap[k], nil
 }

--- a/test/e2e/service/nlb_instance_target_test.go
+++ b/test/e2e/service/nlb_instance_target_test.go
@@ -14,7 +14,7 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework/utils"
 )
 
-var _ = Describe("test k8s service reconciled by the aws load balancer controller", func() {
+var _ = Describe("test k8s service using instance target reconciled by the aws load balancer controller", func() {
 	var (
 		ctx     context.Context
 		stack   NLBInstanceTestStack

--- a/test/e2e/service/nlb_ip_target_test.go
+++ b/test/e2e/service/nlb_ip_target_test.go
@@ -16,7 +16,7 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework/utils"
 )
 
-var _ = Describe("k8s service reconciled by the aws load balancer", func() {
+var _ = Describe("k8s service using ip target reconciled by the aws load balancer", func() {
 	var (
 		ctx         context.Context
 		deployment  *appsv1.Deployment


### PR DESCRIPTION
### Description
based on k8s gateway api requirement: https://gateway-api.sigs.k8s.io/api-types/grpcroute/#cross-serving
> Implementations that support GRPCRoute must enforce uniqueness of hostnames between GRPCRoutes and HTTPRoutes. If a route (A) of type HTTPRoute or GRPCRoute is attached to a Listener and that listener already has another Route (B) of the other type attached and the intersection of the hostnames of A and B is non-empty, then the implementation must reject Route A. That is, the implementation must raise an 'Accepted' condition with a status of 'False' in the corresponding RouteParentStatus.

in this PR 
1. implement hostname uniqueness check, it should update route status but won't error out the reconciliation
2. added unit tests
3. fixed some typos and updated E2E test case name so they can be run separately during dev with `-ginkgo.focus`

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
manually tested with YAML that contains both GrpcRoute and HttpRoute trying to attach to same listener. 
   - when there is no hostname overlap, both are attached and rules are created, status shows accepted
   - when there is overlap, one of them will be rejected. example status:
```
Status:                                                                                 │
│   Parents:                                                                              │
│     Conditions:                                                                         │
│       Last Transition Time:  2025-08-01T18:08:49Z                                       │
│       Message:               HTTPRoute and GRPCRoute have overlap hostname, attachment  │
│ is rejected. Conflict route: sample-gateway-alb/http-app-cross-serve                    │
│       Observed Generation:   1                                                          │
│       Reason:                NotAllowedByListeners                                      │
│       Status:                False                                                      │
│       Type:                  Accepted                                                   │
│       Last Transition Time:  2025-08-01T18:08:49Z                                       │
│       Message:                                                                          │
│       Observed Generation:   1                                                          │
│       Reason:                Accepted                                                   │
│       Status:                True                                                       │
│       Type:                  ResolvedRefs
```

- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [x] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
