### PR TITLE
Updated documentation to reflect the correct order of deletion for ingress-related resources

### DIFF
--- a/docs/guide/ingress/ingress_class.md
+++ b/docs/guide/ingress/ingress_class.md
@@ -415,4 +415,16 @@ When this param is absent or empty, the controller will keep LoadBalancer WAFv2 
 Cluster administrators can use the optional `wafv2AclName` field to specify name of the Amazon WAFv2 web ACL.
 Only Regional WAFv2 is supported.
 When this param is absent or empty, the controller will keep LoadBalancer WAFv2 settings unchanged. To disable WAFv2, explicitly set the param value to 'none'.
-If the field is specified, LBC will ignore the 'alb.ingress.kubernetes.io/wafv2-acl-name' annotation.
+    If the field is specified, LBC will ignore the 'alb.ingress.kubernetes.io/wafv2-acl-name' annotation.
+
+### Resource Cleanup Order
+
+When cleaning up AWS Load Balancer Controller resources, it's important to follow the correct order of deletion to avoid orphaned resources. The recommended order is:
+
+1. Delete the Ingresses first
+2. Delete the IngressClass and IngressClassParams last
+
+If you delete the IngressClass before the Ingresses that reference it, the Ingresses will become orphaned and cannot be cleaned up until the `ingressClassName` is manually removed from their manifests. This is because the AWS Load Balancer Controller's validating webhook requires a valid IngressClass to be present when processing Ingress resources.
+
+!!!warning
+    Deleting IngressClass resources before their associated Ingresses can result in orphaned resources that require manual cleanup. Always delete Ingresses first to ensure proper resource cleanup.


### PR DESCRIPTION
### Issue

Fixes #4341 

### Description

This PR adds documentation about the correct order of deletion for AWS Load Balancer Controller resources, particularly around Ingress and IngressClass resources. The issue arises when users delete IngressClass resources before deleting the associated Ingresses, resulting in orphaned Ingress resources that cannot be cleaned up without manual intervention.

Changes made:
- Added a new section "Resource Cleanup Order" in `docs/guide/ingress/ingress_class.md`
- Clearly documented the recommended order of deletion (Ingresses first, then IngressClass/IngressClassParams)
- Explained why this order is important and the consequences of incorrect deletion order
- Used consistent documentation style with existing content (MkDocs admonitions)
- Added warning block to highlight potential issues

<img width="782" height="483" alt="Screenshot 2025-09-20 at 6 06 51 PM" src="https://github.com/user-attachments/assets/f5c1ed53-4ee4-47f9-acd0-ea609d1cb5ad" />

### Checklist
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested (verified documentation renders correctly with MkDocs)
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2: