### PR TITLE
feature: add load balancer name to IngressClassParams

### DIFF
--- a/apis/elbv2/v1beta1/ingressclassparams_types.go
+++ b/apis/elbv2/v1beta1/ingressclassparams_types.go
@@ -116,6 +116,10 @@ type IPAMConfiguration struct {
 
 // IngressClassParamsSpec defines the desired state of IngressClassParams
 type IngressClassParamsSpec struct {
+	// LoadBalancerName defines the name of the load balancer that will be created with this IngressClassParams.
+	// +optional
+	LoadBalancerName string `json:"loadBalancerName,omitempty"`
+
 	// CertificateArn specifies the ARN of the certificates for all Ingresses that belong to IngressClass with this IngressClassParams.
 	// +optional
 	CertificateArn []string `json:"certificateArn,omitempty"`

--- a/config/crd/bases/elbv2.k8s.aws_ingressclassparams.yaml
+++ b/config/crd/bases/elbv2.k8s.aws_ingressclassparams.yaml
@@ -148,6 +148,10 @@ spec:
                   - value
                   type: object
                 type: array
+              loadBalancerName:
+                description: LoadBalancerName defines the name of the load balancer
+                  that will be created with this IngressClassParams.
+                type: string
               minimumLoadBalancerCapacity:
                 description: MinimumLoadBalancerCapacity define the capacity reservation
                   for LoadBalancers for all Ingress that belong to IngressClass with

--- a/docs/guide/ingress/ingress_class.md
+++ b/docs/guide/ingress/ingress_class.md
@@ -76,6 +76,15 @@ You can use IngressClassParams to enforce settings for a set of Ingresses.
       - key: org
         value: my-org
     ```
+    - with loadBalancerName
+    ```
+    apiVersion: elbv2.k8s.aws/v1beta1
+    kind: IngressClassParams
+    metadata:
+      name: awesome-class
+    spec:
+      loadBalancerName: name-1
+    ```
     - with namespaceSelector
     ```
     apiVersion: elbv2.k8s.aws/v1beta1
@@ -202,6 +211,14 @@ You can use IngressClassParams to enforce settings for a set of Ingresses.
     ```
 
 ### IngressClassParams specification
+
+#### spec.loadBalancerName
+`loadBalancerName` is an optional setting.
+
+Cluster administrators can use the `loadBalancerName` field to specify name of the load balancer that will be provisioned by the controller.
+
+1. If `loadBalancerName` is set, one load balancer per `IngressClass` will be provisioned. LBC will ignore the `alb.ingress.kubernetes.io/load-balancer-name` annotation.
+2. If `loadBalancerName` is not set, Ingresses with this IngressClass can continue to use `alb.ingress.kubernetes.io/load-balancer-name annotation` to specify name of the load balancer.
 
 #### spec.namespaceSelector
 `namespaceSelector` is an optional setting that follows general Kubernetes

--- a/docs/guide/ingress/ingress_class.md
+++ b/docs/guide/ingress/ingress_class.md
@@ -182,7 +182,7 @@ You can use IngressClassParams to enforce settings for a set of Ingresses.
     metadata:
       name: class2048-config
     spec:
-      prefixListsIDs:
+      PrefixListsIDs:
         - pl-00000000
         - pl-11111111
     ```

--- a/docs/guide/ingress/ingress_class.md
+++ b/docs/guide/ingress/ingress_class.md
@@ -191,7 +191,7 @@ You can use IngressClassParams to enforce settings for a set of Ingresses.
     metadata:
       name: class2048-config
     spec:
-      PrefixListsIDs:
+      prefixListsIDs:
         - pl-00000000
         - pl-11111111
     ```

--- a/helm/aws-load-balancer-controller/crds/crds.yaml
+++ b/helm/aws-load-balancer-controller/crds/crds.yaml
@@ -147,6 +147,10 @@ spec:
                   - value
                   type: object
                 type: array
+              loadBalancerName:
+                description: LoadBalancerName defines the name of the load balancer
+                  that will be created with this IngressClassParams.
+                type: string
               minimumLoadBalancerCapacity:
                 description: MinimumLoadBalancerCapacity define the capacity reservation
                   for LoadBalancers for all Ingress that belong to IngressClass with

--- a/pkg/ingress/model_build_load_balancer.go
+++ b/pkg/ingress/model_build_load_balancer.go
@@ -99,6 +99,11 @@ var invalidLoadBalancerNamePattern = regexp.MustCompile("[[:^alnum:]]")
 func (t *defaultModelBuildTask) buildLoadBalancerName(_ context.Context, scheme elbv2model.LoadBalancerScheme) (string, error) {
 	explicitNames := sets.String{}
 	for _, member := range t.ingGroup.Members {
+		if member.IngClassConfig.IngClassParams != nil && member.IngClassConfig.IngClassParams.Spec.LoadBalancerName != "" {
+			loadBalancerName := member.IngClassConfig.IngClassParams.Spec.LoadBalancerName
+			explicitNames.Insert(loadBalancerName)
+			continue
+		}
 		rawName := ""
 		if exists := t.annotationParser.ParseStringAnnotation(annotations.IngressSuffixLoadBalancerName, &rawName, member.Ing.Annotations); !exists {
 			continue

--- a/pkg/ingress/model_build_load_balancer_test.go
+++ b/pkg/ingress/model_build_load_balancer_test.go
@@ -574,6 +574,35 @@ func Test_defaultModelBuildTask_buildLoadBalancerName(t *testing.T) {
 			want: "foo",
 		},
 		{
+			name: "name IngressClassParams",
+			fields: fields{
+				ingGroup: Group{
+					ID: GroupID{Namespace: "awesome-ns", Name: "ing-1"},
+					Members: []ClassifiedIngress{
+						{
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "awesome-ns",
+									Name:      "ing-1",
+									Annotations: map[string]string{
+										"alb.ingress.kubernetes.io/load-balancer-name": "name-2",
+									},
+								},
+							},
+							IngClassConfig: ClassConfiguration{
+								IngClassParams: &v1beta1.IngressClassParams{
+									Spec: v1beta1.IngressClassParamsSpec{
+										LoadBalancerName: "name-1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: "name-1",
+		},
+		{
 			name: "trim name annotation",
 			fields: fields{
 				ingGroup: Group{


### PR DESCRIPTION
### Issue
<!-- Please link the GitHub issues related to this PR, if available -->
Entry point to https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2311. If accepted, we will need to add `WAF arn/name` to `IngressClassParams` spec as well.
### Description
Currently, to provision load balancer with a hard coded name (that is a name which isnt generated from `group.name`), we need to use [alb.ingress.kubernetes.io/load-balancer-name](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/guide/ingress/annotations/#load-balancer-name) annotation, added to at least one ingress resource. When I create an `IngressClass`, I wish I could specify the load balancer name as part of `IngressClassParams` spec and not care about the lifecycle of the `load-balancer-name` annotation.
<!--
Please explain the changes you made here.

Help your reviewers by guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
