### PR TITLE
Support frontend-nlb-tags

### DIFF
--- a/pkg/annotations/constants.go
+++ b/pkg/annotations/constants.go
@@ -73,6 +73,7 @@ const (
 	IngressSuffixFrontendNlbHealthCheckHealthyThresholdCount   = "frontend-nlb-healthcheck-healthy-threshold-count"
 	IngressSuffixFrontendNlHealthCheckbUnhealthyThresholdCount = "frontend-nlb-healthcheck-unhealthy-threshold-count"
 	IngressSuffixFrontendNlbHealthCheckSuccessCodes            = "frontend-nlb-healthcheck-success-codes"
+	IngressSuffixFrontendNlbTags                               = "frontend-nlb-tags"
 
 	// NLB annotation suffixes
 	// prefixes service.beta.kubernetes.io, service.kubernetes.io

--- a/pkg/ingress/model_build_frontend_nlb_test.go
+++ b/pkg/ingress/model_build_frontend_nlb_test.go
@@ -2,6 +2,8 @@ package ingress
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
@@ -13,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/services"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/core"
@@ -793,6 +796,1131 @@ func Test_mergeFrontendNlbListenPortConfigs(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.expectedConfig, got)
+			}
+		})
+	}
+}
+
+func Test_defaultModelBuildTask_buildFrontendNlbTagsViaAnnotation(t *testing.T) {
+	tests := []struct {
+		name        string
+		ingGroup    Group
+		wantTags    map[string]string
+		wantErr     bool
+		expectedErr string
+	}{
+		{
+			name: "valid tag format parsing - single ingress",
+			ingGroup: Group{
+				ID: GroupID{
+					Namespace: "awesome-ns",
+					Name:      "my-ingress",
+				},
+				Members: []ClassifiedIngress{
+					{
+						Ing: &networking.Ingress{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "awesome-ns",
+								Name:      "ing-1",
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment=production,Team=backend,Cost-Center=engineering",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantTags: map[string]string{
+				"Environment": "production",
+				"Team":        "backend",
+				"Cost-Center": "engineering",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid tag format parsing - multiple ingresses with same tags",
+			ingGroup: Group{
+				ID: GroupID{
+					Namespace: "awesome-ns",
+					Name:      "my-ingress",
+				},
+				Members: []ClassifiedIngress{
+					{
+						Ing: &networking.Ingress{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "awesome-ns",
+								Name:      "ing-1",
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment=production,Team=backend",
+								},
+							},
+						},
+					},
+					{
+						Ing: &networking.Ingress{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "awesome-ns",
+								Name:      "ing-2",
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment=production,Cost-Center=engineering",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantTags: map[string]string{
+				"Environment": "production",
+				"Team":        "backend",
+				"Cost-Center": "engineering",
+			},
+			wantErr: false,
+		},
+		{
+			name: "conflicting tags across multiple ingresses",
+			ingGroup: Group{
+				ID: GroupID{
+					Namespace: "awesome-ns",
+					Name:      "my-ingress",
+				},
+				Members: []ClassifiedIngress{
+					{
+						Ing: &networking.Ingress{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "awesome-ns",
+								Name:      "ing-1",
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment=production,Team=backend",
+								},
+							},
+						},
+					},
+					{
+						Ing: &networking.Ingress{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "awesome-ns",
+								Name:      "ing-2",
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment=staging,Team=backend",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantTags:    nil,
+			wantErr:     true,
+			expectedErr: "conflicting frontend NLB tag Environment: production | staging",
+		},
+		{
+			name: "empty annotation",
+			ingGroup: Group{
+				ID: GroupID{
+					Namespace: "awesome-ns",
+					Name:      "my-ingress",
+				},
+				Members: []ClassifiedIngress{
+					{
+						Ing: &networking.Ingress{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "awesome-ns",
+								Name:      "ing-1",
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/frontend-nlb-tags": "",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantTags: map[string]string{},
+			wantErr:  false,
+		},
+		{
+			name: "missing annotation",
+			ingGroup: Group{
+				ID: GroupID{
+					Namespace: "awesome-ns",
+					Name:      "my-ingress",
+				},
+				Members: []ClassifiedIngress{
+					{
+						Ing: &networking.Ingress{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace:   "awesome-ns",
+								Name:        "ing-1",
+								Annotations: map[string]string{},
+							},
+						},
+					},
+				},
+			},
+			wantTags: nil,
+			wantErr:  false,
+		},
+		{
+			name: "special characters in keys and values",
+			ingGroup: Group{
+				ID: GroupID{
+					Namespace: "awesome-ns",
+					Name:      "my-ingress",
+				},
+				Members: []ClassifiedIngress{
+					{
+						Ing: &networking.Ingress{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "awesome-ns",
+								Name:      "ing-1",
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/frontend-nlb-tags": "app.kubernetes.io/name=my-app,app.kubernetes.io/version=1.0.0,special-chars=value_with-special.chars",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantTags: map[string]string{
+				"app.kubernetes.io/name":    "my-app",
+				"app.kubernetes.io/version": "1.0.0",
+				"special-chars":             "value_with-special.chars",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid format - missing equals",
+			ingGroup: Group{
+				ID: GroupID{
+					Namespace: "awesome-ns",
+					Name:      "my-ingress",
+				},
+				Members: []ClassifiedIngress{
+					{
+						Ing: &networking.Ingress{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "awesome-ns",
+								Name:      "ing-1",
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment,Team=backend",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantTags:    nil,
+			wantErr:     true,
+			expectedErr: "failed to parse frontend NLB tags annotation",
+		},
+		{
+			name: "mixed scenarios - some ingresses with tags, some without",
+			ingGroup: Group{
+				ID: GroupID{
+					Namespace: "awesome-ns",
+					Name:      "my-ingress",
+				},
+				Members: []ClassifiedIngress{
+					{
+						Ing: &networking.Ingress{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "awesome-ns",
+								Name:      "ing-1",
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment=production",
+								},
+							},
+						},
+					},
+					{
+						Ing: &networking.Ingress{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace:   "awesome-ns",
+								Name:        "ing-2",
+								Annotations: map[string]string{},
+							},
+						},
+					},
+					{
+						Ing: &networking.Ingress{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "awesome-ns",
+								Name:      "ing-3",
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/frontend-nlb-tags": "Team=backend",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantTags: map[string]string{
+				"Environment": "production",
+				"Team":        "backend",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := &defaultModelBuildTask{
+				ingGroup:         tt.ingGroup,
+				annotationParser: annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io"),
+			}
+
+			got, err := task.buildFrontendNlbTagsViaAnnotation(context.Background())
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.expectedErr != "" {
+					assert.Contains(t, err.Error(), tt.expectedErr)
+				}
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantTags, got)
+			}
+		})
+	}
+}
+
+func Test_defaultModelBuildTask_validateFrontendNlbTags(t *testing.T) {
+	tests := []struct {
+		name        string
+		tags        map[string]string
+		wantErr     bool
+		expectedErr string
+	}{
+		{
+			name: "valid tags",
+			tags: map[string]string{
+				"Environment": "production",
+				"Team":        "backend",
+				"Cost-Center": "engineering",
+			},
+			wantErr: false,
+		},
+		{
+			name: "tag key exceeds character limit",
+			tags: map[string]string{
+				strings.Repeat("a", 129): "value", // 129 characters, exceeds 128 limit
+			},
+			wantErr:     true,
+			expectedErr: "exceeds maximum length of 128 characters",
+		},
+		{
+			name: "tag value exceeds character limit",
+			tags: map[string]string{
+				"key": strings.Repeat("a", 257), // 257 characters, exceeds 256 limit
+			},
+			wantErr:     true,
+			expectedErr: "exceeds maximum length of 256 characters",
+		},
+		{
+			name: "too many tags",
+			tags: func() map[string]string {
+				tags := make(map[string]string)
+				for i := 0; i < 51; i++ { // 51 tags, exceeds 50 limit
+					tags[fmt.Sprintf("key%d", i)] = fmt.Sprintf("value%d", i)
+				}
+				return tags
+			}(),
+			wantErr:     true,
+			expectedErr: "too many tags: 51 (maximum 50 allowed)",
+		},
+		{
+			name: "AWS reserved tag key - lowercase",
+			tags: map[string]string{
+				"aws:cloudformation:stack-name": "my-stack",
+			},
+			wantErr:     true,
+			expectedErr: "is reserved by AWS and cannot be used",
+		},
+		{
+			name: "AWS reserved tag key - uppercase",
+			tags: map[string]string{
+				"AWS:CloudFormation:StackName": "my-stack",
+			},
+			wantErr:     true,
+			expectedErr: "is reserved by AWS and cannot be used",
+		},
+		{
+			name: "empty tag key",
+			tags: map[string]string{
+				"": "value",
+			},
+			wantErr:     true,
+			expectedErr: "tag key cannot be empty",
+		},
+		{
+			name: "valid edge case - exactly at limits",
+			tags: map[string]string{
+				strings.Repeat("a", 128): strings.Repeat("b", 256), // exactly at limits
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := &defaultModelBuildTask{}
+
+			err := task.validateFrontendNlbTags(tt.tags)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.expectedErr != "" {
+					assert.Contains(t, err.Error(), tt.expectedErr)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_defaultModelBuildTask_buildFrontendNlbTags(t *testing.T) {
+	tests := []struct {
+		name                string
+		ingGroup            Group
+		externalManagedTags []string
+		wantTags            map[string]string
+		wantErr             bool
+		expectedErr         string
+	}{
+		{
+			name: "valid tags with validation passing",
+			ingGroup: Group{
+				ID: GroupID{
+					Namespace: "awesome-ns",
+					Name:      "my-ingress",
+				},
+				Members: []ClassifiedIngress{
+					{
+						Ing: &networking.Ingress{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "awesome-ns",
+								Name:      "ing-1",
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment=production,Team=backend",
+								},
+							},
+						},
+					},
+				},
+			},
+			externalManagedTags: []string{},
+			wantTags: map[string]string{
+				"Environment": "production",
+				"Team":        "backend",
+			},
+			wantErr: false,
+		},
+		{
+			name: "no tags annotation returns empty map",
+			ingGroup: Group{
+				ID: GroupID{
+					Namespace: "awesome-ns",
+					Name:      "my-ingress",
+				},
+				Members: []ClassifiedIngress{
+					{
+						Ing: &networking.Ingress{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace:   "awesome-ns",
+								Name:        "ing-1",
+								Annotations: map[string]string{},
+							},
+						},
+					},
+				},
+			},
+			externalManagedTags: []string{},
+			wantTags:            map[string]string{},
+			wantErr:             false,
+		},
+		{
+			name: "validation fails for AWS reserved key",
+			ingGroup: Group{
+				ID: GroupID{
+					Namespace: "awesome-ns",
+					Name:      "my-ingress",
+				},
+				Members: []ClassifiedIngress{
+					{
+						Ing: &networking.Ingress{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "awesome-ns",
+								Name:      "ing-1",
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/frontend-nlb-tags": "aws:cloudformation:stack-name=my-stack",
+								},
+							},
+						},
+					},
+				},
+			},
+			externalManagedTags: []string{},
+			wantTags:            nil,
+			wantErr:             true,
+			expectedErr:         "is reserved by AWS and cannot be used",
+		},
+		{
+			name: "parsing fails for invalid format",
+			ingGroup: Group{
+				ID: GroupID{
+					Namespace: "awesome-ns",
+					Name:      "my-ingress",
+				},
+				Members: []ClassifiedIngress{
+					{
+						Ing: &networking.Ingress{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "awesome-ns",
+								Name:      "ing-1",
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/frontend-nlb-tags": "invalid-format-no-equals",
+								},
+							},
+						},
+					},
+				},
+			},
+			externalManagedTags: []string{},
+			wantTags:            nil,
+			wantErr:             true,
+			expectedErr:         "failed to parse frontend NLB tags annotation",
+		},
+		{
+			name: "external managed tag conflict validation",
+			ingGroup: Group{
+				ID: GroupID{
+					Namespace: "awesome-ns",
+					Name:      "my-ingress",
+				},
+				Members: []ClassifiedIngress{
+					{
+						Ing: &networking.Ingress{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "awesome-ns",
+								Name:      "ing-1",
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment=production,ManagedTag=conflict",
+								},
+							},
+						},
+					},
+				},
+			},
+			externalManagedTags: []string{"ManagedTag", "AnotherManagedTag"},
+			wantTags:            nil,
+			wantErr:             true,
+			expectedErr:         "external managed tag key ManagedTag cannot be specified",
+		},
+		{
+			name: "validation passes with non-conflicting external managed tags",
+			ingGroup: Group{
+				ID: GroupID{
+					Namespace: "awesome-ns",
+					Name:      "my-ingress",
+				},
+				Members: []ClassifiedIngress{
+					{
+						Ing: &networking.Ingress{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "awesome-ns",
+								Name:      "ing-1",
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment=production,Team=backend",
+								},
+							},
+						},
+					},
+				},
+			},
+			externalManagedTags: []string{"ManagedTag", "AnotherManagedTag"},
+			wantTags: map[string]string{
+				"Environment": "production",
+				"Team":        "backend",
+			},
+			wantErr: false,
+		},
+		{
+			name: "validation fails for tag count limit",
+			ingGroup: Group{
+				ID: GroupID{
+					Namespace: "awesome-ns",
+					Name:      "my-ingress",
+				},
+				Members: []ClassifiedIngress{
+					{
+						Ing: &networking.Ingress{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "awesome-ns",
+								Name:      "ing-1",
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/frontend-nlb-tags": func() string {
+										var tags []string
+										for i := 0; i < 51; i++ { // 51 tags, exceeds 50 limit
+											tags = append(tags, fmt.Sprintf("key%d=value%d", i, i))
+										}
+										return strings.Join(tags, ",")
+									}(),
+								},
+							},
+						},
+					},
+				},
+			},
+			externalManagedTags: []string{},
+			wantTags:            nil,
+			wantErr:             true,
+			expectedErr:         "too many tags: 51 (maximum 50 allowed)",
+		},
+		{
+			name: "validation fails for key length limit",
+			ingGroup: Group{
+				ID: GroupID{
+					Namespace: "awesome-ns",
+					Name:      "my-ingress",
+				},
+				Members: []ClassifiedIngress{
+					{
+						Ing: &networking.Ingress{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "awesome-ns",
+								Name:      "ing-1",
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/frontend-nlb-tags": strings.Repeat("a", 129) + "=value", // 129 characters, exceeds 128 limit
+								},
+							},
+						},
+					},
+				},
+			},
+			externalManagedTags: []string{},
+			wantTags:            nil,
+			wantErr:             true,
+			expectedErr:         "exceeds maximum length of 128 characters",
+		},
+		{
+			name: "validation fails for value length limit",
+			ingGroup: Group{
+				ID: GroupID{
+					Namespace: "awesome-ns",
+					Name:      "my-ingress",
+				},
+				Members: []ClassifiedIngress{
+					{
+						Ing: &networking.Ingress{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "awesome-ns",
+								Name:      "ing-1",
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/frontend-nlb-tags": "key=" + strings.Repeat("a", 257), // 257 characters, exceeds 256 limit
+								},
+							},
+						},
+					},
+				},
+			},
+			externalManagedTags: []string{},
+			wantTags:            nil,
+			wantErr:             true,
+			expectedErr:         "exceeds maximum length of 256 characters",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			// Create external managed tags set
+			externalManagedTags := sets.NewString(tt.externalManagedTags...)
+
+			task := &defaultModelBuildTask{
+				ingGroup:            tt.ingGroup,
+				annotationParser:    annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io"),
+				externalManagedTags: externalManagedTags,
+			}
+
+			got, err := task.buildFrontendNlbTags(context.Background())
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.expectedErr != "" {
+					assert.Contains(t, err.Error(), tt.expectedErr)
+				}
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantTags, got)
+			}
+		})
+	}
+}
+
+func Test_defaultModelBuildTask_buildFrontendNlbSpec(t *testing.T) {
+	tests := []struct {
+		name                string
+		ingGroup            Group
+		scheme              elbv2model.LoadBalancerScheme
+		alb                 *elbv2model.LoadBalancer
+		externalManagedTags []string
+		wantTags            map[string]string
+		wantErr             bool
+		expectedErr         string
+	}{
+		{
+			name: "tags integration with NLB spec creation",
+			ingGroup: Group{
+				ID: GroupID{
+					Namespace: "awesome-ns",
+					Name:      "my-ingress",
+				},
+				Members: []ClassifiedIngress{
+					{
+						Ing: &networking.Ingress{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "awesome-ns",
+								Name:      "ing-1",
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment=production,Team=backend",
+								},
+							},
+						},
+					},
+				},
+			},
+			scheme: elbv2model.LoadBalancerSchemeInternal,
+			alb: &elbv2model.LoadBalancer{
+				Spec: elbv2model.LoadBalancerSpec{
+					Name:          "test-alb",
+					IPAddressType: elbv2model.IPAddressTypeIPV4,
+					SecurityGroups: []core.StringToken{
+						core.LiteralStringToken("sg-12345"),
+					},
+					SubnetMappings: []elbv2model.SubnetMapping{
+						{SubnetID: "subnet-12345"},
+					},
+				},
+			},
+			externalManagedTags: []string{},
+			wantTags: map[string]string{
+				"Environment": "production",
+				"Team":        "backend",
+			},
+			wantErr: false,
+		},
+		{
+			name: "no tags annotation - empty tags in spec",
+			ingGroup: Group{
+				ID: GroupID{
+					Namespace: "awesome-ns",
+					Name:      "my-ingress",
+				},
+				Members: []ClassifiedIngress{
+					{
+						Ing: &networking.Ingress{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace:   "awesome-ns",
+								Name:        "ing-1",
+								Annotations: map[string]string{},
+							},
+						},
+					},
+				},
+			},
+			scheme: elbv2model.LoadBalancerSchemeInternal,
+			alb: &elbv2model.LoadBalancer{
+				Spec: elbv2model.LoadBalancerSpec{
+					Name:          "test-alb",
+					IPAddressType: elbv2model.IPAddressTypeIPV4,
+					SecurityGroups: []core.StringToken{
+						core.LiteralStringToken("sg-12345"),
+					},
+					SubnetMappings: []elbv2model.SubnetMapping{
+						{SubnetID: "subnet-12345"},
+					},
+				},
+			},
+			externalManagedTags: []string{},
+			wantTags:            map[string]string{},
+			wantErr:             false,
+		},
+		{
+			name: "tag validation failure prevents spec creation",
+			ingGroup: Group{
+				ID: GroupID{
+					Namespace: "awesome-ns",
+					Name:      "my-ingress",
+				},
+				Members: []ClassifiedIngress{
+					{
+						Ing: &networking.Ingress{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "awesome-ns",
+								Name:      "ing-1",
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/frontend-nlb-tags": "aws:cloudformation:stack-name=my-stack",
+								},
+							},
+						},
+					},
+				},
+			},
+			scheme: elbv2model.LoadBalancerSchemeInternal,
+			alb: &elbv2model.LoadBalancer{
+				Spec: elbv2model.LoadBalancerSpec{
+					Name:          "test-alb",
+					IPAddressType: elbv2model.IPAddressTypeIPV4,
+				},
+			},
+			externalManagedTags: []string{},
+			wantTags:            nil,
+			wantErr:             true,
+			expectedErr:         "is reserved by AWS and cannot be used",
+		},
+		{
+			name: "interaction with existing NLB configuration",
+			ingGroup: Group{
+				ID: GroupID{
+					Namespace: "awesome-ns",
+					Name:      "my-ingress",
+				},
+				Members: []ClassifiedIngress{
+					{
+						Ing: &networking.Ingress{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "awesome-ns",
+								Name:      "ing-1",
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment=production",
+								},
+							},
+						},
+					},
+				},
+			},
+			scheme: elbv2model.LoadBalancerSchemeInternetFacing,
+			alb: &elbv2model.LoadBalancer{
+				Spec: elbv2model.LoadBalancerSpec{
+					Name:          "custom-alb-name",
+					IPAddressType: elbv2model.IPAddressTypeDualStack,
+					SecurityGroups: []core.StringToken{
+						core.LiteralStringToken("sg-custom"),
+					},
+					SubnetMappings: []elbv2model.SubnetMapping{
+						{SubnetID: "subnet-custom"},
+					},
+				},
+			},
+			externalManagedTags: []string{},
+			wantTags: map[string]string{
+				"Environment": "production",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			// Mock EC2 service for security groups and subnets
+			mockEC2 := services.NewMockEC2(ctrl)
+			mockEC2.EXPECT().DescribeSecurityGroupsAsList(gomock.Any(), gomock.Any()).
+				Return([]ec2types.SecurityGroup{
+					{GroupId: awssdk.String("sg-12345")},
+					{GroupId: awssdk.String("sg-custom")},
+				}, nil).AnyTimes()
+
+			mockEC2.EXPECT().DescribeSubnetsAsList(gomock.Any(), gomock.Any()).
+				DoAndReturn(stubDescribeSubnetsAsList).AnyTimes()
+
+			azInfoProvider := networking2.NewMockAZInfoProvider(ctrl)
+			azInfoProvider.EXPECT().FetchAZInfos(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(ctx context.Context, availabilityZoneIDs []string) (map[string]ec2types.AvailabilityZone, error) {
+					ret := make(map[string]ec2types.AvailabilityZone, len(availabilityZoneIDs))
+					for _, id := range availabilityZoneIDs {
+						ret[id] = ec2types.AvailabilityZone{ZoneType: awssdk.String("availability-zone")}
+					}
+					return ret, nil
+				}).AnyTimes()
+
+			sgResolver := networkingpkg.NewDefaultSecurityGroupResolver(mockEC2, "vpc-1")
+			subnetsResolver := networking2.NewDefaultSubnetsResolver(
+				azInfoProvider,
+				mockEC2,
+				"vpc-1",
+				"test-cluster",
+				true,
+				true,
+				true,
+				logr.New(&log.NullLogSink{}),
+			)
+
+			// Create external managed tags set
+			externalManagedTags := sets.NewString(tt.externalManagedTags...)
+
+			task := &defaultModelBuildTask{
+				ingGroup:            tt.ingGroup,
+				annotationParser:    annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io"),
+				externalManagedTags: externalManagedTags,
+				sgResolver:          sgResolver,
+				subnetsResolver:     subnetsResolver,
+				clusterName:         "test-cluster",
+			}
+
+			spec, err := task.buildFrontendNlbSpec(context.Background(), tt.scheme, tt.alb)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.expectedErr != "" {
+					assert.Contains(t, err.Error(), tt.expectedErr)
+				}
+			} else {
+				assert.NoError(t, err)
+
+				// Verify tags are properly integrated into the spec
+				assert.Equal(t, tt.wantTags, spec.Tags)
+
+				// Verify other spec properties are correctly set
+				assert.Equal(t, elbv2model.LoadBalancerTypeNetwork, spec.Type)
+				assert.Equal(t, tt.scheme, spec.Scheme)
+				assert.Equal(t, tt.alb.Spec.IPAddressType, spec.IPAddressType)
+
+				// Verify name is generated
+				assert.NotEmpty(t, spec.Name)
+
+				// Verify security groups and subnets are inherited from ALB when not explicitly set
+				if len(tt.alb.Spec.SecurityGroups) > 0 {
+					assert.Equal(t, tt.alb.Spec.SecurityGroups, spec.SecurityGroups)
+				}
+				if len(tt.alb.Spec.SubnetMappings) > 0 {
+					assert.Equal(t, tt.alb.Spec.SubnetMappings, spec.SubnetMappings)
+				}
+			}
+		})
+	}
+}
+
+func Test_defaultModelBuildTask_buildFrontendNlbModel(t *testing.T) {
+	tests := []struct {
+		name                        string
+		ingGroup                    Group
+		alb                         *elbv2model.LoadBalancer
+		listenerPortConfigByIngress map[types.NamespacedName]map[int32]listenPortConfig
+		wantErr                     bool
+		expectedErr                 string
+		expectNlbCreated            bool
+	}{
+		{
+			name: "frontend NLB enabled with tags - model created",
+			ingGroup: Group{
+				ID: GroupID{
+					Namespace: "awesome-ns",
+					Name:      "my-ingress",
+				},
+				Members: []ClassifiedIngress{
+					{
+						Ing: &networking.Ingress{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "awesome-ns",
+								Name:      "ing-1",
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/enable-frontend-nlb": "true",
+									"alb.ingress.kubernetes.io/frontend-nlb-tags":   "Environment=production,Team=backend",
+								},
+							},
+						},
+					},
+				},
+			},
+			alb: &elbv2model.LoadBalancer{
+				Spec: elbv2model.LoadBalancerSpec{
+					Name:          "test-alb",
+					Scheme:        elbv2model.LoadBalancerSchemeInternal,
+					IPAddressType: elbv2model.IPAddressTypeIPV4,
+					SecurityGroups: []core.StringToken{
+						core.LiteralStringToken("sg-12345"),
+					},
+					SubnetMappings: []elbv2model.SubnetMapping{
+						{SubnetID: "subnet-12345"},
+					},
+				},
+			},
+			listenerPortConfigByIngress: map[types.NamespacedName]map[int32]listenPortConfig{},
+			wantErr:                     false,
+			expectNlbCreated:            true,
+		},
+		{
+			name: "frontend NLB disabled - no model created",
+			ingGroup: Group{
+				ID: GroupID{
+					Namespace: "awesome-ns",
+					Name:      "my-ingress",
+				},
+				Members: []ClassifiedIngress{
+					{
+						Ing: &networking.Ingress{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "awesome-ns",
+								Name:      "ing-1",
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/enable-frontend-nlb": "false",
+									"alb.ingress.kubernetes.io/frontend-nlb-tags":   "Environment=production",
+								},
+							},
+						},
+					},
+				},
+			},
+			alb: &elbv2model.LoadBalancer{
+				Spec: elbv2model.LoadBalancerSpec{
+					Name:   "test-alb",
+					Scheme: elbv2model.LoadBalancerSchemeInternal,
+				},
+			},
+			listenerPortConfigByIngress: map[types.NamespacedName]map[int32]listenPortConfig{},
+			wantErr:                     false,
+			expectNlbCreated:            false,
+		},
+		{
+			name: "no frontend NLB annotation - no model created",
+			ingGroup: Group{
+				ID: GroupID{
+					Namespace: "awesome-ns",
+					Name:      "my-ingress",
+				},
+				Members: []ClassifiedIngress{
+					{
+						Ing: &networking.Ingress{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "awesome-ns",
+								Name:      "ing-1",
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment=production",
+								},
+							},
+						},
+					},
+				},
+			},
+			alb: &elbv2model.LoadBalancer{
+				Spec: elbv2model.LoadBalancerSpec{
+					Name:   "test-alb",
+					Scheme: elbv2model.LoadBalancerSchemeInternal,
+				},
+			},
+			listenerPortConfigByIngress: map[types.NamespacedName]map[int32]listenPortConfig{},
+			wantErr:                     false,
+			expectNlbCreated:            false,
+		},
+		{
+			name: "frontend NLB enabled but invalid tags - error",
+			ingGroup: Group{
+				ID: GroupID{
+					Namespace: "awesome-ns",
+					Name:      "my-ingress",
+				},
+				Members: []ClassifiedIngress{
+					{
+						Ing: &networking.Ingress{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "awesome-ns",
+								Name:      "ing-1",
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/enable-frontend-nlb": "true",
+									"alb.ingress.kubernetes.io/frontend-nlb-tags":   "aws:reserved=value",
+								},
+							},
+						},
+					},
+				},
+			},
+			alb: &elbv2model.LoadBalancer{
+				Spec: elbv2model.LoadBalancerSpec{
+					Name:   "test-alb",
+					Scheme: elbv2model.LoadBalancerSchemeInternal,
+				},
+			},
+			listenerPortConfigByIngress: map[types.NamespacedName]map[int32]listenPortConfig{},
+			wantErr:                     true,
+			expectedErr:                 "is reserved by AWS and cannot be used",
+			expectNlbCreated:            false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			// Mock EC2 service
+			mockEC2 := services.NewMockEC2(ctrl)
+			mockEC2.EXPECT().DescribeSecurityGroupsAsList(gomock.Any(), gomock.Any()).
+				Return([]ec2types.SecurityGroup{
+					{GroupId: awssdk.String("sg-12345")},
+				}, nil).AnyTimes()
+
+			mockEC2.EXPECT().DescribeSubnetsAsList(gomock.Any(), gomock.Any()).
+				DoAndReturn(stubDescribeSubnetsAsList).AnyTimes()
+
+			azInfoProvider := networking2.NewMockAZInfoProvider(ctrl)
+			azInfoProvider.EXPECT().FetchAZInfos(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(ctx context.Context, availabilityZoneIDs []string) (map[string]ec2types.AvailabilityZone, error) {
+					ret := make(map[string]ec2types.AvailabilityZone, len(availabilityZoneIDs))
+					for _, id := range availabilityZoneIDs {
+						ret[id] = ec2types.AvailabilityZone{ZoneType: awssdk.String("availability-zone")}
+					}
+					return ret, nil
+				}).AnyTimes()
+
+			sgResolver := networkingpkg.NewDefaultSecurityGroupResolver(mockEC2, "vpc-1")
+			subnetsResolver := networking2.NewDefaultSubnetsResolver(
+				azInfoProvider,
+				mockEC2,
+				"vpc-1",
+				"test-cluster",
+				true,
+				true,
+				true,
+				logr.New(&log.NullLogSink{}),
+			)
+
+			stack := core.NewDefaultStack(core.StackID{Name: "awesome-stack"})
+			desiredState := &core.FrontendNlbTargetGroupDesiredState{
+				TargetGroups: make(map[string]*core.FrontendNlbTargetGroupState),
+			}
+
+			task := &defaultModelBuildTask{
+				ingGroup:                           tt.ingGroup,
+				annotationParser:                   annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io"),
+				externalManagedTags:                sets.NewString(),
+				sgResolver:                         sgResolver,
+				subnetsResolver:                    subnetsResolver,
+				clusterName:                        "test-cluster",
+				stack:                              stack,
+				frontendNlbTargetGroupDesiredState: desiredState,
+			}
+
+			err := task.buildFrontendNlbModel(context.Background(), tt.alb, tt.listenerPortConfigByIngress)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.expectedErr != "" {
+					assert.Contains(t, err.Error(), tt.expectedErr)
+				}
+			} else {
+				assert.NoError(t, err)
+
+				if tt.expectNlbCreated {
+					// Verify that the frontend NLB was created in the task
+					assert.NotNil(t, task.frontendNlb, "Frontend NLB should be created when enabled")
+				} else {
+					// Verify that no frontend NLB was created
+					assert.Nil(t, task.frontendNlb, "Frontend NLB should not be created when disabled")
+				}
 			}
 		})
 	}

--- a/webhooks/networking/ingress_validator_test.go
+++ b/webhooks/networking/ingress_validator_test.go
@@ -2,6 +2,8 @@ package networking
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
@@ -1163,6 +1165,1361 @@ func Test_ingressValidator_checkIngressAnnotationConditions(t *testing.T) {
 				logger:                        logr.Discard(),
 			}
 			err := v.checkIngressAnnotationConditions(tt.args.ing)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_ingressValidator_checkFrontendNlbTagsAnnotation(t *testing.T) {
+	type args struct {
+		ing *networking.Ingress
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr error
+	}{
+		{
+			name: "ingress without frontend NLB tags annotation",
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:   "ns-1",
+						Name:        "ing-1",
+						Annotations: map[string]string{},
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "ingress with valid frontend NLB tags annotation",
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns-1",
+						Name:      "ing-1",
+						Annotations: map[string]string{
+							"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment=production,Team=backend",
+						},
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "ingress with empty frontend NLB tags annotation",
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns-1",
+						Name:      "ing-1",
+						Annotations: map[string]string{
+							"alb.ingress.kubernetes.io/frontend-nlb-tags": "",
+						},
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "ingress with malformed frontend NLB tags annotation - missing equals",
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns-1",
+						Name:      "ing-1",
+						Annotations: map[string]string{
+							"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment,Team=backend",
+						},
+					},
+				},
+			},
+			wantErr: errors.New("invalid frontend NLB tags format: tag 'Environment' must be in 'key=value' format"),
+		},
+		{
+			name: "ingress with tag key exceeding maximum length",
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns-1",
+						Name:      "ing-1",
+						Annotations: map[string]string{
+							"alb.ingress.kubernetes.io/frontend-nlb-tags": "VeryLongTagKeyThatExceedsTheMaximumAllowedLengthOfOneHundredTwentyEightCharactersWhichIsTheAWSLimitForTagKeysAndShouldCauseValidationError=value",
+						},
+					},
+				},
+			},
+			wantErr: errors.New("invalid frontend NLB tags: tag key exceeds maximum length of 128 characters"),
+		},
+		{
+			name: "ingress with tag value exceeding maximum length",
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns-1",
+						Name:      "ing-1",
+						Annotations: map[string]string{
+							"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment=" + strings.Repeat("a", 257),
+						},
+					},
+				},
+			},
+			wantErr: errors.New("invalid frontend NLB tags: tag value exceeds maximum length of 256 characters"),
+		},
+		{
+			name: "ingress with AWS reserved tag key",
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns-1",
+						Name:      "ing-1",
+						Annotations: map[string]string{
+							"alb.ingress.kubernetes.io/frontend-nlb-tags": "aws:cloudformation:stack-name=my-stack,Environment=production",
+						},
+					},
+				},
+			},
+			wantErr: errors.New("invalid frontend NLB tags: tag key 'aws:cloudformation:stack-name' is reserved (aws:* pattern)"),
+		},
+		{
+			name: "ingress with AWS reserved tag key - case insensitive",
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns-1",
+						Name:      "ing-1",
+						Annotations: map[string]string{
+							"alb.ingress.kubernetes.io/frontend-nlb-tags": "AWS:CloudFormation:StackName=my-stack,Environment=production",
+						},
+					},
+				},
+			},
+			wantErr: errors.New("invalid frontend NLB tags: tag key 'AWS:CloudFormation:StackName' is reserved (aws:* pattern)"),
+		},
+		{
+			name: "ingress with too many tags",
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns-1",
+						Name:      "ing-1",
+						Annotations: map[string]string{
+							"alb.ingress.kubernetes.io/frontend-nlb-tags": func() string {
+								var tags []string
+								for i := 1; i <= 51; i++ {
+									tags = append(tags, fmt.Sprintf("tag%d=value%d", i, i))
+								}
+								return strings.Join(tags, ",")
+							}(),
+						},
+					},
+				},
+			},
+			wantErr: errors.New("invalid frontend NLB tags: number of tags (51) exceeds maximum allowed (50)"),
+		},
+		{
+			name: "ingress with exactly 50 tags - should pass",
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns-1",
+						Name:      "ing-1",
+						Annotations: map[string]string{
+							"alb.ingress.kubernetes.io/frontend-nlb-tags": func() string {
+								var tags []string
+								for i := 1; i <= 50; i++ {
+									tags = append(tags, fmt.Sprintf("tag%d=value%d", i, i))
+								}
+								return strings.Join(tags, ",")
+							}(),
+						},
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "ingress with tag key at maximum length - should pass",
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns-1",
+						Name:      "ing-1",
+						Annotations: map[string]string{
+							"alb.ingress.kubernetes.io/frontend-nlb-tags": strings.Repeat("a", 128) + "=value",
+						},
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "ingress with tag value at maximum length - should pass",
+			args: args{
+				ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns-1",
+						Name:      "ing-1",
+						Annotations: map[string]string{
+							"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment=" + strings.Repeat("a", 256),
+						},
+					},
+				},
+			},
+			wantErr: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			annotationParser := annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io")
+			v := &ingressValidator{
+				annotationParser: annotationParser,
+				logger:           logr.Discard(),
+			}
+			err := v.checkFrontendNlbTagsAnnotation(tt.args.ing)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_ingressValidator_checkFrontendNlbTagsAnnotation_Comprehensive(t *testing.T) {
+	tests := []struct {
+		name    string
+		ing     *networking.Ingress
+		wantErr error
+	}{
+		{
+			name: "valid frontend NLB tags annotation",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment=production,Team=backend",
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "valid frontend NLB tags with special characters",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment=prod-test,Team=backend_team,Version=1.2.3",
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "valid single tag",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment=production",
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "ingress without frontend NLB tags annotation",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/scheme": "internet-facing",
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "empty frontend NLB tags annotation",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "",
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "invalid format - missing equals sign",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment,Team=backend",
+					},
+				},
+			},
+			wantErr: errors.New("invalid frontend NLB tags format: tag 'Environment' must be in 'key=value' format"),
+		},
+		{
+			name: "invalid format - empty key",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "=production,Team=backend",
+					},
+				},
+			},
+			wantErr: errors.New("invalid frontend NLB tags format: tag key cannot be empty"),
+		},
+		{
+			name: "invalid format - empty value",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment=,Team=backend",
+					},
+				},
+			},
+			wantErr: errors.New("invalid frontend NLB tags format: tag value cannot be empty"),
+		},
+		{
+			name: "valid format - multiple equals signs in value",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment=prod=test,Team=backend",
+					},
+				},
+			},
+			wantErr: nil, // Multiple equals signs in value are allowed
+		},
+		{
+			name: "tag key exceeds character limit",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": strings.Repeat("a", 129) + "=value",
+					},
+				},
+			},
+			wantErr: errors.New("invalid frontend NLB tags: tag key exceeds maximum length of 128 characters"),
+		},
+		{
+			name: "tag value exceeds character limit",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment=" + strings.Repeat("a", 257),
+					},
+				},
+			},
+			wantErr: errors.New("invalid frontend NLB tags: tag value exceeds maximum length of 256 characters"),
+		},
+		{
+			name: "too many tags",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": func() string {
+							var tags []string
+							for i := 0; i < 51; i++ {
+								tags = append(tags, fmt.Sprintf("key%d=value%d", i, i))
+							}
+							return strings.Join(tags, ",")
+						}(),
+					},
+				},
+			},
+			wantErr: errors.New("invalid frontend NLB tags: number of tags (51) exceeds maximum allowed (50)"),
+		},
+		{
+			name: "reserved AWS tag key",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "aws:cloudformation:stack-name=mystack,Team=backend",
+					},
+				},
+			},
+			wantErr: errors.New("invalid frontend NLB tags: tag key 'aws:cloudformation:stack-name' is reserved (aws:* pattern)"),
+		},
+		{
+			name: "reserved AWS tag key with different case",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "AWS:Region=us-west-2,Team=backend",
+					},
+				},
+			},
+			wantErr: errors.New("invalid frontend NLB tags: tag key 'AWS:Region' is reserved (aws:* pattern)"),
+		},
+		{
+			name: "duplicate tag keys",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment=production,Team=backend,Environment=staging",
+					},
+				},
+			},
+			wantErr: errors.New("invalid frontend NLB tags: duplicate tag key 'Environment'"),
+		},
+		{
+			name: "whitespace in tags",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": " Environment = production , Team = backend ",
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "maximum allowed tags (50)",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": func() string {
+							var tags []string
+							for i := 0; i < 50; i++ {
+								tags = append(tags, fmt.Sprintf("key%d=value%d", i, i))
+							}
+							return strings.Join(tags, ",")
+						}(),
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "maximum key length (128 characters)",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": strings.Repeat("a", 128) + "=value",
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "maximum value length (256 characters)",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment=" + strings.Repeat("a", 256),
+					},
+				},
+			},
+			wantErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			annotationParser := annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io")
+			v := &ingressValidator{
+				annotationParser: annotationParser,
+				logger:           logr.New(&log.NullLogSink{}),
+			}
+			err := v.checkFrontendNlbTagsAnnotation(tt.ing)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_ingressValidator_checkFrontendNlbTagsAnnotation_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name    string
+		ing     *networking.Ingress
+		wantErr error
+	}{
+		{
+			name: "malformed annotation - only commas",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": ",,,",
+					},
+				},
+			},
+			wantErr: nil, // Empty tags after splitting should be ignored
+		},
+		{
+			name: "malformed annotation - trailing comma",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment=production,",
+					},
+				},
+			},
+			wantErr: nil, // Trailing comma should be handled gracefully
+		},
+		{
+			name: "malformed annotation - leading comma",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": ",Environment=production",
+					},
+				},
+			},
+			wantErr: nil, // Leading comma should be handled gracefully
+		},
+		{
+			name: "special characters in key and value",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "app.kubernetes.io/name=my-app,app.kubernetes.io/version=1.0.0",
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "unicode characters in tags",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment=测试,Team=backend",
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "numeric keys and values",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "123=456,789=012",
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "case sensitivity test",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment=production,environment=staging",
+					},
+				},
+			},
+			wantErr: nil, // Keys are case-sensitive, so this should be allowed
+		},
+		{
+			name: "performance test - large tag set within limits",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": func() string {
+							var tags []string
+							// Create 45 tags with maximum allowed key and value lengths
+							for i := 0; i < 45; i++ {
+								key := fmt.Sprintf("key%d", i) + strings.Repeat("a", 124-len(fmt.Sprintf("key%d", i)))
+								value := strings.Repeat("v", 256)
+								tags = append(tags, key+"="+value)
+							}
+							return strings.Join(tags, ",")
+						}(),
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "external managed tag conflict simulation",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "kubernetes.io/cluster/my-cluster=owned,Environment=production",
+					},
+				},
+			},
+			wantErr: nil, // This test simulates external managed tags, but validation should pass at webhook level
+		},
+		{
+			name: "reserved tag key variations",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "aws:ec2:instance-id=i-1234567890abcdef0",
+					},
+				},
+			},
+			wantErr: errors.New("invalid frontend NLB tags: tag key 'aws:ec2:instance-id' is reserved (aws:* pattern)"),
+		},
+		{
+			name: "mixed valid and invalid tags",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment=production,aws:region=us-west-2,Team=backend",
+					},
+				},
+			},
+			wantErr: errors.New("invalid frontend NLB tags: tag key 'aws:region' is reserved (aws:* pattern)"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			annotationParser := annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io")
+			v := &ingressValidator{
+				annotationParser: annotationParser,
+				logger:           logr.New(&log.NullLogSink{}),
+			}
+			err := v.checkFrontendNlbTagsAnnotation(tt.ing)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_ingressValidator_checkFrontendNlbTagsAnnotation_PerformanceAndLimits(t *testing.T) {
+	tests := []struct {
+		name    string
+		ing     *networking.Ingress
+		wantErr error
+	}{
+		{
+			name: "performance test - parsing large valid annotation",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": func() string {
+							var tags []string
+							// Create 50 tags with reasonable key and value lengths
+							for i := 0; i < 50; i++ {
+								key := fmt.Sprintf("performance-test-key-%d", i)
+								value := fmt.Sprintf("performance-test-value-%d", i)
+								tags = append(tags, key+"="+value)
+							}
+							return strings.Join(tags, ",")
+						}(),
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "boundary test - exactly 50 tags",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": func() string {
+							var tags []string
+							for i := 0; i < 50; i++ {
+								tags = append(tags, fmt.Sprintf("key%d=value%d", i, i))
+							}
+							return strings.Join(tags, ",")
+						}(),
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "boundary test - 51 tags (exceeds limit)",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": func() string {
+							var tags []string
+							for i := 0; i < 51; i++ {
+								tags = append(tags, fmt.Sprintf("key%d=value%d", i, i))
+							}
+							return strings.Join(tags, ",")
+						}(),
+					},
+				},
+			},
+			wantErr: errors.New("invalid frontend NLB tags: number of tags (51) exceeds maximum allowed (50)"),
+		},
+		{
+			name: "boundary test - key exactly 128 characters",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": strings.Repeat("a", 128) + "=value",
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "boundary test - key 129 characters (exceeds limit)",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": strings.Repeat("a", 129) + "=value",
+					},
+				},
+			},
+			wantErr: errors.New("invalid frontend NLB tags: tag key exceeds maximum length of 128 characters"),
+		},
+		{
+			name: "boundary test - value exactly 256 characters",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "key=" + strings.Repeat("v", 256),
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "boundary test - value 257 characters (exceeds limit)",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "key=" + strings.Repeat("v", 257),
+					},
+				},
+			},
+			wantErr: errors.New("invalid frontend NLB tags: tag value exceeds maximum length of 256 characters"),
+		},
+		{
+			name: "stress test - complex annotation with mixed valid and invalid patterns",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "valid-key=valid-value,aws:invalid=reserved,another-valid=value",
+					},
+				},
+			},
+			wantErr: errors.New("invalid frontend NLB tags: tag key 'aws:invalid' is reserved (aws:* pattern)"),
+		},
+		{
+			name: "external managed tag simulation - kubernetes tags",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "kubernetes.io/cluster/test=owned,kubernetes.io/service-name=test-service",
+					},
+				},
+			},
+			wantErr: nil, // These should be allowed at webhook level
+		},
+		{
+			name: "external managed tag simulation - elbv2 controller tags",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "elbv2.k8s.aws/cluster=test-cluster,ingress.k8s.aws/resource=LoadBalancer",
+					},
+				},
+			},
+			wantErr: nil, // These should be allowed at webhook level
+		},
+		{
+			name: "reserved tag variations - different aws prefixes",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "aws:ec2:instance-id=i-123",
+					},
+				},
+			},
+			wantErr: errors.New("invalid frontend NLB tags: tag key 'aws:ec2:instance-id' is reserved (aws:* pattern)"),
+		},
+		{
+			name: "case insensitive aws prefix check",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "Aws:Ec2:InstanceId=i-123",
+					},
+				},
+			},
+			wantErr: errors.New("invalid frontend NLB tags: tag key 'Aws:Ec2:InstanceId' is reserved (aws:* pattern)"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			annotationParser := annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io")
+			v := &ingressValidator{
+				annotationParser: annotationParser,
+				logger:           logr.New(&log.NullLogSink{}),
+			}
+			err := v.checkFrontendNlbTagsAnnotation(tt.ing)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_ingressValidator_ValidateCreate_FrontendNlbTags(t *testing.T) {
+	tests := []struct {
+		name    string
+		ing     *networking.Ingress
+		wantErr error
+	}{
+		{
+			name: "create ingress with valid frontend NLB tags",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"kubernetes.io/ingress.class":                 "alb",
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment=production,Team=backend",
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "create ingress with invalid frontend NLB tags",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"kubernetes.io/ingress.class":                 "alb",
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "aws:region=us-west-2",
+					},
+				},
+			},
+			wantErr: errors.New("invalid frontend NLB tags: tag key 'aws:region' is reserved (aws:* pattern)"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			k8sSchema := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sSchema)
+			elbv2api.AddToScheme(k8sSchema)
+			k8sClient := testclient.NewClientBuilder().
+				WithScheme(k8sSchema).
+				Build()
+
+			classAnnotationMatcher := ingress.NewDefaultClassAnnotationMatcher("alb")
+			mockMetricsCollector := lbcmetrics.NewMockCollector()
+			annotationParser := annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io")
+
+			v := &ingressValidator{
+				annotationParser:                   annotationParser,
+				classLoader:                        ingress.NewDefaultClassLoader(k8sClient, false),
+				classAnnotationMatcher:             classAnnotationMatcher,
+				manageIngressesWithoutIngressClass: false,
+				logger:                             logr.New(&log.NullLogSink{}),
+				metricsCollector:                   mockMetricsCollector,
+			}
+
+			err := v.ValidateCreate(ctx, tt.ing)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_ingressValidator_ValidateUpdate_FrontendNlbTags(t *testing.T) {
+	tests := []struct {
+		name    string
+		ing     *networking.Ingress
+		oldIng  *networking.Ingress
+		wantErr error
+	}{
+		{
+			name: "update ingress with valid frontend NLB tags",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"kubernetes.io/ingress.class":                 "alb",
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment=staging,Team=backend",
+					},
+				},
+			},
+			oldIng: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"kubernetes.io/ingress.class":                 "alb",
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment=production,Team=backend",
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "update ingress with invalid frontend NLB tags",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"kubernetes.io/ingress.class":                 "alb",
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "aws:cloudformation:stack-name=test",
+					},
+				},
+			},
+			oldIng: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"kubernetes.io/ingress.class":                 "alb",
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment=production",
+					},
+				},
+			},
+			wantErr: errors.New("invalid frontend NLB tags: tag key 'aws:cloudformation:stack-name' is reserved (aws:* pattern)"),
+		},
+		{
+			name: "update ingress removing frontend NLB tags",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"kubernetes.io/ingress.class": "alb",
+					},
+				},
+			},
+			oldIng: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"kubernetes.io/ingress.class":                 "alb",
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment=production",
+					},
+				},
+			},
+			wantErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			k8sSchema := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sSchema)
+			elbv2api.AddToScheme(k8sSchema)
+			k8sClient := testclient.NewClientBuilder().
+				WithScheme(k8sSchema).
+				Build()
+
+			classAnnotationMatcher := ingress.NewDefaultClassAnnotationMatcher("alb")
+			mockMetricsCollector := lbcmetrics.NewMockCollector()
+			annotationParser := annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io")
+
+			v := &ingressValidator{
+				annotationParser:                   annotationParser,
+				classLoader:                        ingress.NewDefaultClassLoader(k8sClient, false),
+				classAnnotationMatcher:             classAnnotationMatcher,
+				manageIngressesWithoutIngressClass: false,
+				logger:                             logr.New(&log.NullLogSink{}),
+				metricsCollector:                   mockMetricsCollector,
+			}
+
+			err := v.ValidateUpdate(ctx, tt.ing, tt.oldIng)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_ingressValidator_checkFrontendNlbTagsAnnotation_AdditionalEdgeCases(t *testing.T) {
+	tests := []struct {
+		name    string
+		ing     *networking.Ingress
+		wantErr error
+	}{
+		{
+			name: "extremely long annotation value with valid tags",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": func() string {
+							// Create a very long but valid annotation
+							var tags []string
+							for i := 0; i < 25; i++ {
+								key := fmt.Sprintf("very-long-key-name-with-lots-of-characters-%d", i)
+								value := fmt.Sprintf("very-long-value-with-lots-of-characters-and-details-%d", i)
+								tags = append(tags, key+"="+value)
+							}
+							return strings.Join(tags, ",")
+						}(),
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "annotation with only whitespace",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "   \t\n   ",
+					},
+				},
+			},
+			wantErr: nil, // Should be treated as empty
+		},
+		{
+			name: "annotation with mixed whitespace and valid tags",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "  Environment = production  ,  Team = backend  ",
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "annotation with empty tag pairs mixed with valid ones",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment=production,,,,Team=backend,,,",
+					},
+				},
+			},
+			wantErr: nil, // Empty pairs should be ignored
+		},
+		{
+			name: "annotation with special characters in values",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment=prod-test_env.v1,Team=backend@company.com,Version=1.2.3-beta+build.123",
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "annotation with URL-like values",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "Repository=https://github.com/company/repo,Documentation=https://docs.company.com/api",
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "annotation with JSON-like values (without commas)",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "Config={\"env\":\"prod\"},Metadata={\"version\":\"1.0\"}",
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "annotation with path-like keys",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "app.kubernetes.io/name=myapp,app.kubernetes.io/version=1.0.0,company.com/team=backend",
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "annotation with boundary key length (exactly 128 chars)",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": strings.Repeat("k", 128) + "=value",
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "annotation with boundary value length (exactly 256 chars)",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "key=" + strings.Repeat("v", 256),
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "annotation with key exceeding limit by 1 char (129 chars)",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": strings.Repeat("k", 129) + "=value",
+					},
+				},
+			},
+			wantErr: errors.New("invalid frontend NLB tags: tag key exceeds maximum length of 128 characters"),
+		},
+		{
+			name: "annotation with value exceeding limit by 1 char (257 chars)",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "key=" + strings.Repeat("v", 257),
+					},
+				},
+			},
+			wantErr: errors.New("invalid frontend NLB tags: tag value exceeds maximum length of 256 characters"),
+		},
+		{
+			name: "annotation with exactly 50 tags (boundary test)",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": func() string {
+							var tags []string
+							for i := 0; i < 50; i++ {
+								tags = append(tags, fmt.Sprintf("tag%02d=value%02d", i, i))
+							}
+							return strings.Join(tags, ",")
+						}(),
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "annotation with 51 tags (exceeds limit)",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": func() string {
+							var tags []string
+							for i := 0; i < 51; i++ {
+								tags = append(tags, fmt.Sprintf("tag%02d=value%02d", i, i))
+							}
+							return strings.Join(tags, ",")
+						}(),
+					},
+				},
+			},
+			wantErr: errors.New("invalid frontend NLB tags: number of tags (51) exceeds maximum allowed (50)"),
+		},
+		{
+			name: "annotation with various AWS reserved key patterns",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "aws:autoscaling:groupName=test",
+					},
+				},
+			},
+			wantErr: errors.New("invalid frontend NLB tags: tag key 'aws:autoscaling:groupName' is reserved (aws:* pattern)"),
+		},
+		{
+			name: "annotation with mixed case AWS reserved key",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "AwS:CloudFormation:StackId=test",
+					},
+				},
+			},
+			wantErr: errors.New("invalid frontend NLB tags: tag key 'AwS:CloudFormation:StackId' is reserved (aws:* pattern)"),
+		},
+		{
+			name: "annotation with non-AWS reserved-looking key (should pass)",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "myaws:custom:key=value,aws-like-key=value",
+					},
+				},
+			},
+			wantErr: nil, // These don't start with "aws:" so should be allowed
+		},
+		{
+			name: "annotation with duplicate keys (case sensitive)",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment=prod,environment=staging",
+					},
+				},
+			},
+			wantErr: nil, // Keys are case-sensitive, so this should be allowed
+		},
+		{
+			name: "annotation with actual duplicate keys",
+			ing: &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns-1",
+					Name:      "ing-1",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/frontend-nlb-tags": "Environment=prod,Team=backend,Environment=staging",
+					},
+				},
+			},
+			wantErr: errors.New("invalid frontend NLB tags: duplicate tag key 'Environment'"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			annotationParser := annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io")
+			v := &ingressValidator{
+				annotationParser: annotationParser,
+				logger:           logr.New(&log.NullLogSink{}),
+			}
+			err := v.checkFrontendNlbTagsAnnotation(tt.ing)
 			if tt.wantErr != nil {
 				assert.EqualError(t, err, tt.wantErr.Error())
 			} else {


### PR DESCRIPTION
### Issue

- [Resource tags don't propagate to frontend NLB #4279](https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4279)

### Description

<!--
Please explain the changes you made here.

Help your reviewers by guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

This enhancement introduce the new `alb.ingress.kubernetes.io/frontend-nlb-tags` annotation, which support tagging for front-end NLB resource. Example:

```
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  namespace: game-2048
  name: ingress-2048
  annotations:
    alb.ingress.kubernetes.io/scheme: internet-facing
    alb.ingress.kubernetes.io/target-type: ip
    alb.ingress.kubernetes.io/enable-frontend-nlb: "true"
    alb.ingress.kubernetes.io/frontend-nlb-tags: "Environment=test,Team=platform,Project=aws-load-balancer-controller"
```

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
