### PR TITLE
modify PrefixListsIDs with backward compatibility

### DIFF
--- a/apis/elbv2/v1beta1/ingressclassparams_types.go
+++ b/apis/elbv2/v1beta1/ingressclassparams_types.go
@@ -115,6 +115,7 @@ type IPAMConfiguration struct {
 }
 
 // IngressClassParamsSpec defines the desired state of IngressClassParams
+// +kubebuilder:validation:XValidation:rule="!(has(self.prefixListsIDs) && has(self.PrefixListsIDs))", message="cannot specify both 'prefixListsIDs' and 'PrefixListsIDs' fields"
 type IngressClassParamsSpec struct {
 	// CertificateArn specifies the ARN of the certificates for all Ingresses that belong to IngressClass with this IngressClassParams.
 	// +optional
@@ -172,8 +173,14 @@ type IngressClassParamsSpec struct {
 	// +optional
 	IPAMConfiguration *IPAMConfiguration `json:"ipamConfiguration,omitempty"`
 
+	// PrefixListsIDsLegacy defines the security group prefix lists for all Ingresses that belong to IngressClass with this IngressClassParams.
+	// Not Recommended, Use PrefixListsIDs (prefixListsIDs in JSON) instead
+	// +optional
+	PrefixListsIDsLegacy []string `json:"PrefixListsIDs,omitempty"`
+
 	// PrefixListsIDs defines the security group prefix lists for all Ingresses that belong to IngressClass with this IngressClassParams.
-	PrefixListsIDs []string `json:"PrefixListsIDs,omitempty"`
+	// +optional
+	PrefixListsIDs []string `json:"prefixListsIDs,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/elbv2/v1beta1/zz_generated.deepcopy.go
+++ b/apis/elbv2/v1beta1/zz_generated.deepcopy.go
@@ -200,6 +200,11 @@ func (in *IngressClassParamsSpec) DeepCopyInto(out *IngressClassParamsSpec) {
 		*out = new(IPAMConfiguration)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.PrefixListsIDsLegacy != nil {
+		in, out := &in.PrefixListsIDsLegacy, &out.PrefixListsIDsLegacy
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.PrefixListsIDs != nil {
 		in, out := &in.PrefixListsIDs, &out.PrefixListsIDs
 		*out = make([]string, len(*in))

--- a/config/crd/bases/elbv2.k8s.aws_ingressclassparams.yaml
+++ b/config/crd/bases/elbv2.k8s.aws_ingressclassparams.yaml
@@ -56,8 +56,9 @@ spec:
             description: IngressClassParamsSpec defines the desired state of IngressClassParams
             properties:
               PrefixListsIDs:
-                description: PrefixListsIDs defines the security group prefix lists
-                  for all Ingresses that belong to IngressClass with this IngressClassParams.
+                description: |-
+                  PrefixListsIDsLegacy defines the security group prefix lists for all Ingresses that belong to IngressClass with this IngressClassParams.
+                  Not Recommended, Use PrefixListsIDs (prefixListsIDs in JSON) instead
                 items:
                   type: string
                 type: array
@@ -208,6 +209,12 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              prefixListsIDs:
+                description: PrefixListsIDs defines the security group prefix lists
+                  for all Ingresses that belong to IngressClass with this IngressClassParams.
+                items:
+                  type: string
+                type: array
               scheme:
                 description: Scheme defines the scheme for all Ingresses that belong
                   to IngressClass with this IngressClassParams.
@@ -269,6 +276,9 @@ spec:
                 - ip
                 type: string
             type: object
+            x-kubernetes-validations:
+            - message: cannot specify both 'prefixListsIDs' and 'PrefixListsIDs' fields
+              rule: '!(has(self.prefixListsIDs) && has(self.PrefixListsIDs))'
         type: object
     served: true
     storage: true

--- a/docs/guide/ingress/ingress_class.md
+++ b/docs/guide/ingress/ingress_class.md
@@ -175,7 +175,18 @@ You can use IngressClassParams to enforce settings for a set of Ingresses.
       ipamConfiguration: 
         ipv4IPAMPoolId: ipam-pool-000000000
     ```
-    - with PrefixListsIDs
+    - with PrefixListsIDs (not recommended, use prefixListsIDs instead)
+    ```
+    apiVersion: elbv2.k8s.aws/v1beta1
+    kind: IngressClassParams
+    metadata:
+      name: class2048-config
+    spec:
+      PrefixListsIDs:
+        - pl-00000000
+        - pl-11111111
+    ```
+    - with prefixListsIDs
     ```
     apiVersion: elbv2.k8s.aws/v1beta1
     kind: IngressClassParams
@@ -321,12 +332,24 @@ Cluster administrators can use `ipamConfiguration` field to specify the IPv4 IPA
 
 #### spec.PrefixListsIDs
 
+We accept either `spec.prefixListsIDs` or `spec.PrefixListsIDs`. Specify both is not allowed. But `spec.PrefixListsIDs` is not recommended, use `spec.prefixListsIDs` instead. 
+
 `PrefixListsIDs` is an optional setting.
 
 Cluster administrators can use `PrefixListsIDs` field to specify the managed prefix lists that are allowed to access the load balancers that belong to this IngressClass. You can specify the list of prefix list IDs in the `spec.PrefixListsIDs` field.
 
 1. If `PrefixListsIDs` is set, the prefix lists defined will be applied to the load balancer that belong to this IngressClass. If you specify invalid prefix list IDs, the controller will fail to reconcile ingresses belonging to the particular ingress class.
 2. If `PrefixListsIDs` un-specified, Ingresses with this IngressClass can continue to use `alb.ingress.kubernetes.io/security-group-prefix-lists` annotation to specify the load balancer prefix lists.
+
+
+#### spec.prefixListsIDs
+
+`prefixListsIDs` is an optional setting.
+
+Cluster administrators can use `prefixListsIDs` field to specify the managed prefix lists that are allowed to access the load balancers that belong to this IngressClass. You can specify the list of prefix list IDs in the `spec.prefixListsIDs` field.
+
+1. If `prefixListsIDs` is set, the prefix lists defined will be applied to the load balancer that belong to this IngressClass. If you specify invalid prefix list IDs, the controller will fail to reconcile ingresses belonging to the particular ingress class.
+2. If `prefixListsIDs` un-specified, Ingresses with this IngressClass can continue to use `alb.ingress.kubernetes.io/security-group-prefix-lists` annotation to specify the load balancer prefix lists.
 
 #### spec.listeners
 

--- a/helm/aws-load-balancer-controller/crds/crds.yaml
+++ b/helm/aws-load-balancer-controller/crds/crds.yaml
@@ -55,8 +55,9 @@ spec:
             description: IngressClassParamsSpec defines the desired state of IngressClassParams
             properties:
               PrefixListsIDs:
-                description: PrefixListsIDs defines the security group prefix lists
-                  for all Ingresses that belong to IngressClass with this IngressClassParams.
+                description: |-
+                  PrefixListsIDsLegacy defines the security group prefix lists for all Ingresses that belong to IngressClass with this IngressClassParams.
+                  Not Recommended, Use PrefixListsIDs (prefixListsIDs in JSON) instead
                 items:
                   type: string
                 type: array
@@ -207,6 +208,12 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              prefixListsIDs:
+                description: PrefixListsIDs defines the security group prefix lists
+                  for all Ingresses that belong to IngressClass with this IngressClassParams.
+                items:
+                  type: string
+                type: array
               scheme:
                 description: Scheme defines the scheme for all Ingresses that belong
                   to IngressClass with this IngressClassParams.
@@ -268,6 +275,9 @@ spec:
                 - ip
                 type: string
             type: object
+            x-kubernetes-validations:
+            - message: cannot specify both 'prefixListsIDs' and 'PrefixListsIDs' fields
+              rule: '!(has(self.prefixListsIDs) && has(self.PrefixListsIDs))'
         type: object
     served: true
     storage: true

--- a/pkg/ingress/model_build_listener.go
+++ b/pkg/ingress/model_build_listener.go
@@ -279,8 +279,12 @@ func (t *defaultModelBuildTask) computeIngressExplicitSSLPolicy(_ context.Contex
 }
 
 func (t *defaultModelBuildTask) computeIngressExplicitPrefixListIDs(_ context.Context, ing *ClassifiedIngress) []string {
-	if ing.IngClassConfig.IngClassParams != nil && len(ing.IngClassConfig.IngClassParams.Spec.PrefixListsIDs) != 0 {
-		return ing.IngClassConfig.IngClassParams.Spec.PrefixListsIDs
+	if ing.IngClassConfig.IngClassParams != nil {
+		if len(ing.IngClassConfig.IngClassParams.Spec.PrefixListsIDs) != 0 {
+			return ing.IngClassConfig.IngClassParams.Spec.PrefixListsIDs
+		} else if len(ing.IngClassConfig.IngClassParams.Spec.PrefixListsIDsLegacy) != 0 {
+			return ing.IngClassConfig.IngClassParams.Spec.PrefixListsIDsLegacy
+		}
 	}
 	var prefixListIDs []string
 	t.annotationParser.ParseStringSliceAnnotation(annotations.IngressSuffixSecurityGroupPrefixLists, &prefixListIDs, ing.Ing.Annotations)

--- a/pkg/ingress/model_builder_test.go
+++ b/pkg/ingress/model_builder_test.go
@@ -4141,6 +4141,132 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 }`,
 		},
 		{
+			name: "Ingress - ingress with managed prefix list in IngressClassParam - input PrefixListsIDsLegacy",
+			env: env{
+				svcs: []*corev1.Service{ns_1_svc_1, ns_1_svc_2, ns_1_svc_3},
+			},
+			fields: fields{
+				resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
+				listLoadBalancersCalls:   []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
+				enableBackendSG:          true,
+			},
+			args: args{
+				ingGroup: Group{
+					ID: GroupID{Namespace: "ns-1", Name: "ing-1"},
+					Members: []ClassifiedIngress{
+						{
+							IngClassConfig: ClassConfiguration{
+								IngClassParams: &v1beta1.IngressClassParams{
+									Spec: v1beta1.IngressClassParamsSpec{
+										PrefixListsIDsLegacy: []string{
+											"pl-11111111",
+											"pl-22222222",
+										},
+									},
+								},
+							},
+							Ing: &networking.Ingress{ObjectMeta: metav1.ObjectMeta{
+								Namespace: "ns-1",
+								Name:      "ing-1",
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/security-group-prefix-lists": "pl-00000000",
+								},
+							},
+								Spec: networking.IngressSpec{
+									Rules: []networking.IngressRule{
+										{
+											Host: "app-1.example.com",
+											IngressRuleValue: networking.IngressRuleValue{
+												HTTP: &networking.HTTPIngressRuleValue{
+													Paths: []networking.HTTPIngressPath{
+														{
+															Path: "/svc-1",
+															Backend: networking.IngressBackend{
+																Service: &networking.IngressServiceBackend{
+																	Name: ns_1_svc_1.Name,
+																	Port: networking.ServiceBackendPort{
+																		Name: "http",
+																	},
+																},
+															},
+														},
+														{
+															Path: "/svc-2",
+															Backend: networking.IngressBackend{
+																Service: &networking.IngressServiceBackend{
+																	Name: ns_1_svc_2.Name,
+																	Port: networking.ServiceBackendPort{
+																		Name: "http",
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+										{
+											Host: "app-2.example.com",
+											IngressRuleValue: networking.IngressRuleValue{
+												HTTP: &networking.HTTPIngressRuleValue{
+													Paths: []networking.HTTPIngressPath{
+														{
+															Path: "/svc-3",
+															Backend: networking.IngressBackend{
+																Service: &networking.IngressServiceBackend{
+																	Name: ns_1_svc_3.Name,
+																	Port: networking.ServiceBackendPort{
+																		Name: "https",
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantStackPatch: `
+{
+	"resources": {
+		"AWS::EC2::SecurityGroup": {
+			"ManagedLBSecurityGroup": {
+				"spec": {
+					"ingress": [
+						{
+							"fromPort": 80,
+							"ipProtocol": "tcp",
+							"prefixLists": [
+								{
+									"listID": "pl-11111111"
+								}
+							],
+							"toPort": 80
+						},
+						{
+							"fromPort": 80,
+							"ipProtocol": "tcp",
+							"prefixLists": [
+								{
+									"listID": "pl-22222222"
+								}
+							],
+							"toPort": 80
+						}
+					]
+				}
+			}
+		}
+	}
+}`,
+		},
+		{
 			name: "Ingress - ingress with managed prefix list",
 			env: env{
 				svcs: []*corev1.Service{ns_1_svc_1, ns_1_svc_2, ns_1_svc_3},


### PR DESCRIPTION
### Description
- support both `PrefixListsIDs` and `prefixListsIDs` in json for ingressclassparams
- added kubebuilder validation, only one of them can be specified
- updated doc instruction

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested, yaml file
```
# Ingress Class Param
apiVersion: elbv2.k8s.aws/v1beta1
kind: IngressClassParams
metadata:
  name: test-alb-class-params
spec:
  scheme: internet-facing
  PrefixListsIDs: []
  prefixListsIDs: []
```

gives 
```
The IngressClassParams "test-alb-class-params" is invalid: spec: Invalid value: "object": cannot specify both 'prefixListsIDs' and 'PrefixListsIDs' fields
```
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
