### PR TITLE
feat: Support configure target-group-attributes for different service port #4326

### DIFF
--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -264,13 +264,27 @@ for proxy protocol v2 configuration.
         The only valid value for this annotation is `*`.
 
 - <a name="target-group-attributes">`service.beta.kubernetes.io/aws-load-balancer-target-group-attributes`</a> specifies the
-[Target Group Attributes](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html#target-group-attributes) to be configured.
+[Target Group Attributes](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html#target-group-attributes) to be configured. You can specify attributes globally for all target groups or override them for specific ports using port-specific annotations.
 
     !!!example
         - set the deregistration delay to 120 seconds (available range is 0-3600 seconds)
             ```
+            # Global attributes for all target groups
             service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: deregistration_delay.timeout_seconds=120
+            
+            # Port-specific attributes (overrides global attributes for port 3306)
+            service.beta.kubernetes.io/aws-load-balancer-target-group-attributes.3306: proxy_protocol_v2.client_to_server.header_placement=on_first_ack
             ```
+            
+        - Port-specific attributes with empty values
+            ```
+            # Global attributes for all target groups
+            service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: target.group-attr-1=80
+            
+            # Port-specific attributes (empty values don't override global attributes)
+            service.beta.kubernetes.io/aws-load-balancer-target-group-attributes.3306: target.group-attr-1=
+            ```
+            Note: When a port-specific attribute value is empty, it will not override the global attribute value. This allows you to selectively remove attributes for specific ports without affecting other ports that should inherit the global value.
         - enable source IP affinity
             ```
             service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: stickiness.enabled=true,stickiness.type=source_ip


### PR DESCRIPTION
### Issue

Fixes #4326

### Description

This PR introduces the ability to configure target group attributes for specific ports in Network Load Balancers (NLB). Previously, target group attributes were applied uniformly across all ports in a service. With this change, users can now specify different attributes for different ports, providing more granular control over target group behavior.

Key changes:
• Added support for port-specific target group attributes using the format `service.beta.kubernetes.io/aws-load-balancer-target-group-attributes.{port}`
• Maintained backward compatibility with existing `service.beta.kubernetes.io/aws-load-balancer-target-group-attributes` annotation
• Port-specific attributes override the default attributes when specified
• Empty values in port-specific attributes don't override global values, allowing selective attribute inheritance

Example usage:
```yaml
# Set deregistration delay globally to 60 seconds, with different values for ports 80 and 443
annotations:
  service.beta.kubernetes.io/aws-load-balancer-type: nlb
  # Global attributes for all target groups
  service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: deregistration_delay.timeout_seconds=60
  # Port-specific attributes
  service.beta.kubernetes.io/aws-load-balancer-target-group-attributes.80: deregistration_delay.timeout_seconds=30
  service.beta.kubernetes.io/aws-load-balancer-target-group-attributes.443: deregistration_delay.timeout_seconds=120

# Example with empty values (inheriting from global attributes)
annotations:
  service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: target.group-attr-1=80
  # Empty value will keep the global attribute value
  service.beta.kubernetes.io/aws-load-balancer-target-group-attributes.3306: target.group-attr-1=
 ```
 
**Note:** When a port-specific attribute has an empty value, it will not override the global attribute value. This allows you to selectively inherit global values while overriding others.

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
