### PR TITLE
[feat:gw api] Add generic loader for Rules CRD

### DIFF
--- a/pkg/gateway/routeutils/backend_test.go
+++ b/pkg/gateway/routeutils/backend_test.go
@@ -9,6 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/gateway/constants"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/testutils"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwbeta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -770,6 +771,141 @@ func Test_referenceGrantCheck(t *testing.T) {
 			}
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func Test_listenerRuleConfigLoader(t *testing.T) {
+	testCases := []struct {
+		name                    string
+		listenerRuleConfigs     []elbv2gw.ListenerRuleConfiguration
+		listenerRuleConfigsRefs []gwv1.LocalObjectReference
+		routeIdentifier         types.NamespacedName
+		routeKind               RouteKind
+		expectWarning           bool
+		expectFatal             bool
+		expectedConfig          *elbv2gw.ListenerRuleConfiguration
+	}{
+		{
+			name:                    "no references - should return nil",
+			listenerRuleConfigsRefs: []gwv1.LocalObjectReference{},
+			routeIdentifier: types.NamespacedName{
+				Namespace: "test-ns",
+				Name:      "test-route",
+			},
+			routeKind:      HTTPRouteKind,
+			expectedConfig: nil,
+		},
+		{
+			name: "single valid reference - should return config",
+			listenerRuleConfigs: []elbv2gw.ListenerRuleConfiguration{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-config",
+						Namespace: "test-ns",
+					},
+				},
+			},
+			listenerRuleConfigsRefs: []gwv1.LocalObjectReference{
+				{
+					Group: constants.ControllerCRDGroupVersion,
+					Kind:  constants.ListenerRuleConfiguration,
+					Name:  "test-config",
+				},
+			},
+			routeIdentifier: types.NamespacedName{
+				Namespace: "test-ns",
+				Name:      "test-route",
+			},
+			routeKind: HTTPRouteKind,
+			expectedConfig: &elbv2gw.ListenerRuleConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-config",
+					Namespace: "test-ns",
+				},
+			},
+		},
+		{
+			name: "multiple references - should return warning error",
+			listenerRuleConfigsRefs: []gwv1.LocalObjectReference{
+				{
+					Group: constants.ControllerCRDGroupVersion,
+					Kind:  constants.ListenerRuleConfiguration,
+					Name:  "config-1",
+				},
+				{
+					Group: constants.ControllerCRDGroupVersion,
+					Kind:  constants.ListenerRuleConfiguration,
+					Name:  "config-2",
+				},
+			},
+			routeIdentifier: types.NamespacedName{
+				Namespace: "test-ns",
+				Name:      "test-route",
+			},
+			routeKind:     HTTPRouteKind,
+			expectWarning: true,
+		},
+		{
+			name: "config not found - should return warning error",
+			listenerRuleConfigsRefs: []gwv1.LocalObjectReference{
+				{
+					Group: constants.ControllerCRDGroupVersion,
+					Kind:  constants.ListenerRuleConfiguration,
+					Name:  "non-existent-config",
+				},
+			},
+			routeIdentifier: types.NamespacedName{
+				Namespace: "test-ns",
+				Name:      "test-route",
+			},
+			routeKind:     HTTPRouteKind,
+			expectWarning: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			k8sClient := testutils.GenerateTestClient()
+
+			// Create any listener rule configurations needed for the test
+			for _, config := range tc.listenerRuleConfigs {
+				err := k8sClient.Create(context.Background(), &config)
+				assert.NoError(t, err)
+			}
+
+			// Call the function under test
+			result, warningErr, fatalErr := listenerRuleConfigLoader(
+				context.Background(),
+				k8sClient,
+				tc.routeIdentifier,
+				tc.routeKind,
+				tc.listenerRuleConfigsRefs,
+			)
+
+			// Assert error expectations
+			if tc.expectWarning {
+				assert.Error(t, warningErr)
+				assert.NoError(t, fatalErr)
+			} else if tc.expectFatal {
+				assert.Error(t, fatalErr)
+				assert.NoError(t, warningErr)
+			} else {
+				assert.NoError(t, warningErr)
+				assert.NoError(t, fatalErr)
+			}
+
+			// Assert result expectations
+			if tc.expectedConfig == nil {
+				assert.Nil(t, result)
+			} else {
+				assert.NotNil(t, result)
+				// Reset resource version from the create call
+				if result != nil {
+					result.ResourceVersion = ""
+				}
+				assert.Equal(t, tc.expectedConfig, result)
+			}
 		})
 	}
 }

--- a/pkg/gateway/routeutils/descriptor.go
+++ b/pkg/gateway/routeutils/descriptor.go
@@ -18,7 +18,7 @@ type routeMetadataDescriptor interface {
 	GetParentRefs() []gwv1.ParentReference
 	GetRawRoute() interface{}
 	GetBackendRefs() []gwv1.BackendRef
-	GetListenerRuleConfigs() []gwv1.LocalObjectReference
+	GetRouteListenerRuleConfigRefs() []gwv1.LocalObjectReference
 	GetRouteGeneration() int64
 	GetRouteCreateTimestamp() time.Time
 }

--- a/pkg/gateway/routeutils/http_test.go
+++ b/pkg/gateway/routeutils/http_test.go
@@ -6,9 +6,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/gateway/constants"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/testutils"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 	"testing"
 )
@@ -26,8 +29,9 @@ func Test_ConvertHTTPRuleToRouteRule(t *testing.T) {
 	backends := []Backend{
 		{}, {},
 	}
+	listenerRuleCfg := &elbv2gw.ListenerRuleConfiguration{}
 
-	result := convertHTTPRouteRule(rule, backends)
+	result := convertHTTPRouteRule(rule, backends, listenerRuleCfg)
 
 	assert.Equal(t, backends, result.GetBackends())
 	assert.Equal(t, rule, result.GetRawRouteRule().(*gwv1.HTTPRouteRule))
@@ -133,6 +137,10 @@ func Test_HTTP_LoadAttachedRules(t *testing.T) {
 		}, nil, nil
 	}
 
+	mockListenerRuleConfigLoader := func(ctx context.Context, k8sClient client.Client, routeIdentifier types.NamespacedName, routeKind RouteKind, listenerRuleConfigRefs []gwv1.LocalObjectReference) (*elbv2gw.ListenerRuleConfiguration, error, error) {
+		return &elbv2gw.ListenerRuleConfiguration{}, nil, nil
+	}
+
 	routeDescription := httpRouteDescription{
 		route: &gwv1.HTTPRoute{
 			Spec: gwv1.HTTPRouteSpec{Rules: []gwv1.HTTPRouteRule{
@@ -141,6 +149,16 @@ func Test_HTTP_LoadAttachedRules(t *testing.T) {
 						{},
 						{},
 					},
+					Filters: []gwv1.HTTPRouteFilter{
+						{
+							Type: gwv1.HTTPRouteFilterExtensionRef,
+							ExtensionRef: &gwv1.LocalObjectReference{
+								Group: constants.ControllerCRDGroupVersion,
+								Kind:  constants.ListenerRuleConfiguration,
+								Name:  "test-config-1",
+							},
+						},
+					},
 				},
 				{
 					BackendRefs: []gwv1.HTTPBackendRef{
@@ -149,14 +167,34 @@ func Test_HTTP_LoadAttachedRules(t *testing.T) {
 						{},
 						{},
 					},
+					Filters: []gwv1.HTTPRouteFilter{
+						{
+							Type: gwv1.HTTPRouteFilterExtensionRef,
+							ExtensionRef: &gwv1.LocalObjectReference{
+								Group: constants.ControllerCRDGroupVersion,
+								Kind:  constants.ListenerRuleConfiguration,
+								Name:  "test-config-1",
+							},
+						},
+					},
 				},
 				{
 					BackendRefs: []gwv1.HTTPBackendRef{},
+					Filters: []gwv1.HTTPRouteFilter{
+						{
+							Type: gwv1.HTTPRouteFilterExtensionRef,
+							ExtensionRef: &gwv1.LocalObjectReference{
+								Group: constants.ControllerCRDGroupVersion,
+								Kind:  constants.ListenerRuleConfiguration,
+								Name:  "test-config-1",
+							},
+						},
+					},
 				},
 			}},
 		},
 		rules:           nil,
-		ruleAccumulator: newAttachedRuleAccumulator[gwv1.HTTPRouteRule](mockLoader),
+		ruleAccumulator: newAttachedRuleAccumulator[gwv1.HTTPRouteRule](mockLoader, mockListenerRuleConfigLoader),
 	}
 
 	result, errs := routeDescription.loadAttachedRules(context.Background(), nil)
@@ -167,9 +205,13 @@ func Test_HTTP_LoadAttachedRules(t *testing.T) {
 	assert.Equal(t, 2, len(convertedRules[0].GetBackends()))
 	assert.Equal(t, 4, len(convertedRules[1].GetBackends()))
 	assert.Equal(t, 0, len(convertedRules[2].GetBackends()))
+
+	assert.NotNil(t, convertedRules[0].GetListenerRuleConfig())
+	assert.NotNil(t, convertedRules[1].GetListenerRuleConfig())
+	assert.NotNil(t, convertedRules[2].GetListenerRuleConfig())
 }
 
-func Test_HTTP_GetListenerRuleConfigs(t *testing.T) {
+func Test_HTTP_GetRouteListenerRuleConfigRefs(t *testing.T) {
 	tests := []struct {
 		name     string
 		route    *gwv1.HTTPRoute
@@ -323,7 +365,7 @@ func Test_HTTP_GetListenerRuleConfigs(t *testing.T) {
 				route: tt.route,
 			}
 
-			got := httpRoute.GetListenerRuleConfigs()
+			got := httpRoute.GetRouteListenerRuleConfigRefs()
 
 			// Check if the length matches
 			assert.Equal(t, len(tt.expected), len(got), "Expected %d rule configs, got %d", len(tt.expected), len(got))

--- a/pkg/gateway/routeutils/listener_rule_config_utils.go
+++ b/pkg/gateway/routeutils/listener_rule_config_utils.go
@@ -35,7 +35,7 @@ func FilterRoutesByListenerRuleCfg(routes []preLoadRouteDescriptor, ruleConfig *
 
 // isListenerRuleConfigReferredByRoute checks if a route references a specific ruleConfig.
 func isListenerRuleConfigReferredByRoute(route preLoadRouteDescriptor, ruleConfig types.NamespacedName) bool {
-	for _, config := range route.GetListenerRuleConfigs() {
+	for _, config := range route.GetRouteListenerRuleConfigRefs() {
 		namespace := route.GetRouteNamespacedName().Namespace
 		if string(config.Name) == ruleConfig.Name && namespace == ruleConfig.Namespace {
 			return true

--- a/pkg/gateway/routeutils/loader_test.go
+++ b/pkg/gateway/routeutils/loader_test.go
@@ -57,7 +57,7 @@ func (m *mockRoute) GetBackendRefs() []gwv1.BackendRef {
 	//TODO implement me
 	panic("implement me")
 }
-func (m *mockRoute) GetListenerRuleConfigs() []gwv1.LocalObjectReference {
+func (m *mockRoute) GetRouteListenerRuleConfigRefs() []gwv1.LocalObjectReference {
 	//TODO implement me
 	panic("implement me")
 }

--- a/pkg/gateway/routeutils/mock_route.go
+++ b/pkg/gateway/routeutils/mock_route.go
@@ -2,13 +2,15 @@ package routeutils
 
 import (
 	"k8s.io/apimachinery/pkg/types"
+	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 	"time"
 )
 
 type MockRule struct {
-	RawRule     interface{}
-	BackendRefs []Backend
+	RawRule            interface{}
+	BackendRefs        []Backend
+	ListenerRuleConfig *elbv2gw.ListenerRuleConfiguration
 }
 
 func (m *MockRule) GetRawRouteRule() interface{} {
@@ -22,6 +24,10 @@ func (m *MockRule) GetSectionName() *gwv1.SectionName {
 
 func (m *MockRule) GetBackends() []Backend {
 	return m.BackendRefs
+}
+
+func (m *MockRule) GetListenerRuleConfig() *elbv2gw.ListenerRuleConfiguration {
+	return m.ListenerRuleConfig
 }
 
 var _ RouteRule = &MockRule{}
@@ -40,7 +46,7 @@ func (m *MockRoute) GetBackendRefs() []gwv1.BackendRef {
 	panic("implement me")
 }
 
-func (m *MockRoute) GetListenerRuleConfigs() []gwv1.LocalObjectReference {
+func (m *MockRoute) GetRouteListenerRuleConfigRefs() []gwv1.LocalObjectReference {
 	//TODO implement me
 	panic("implement me")
 }

--- a/pkg/gateway/routeutils/route_rule.go
+++ b/pkg/gateway/routeutils/route_rule.go
@@ -1,6 +1,7 @@
 package routeutils
 
 import (
+	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -9,4 +10,5 @@ type RouteRule interface {
 	GetRawRouteRule() interface{}
 	GetSectionName() *gwv1.SectionName
 	GetBackends() []Backend
+	GetListenerRuleConfig() *elbv2gw.ListenerRuleConfiguration
 }

--- a/pkg/gateway/routeutils/udp_test.go
+++ b/pkg/gateway/routeutils/udp_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/testutils"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -115,6 +116,9 @@ func Test_UDP_LoadAttachedRules(t *testing.T) {
 			Weight: weight,
 		}, nil, nil
 	}
+	mockListenerRuleConfigLoader := func(ctx context.Context, k8sClient client.Client, routeIdentifier types.NamespacedName, routeKind RouteKind, listenerRuleConfigRefs []gwv1.LocalObjectReference) (*elbv2gw.ListenerRuleConfiguration, error, error) {
+		return nil, nil, nil
+	}
 
 	routeDescription := udpRouteDescription{
 		route: &gwalpha2.UDPRoute{
@@ -139,7 +143,7 @@ func Test_UDP_LoadAttachedRules(t *testing.T) {
 			}},
 		},
 		rules:           nil,
-		ruleAccumulator: newAttachedRuleAccumulator[gwalpha2.UDPRouteRule](mockLoader),
+		ruleAccumulator: newAttachedRuleAccumulator[gwalpha2.UDPRouteRule](mockLoader, mockListenerRuleConfigLoader),
 	}
 
 	result, errs := routeDescription.loadAttachedRules(context.Background(), nil)
@@ -150,4 +154,8 @@ func Test_UDP_LoadAttachedRules(t *testing.T) {
 	assert.Equal(t, 2, len(convertedRules[0].GetBackends()))
 	assert.Equal(t, 4, len(convertedRules[1].GetBackends()))
 	assert.Equal(t, 0, len(convertedRules[2].GetBackends()))
+
+	assert.Nil(t, convertedRules[0].GetListenerRuleConfig())
+	assert.Nil(t, convertedRules[1].GetListenerRuleConfig())
+	assert.Nil(t, convertedRules[2].GetListenerRuleConfig())
 }

--- a/pkg/gateway/routeutils/utils_test.go
+++ b/pkg/gateway/routeutils/utils_test.go
@@ -61,7 +61,7 @@ func (m mockPreLoadRouteDescriptor) GetBackendRefs() []gwv1.BackendRef {
 	return m.backendRefs
 }
 
-func (m mockPreLoadRouteDescriptor) GetListenerRuleConfigs() []gwv1.LocalObjectReference {
+func (m mockPreLoadRouteDescriptor) GetRouteListenerRuleConfigRefs() []gwv1.LocalObjectReference {
 	return m.listenerRuleConfigurations
 }
 


### PR DESCRIPTION
### Description

Added a generic loader to load the rules CRD while loading routes. 

- __Enhanced Route Processing__: Added `listenerRuleConfigLoader` function to load `ListenerRuleConfiguration` CRDs referenced by route rules

- __ExtensionRef Support__: Implemented generic helper `getListenerRuleConfigForRuleGeneric` to extract ListenerRuleConfiguration references from route rule filters

- __Error Handling__: Added comprehensive error handling for:

  - Multiple listener rule config references (warning - only one allowed per rule)
  - Missing/not found configurations (warning with proper status updates)
  - Kubernetes API failures (fatal errors)

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
