### PR TITLE
feat: Introduce annotation for setting explicit egress CIDR ranges on Service LB frontend security group

### DIFF
--- a/pkg/annotations/constants.go
+++ b/pkg/annotations/constants.go
@@ -125,4 +125,5 @@ const (
 	SvcLBSuffixEnableIcmpForPathMtuDiscovery             = "aws-load-balancer-enable-icmp-for-path-mtu-discovery"
 	SvcLBSuffixEnableTCPUDPListener                      = "aws-load-balancer-enable-tcp-udp-listener"
 	SvcLBSuffixDisableNLBSG                              = "aws-load-balancer-disable-nlb-sg"
+	SvcLBSuffixOutboundCIDRs                             = "aws-load-balancer-outbound-cidrs"
 )

--- a/pkg/aws/services/ec2.go
+++ b/pkg/aws/services/ec2.go
@@ -33,7 +33,9 @@ type EC2 interface {
 	CreateSecurityGroupWithContext(ctx context.Context, input *ec2.CreateSecurityGroupInput) (*ec2.CreateSecurityGroupOutput, error)
 	DeleteSecurityGroupWithContext(ctx context.Context, input *ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error)
 	AuthorizeSecurityGroupIngressWithContext(ctx context.Context, input *ec2.AuthorizeSecurityGroupIngressInput) (*ec2.AuthorizeSecurityGroupIngressOutput, error)
+	AuthorizeSecurityGroupEgressWithContext(ctx context.Context, input *ec2.AuthorizeSecurityGroupEgressInput) (*ec2.AuthorizeSecurityGroupEgressOutput, error)
 	RevokeSecurityGroupIngressWithContext(ctx context.Context, input *ec2.RevokeSecurityGroupIngressInput) (*ec2.RevokeSecurityGroupIngressOutput, error)
+	RevokeSecurityGroupEgressWithContext(ctx context.Context, input *ec2.RevokeSecurityGroupEgressInput) (*ec2.RevokeSecurityGroupEgressOutput, error)
 	DescribeAvailabilityZonesWithContext(ctx context.Context, input *ec2.DescribeAvailabilityZonesInput) (*ec2.DescribeAvailabilityZonesOutput, error)
 	DescribeVpcsWithContext(ctx context.Context, input *ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error)
 	DescribeInstancesWithContext(ctx context.Context, input *ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error)
@@ -202,12 +204,28 @@ func (c *ec2Client) AuthorizeSecurityGroupIngressWithContext(ctx context.Context
 	return client.AuthorizeSecurityGroupIngress(ctx, input)
 }
 
+func (c *ec2Client) AuthorizeSecurityGroupEgressWithContext(ctx context.Context, input *ec2.AuthorizeSecurityGroupEgressInput) (*ec2.AuthorizeSecurityGroupEgressOutput, error) {
+	client, err := c.awsClientsProvider.GetEC2Client(ctx, "AuthorizeSecurityGroupIngress")
+	if err != nil {
+		return nil, err
+	}
+	return client.AuthorizeSecurityGroupEgress(ctx, input)
+}
+
 func (c *ec2Client) RevokeSecurityGroupIngressWithContext(ctx context.Context, input *ec2.RevokeSecurityGroupIngressInput) (*ec2.RevokeSecurityGroupIngressOutput, error) {
 	client, err := c.awsClientsProvider.GetEC2Client(ctx, "RevokeSecurityGroupIngress")
 	if err != nil {
 		return nil, err
 	}
 	return client.RevokeSecurityGroupIngress(ctx, input)
+}
+
+func (c *ec2Client) RevokeSecurityGroupEgressWithContext(ctx context.Context, input *ec2.RevokeSecurityGroupEgressInput) (*ec2.RevokeSecurityGroupEgressOutput, error) {
+	client, err := c.awsClientsProvider.GetEC2Client(ctx, "RevokeSecurityGroupEgress")
+	if err != nil {
+		return nil, err
+	}
+	return client.RevokeSecurityGroupEgress(ctx, input)
 }
 
 func (c *ec2Client) DescribeAvailabilityZonesWithContext(ctx context.Context, input *ec2.DescribeAvailabilityZonesInput) (*ec2.DescribeAvailabilityZonesOutput, error) {

--- a/pkg/aws/services/ec2_mocks.go
+++ b/pkg/aws/services/ec2_mocks.go
@@ -36,6 +36,21 @@ func (m *MockEC2) EXPECT() *MockEC2MockRecorder {
 	return m.recorder
 }
 
+// AuthorizeSecurityGroupEgressWithContext mocks base method.
+func (m *MockEC2) AuthorizeSecurityGroupEgressWithContext(arg0 context.Context, arg1 *ec2.AuthorizeSecurityGroupEgressInput) (*ec2.AuthorizeSecurityGroupEgressOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AuthorizeSecurityGroupEgressWithContext", arg0, arg1)
+	ret0, _ := ret[0].(*ec2.AuthorizeSecurityGroupEgressOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AuthorizeSecurityGroupEgressWithContext indicates an expected call of AuthorizeSecurityGroupEgressWithContext.
+func (mr *MockEC2MockRecorder) AuthorizeSecurityGroupEgressWithContext(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthorizeSecurityGroupEgressWithContext", reflect.TypeOf((*MockEC2)(nil).AuthorizeSecurityGroupEgressWithContext), arg0, arg1)
+}
+
 // AuthorizeSecurityGroupIngressWithContext mocks base method.
 func (m *MockEC2) AuthorizeSecurityGroupIngressWithContext(arg0 context.Context, arg1 *ec2.AuthorizeSecurityGroupIngressInput) (*ec2.AuthorizeSecurityGroupIngressOutput, error) {
 	m.ctrl.T.Helper()
@@ -244,6 +259,21 @@ func (m *MockEC2) DescribeVpcsWithContext(arg0 context.Context, arg1 *ec2.Descri
 func (mr *MockEC2MockRecorder) DescribeVpcsWithContext(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcsWithContext", reflect.TypeOf((*MockEC2)(nil).DescribeVpcsWithContext), arg0, arg1)
+}
+
+// RevokeSecurityGroupEgressWithContext mocks base method.
+func (m *MockEC2) RevokeSecurityGroupEgressWithContext(arg0 context.Context, arg1 *ec2.RevokeSecurityGroupEgressInput) (*ec2.RevokeSecurityGroupEgressOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RevokeSecurityGroupEgressWithContext", arg0, arg1)
+	ret0, _ := ret[0].(*ec2.RevokeSecurityGroupEgressOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RevokeSecurityGroupEgressWithContext indicates an expected call of RevokeSecurityGroupEgressWithContext.
+func (mr *MockEC2MockRecorder) RevokeSecurityGroupEgressWithContext(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeSecurityGroupEgressWithContext", reflect.TypeOf((*MockEC2)(nil).RevokeSecurityGroupEgressWithContext), arg0, arg1)
 }
 
 // RevokeSecurityGroupIngressWithContext mocks base method.

--- a/pkg/model/ec2/security_group.go
+++ b/pkg/model/ec2/security_group.go
@@ -61,6 +61,9 @@ type SecurityGroupSpec struct {
 
 	// +optional
 	Ingress []IPPermission `json:"ingress,omitempty"`
+
+	// +optional
+	Egress []IPPermission `json:"egress,omitempty"`
 }
 
 // SecurityGroupStatus defines the observed state of SecurityGroup

--- a/pkg/networking/networking_manager_test.go
+++ b/pkg/networking/networking_manager_test.go
@@ -2069,8 +2069,8 @@ func Test_AttemptGarbageCollection(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, len(tt.expectedSgReconciles), len(mockReconciler.calls))
-				for _, call := range mockReconciler.calls {
+				assert.Equal(t, len(tt.expectedSgReconciles), len(mockReconciler.ingressCalls))
+				for _, call := range mockReconciler.ingressCalls {
 					assert.True(t, tt.expectedSgReconciles.Has(call.sgID), fmt.Sprintf("expected sgID: %s to be in calls", call.sgID))
 				}
 			}
@@ -2083,12 +2083,29 @@ type reconcileIngressCall struct {
 	desiredPermissions []IPPermissionInfo
 	opts               []SecurityGroupReconcileOption
 }
+
+type reconcileEgressCall struct {
+	sgID               string
+	desiredPermissions []IPPermissionInfo
+	opts               []SecurityGroupReconcileOption
+}
+
 type mockSGReconciler struct {
-	calls []reconcileIngressCall
+	ingressCalls []reconcileIngressCall
+	egressCalls  []reconcileEgressCall
 }
 
 func (m *mockSGReconciler) ReconcileIngress(ctx context.Context, sgID string, desiredPermissions []IPPermissionInfo, opts ...SecurityGroupReconcileOption) error {
-	m.calls = append(m.calls, reconcileIngressCall{
+	m.ingressCalls = append(m.ingressCalls, reconcileIngressCall{
+		sgID:               sgID,
+		desiredPermissions: desiredPermissions,
+		opts:               opts,
+	})
+	return nil
+}
+
+func (m *mockSGReconciler) ReconcileEgress(ctx context.Context, sgID string, desiredPermissions []IPPermissionInfo, opts ...SecurityGroupReconcileOption) error {
+	m.egressCalls = append(m.egressCalls, reconcileEgressCall{
 		sgID:               sgID,
 		desiredPermissions: desiredPermissions,
 		opts:               opts,

--- a/pkg/networking/security_group_info.go
+++ b/pkg/networking/security_group_info.go
@@ -23,6 +23,9 @@ type SecurityGroupInfo struct {
 	// Ingress permission for securityGroup.
 	Ingress []IPPermissionInfo
 
+	// Egress permission for securityGroup
+	Egress []IPPermissionInfo
+
 	// Tags for securityGroup.
 	Tags map[string]string
 }
@@ -74,10 +77,17 @@ func NewRawSecurityGroupInfo(sdkSG ec2types.SecurityGroup) SecurityGroupInfo {
 			ingress = append(ingress, NewRawIPPermission(expandedPermission))
 		}
 	}
+	var egress []IPPermissionInfo
+	for _, sdkPermission := range sdkSG.IpPermissionsEgress {
+		for _, expandedPermission := range expandSDKIPPermission(sdkPermission) {
+			egress = append(egress, NewRawIPPermission(expandedPermission))
+		}
+	}
 	tags := buildSecurityGroupTags(sdkSG)
 	return SecurityGroupInfo{
 		SecurityGroupID: sgID,
 		Ingress:         ingress,
+		Egress:          egress,
 		Tags:            tags,
 	}
 }

--- a/pkg/networking/security_group_manager_mocks.go
+++ b/pkg/networking/security_group_manager_mocks.go
@@ -35,6 +35,20 @@ func (m *MockSecurityGroupManager) EXPECT() *MockSecurityGroupManagerMockRecorde
 	return m.recorder
 }
 
+// AuthorizeSGEgress mocks base method.
+func (m *MockSecurityGroupManager) AuthorizeSGEgress(arg0 context.Context, arg1 string, arg2 []IPPermissionInfo) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AuthorizeSGEgress", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AuthorizeSGEgress indicates an expected call of AuthorizeSGEgress.
+func (mr *MockSecurityGroupManagerMockRecorder) AuthorizeSGEgress(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthorizeSGEgress", reflect.TypeOf((*MockSecurityGroupManager)(nil).AuthorizeSGEgress), arg0, arg1, arg2)
+}
+
 // AuthorizeSGIngress mocks base method.
 func (m *MockSecurityGroupManager) AuthorizeSGIngress(arg0 context.Context, arg1 string, arg2 []IPPermissionInfo) error {
 	m.ctrl.T.Helper()
@@ -82,6 +96,20 @@ func (m *MockSecurityGroupManager) FetchSGInfosByRequest(arg0 context.Context, a
 func (mr *MockSecurityGroupManagerMockRecorder) FetchSGInfosByRequest(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchSGInfosByRequest", reflect.TypeOf((*MockSecurityGroupManager)(nil).FetchSGInfosByRequest), arg0, arg1)
+}
+
+// RevokeSGEgress mocks base method.
+func (m *MockSecurityGroupManager) RevokeSGEgress(arg0 context.Context, arg1 string, arg2 []IPPermissionInfo) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RevokeSGEgress", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RevokeSGEgress indicates an expected call of RevokeSGEgress.
+func (mr *MockSecurityGroupManagerMockRecorder) RevokeSGEgress(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeSGEgress", reflect.TypeOf((*MockSecurityGroupManager)(nil).RevokeSGEgress), arg0, arg1, arg2)
 }
 
 // RevokeSGIngress mocks base method.


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description

This PR implements a new annotation (`service.beta.kubernetes.io/aws-load-balancer-outbound-cidrs`) for Service load balancers to enable explicitly specifying a list of CIDR ranges to be added as egress rules to managed frontend security groups. 

Currently, `aws-load-balancer-controller` doesn't set any explicit egress rules during SG creation, relying instead on AWS to create a default all-protocol `0.0.0.0/0` rule when no explicit egress rules are specified during SG creation. This egress rule is necessary for health checks on target groups, etc.

However, some organizations may have security scans that trigger on this `0.0.0.0/0` rule, and it would be desirable to be able to scope that down to a specific set of CIDR ranges instead (e.g. the VPC CIDR, for example). There is currently no mechanism in `aws-load-balancer-controller` to allow setting this, so that is what this is intended to provide.

Note that this only implements this for the Service load balancer (e.g. nlb) workflow. I wanted to keep the PR more narrowly scoped, but it would probably relatively simple to implement for other workflows as well. There is also the `backend` SG where a command flag would need to be introduced, but it's easy enough just to use a statically created SG for the backend SG using the existing mechanisms instead.

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
