### PR TITLE
feat(nlb): add eip auto selection support for nlb

### DIFF
--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -174,6 +174,21 @@ on the load balancer.
         service.beta.kubernetes.io/aws-load-balancer-eip-allocations: eipalloc-xyz, eipalloc-zzz
         ```
 
+- <a name="eip-tags">`service.beta.kubernetes.io/aws-load-balancer-eip-tags`</a> specifies a set of AWS tags to dynamically select unassociated Elastic IPs for an internet-facing NLB.
+
+    !!!note
+        - This configuration is optional, and you can use it to assign static IP addresses to your NLB by tag selection.
+        - You must specify tags in the format `key1=value1,key2=value2`.
+        - The controller will select unassociated EIPs matching all tags and assign them to the NLB subnets.
+        - NLB must be internet-facing.
+        - You must tag your EIPs in AWS before using this annotation.
+        - The number of matching, unassociated EIPs must be at least the number of subnets.
+
+    !!!example
+        ```
+        service.beta.kubernetes.io/aws-load-balancer-eip-tags: k8s-cluster=my-prod-cluster,purpose=ingress-nlb
+        ```
+
 
 - <a name="private-ipv4-addresses">`service.beta.kubernetes.io/aws-load-balancer-private-ipv4-addresses`</a> specifies a list of private IPv4 addresses for an internal NLB.
 

--- a/pkg/annotations/constants.go
+++ b/pkg/annotations/constants.go
@@ -105,6 +105,7 @@ const (
 	SvcLBSuffixTargetGroupAttributes                     = "aws-load-balancer-target-group-attributes"
 	SvcLBSuffixSubnets                                   = "aws-load-balancer-subnets"
 	SvcLBSuffixEIPAllocations                            = "aws-load-balancer-eip-allocations"
+	SvcLBSuffixEIPTags                                   = "aws-load-balancer-eip-tags"
 	SvcLBSuffixPrivateIpv4Addresses                      = "aws-load-balancer-private-ipv4-addresses"
 	SvcLBSuffixIpv6Addresses                             = "aws-load-balancer-ipv6-addresses"
 	SvcLBSuffixALPNPolicy                                = "aws-load-balancer-alpn-policy"

--- a/pkg/aws/services/ec2.go
+++ b/pkg/aws/services/ec2.go
@@ -37,6 +37,9 @@ type EC2 interface {
 	DescribeAvailabilityZonesWithContext(ctx context.Context, input *ec2.DescribeAvailabilityZonesInput) (*ec2.DescribeAvailabilityZonesOutput, error)
 	DescribeVpcsWithContext(ctx context.Context, input *ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error)
 	DescribeInstancesWithContext(ctx context.Context, input *ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error)
+
+	// DescribeAddressesAsList wraps the DescribeAddresses API, aggregates results into a list.
+	DescribeAddressesAsList(ctx context.Context, input *ec2.DescribeAddressesInput) ([]types.Address, error)
 }
 
 // NewEC2 constructs new EC2 implementation.
@@ -48,6 +51,18 @@ func NewEC2(awsClientsProvider provider.AWSClientsProvider) EC2 {
 
 type ec2Client struct {
 	awsClientsProvider provider.AWSClientsProvider
+}
+
+func (c *ec2Client) DescribeAddressesAsList(ctx context.Context, input *ec2.DescribeAddressesInput) ([]types.Address, error) {
+	client, err := c.awsClientsProvider.GetEC2Client(ctx, "DescribeAddresses")
+	if err != nil {
+		return nil, err
+	}
+	output, err := client.DescribeAddresses(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	return output.Addresses, nil
 }
 
 func (c *ec2Client) DescribeInstancesWithContext(ctx context.Context, input *ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {

--- a/pkg/service/model_build_load_balancer.go
+++ b/pkg/service/model_build_load_balancer.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 	"strconv"
 
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/pkg/errors"
@@ -335,6 +337,8 @@ func (t *defaultModelBuildTask) buildLoadBalancerTags(ctx context.Context) (map[
 func (t *defaultModelBuildTask) buildLoadBalancerSubnetMappings(_ context.Context, ipAddressType elbv2model.IPAddressType, scheme elbv2model.LoadBalancerScheme, ec2Subnets []ec2types.Subnet, enablePrefixForIpv6SourceNat elbv2model.EnablePrefixForIpv6SourceNat) ([]elbv2model.SubnetMapping, error) {
 	var eipAllocation []string
 	eipConfigured := t.annotationParser.ParseStringSliceAnnotation(annotations.SvcLBSuffixEIPAllocations, &eipAllocation, t.service.Annotations)
+	var eipTags string
+	eipTagsConfigured := t.annotationParser.ParseStringAnnotation(annotations.SvcLBSuffixEIPTags, &eipTags, t.service.Annotations)
 	if eipConfigured {
 		if scheme != elbv2model.LoadBalancerSchemeInternetFacing {
 			return nil, errors.Errorf("EIP allocations can only be set for internet facing load balancers")
@@ -342,6 +346,48 @@ func (t *defaultModelBuildTask) buildLoadBalancerSubnetMappings(_ context.Contex
 		if len(eipAllocation) != len(ec2Subnets) {
 			return nil, errors.Errorf("count of EIP allocations (%d) and subnets (%d) must match", len(eipAllocation), len(ec2Subnets))
 		}
+	} else if eipTagsConfigured {
+		if scheme != elbv2model.LoadBalancerSchemeInternetFacing {
+			return nil, errors.Errorf("EIP tags can only be set for internet facing load balancers")
+		}
+		// Parse tags string into map
+		tagMap := make(map[string]string)
+		for _, kv := range regexp.MustCompile(`,`).Split(eipTags, -1) {
+			parts := regexp.MustCompile(`=`).Split(kv, 2)
+			if len(parts) == 2 {
+				tagMap[parts[0]] = parts[1]
+			}
+		}
+		// Build EC2 filter for DescribeAddresses
+		var filters []ec2types.Filter
+		for k, v := range tagMap {
+			filters = append(filters, ec2types.Filter{
+				Name:   awssdk.String(fmt.Sprintf("tag:%s", k)),
+				Values: []string{v},
+			})
+		}
+		filters = append(filters, ec2types.Filter{
+			Name:   awssdk.String("domain"),
+			Values: []string{"vpc"},
+		})
+		filters = append(filters, ec2types.Filter{
+			Name:   awssdk.String("association-id"),
+			Values: []string{""}, // Only unassociated
+		})
+		addresses, err := t.ec2Client.DescribeAddressesAsList(context.Background(), &ec2.DescribeAddressesInput{
+			Filters: filters,
+		})
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to describe EIPs by tags")
+		}
+		if len(addresses) < len(ec2Subnets) {
+			return nil, errors.Errorf("not enough unassociated EIPs with specified tags; needed %d, found %d", len(ec2Subnets), len(addresses))
+		}
+		eipAllocation = make([]string, len(ec2Subnets))
+		for i := range ec2Subnets {
+			eipAllocation[i] = awssdk.ToString(addresses[i].AllocationId)
+		}
+		eipConfigured = true
 	}
 
 	var ipv4Addresses []netip.Addr


### PR DESCRIPTION
### Issue

This pull request introduces a new annotation, `service.beta.kubernetes.io/aws-load-balancer-eip-tags`, allowing users to dynamically assign Elastic IPs (EIPs) to an internet-facing Network Load Balancer (NLB) based on their AWS tags.

We don't want to hardcode certain IP allocations, and unfortunately the NLB does not support selecting IPs directly from an IPAMPool.

### Description

This change adds a new annotation, `service.beta.kubernetes.io/aws-load-balancer-eip-tags`, that enables selecting unassociated EIPs for an internet-facing NLB by their tags instead of their specific allocation IDs. This simplifies the process for users who manage many EIPs, as they no longer need to manually find and specify individual allocation IDs.

The annotation's value is a comma-separated list of `key=value` pairs, which the controller uses to filter available EIPs. It finds all unassociated EIPs that match all specified tags. The controller then assigns these EIPs to the NLB, ensuring there are enough matching EIPs for the number of subnets the NLB is deployed in. This new annotation provides a more flexible way to manage and assign static IPs to NLBs.

This functionality complements the existing `service.beta.kubernetes.io/aws-load-balancer-eip-allocations` annotation, offering an alternative for EIP management.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [X] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [X] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
