### PR TITLE
fix metric population by requeueneeded error

### DIFF
--- a/controllers/elbv2/targetgroupbinding_controller.go
+++ b/controllers/elbv2/targetgroupbinding_controller.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/aws-load-balancer-controller/controllers/elbv2/eventhandlers"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/config"
-	errmetrics "sigs.k8s.io/aws-load-balancer-controller/pkg/error"
+	ctrlerrors "sigs.k8s.io/aws-load-balancer-controller/pkg/error"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/runtime"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/targetgroupbinding"
@@ -131,7 +131,7 @@ func (r *targetGroupBindingReconciler) reconcileTargetGroupBinding(ctx context.C
 	r.metricsCollector.ObserveControllerReconcileLatency(controllerName, "add_finalizers", finalizerFn)
 	if err != nil {
 		r.eventRecorder.Event(tgb, corev1.EventTypeWarning, k8s.TargetGroupBindingEventReasonFailedAddFinalizer, fmt.Sprintf("Failed add finalizer due to %v", err))
-		return errmetrics.NewErrorWithMetrics(controllerName, "add_finalizers_error", err, r.metricsCollector)
+		return ctrlerrors.NewErrorWithMetrics(controllerName, "add_finalizers_error", err, r.metricsCollector)
 	}
 
 	var deferred bool
@@ -140,7 +140,7 @@ func (r *targetGroupBindingReconciler) reconcileTargetGroupBinding(ctx context.C
 	}
 	r.metricsCollector.ObserveControllerReconcileLatency(controllerName, "reconcile_targetgroupbinding", tgbResourceFn)
 	if err != nil {
-		return errmetrics.NewErrorWithMetrics(controllerName, "reconcile_targetgroupbinding_error", err, r.metricsCollector)
+		return ctrlerrors.NewErrorWithMetrics(controllerName, "reconcile_targetgroupbinding_error", err, r.metricsCollector)
 	}
 
 	if deferred {
@@ -155,7 +155,7 @@ func (r *targetGroupBindingReconciler) reconcileTargetGroupBinding(ctx context.C
 	}
 	r.metricsCollector.ObserveControllerReconcileLatency(controllerName, "update_status", updateTargetGroupBindingStatusFn)
 	if err != nil {
-		return errmetrics.NewErrorWithMetrics(controllerName, "update_status_error", err, r.metricsCollector)
+		return ctrlerrors.NewErrorWithMetrics(controllerName, "update_status_error", err, r.metricsCollector)
 	}
 
 	r.eventRecorder.Event(tgb, corev1.EventTypeNormal, k8s.TargetGroupBindingEventReasonSuccessfullyReconciled, "Successfully reconciled")

--- a/controllers/gateway/gateway_controller.go
+++ b/controllers/gateway/gateway_controller.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy"
 	elbv2deploy "sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/elbv2"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/tracking"
+	ctrlerrors "sigs.k8s.io/aws-load-balancer-controller/pkg/error"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/gateway/constants"
 	gatewaymodel "sigs.k8s.io/aws-load-balancer-controller/pkg/gateway/model"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/gateway/referencecounter"
@@ -336,7 +337,7 @@ func (r *gatewayReconciler) reconcileUpdate(ctx context.Context, gw *gwv1.Gatewa
 
 func (r *gatewayReconciler) deployModel(ctx context.Context, gw *gwv1.Gateway, stack core.Stack, secrets []types.NamespacedName) error {
 	if err := r.stackDeployer.Deploy(ctx, stack, r.metricsCollector, r.controllerName, nil); err != nil {
-		var requeueNeededAfter *runtime.RequeueNeededAfter
+		var requeueNeededAfter *ctrlerrors.RequeueNeededAfter
 		if errors.As(err, &requeueNeededAfter) {
 			return err
 		}
@@ -401,7 +402,7 @@ func (r *gatewayReconciler) updateGatewayStatusSuccess(ctx context.Context, lbSt
 	}
 
 	if requeueNeeded {
-		return runtime.NewRequeueNeededAfter(requeueMessage, statusUpdateRequeueTime)
+		return ctrlerrors.NewRequeueNeededAfter(requeueMessage, statusUpdateRequeueTime)
 	}
 
 	return nil

--- a/controllers/gateway/listenerrule_configuration_controller.go
+++ b/controllers/gateway/listenerrule_configuration_controller.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/config"
+	ctrlerrors "sigs.k8s.io/aws-load-balancer-controller/pkg/error"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/gateway/constants"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/gateway/routeutils"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
@@ -101,7 +102,7 @@ func (r *listenerRuleConfigurationReconciler) handleUpdate(ctx context.Context, 
 			if err := r.updateStatus(ctx, listenerRuleConf, false, secretValidationErr.Error()); err != nil {
 				return err
 			}
-			return runtime.NewRequeueNeededAfter("Required secret not yet available", secretValidationRequeueInterval)
+			return ctrlerrors.NewRequeueNeededAfter("Required secret not yet available", secretValidationRequeueInterval)
 		}
 		return secretValidationErr
 	}

--- a/controllers/ingress/group_controller.go
+++ b/controllers/ingress/group_controller.go
@@ -23,7 +23,7 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy"
 	elbv2deploy "sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/elbv2"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/tracking"
-	errmetrics "sigs.k8s.io/aws-load-balancer-controller/pkg/error"
+	ctrlerrors "sigs.k8s.io/aws-load-balancer-controller/pkg/error"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/ingress"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	lbcmetrics "sigs.k8s.io/aws-load-balancer-controller/pkg/metrics/lbc"
@@ -141,7 +141,7 @@ func (r *groupReconciler) reconcile(ctx context.Context, req reconcile.Request) 
 	}
 	r.metricsCollector.ObserveControllerReconcileLatency(controllerName, "fetch_ingress", loadIngressFn)
 	if err != nil {
-		return errmetrics.NewErrorWithMetrics(controllerName, "fetch_ingress_error", err, r.metricsCollector)
+		return ctrlerrors.NewErrorWithMetrics(controllerName, "fetch_ingress_error", err, r.metricsCollector)
 	}
 
 	addFinalizerFn := func() {
@@ -150,7 +150,7 @@ func (r *groupReconciler) reconcile(ctx context.Context, req reconcile.Request) 
 	r.metricsCollector.ObserveControllerReconcileLatency(controllerName, "add_group_finalizer", addFinalizerFn)
 	if err != nil {
 		r.recordIngressGroupEvent(ctx, ingGroup, corev1.EventTypeWarning, k8s.IngressEventReasonFailedAddFinalizer, fmt.Sprintf("Failed add finalizer due to %v", err))
-		return errmetrics.NewErrorWithMetrics(controllerName, "add_group_finalizer_error", err, r.metricsCollector)
+		return ctrlerrors.NewErrorWithMetrics(controllerName, "add_group_finalizer_error", err, r.metricsCollector)
 	}
 
 	_, lb, frontendNlb, err := r.buildAndDeployModel(ctx, ingGroup)
@@ -181,7 +181,7 @@ func (r *groupReconciler) reconcile(ctx context.Context, req reconcile.Request) 
 		}
 		r.metricsCollector.ObserveControllerReconcileLatency(controllerName, "dns_resolve_and_update_status", dnsResolveAndUpdateStatus)
 		if statusErr != nil {
-			return errmetrics.NewErrorWithMetrics(controllerName, "dns_resolve_and_update_status_error", statusErr, r.metricsCollector)
+			return ctrlerrors.NewErrorWithMetrics(controllerName, "dns_resolve_and_update_status_error", statusErr, r.metricsCollector)
 		}
 	}
 
@@ -192,7 +192,7 @@ func (r *groupReconciler) reconcile(ctx context.Context, req reconcile.Request) 
 		r.metricsCollector.ObserveControllerReconcileLatency(controllerName, "remove_group_finalizer", removeGroupFinalizerFn)
 		if err != nil {
 			r.recordIngressGroupEvent(ctx, ingGroup, corev1.EventTypeWarning, k8s.IngressEventReasonFailedRemoveFinalizer, fmt.Sprintf("Failed remove finalizer due to %v", err))
-			return errmetrics.NewErrorWithMetrics(controllerName, "remove_group_finalizer_error", err, r.metricsCollector)
+			return ctrlerrors.NewErrorWithMetrics(controllerName, "remove_group_finalizer_error", err, r.metricsCollector)
 		}
 	}
 
@@ -214,7 +214,7 @@ func (r *groupReconciler) buildAndDeployModel(ctx context.Context, ingGroup ingr
 	r.metricsCollector.ObserveControllerReconcileLatency(controllerName, "build_model", buildModelFn)
 	if err != nil {
 		r.recordIngressGroupEvent(ctx, ingGroup, corev1.EventTypeWarning, k8s.IngressEventReasonFailedBuildModel, fmt.Sprintf("Failed build model due to %v", err))
-		return nil, nil, nil, errmetrics.NewErrorWithMetrics(controllerName, "build_model_error", err, r.metricsCollector)
+		return nil, nil, nil, ctrlerrors.NewErrorWithMetrics(controllerName, "build_model_error", err, r.metricsCollector)
 	}
 	stackJSON, err := r.stackMarshaller.Marshal(stack)
 	if err != nil {
@@ -228,12 +228,12 @@ func (r *groupReconciler) buildAndDeployModel(ctx context.Context, ingGroup ingr
 	}
 	r.metricsCollector.ObserveControllerReconcileLatency(controllerName, "deploy_model", deployModelFn)
 	if err != nil {
-		var requeueNeededAfter *runtime.RequeueNeededAfter
+		var requeueNeededAfter *ctrlerrors.RequeueNeededAfter
 		if errors.As(err, &requeueNeededAfter) {
 			return nil, nil, nil, err
 		}
 		r.recordIngressGroupEvent(ctx, ingGroup, corev1.EventTypeWarning, k8s.IngressEventReasonFailedDeployModel, fmt.Sprintf("Failed deploy model due to %v", err))
-		return nil, nil, nil, errmetrics.NewErrorWithMetrics(controllerName, "deploy_model_error", err, r.metricsCollector)
+		return nil, nil, nil, ctrlerrors.NewErrorWithMetrics(controllerName, "deploy_model_error", err, r.metricsCollector)
 	}
 	r.logger.Info("successfully deployed model", "ingressGroup", ingGroup.ID)
 	r.secretsManager.MonitorSecrets(ingGroup.ID.String(), secrets)
@@ -243,7 +243,7 @@ func (r *groupReconciler) buildAndDeployModel(ctx context.Context, ingGroup ingr
 		inactiveResources = append(inactiveResources, k8s.ToSliceOfNamespacedNames(ingGroup.Members)...)
 	}
 	if err := r.backendSGProvider.Release(ctx, networkingpkg.ResourceTypeIngress, inactiveResources); err != nil {
-		return nil, nil, nil, errmetrics.NewErrorWithMetrics(controllerName, "release_auto_generated_backend_sg_error", err, r.metricsCollector)
+		return nil, nil, nil, ctrlerrors.NewErrorWithMetrics(controllerName, "release_auto_generated_backend_sg_error", err, r.metricsCollector)
 	}
 	return stack, lb, frontendNlb, nil
 }

--- a/controllers/service/service_controller.go
+++ b/controllers/service/service_controller.go
@@ -20,7 +20,7 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy"
 	elbv2deploy "sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/elbv2"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/tracking"
-	errmetrics "sigs.k8s.io/aws-load-balancer-controller/pkg/error"
+	ctrlerrors "sigs.k8s.io/aws-load-balancer-controller/pkg/error"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	lbcmetrics "sigs.k8s.io/aws-load-balancer-controller/pkg/metrics/lbc"
 	metricsutil "sigs.k8s.io/aws-load-balancer-controller/pkg/metrics/util"
@@ -123,7 +123,7 @@ func (r *serviceReconciler) reconcile(ctx context.Context, req reconcile.Request
 	}
 	r.metricsCollector.ObserveControllerReconcileLatency(controllerName, "build_model", buildModelFn)
 	if err != nil {
-		return errmetrics.NewErrorWithMetrics(controllerName, "build_model_error", err, r.metricsCollector)
+		return ctrlerrors.NewErrorWithMetrics(controllerName, "build_model_error", err, r.metricsCollector)
 	}
 
 	if lb == nil {
@@ -132,7 +132,7 @@ func (r *serviceReconciler) reconcile(ctx context.Context, req reconcile.Request
 		}
 		r.metricsCollector.ObserveControllerReconcileLatency(controllerName, "cleanup_load_balancer", cleanupLoadBalancerFn)
 		if err != nil {
-			return errmetrics.NewErrorWithMetrics(controllerName, "cleanup_load_balancer_error", err, r.metricsCollector)
+			return ctrlerrors.NewErrorWithMetrics(controllerName, "cleanup_load_balancer_error", err, r.metricsCollector)
 		}
 	}
 	return r.reconcileLoadBalancerResources(ctx, svc, stack, lb, backendSGRequired)
@@ -155,7 +155,7 @@ func (r *serviceReconciler) buildModel(ctx context.Context, svc *corev1.Service)
 
 func (r *serviceReconciler) deployModel(ctx context.Context, svc *corev1.Service, stack core.Stack) error {
 	if err := r.stackDeployer.Deploy(ctx, stack, r.metricsCollector, "service", nil); err != nil {
-		var requeueNeededAfter *runtime.RequeueNeededAfter
+		var requeueNeededAfter *ctrlerrors.RequeueNeededAfter
 		if errors.As(err, &requeueNeededAfter) {
 			return err
 		}
@@ -177,7 +177,7 @@ func (r *serviceReconciler) reconcileLoadBalancerResources(ctx context.Context, 
 	r.metricsCollector.ObserveControllerReconcileLatency(controllerName, "add_finalizers", addFinalizersFn)
 	if err != nil {
 		r.eventRecorder.Event(svc, corev1.EventTypeWarning, k8s.ServiceEventReasonFailedAddFinalizer, fmt.Sprintf("Failed add finalizer due to %v", err))
-		return errmetrics.NewErrorWithMetrics(controllerName, "add_finalizers_error", err, r.metricsCollector)
+		return ctrlerrors.NewErrorWithMetrics(controllerName, "add_finalizers_error", err, r.metricsCollector)
 	}
 
 	deployModelFn := func() {
@@ -185,7 +185,7 @@ func (r *serviceReconciler) reconcileLoadBalancerResources(ctx context.Context, 
 	}
 	r.metricsCollector.ObserveControllerReconcileLatency(controllerName, "deploy_model", deployModelFn)
 	if err != nil {
-		return errmetrics.NewErrorWithMetrics(controllerName, "deploy_model_error", err, r.metricsCollector)
+		return ctrlerrors.NewErrorWithMetrics(controllerName, "deploy_model_error", err, r.metricsCollector)
 	}
 
 	var lbDNS string
@@ -194,12 +194,12 @@ func (r *serviceReconciler) reconcileLoadBalancerResources(ctx context.Context, 
 	}
 	r.metricsCollector.ObserveControllerReconcileLatency(controllerName, "DNS_resolve", dnsResolveFn)
 	if err != nil {
-		return errmetrics.NewErrorWithMetrics(controllerName, "dns_resolve_error", err, r.metricsCollector)
+		return ctrlerrors.NewErrorWithMetrics(controllerName, "dns_resolve_error", err, r.metricsCollector)
 	}
 
 	if !backendSGRequired {
 		if err := r.backendSGProvider.Release(ctx, networking.ResourceTypeService, []types.NamespacedName{k8s.NamespacedName(svc)}); err != nil {
-			return errmetrics.NewErrorWithMetrics(controllerName, "release_auto_generated_backend_sg_error", err, r.metricsCollector)
+			return ctrlerrors.NewErrorWithMetrics(controllerName, "release_auto_generated_backend_sg_error", err, r.metricsCollector)
 		}
 	}
 
@@ -209,7 +209,7 @@ func (r *serviceReconciler) reconcileLoadBalancerResources(ctx context.Context, 
 	r.metricsCollector.ObserveControllerReconcileLatency(controllerName, "update_status", updateStatusFn)
 	if err != nil {
 		r.eventRecorder.Event(svc, corev1.EventTypeWarning, k8s.ServiceEventReasonFailedUpdateStatus, fmt.Sprintf("Failed update status due to %v", err))
-		return errmetrics.NewErrorWithMetrics(controllerName, "update_status_error", err, r.metricsCollector)
+		return ctrlerrors.NewErrorWithMetrics(controllerName, "update_status_error", err, r.metricsCollector)
 	}
 	r.eventRecorder.Event(svc, corev1.EventTypeNormal, k8s.ServiceEventReasonSuccessfullyReconciled, "Successfully reconciled")
 	return nil

--- a/pkg/deploy/elbv2/frontend_nlb_target_synthesizer.go
+++ b/pkg/deploy/elbv2/frontend_nlb_target_synthesizer.go
@@ -2,6 +2,7 @@ package elbv2
 
 import (
 	"context"
+	ctrlerrors "sigs.k8s.io/aws-load-balancer-controller/pkg/error"
 	"time"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
@@ -12,7 +13,6 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/tracking"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/core"
 	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
-	"sigs.k8s.io/aws-load-balancer-controller/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -147,7 +147,7 @@ func (s *frontendNlbTargetSynthesizer) PostSynthesize(ctx context.Context) error
 
 			if err != nil {
 				requeueMsg := "Failed to register target, retrying after deplay for target group: " + resTG.Status.TargetGroupARN
-				return runtime.NewRequeueNeededAfter(requeueMsg, 15*time.Second)
+				return ctrlerrors.NewRequeueNeededAfter(requeueMsg, 15*time.Second)
 			}
 
 		}

--- a/pkg/deploy/elbv2/load_balancer_synthesizer.go
+++ b/pkg/deploy/elbv2/load_balancer_synthesizer.go
@@ -11,9 +11,9 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/services"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/config"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/tracking"
+	ctrlerrors "sigs.k8s.io/aws-load-balancer-controller/pkg/error"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/core"
 	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
-	"sigs.k8s.io/aws-load-balancer-controller/pkg/runtime"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/shared_constants"
 	"strings"
 )
@@ -131,7 +131,7 @@ func (s *loadBalancerSynthesizer) PostSynthesize(ctx context.Context) error {
 		}
 		if isLoadBalancerProvisioning {
 			requeueMsg := "monitor provisioning state for load balancer: " + awssdk.ToString(resAndSDKLB.sdkLB.LoadBalancer.LoadBalancerName)
-			return runtime.NewRequeueNeededAfter(requeueMsg, s.controllerConfig.LBStabilizationMonitorInterval)
+			return ctrlerrors.NewRequeueNeededAfter(requeueMsg, s.controllerConfig.LBStabilizationMonitorInterval)
 		}
 		if err := s.capacityReservationReconciler.Reconcile(ctx, resAndSDKLB.resLB, resAndSDKLB.sdkLB); err != nil {
 			return err

--- a/pkg/deploy/stack_deployer.go
+++ b/pkg/deploy/stack_deployer.go
@@ -15,7 +15,7 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/tracking"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/wafregional"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/wafv2"
-	errmetrics "sigs.k8s.io/aws-load-balancer-controller/pkg/error"
+	ctrlerrors "sigs.k8s.io/aws-load-balancer-controller/pkg/error"
 	lbcmetrics "sigs.k8s.io/aws-load-balancer-controller/pkg/metrics/lbc"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/core"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/networking"
@@ -157,7 +157,7 @@ func (d *defaultStackDeployer) Deploy(ctx context.Context, stack core.Stack, met
 		}
 		d.metricsCollector.ObserveControllerReconcileLatency(controllerName, synthesizerType, synthesizeFn)
 		if err != nil {
-			return errmetrics.NewErrorWithMetrics(controllerName, synthesizerType, err, d.metricsCollector)
+			return ctrlerrors.NewErrorWithMetrics(controllerName, synthesizerType, err, d.metricsCollector)
 		}
 	}
 	for i := len(synthesizers) - 1; i >= 0; i-- {

--- a/pkg/error/error_with_metrics_test.go
+++ b/pkg/error/error_with_metrics_test.go
@@ -1,0 +1,44 @@
+package ctrlerrors
+
+import (
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	lbcmetrics "sigs.k8s.io/aws-load-balancer-controller/pkg/metrics/lbc"
+	"testing"
+)
+
+func Test_NewErrorWithMetrics(t *testing.T) {
+	resourceType := "test-resource"
+	category := "test-category"
+	testCases := []struct {
+		name                string
+		err                 error
+		expectedInvocations int
+	}{
+		{
+			name:                "real error",
+			err:                 errors.New("bad thing"),
+			expectedInvocations: 1,
+		},
+		{
+			name: "requeue needed error",
+			err:  &RequeueNeeded{},
+		},
+		{
+			name: "requeue needed after error",
+			err:  &RequeueNeededAfter{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			collector := lbcmetrics.NewMockCollector()
+			res := NewErrorWithMetrics(resourceType, category, tc.err, collector)
+			assert.Equal(t, tc.err, res.Err)
+			assert.Equal(t, resourceType, res.ResourceType)
+			assert.Equal(t, category, res.ErrorCategory)
+			mc := collector.(*lbcmetrics.MockCollector)
+			assert.Equal(t, tc.expectedInvocations, len(mc.Invocations[lbcmetrics.MetricControllerReconcileErrors]))
+		})
+	}
+}

--- a/pkg/error/errors.go
+++ b/pkg/error/errors.go
@@ -1,4 +1,4 @@
-package runtime
+package ctrlerrors
 
 import (
 	"fmt"

--- a/pkg/error/errors_test.go
+++ b/pkg/error/errors_test.go
@@ -1,4 +1,4 @@
-package runtime
+package ctrlerrors
 
 import (
 	"github.com/stretchr/testify/assert"

--- a/pkg/runtime/reconcile.go
+++ b/pkg/runtime/reconcile.go
@@ -3,7 +3,7 @@ package runtime
 import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
-	errmetrics "sigs.k8s.io/aws-load-balancer-controller/pkg/error"
+	ctrlerrors "sigs.k8s.io/aws-load-balancer-controller/pkg/error"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -14,13 +14,13 @@ func HandleReconcileError(inputErr error, log logr.Logger) (ctrl.Result, error) 
 		return ctrl.Result{}, nil
 	}
 
-	var requeueNeededAfter *RequeueNeededAfter
+	var requeueNeededAfter *ctrlerrors.RequeueNeededAfter
 	if errors.As(resolvedErr, &requeueNeededAfter) {
 		log.V(1).Info("requeue after", "duration", requeueNeededAfter.Duration(), "reason", requeueNeededAfter.Reason())
 		return ctrl.Result{RequeueAfter: requeueNeededAfter.Duration()}, nil
 	}
 
-	var requeueNeeded *RequeueNeeded
+	var requeueNeeded *ctrlerrors.RequeueNeeded
 	if errors.As(resolvedErr, &requeueNeeded) {
 		log.V(1).Info("requeue", "reason", requeueNeeded.Reason())
 		return ctrl.Result{Requeue: true}, nil
@@ -34,7 +34,7 @@ func handleNestedError(err error) error {
 		return nil
 	}
 
-	var wrappedError *errmetrics.ErrorWithMetrics
+	var wrappedError *ctrlerrors.ErrorWithMetrics
 	if errors.As(err, &wrappedError) {
 		return wrappedError.Err
 	}

--- a/pkg/runtime/reconcile_test.go
+++ b/pkg/runtime/reconcile_test.go
@@ -1,7 +1,7 @@
 package runtime
 
 import (
-	errmetrics "sigs.k8s.io/aws-load-balancer-controller/pkg/error"
+	ctrlerrors "sigs.k8s.io/aws-load-balancer-controller/pkg/error"
 	"testing"
 	"time"
 
@@ -18,7 +18,7 @@ func TestHandleReconcileError(t *testing.T) {
 	}
 
 	otherErrType := errors.New("some error")
-	wrappedOtherErrorType := &errmetrics.ErrorWithMetrics{
+	wrappedOtherErrorType := &ctrlerrors.ErrorWithMetrics{
 		Err:          otherErrType,
 		ResourceType: "foo",
 	}
@@ -39,7 +39,7 @@ func TestHandleReconcileError(t *testing.T) {
 		{
 			name: "input err is nil",
 			args: args{
-				err: &errmetrics.ErrorWithMetrics{},
+				err: &ctrlerrors.ErrorWithMetrics{},
 			},
 			want:    ctrl.Result{},
 			wantErr: nil,
@@ -47,7 +47,7 @@ func TestHandleReconcileError(t *testing.T) {
 		{
 			name: "input err is RequeueNeededAfter",
 			args: args{
-				err: NewRequeueNeededAfter("some error", 3*time.Second),
+				err: ctrlerrors.NewRequeueNeededAfter("some error", 3*time.Second),
 			},
 			want: ctrl.Result{
 				RequeueAfter: 3 * time.Second,
@@ -57,7 +57,7 @@ func TestHandleReconcileError(t *testing.T) {
 		{
 			name: "input err is RequeueNeeded",
 			args: args{
-				err: NewRequeueNeeded("some error"),
+				err: ctrlerrors.NewRequeueNeeded("some error"),
 			},
 			want: ctrl.Result{
 				Requeue: true,
@@ -67,8 +67,8 @@ func TestHandleReconcileError(t *testing.T) {
 		{
 			name: "input err is ErrorWithMetrics and is RequeueNeededAfter",
 			args: args{
-				err: &errmetrics.ErrorWithMetrics{
-					Err: NewRequeueNeededAfter("some error", 3*time.Second),
+				err: &ctrlerrors.ErrorWithMetrics{
+					Err: ctrlerrors.NewRequeueNeededAfter("some error", 3*time.Second),
 				},
 			},
 			want: ctrl.Result{
@@ -79,8 +79,8 @@ func TestHandleReconcileError(t *testing.T) {
 		{
 			name: "input err is ErrorWithMetrics and is RequeueNeeded",
 			args: args{
-				err: &errmetrics.ErrorWithMetrics{
-					Err: NewRequeueNeeded("some error"),
+				err: &ctrlerrors.ErrorWithMetrics{
+					Err: ctrlerrors.NewRequeueNeeded("some error"),
 				},
 			},
 			want: ctrl.Result{

--- a/pkg/service/model_builder.go
+++ b/pkg/service/model_builder.go
@@ -17,7 +17,7 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/config"
 	elbv2deploy "sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/elbv2"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/tracking"
-	errmetrics "sigs.k8s.io/aws-load-balancer-controller/pkg/error"
+	ctrlerrors "sigs.k8s.io/aws-load-balancer-controller/pkg/error"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	lbcmetrics "sigs.k8s.io/aws-load-balancer-controller/pkg/metrics/lbc"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/core"
@@ -256,19 +256,19 @@ func (t *defaultModelBuildTask) run(ctx context.Context) error {
 func (t *defaultModelBuildTask) buildModel(ctx context.Context) error {
 	scheme, err := t.buildLoadBalancerScheme(ctx)
 	if err != nil {
-		return errmetrics.NewErrorWithMetrics(controllerName, "build_load_balancer_scheme_error", err, t.metricsCollector)
+		return ctrlerrors.NewErrorWithMetrics(controllerName, "build_load_balancer_scheme_error", err, t.metricsCollector)
 	}
 	t.ec2Subnets, err = t.buildLoadBalancerSubnets(ctx, scheme)
 	if err != nil {
-		return errmetrics.NewErrorWithMetrics(controllerName, "build_load_balancer_subnets_error", err, t.metricsCollector)
+		return ctrlerrors.NewErrorWithMetrics(controllerName, "build_load_balancer_subnets_error", err, t.metricsCollector)
 	}
 	err = t.buildLoadBalancer(ctx, scheme)
 	if err != nil {
-		return errmetrics.NewErrorWithMetrics(controllerName, "build_load_balancer_error", err, t.metricsCollector)
+		return ctrlerrors.NewErrorWithMetrics(controllerName, "build_load_balancer_error", err, t.metricsCollector)
 	}
 	err = t.buildListeners(ctx, scheme)
 	if err != nil {
-		return errmetrics.NewErrorWithMetrics(controllerName, "build_listeners_error", err, t.metricsCollector)
+		return ctrlerrors.NewErrorWithMetrics(controllerName, "build_listeners_error", err, t.metricsCollector)
 	}
 	return nil
 }

--- a/pkg/targetgroupbinding/resource_manager.go
+++ b/pkg/targetgroupbinding/resource_manager.go
@@ -22,11 +22,10 @@ import (
 	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/services"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/backend"
-	errmetrics "sigs.k8s.io/aws-load-balancer-controller/pkg/error"
+	ctrlerrors "sigs.k8s.io/aws-load-balancer-controller/pkg/error"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	lbcmetrics "sigs.k8s.io/aws-load-balancer-controller/pkg/metrics/lbc"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/networking"
-	"sigs.k8s.io/aws-load-balancer-controller/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -163,13 +162,13 @@ func (m *defaultResourceManager) reconcileWithIPTargetType(ctx context.Context, 
 			m.eventRecorder.Event(tgb, corev1.EventTypeWarning, k8s.TargetGroupBindingEventReasonBackendNotFound, err.Error())
 			return "", oldCheckPoint, false, m.Cleanup(ctx, tgb)
 		}
-		return "", "", false, errmetrics.NewErrorWithMetrics(controllerName, "resolve_pod_endpoints_error", err, m.metricsCollector)
+		return "", "", false, ctrlerrors.NewErrorWithMetrics(controllerName, "resolve_pod_endpoints_error", err, m.metricsCollector)
 	}
 
 	newCheckPoint, err := calculateTGBReconcileCheckpoint(endpoints, tgb)
 
 	if err != nil {
-		return "", "", false, errmetrics.NewErrorWithMetrics(controllerName, "calculate_tgb_reconcile_checkpoint_error", err, m.metricsCollector)
+		return "", "", false, ctrlerrors.NewErrorWithMetrics(controllerName, "calculate_tgb_reconcile_checkpoint_error", err, m.metricsCollector)
 	}
 
 	if !containsPotentialReadyEndpoints && oldCheckPoint == newCheckPoint {
@@ -179,7 +178,7 @@ func (m *defaultResourceManager) reconcileWithIPTargetType(ctx context.Context, 
 
 	targets, err := m.targetsManager.ListTargets(ctx, tgb)
 	if err != nil {
-		return "", "", false, errmetrics.NewErrorWithMetrics(controllerName, "list_targets_error", err, m.metricsCollector)
+		return "", "", false, ctrlerrors.NewErrorWithMetrics(controllerName, "list_targets_error", err, m.metricsCollector)
 	}
 
 	notDrainingTargets, _ := partitionTargetsByDrainingStatus(targets)
@@ -212,7 +211,7 @@ func (m *defaultResourceManager) reconcileWithIPTargetType(ctx context.Context, 
 		err = m.updateTGBCheckPoint(ctx, tgb, "", oldCheckPoint)
 		if err != nil {
 			tgbScopedLogger.Error(err, "Unable to update checkpoint before mutating change")
-			return "", "", false, errmetrics.NewErrorWithMetrics(controllerName, "update_tgb_checkpoint_error", err, m.metricsCollector)
+			return "", "", false, ctrlerrors.NewErrorWithMetrics(controllerName, "update_tgb_checkpoint_error", err, m.metricsCollector)
 		}
 	}
 
@@ -220,7 +219,7 @@ func (m *defaultResourceManager) reconcileWithIPTargetType(ctx context.Context, 
 	if len(unmatchedTargets) > 0 {
 		updateTrackedTargets, err = m.deregisterTargets(ctx, tgb, unmatchedTargets)
 		if err != nil {
-			return "", "", false, errmetrics.NewErrorWithMetrics(controllerName, "deregister_targets_error", err, m.metricsCollector)
+			return "", "", false, ctrlerrors.NewErrorWithMetrics(controllerName, "deregister_targets_error", err, m.metricsCollector)
 		}
 	}
 
@@ -238,36 +237,36 @@ func (m *defaultResourceManager) reconcileWithIPTargetType(ctx context.Context, 
 		updateTrackedTargets = false
 
 		if err := m.multiClusterManager.UpdateTrackedIPTargets(ctx, true, endpoints, tgb); err != nil {
-			return "", "", false, errmetrics.NewErrorWithMetrics(controllerName, "update_tracked_ip_targets_error", err, m.metricsCollector)
+			return "", "", false, ctrlerrors.NewErrorWithMetrics(controllerName, "update_tracked_ip_targets_error", err, m.metricsCollector)
 		}
 
 		if err := m.registerPodEndpoints(ctx, tgb, unmatchedEndpoints); err != nil {
-			return "", "", false, errmetrics.NewErrorWithMetrics(controllerName, "register_pod_endpoint_error", err, m.metricsCollector)
+			return "", "", false, ctrlerrors.NewErrorWithMetrics(controllerName, "register_pod_endpoint_error", err, m.metricsCollector)
 		}
 	}
 
 	if err := m.multiClusterManager.UpdateTrackedIPTargets(ctx, updateTrackedTargets, endpoints, tgb); err != nil {
-		return "", "", false, errmetrics.NewErrorWithMetrics(controllerName, "update_tracked_ip_targets_error", err, m.metricsCollector)
+		return "", "", false, ctrlerrors.NewErrorWithMetrics(controllerName, "update_tracked_ip_targets_error", err, m.metricsCollector)
 	}
 
 	anyPodNeedFurtherProbe, err := m.updateTargetHealthPodCondition(ctx, targetHealthCondType, matchedEndpointAndTargets, unmatchedEndpoints, tgb)
 	if err != nil {
-		return "", "", false, errmetrics.NewErrorWithMetrics(controllerName, "update_target_health_pod_condition_error", err, m.metricsCollector)
+		return "", "", false, ctrlerrors.NewErrorWithMetrics(controllerName, "update_target_health_pod_condition_error", err, m.metricsCollector)
 	}
 
 	if anyPodNeedFurtherProbe {
 		tgbScopedLogger.Info("Requeue for target monitor target health")
-		return "", "", false, runtime.NewRequeueNeededAfter("monitor targetHealth", m.requeueDuration)
+		return "", "", false, ctrlerrors.NewRequeueNeededAfter("monitor targetHealth", m.requeueDuration)
 	}
 
 	if containsPotentialReadyEndpoints {
 		tgbScopedLogger.Info("Requeue for potentially ready endpoints")
-		return "", "", false, runtime.NewRequeueNeededAfter("monitor potential ready endpoints", m.requeueDuration)
+		return "", "", false, ctrlerrors.NewRequeueNeededAfter("monitor potential ready endpoints", m.requeueDuration)
 	}
 
 	if needNetworkingRequeue {
 		tgbScopedLogger.Info("Requeue for networking requeue")
-		return "", "", false, runtime.NewRequeueNeededAfter("networking reconciliation", m.requeueDuration)
+		return "", "", false, ctrlerrors.NewRequeueNeededAfter("networking reconciliation", m.requeueDuration)
 	}
 
 	tgbScopedLogger.Info("Successful reconcile", "checkpoint", newCheckPoint)
@@ -279,7 +278,7 @@ func (m *defaultResourceManager) reconcileWithInstanceTargetType(ctx context.Con
 	svcKey := buildServiceReferenceKey(tgb, tgb.Spec.ServiceRef)
 	nodeSelector, err := backend.GetTrafficProxyNodeSelector(tgb)
 	if err != nil {
-		return "", "", false, errmetrics.NewErrorWithMetrics(controllerName, "get_traffic_proxy_node_selector_error", err, m.metricsCollector)
+		return "", "", false, ctrlerrors.NewErrorWithMetrics(controllerName, "get_traffic_proxy_node_selector_error", err, m.metricsCollector)
 	}
 
 	oldCheckPoint := GetTGBReconcileCheckpoint(tgb)
@@ -290,13 +289,13 @@ func (m *defaultResourceManager) reconcileWithInstanceTargetType(ctx context.Con
 			m.eventRecorder.Event(tgb, corev1.EventTypeWarning, k8s.TargetGroupBindingEventReasonBackendNotFound, err.Error())
 			return "", oldCheckPoint, false, m.Cleanup(ctx, tgb)
 		}
-		return "", "", false, errmetrics.NewErrorWithMetrics(controllerName, "resolve_nodeport_endpoints_error", err, m.metricsCollector)
+		return "", "", false, ctrlerrors.NewErrorWithMetrics(controllerName, "resolve_nodeport_endpoints_error", err, m.metricsCollector)
 	}
 
 	newCheckPoint, err := calculateTGBReconcileCheckpoint(endpoints, tgb)
 
 	if err != nil {
-		return "", "", false, errmetrics.NewErrorWithMetrics(controllerName, "calculate_tgb_reconcile_checkpoint_error", err, m.metricsCollector)
+		return "", "", false, ctrlerrors.NewErrorWithMetrics(controllerName, "calculate_tgb_reconcile_checkpoint_error", err, m.metricsCollector)
 	}
 
 	if newCheckPoint == oldCheckPoint {
@@ -306,7 +305,7 @@ func (m *defaultResourceManager) reconcileWithInstanceTargetType(ctx context.Con
 
 	targets, err := m.targetsManager.ListTargets(ctx, tgb)
 	if err != nil {
-		return "", "", false, errmetrics.NewErrorWithMetrics(controllerName, "list_targets_error", err, m.metricsCollector)
+		return "", "", false, ctrlerrors.NewErrorWithMetrics(controllerName, "list_targets_error", err, m.metricsCollector)
 	}
 
 	notDrainingTargets, _ := partitionTargetsByDrainingStatus(targets)
@@ -315,7 +314,7 @@ func (m *defaultResourceManager) reconcileWithInstanceTargetType(ctx context.Con
 
 	if err := m.networkingManager.ReconcileForNodePortEndpoints(ctx, tgb, endpoints); err != nil {
 		tgbScopedLogger.Error(err, "Requesting network requeue due to error from ReconcileForNodePortEndpoints")
-		return "", "", false, errmetrics.NewErrorWithMetrics(controllerName, "reconcile_nodeport_endpoints_error", err, m.metricsCollector)
+		return "", "", false, ctrlerrors.NewErrorWithMetrics(controllerName, "reconcile_nodeport_endpoints_error", err, m.metricsCollector)
 	}
 
 	if len(unmatchedEndpoints) > 0 || len(unmatchedTargets) > 0 {
@@ -323,7 +322,7 @@ func (m *defaultResourceManager) reconcileWithInstanceTargetType(ctx context.Con
 		err = m.updateTGBCheckPoint(ctx, tgb, "", oldCheckPoint)
 		if err != nil {
 			tgbScopedLogger.Error(err, "Unable to update checkpoint before mutating change")
-			return "", "", false, errmetrics.NewErrorWithMetrics(controllerName, "update_tgb_checkpoint_error", err, m.metricsCollector)
+			return "", "", false, ctrlerrors.NewErrorWithMetrics(controllerName, "update_tgb_checkpoint_error", err, m.metricsCollector)
 		}
 	}
 
@@ -332,23 +331,23 @@ func (m *defaultResourceManager) reconcileWithInstanceTargetType(ctx context.Con
 	if len(unmatchedTargets) > 0 {
 		updateTrackedTargets, err = m.deregisterTargets(ctx, tgb, unmatchedTargets)
 		if err != nil {
-			return "", "", false, errmetrics.NewErrorWithMetrics(controllerName, "deregister_targets_error", err, m.metricsCollector)
+			return "", "", false, ctrlerrors.NewErrorWithMetrics(controllerName, "deregister_targets_error", err, m.metricsCollector)
 		}
 	}
 
 	if len(unmatchedEndpoints) > 0 {
 		updateTrackedTargets = false
 		if err := m.multiClusterManager.UpdateTrackedInstanceTargets(ctx, true, endpoints, tgb); err != nil {
-			return "", "", false, errmetrics.NewErrorWithMetrics(controllerName, "update_tracked_instance_targets_error", err, m.metricsCollector)
+			return "", "", false, ctrlerrors.NewErrorWithMetrics(controllerName, "update_tracked_instance_targets_error", err, m.metricsCollector)
 		}
 
 		if err := m.registerNodePortEndpoints(ctx, tgb, unmatchedEndpoints); err != nil {
-			return "", "", false, errmetrics.NewErrorWithMetrics(controllerName, "update_node_port_endpoints_error", err, m.metricsCollector)
+			return "", "", false, ctrlerrors.NewErrorWithMetrics(controllerName, "update_node_port_endpoints_error", err, m.metricsCollector)
 		}
 	}
 
 	if err := m.multiClusterManager.UpdateTrackedInstanceTargets(ctx, updateTrackedTargets, endpoints, tgb); err != nil {
-		return "", "", false, errmetrics.NewErrorWithMetrics(controllerName, "update_tracked_instance_targets_error", err, m.metricsCollector)
+		return "", "", false, ctrlerrors.NewErrorWithMetrics(controllerName, "update_tracked_instance_targets_error", err, m.metricsCollector)
 	}
 
 	tgbScopedLogger.Info("Successful reconcile", "checkpoint", newCheckPoint)


### PR DESCRIPTION
### Issue

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4324

### Description

Our metric collector didn't differentiate between "real" and "expected" errors. This changes add the ability to detect a RequeueNeeded* error, and when the Requeue error is detected we *do not* emit a metric pertaining to the error.

Note, I had to move the RequeueNeeded errors out of the runtime package to prevent an import cycle.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
