### PR TITLE
[feat gw-api]support multiple header value in condition

### DIFF
--- a/pkg/gateway/routeutils/route_rule_condition_test.go
+++ b/pkg/gateway/routeutils/route_rule_condition_test.go
@@ -1,6 +1,7 @@
 package routeutils
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -692,6 +693,74 @@ func Test_buildGrpcMethodCondition(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestGenerateValuesFromMatchHeaderValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "simple comma separation",
+			input:    "a,b,c",
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			name:     "escaped comma",
+			input:    "a\\,b,c",
+			expected: []string{"a,b", "c"},
+		},
+		{
+			name:     "escaped backslash",
+			input:    "a\\\\,b",
+			expected: []string{"a\\", "b"},
+		},
+		{
+			name:     "multiple escaped commas",
+			input:    "a\\,b\\,c",
+			expected: []string{"a,b,c"},
+		},
+		{
+			name:     "mixed escapes",
+			input:    "a\\\\,b\\,c,d",
+			expected: []string{"a\\", "b,c", "d"},
+		},
+		{
+			name:     "no commas",
+			input:    "single-value",
+			expected: []string{"single-value"},
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: []string{""},
+		},
+		{
+			name:     "only commas",
+			input:    ",,",
+			expected: []string{"", "", ""},
+		},
+		{
+			name:     "escaped other characters",
+			input:    "a\\n,b\\t",
+			expected: []string{"an", "bt"},
+		},
+		{
+			name:     "backslash at end",
+			input:    "a\\",
+			expected: []string{"a\\"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := generateValuesFromMatchHeaderValue(tt.input)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("got %v, want %v", result, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
### Description
route match headers does not allow multiple http header values for same header name, but ALB supports it. we now allow customer to parsing string with comma so we can separate values by comma. customer can also choose to escape it if needs to be literal. 

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
```
      matches:
        - headers:
            - name: "version"
              type: Exact
              value: "bar\\,bat"
            - name: "headerOne"
              type: Exact
              value: "value1,value2"
```
gives 
<img width="581" height="178" alt="Screenshot 2025-08-26 at 1 52 12 PM" src="https://github.com/user-attachments/assets/02a58294-df0c-400f-82d1-3935cea78f29" />

- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
