### PR TITLE
temporaily remove certs from e2e test until certs are re-generated

### DIFF
--- a/scripts/ci_e2e_test.sh
+++ b/scripts/ci_e2e_test.sh
@@ -204,13 +204,13 @@ test_controller_image() {
 
   AWS_ACCOUNT_ID=$(aws sts get-caller-identity --region ${AWS_REGION} --query Account --output text)
   S3_BUCKET=${S3_BUCKET:-"lb-controller-e2e-${AWS_ACCOUNT_ID}"}
-  CERTIFICATE_ARN_PREFIX=arn:aws:acm:${AWS_REGION}:${AWS_ACCOUNT_ID}:certificate
-  echo "updated the CERT_IDs"
-  CERT_ID1="d39a65e5-44f6-4734-9034-6c82ae7df73b"
-  CERT_ID2="35d7e09b-c4a9-447e-ba8c-7f9f29b77c8f"
-  CERT_ID3="f44d1a16-409a-4937-a420-b42dab2d384a"
-  CERTIFICATE_ARNS=${CERTIFICATE_ARNS:-"${CERTIFICATE_ARN_PREFIX}/${CERT_ID1},${CERTIFICATE_ARN_PREFIX}/${CERT_ID2},${CERTIFICATE_ARN_PREFIX}/${CERT_ID3}"}
-  echo "creating s3 bucket $S3_BUCKET"
+  #CERTIFICATE_ARN_PREFIX=arn:aws:acm:${AWS_REGION}:${AWS_ACCOUNT_ID}:certificate
+  #echo "updated the CERT_IDs"
+  #CERT_ID1="d39a65e5-44f6-4734-9034-6c82ae7df73b"
+  #CERT_ID2="35d7e09b-c4a9-447e-ba8c-7f9f29b77c8f"
+  #CERT_ID3="f44d1a16-409a-4937-a420-b42dab2d384a"
+  #CERTIFICATE_ARNS=${CERTIFICATE_ARNS:-"${CERTIFICATE_ARN_PREFIX}/${CERT_ID1},${CERTIFICATE_ARN_PREFIX}/${CERT_ID2},${CERTIFICATE_ARN_PREFIX}/${CERT_ID3}"}
+  #echo "creating s3 bucket $S3_BUCKET"
   aws s3api create-bucket --bucket $S3_BUCKET --region $AWS_REGION --create-bucket-configuration LocationConstraint=$AWS_REGION || true
   ginkgo -timeout 3h -v -r test/e2e -- \
     --kubeconfig=${CLUSTER_KUBECONFIG} \
@@ -219,8 +219,8 @@ test_controller_image() {
     --aws-vpc-id=${cluster_vpc_id} \
     --helm-chart=${HELM_DIR}/aws-load-balancer-controller \
     --controller-image=${CONTROLLER_IMAGE_NAME} \
-    --s3-bucket-name=${S3_BUCKET} \
-    --certificate-arns=${CERTIFICATE_ARNS}
+    --s3-bucket-name=${S3_BUCKET} #\
+   # --certificate-arns=${CERTIFICATE_ARNS}
 }
 
 


### PR DESCRIPTION
### Issue

https://github.com/kubernetes/k8s.io/issues/8552

### Description

The certs have expired, and we need them regenerated. It's better to have some E2E test coverage rather than none.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
