### PR TITLE
Add E2E tests that validate route statuses are properly set

### DIFF
--- a/test/e2e/gateway/alb_instance_target_test.go
+++ b/test/e2e/gateway/alb_instance_target_test.go
@@ -2,11 +2,26 @@ package gateway
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
+	"strings"
+	"time"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/gavv/httpexpect/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
+	"k8s.io/apimachinery/pkg/types"
 	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
-	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/gateway/constants"
+	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
+	"sigs.k8s.io/aws-load-balancer-controller/test/e2e/gateway/grpc/echo"
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework/http"
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework/utils"
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework/verifier"
@@ -122,1602 +137,1688 @@ var _ = Describe("test k8s alb gateway using instance targets reconciled by the 
 				err := tf.HTTPVerifier.VerifyURL(url, http.ResponseCodeMatches(200))
 				Expect(err).NotTo(HaveOccurred())
 			})
-			By("confirming the http routes have been updated with a valid status", func() {
-				for _, createdRoute := range stack.albResourceStack.httprs {
-					retrievedRoute := gwv1.HTTPRoute{}
-					err := tf.K8sClient.Get(ctx, k8s.NamespacedName(createdRoute), &retrievedRoute)
-					Expect(err).NotTo(HaveOccurred())
-					// We only have one listener attaching to the route.
-					Expect(len(retrievedRoute.Status.RouteStatus.Parents)).To(Equal(1))
-					fmt.Printf("---->%+v\n", retrievedRoute.Status.RouteStatus)
-					if createdRoute.Name == defaultName+"-otherns" {
-						Expect(string(retrievedRoute.Status.RouteStatus.Parents[0].ParentRef.Name)).To(Equal(stack.albResourceStack.commonStack.gw.Name))
-						Expect(retrievedRoute.Status.RouteStatus.Parents[0].ParentRef.Namespace).To(BeNil())
-						Expect(string(*retrievedRoute.Status.RouteStatus.Parents[0].ParentRef.SectionName)).To(Equal("other-ns"))
-						Expect(string(*retrievedRoute.Status.RouteStatus.Parents[0].ParentRef.Kind)).To(Equal("Gateway"))
-					} else {
-						Expect(string(retrievedRoute.Status.RouteStatus.Parents[0].ParentRef.Name)).To(Equal(stack.albResourceStack.commonStack.gw.Name))
-						Expect(retrievedRoute.Status.RouteStatus.Parents[0].ParentRef.Namespace).To(BeNil())
-						Expect(string(*retrievedRoute.Status.RouteStatus.Parents[0].ParentRef.SectionName)).To(Equal("test-listener"))
-						Expect(string(*retrievedRoute.Status.RouteStatus.Parents[0].ParentRef.Kind)).To(Equal("Gateway"))
-					}
-
-				}
+			By("cross-ns listener should return 503 as no ref grant is available", func() {
+				url := fmt.Sprintf("http://%v:5000/any-path", dnsName)
+				err := tf.HTTPVerifier.VerifyURL(url, http.ResponseCodeMatches(503))
+				Expect(err).NotTo(HaveOccurred())
 			})
-			/*
-						By("cross-ns listener should return 503 as no ref grant is available", func() {
-							url := fmt.Sprintf("http://%v:5000/any-path", dnsName)
-							err := tf.HTTPVerifier.VerifyURL(url, http.ResponseCodeMatches(503))
-							Expect(err).NotTo(HaveOccurred())
-						})
-						By("deploying ref grant", func() {
-							err := auxiliaryStack.CreateReferenceGrants(ctx, tf, stack.albResourceStack.commonStack.ns)
-							Expect(err).NotTo(HaveOccurred())
-							// Give some time to have the listener get materialized.
-							time.Sleep(2 * time.Minute)
-						})
-						By("ensuring cross namespace is materialized", func() {
-							nodeList, err := stack.GetWorkerNodes(ctx, tf)
-							Expect(err).ToNot(HaveOccurred())
-							expectedTargetGroups := []verifier.ExpectedTargetGroup{
-								{
-									Protocol:      "HTTP",
-									Port:          stack.albResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort,
-									NumTargets:    len(nodeList),
-									TargetType:    "instance",
-									TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
-								},
-								{
-									Protocol:      "HTTP",
-									Port:          auxiliaryStack.svcs[0].Spec.Ports[0].NodePort,
-									NumTargets:    len(nodeList),
-									TargetType:    "instance",
-									TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
-								},
-							}
+			By("confirming the route status", func() {
+				validationInfo := map[string]routeValidationInfo{
+					k8s.NamespacedName(stack.albResourceStack.httprs[0]).String(): {
+						parentGatewayName: stack.albResourceStack.commonStack.gw.Name,
+						listenerInfo: []listenerValidationInfo{
+							{
+								listenerName:       "test-listener",
+								parentKind:         "Gateway",
+								resolvedRefReason:  "Accepted",
+								resolvedRefsStatus: "True",
+								acceptedReason:     "Accepted",
+								acceptedStatus:     "True",
+							},
+						},
+					},
+					k8s.NamespacedName(stack.albResourceStack.httprs[1]).String(): {
+						parentGatewayName: stack.albResourceStack.commonStack.gw.Name,
+						listenerInfo: []listenerValidationInfo{
+							{
+								listenerName:       "other-ns",
+								parentKind:         "Gateway",
+								resolvedRefReason:  "RefNotPermitted",
+								resolvedRefsStatus: "False",
+								acceptedReason:     "RefNotPermitted",
+								acceptedStatus:     "False",
+							},
+						},
+					},
+				}
+				validateRouteStatus(tf, stack.albResourceStack.httprs, httpRouteStatusConverter, validationInfo)
+			})
+			By("deploying ref grant", func() {
+				err := auxiliaryStack.CreateReferenceGrants(ctx, tf, stack.albResourceStack.commonStack.ns)
+				Expect(err).NotTo(HaveOccurred())
+				// Give some time to have the listener get materialized.
+				time.Sleep(2 * time.Minute)
+			})
+			By("ensuring cross namespace is materialized", func() {
+				nodeList, err := stack.GetWorkerNodes(ctx, tf)
+				Expect(err).ToNot(HaveOccurred())
+				expectedTargetGroups := []verifier.ExpectedTargetGroup{
+					{
+						Protocol:      "HTTP",
+						Port:          stack.albResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort,
+						NumTargets:    len(nodeList),
+						TargetType:    "instance",
+						TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
+					},
+					{
+						Protocol:      "HTTP",
+						Port:          auxiliaryStack.svcs[0].Spec.Ports[0].NodePort,
+						NumTargets:    len(nodeList),
+						TargetType:    "instance",
+						TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
+					},
+				}
 
-							err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
-								Type:         "application",
-								Scheme:       "internet-facing",
-								Listeners:    stack.albResourceStack.getListenersPortMap(),
-								TargetGroups: expectedTargetGroups,
-							})
-							Expect(err).NotTo(HaveOccurred())
-						})
-						By("sending http request cross namespace service", func() {
-							url := fmt.Sprintf("http://%v:5000/any-path", dnsName)
-							err := tf.HTTPVerifier.VerifyURL(url, http.ResponseCodeMatches(200))
-							Expect(err).NotTo(HaveOccurred())
-						})
-						By("removing ref grant", func() {
-							err := auxiliaryStack.DeleteReferenceGrants(ctx, tf)
-							Expect(err).NotTo(HaveOccurred())
-							// Give some time to have the reference grant to be deleted
-							time.Sleep(2 * time.Minute)
-						})
-						By("cross-ns listener should return 503 as no ref grant is available", func() {
-							url := fmt.Sprintf("http://%v:5000/any-path", dnsName)
-							err := tf.HTTPVerifier.VerifyURL(url, http.ResponseCodeMatches(503))
-							Expect(err).NotTo(HaveOccurred())
-						})
-					})
+				err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
+					Type:         "application",
+					Scheme:       "internet-facing",
+					Listeners:    stack.albResourceStack.getListenersPortMap(),
+					TargetGroups: expectedTargetGroups,
 				})
-
-				Context("with ALB instance target configuration with HTTPRoute specified matches", func() {
-					BeforeEach(func() {})
-					It("should provision internet-facing load balancer resources", func() {
-						interf := elbv2gw.LoadBalancerSchemeInternetFacing
-						lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
-							Scheme: &interf,
-						}
-						tgSpec := elbv2gw.TargetGroupConfigurationSpec{}
-						lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{}
-						gwListeners := []gwv1.Listener{
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("sending http request cross namespace service", func() {
+				url := fmt.Sprintf("http://%v:5000/any-path", dnsName)
+				err := tf.HTTPVerifier.VerifyURL(url, http.ResponseCodeMatches(200))
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("confirming the http route status after ref grant is materialized", func() {
+				validationInfo := map[string]routeValidationInfo{
+					k8s.NamespacedName(stack.albResourceStack.httprs[0]).String(): {
+						parentGatewayName: stack.albResourceStack.commonStack.gw.Name,
+						listenerInfo: []listenerValidationInfo{
 							{
-								Name:     "test-listener",
-								Port:     80,
-								Protocol: gwv1.HTTPProtocolType,
+								listenerName:       "test-listener",
+								parentKind:         "Gateway",
+								resolvedRefReason:  "Accepted",
+								resolvedRefsStatus: "True",
+								acceptedReason:     "Accepted",
+								acceptedStatus:     "True",
 							},
-						}
-						httpr := buildHTTPRoute([]string{}, httpRouteRuleWithMatchesAndTargetGroupWeights, nil)
+						},
+					},
+					k8s.NamespacedName(stack.albResourceStack.httprs[1]).String(): {
+						parentGatewayName: stack.albResourceStack.commonStack.gw.Name,
+						listenerInfo: []listenerValidationInfo{
+							{
+								listenerName:       "other-ns",
+								parentKind:         "Gateway",
+								resolvedRefReason:  "Accepted",
+								resolvedRefsStatus: "True",
+								acceptedReason:     "Accepted",
+								acceptedStatus:     "True",
+							},
+						},
+					},
+				}
+				validateRouteStatus(tf, stack.albResourceStack.httprs, httpRouteStatusConverter, validationInfo)
+			})
+			By("removing ref grant", func() {
+				err := auxiliaryStack.DeleteReferenceGrants(ctx, tf)
+				Expect(err).NotTo(HaveOccurred())
+				// Give some time to have the reference grant to be deleted
+				time.Sleep(2 * time.Minute)
+			})
+			By("cross-ns listener should return 503 as no ref grant is available", func() {
+				url := fmt.Sprintf("http://%v:5000/any-path", dnsName)
+				err := tf.HTTPVerifier.VerifyURL(url, http.ResponseCodeMatches(503))
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("confirming the route status", func() {
+				validationInfo := map[string]routeValidationInfo{
+					k8s.NamespacedName(stack.albResourceStack.httprs[0]).String(): {
+						parentGatewayName: stack.albResourceStack.commonStack.gw.Name,
+						listenerInfo: []listenerValidationInfo{
+							{
+								listenerName:       "test-listener",
+								parentKind:         "Gateway",
+								resolvedRefReason:  "Accepted",
+								resolvedRefsStatus: "True",
+								acceptedReason:     "Accepted",
+								acceptedStatus:     "True",
+							},
+						},
+					},
+					k8s.NamespacedName(stack.albResourceStack.httprs[1]).String(): {
+						parentGatewayName: stack.albResourceStack.commonStack.gw.Name,
+						listenerInfo: []listenerValidationInfo{
+							{
+								listenerName:       "other-ns",
+								parentKind:         "Gateway",
+								resolvedRefReason:  "RefNotPermitted",
+								resolvedRefsStatus: "False",
+								acceptedReason:     "RefNotPermitted",
+								acceptedStatus:     "False",
+							},
+						},
+					},
+				}
+				validateRouteStatus(tf, stack.albResourceStack.httprs, httpRouteStatusConverter, validationInfo)
+			})
+		})
+	})
 
-						By("deploying stack", func() {
-							err := stack.DeployHTTP(ctx, nil, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec, lrcSpec, nil, true)
-							Expect(err).NotTo(HaveOccurred())
-						})
+	Context("with ALB instance target configuration with HTTPRoute specified matches", func() {
+		BeforeEach(func() {})
+		It("should provision internet-facing load balancer resources", func() {
+			interf := elbv2gw.LoadBalancerSchemeInternetFacing
+			lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
+				Scheme: &interf,
+			}
+			tgSpec := elbv2gw.TargetGroupConfigurationSpec{}
+			lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{}
+			gwListeners := []gwv1.Listener{
+				{
+					Name:     "test-listener",
+					Port:     80,
+					Protocol: gwv1.HTTPProtocolType,
+				},
+			}
+			httpr := buildHTTPRoute([]string{}, httpRouteRuleWithMatchesAndTargetGroupWeights, nil)
 
-						By("checking gateway status for lb dns name", func() {
-							dnsName = stack.GetLoadBalancerIngressHostName()
-							Expect(dnsName).ToNot(BeEmpty())
-						})
+			By("deploying stack", func() {
+				err := stack.DeployHTTP(ctx, nil, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec, lrcSpec, nil, true)
+				Expect(err).NotTo(HaveOccurred())
+			})
 
-						By("querying AWS loadbalancer from the dns name", func() {
-							var err error
-							lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
-							Expect(err).NotTo(HaveOccurred())
-							Expect(lbARN).ToNot(BeEmpty())
-						})
+			By("checking gateway status for lb dns name", func() {
+				dnsName = stack.GetLoadBalancerIngressHostName()
+				Expect(dnsName).ToNot(BeEmpty())
+			})
 
-						By("verifying AWS loadbalancer resources", func() {
-							nodeList, err := stack.GetWorkerNodes(ctx, tf)
-							Expect(err).ToNot(HaveOccurred())
-							expectedTargetGroups := []verifier.ExpectedTargetGroup{
-								{
-									Protocol:      "HTTP",
-									Port:          stack.albResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort,
-									NumTargets:    len(nodeList),
-									TargetType:    "instance",
-									TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
-								},
-							}
-							err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
-								Type:         "application",
-								Scheme:       "internet-facing",
-								Listeners:    stack.albResourceStack.getListenersPortMap(),
-								TargetGroups: expectedTargetGroups,
-							})
-							Expect(err).NotTo(HaveOccurred())
-						})
+			By("querying AWS loadbalancer from the dns name", func() {
+				var err error
+				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(lbARN).ToNot(BeEmpty())
+			})
 
-						By("verifying HTTP load balancer listener", func() {
-							err := verifier.VerifyLoadBalancerListener(ctx, tf, lbARN, int32(gwListeners[0].Port), &verifier.ListenerExpectation{
-								ProtocolPort: "HTTP:80",
-							})
-							Expect(err).NotTo(HaveOccurred())
-						})
-						By("verifying listener rules", func() {
-							err := verifier.VerifyLoadBalancerListenerRules(ctx, tf, lbARN, int32(gwListeners[0].Port), []verifier.ListenerRuleExpectation{
-								{
-									Conditions: []elbv2types.RuleCondition{
-										{
-											Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
-											PathPatternConfig: &elbv2types.PathPatternConditionConfig{
-												Values: []string{testPathString},
-											},
-										},
-									},
-									Actions: []elbv2types.Action{
-										{
-											Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
-											ForwardConfig: &elbv2types.ForwardActionConfig{
-												TargetGroups: []elbv2types.TargetGroupTuple{
-													{
-														TargetGroupArn: awssdk.String(testTargetGroupArn),
-														Weight:         awssdk.Int32(50),
-													},
-												},
-											},
-										},
-									},
-									Priority: 1,
-								},
-								{
-									Conditions: []elbv2types.RuleCondition{
-										{
-											Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
-											PathPatternConfig: &elbv2types.PathPatternConditionConfig{
-												Values: []string{testPathString, fmt.Sprintf("%s/*", testPathString)},
-											},
-										},
-										{
-											Field: awssdk.String(string(elbv2model.RuleConditionFieldHTTPRequestMethod)),
-											HttpRequestMethodConfig: &elbv2types.HttpRequestMethodConditionConfig{
-												Values: []string{
-													"GET",
-												},
-											},
-										},
-										{
-											Field: awssdk.String(string(elbv2model.RuleConditionFieldHTTPHeader)),
-											HttpHeaderConfig: &elbv2types.HttpHeaderConditionConfig{
-												HttpHeaderName: awssdk.String(testHttpHeaderNameOne),
-												Values: []string{
-													testHttpHeaderValueOne,
-												},
-											},
-										},
-										{
-											Field: awssdk.String(string(elbv2model.RuleConditionFieldHTTPHeader)),
-											HttpHeaderConfig: &elbv2types.HttpHeaderConditionConfig{
-												HttpHeaderName: awssdk.String(testHttpHeaderNameTwo),
-												Values: []string{
-													testHttpHeaderValueTwo,
-												},
-											},
-										},
-									},
-									Actions: []elbv2types.Action{
-										{
-											Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
-											ForwardConfig: &elbv2types.ForwardActionConfig{
-												TargetGroups: []elbv2types.TargetGroupTuple{
-													{
-														TargetGroupArn: awssdk.String(testTargetGroupArn),
-														Weight:         awssdk.Int32(30),
-													},
-												},
-											},
-										},
-									},
-									Priority: 2,
-								},
-								{
-									Conditions: []elbv2types.RuleCondition{
-										{
-											Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
-											PathPatternConfig: &elbv2types.PathPatternConditionConfig{
-												Values: []string{testPathString, fmt.Sprintf("%s/*", testPathString)},
-											},
-										},
-										{
-											Field: awssdk.String(string(elbv2model.RuleConditionFieldQueryString)),
-											QueryStringConfig: &elbv2types.QueryStringConditionConfig{
-												Values: []elbv2types.QueryStringKeyValuePair{
-													{
-														Key:   awssdk.String(testQueryStringKeyOne),
-														Value: awssdk.String(testQueryStringValueOne),
-													},
-												},
-											},
-										},
-										{
-											Field: awssdk.String(string(elbv2model.RuleConditionFieldQueryString)),
-											QueryStringConfig: &elbv2types.QueryStringConditionConfig{
-												Values: []elbv2types.QueryStringKeyValuePair{
-													{
-														Key:   awssdk.String(testQueryStringKeyTwo),
-														Value: awssdk.String(testQueryStringValueTwo),
-													},
-												},
-											},
-										},
-									},
-									Actions: []elbv2types.Action{
-										{
-											Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
-											ForwardConfig: &elbv2types.ForwardActionConfig{
-												TargetGroups: []elbv2types.TargetGroupTuple{
-													{
-														TargetGroupArn: awssdk.String(testTargetGroupArn),
-														Weight:         awssdk.Int32(30),
-													},
-												},
-											},
-										},
-									},
-									Priority: 3,
-								},
-							})
-							Expect(err).NotTo(HaveOccurred())
-						})
-						By("waiting for target group targets to be healthy", func() {
-							nodeList, err := stack.GetWorkerNodes(ctx, tf)
-							Expect(err).ToNot(HaveOccurred())
-							err = verifier.WaitUntilTargetsAreHealthy(ctx, tf, lbARN, len(nodeList))
-							Expect(err).NotTo(HaveOccurred())
-						})
-						By("waiting until DNS name is available", func() {
-							err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
-							Expect(err).NotTo(HaveOccurred())
-						})
-						By("sending http request to the lb", func() {
-							url := fmt.Sprintf("http://%v%s", dnsName, testPathString)
-							err := tf.HTTPVerifier.VerifyURL(url, http.ResponseCodeMatches(200))
-							Expect(err).NotTo(HaveOccurred())
-						})
-					})
+			By("verifying AWS loadbalancer resources", func() {
+				nodeList, err := stack.GetWorkerNodes(ctx, tf)
+				Expect(err).ToNot(HaveOccurred())
+				expectedTargetGroups := []verifier.ExpectedTargetGroup{
+					{
+						Protocol:      "HTTP",
+						Port:          stack.albResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort,
+						NumTargets:    len(nodeList),
+						TargetType:    "instance",
+						TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
+					},
+				}
+				err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
+					Type:         "application",
+					Scheme:       "internet-facing",
+					Listeners:    stack.albResourceStack.getListenersPortMap(),
+					TargetGroups: expectedTargetGroups,
 				})
+				Expect(err).NotTo(HaveOccurred())
+			})
 
-				Context("with ALB instance target configuration with HTTPRoute specified filter", func() {
-					BeforeEach(func() {})
-					It("should provision internet-facing load balancer resources", func() {
-						interf := elbv2gw.LoadBalancerSchemeInternetFacing
-						lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
-							Scheme: &interf,
-						}
-						tgSpec := elbv2gw.TargetGroupConfigurationSpec{}
-						lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{}
-						gwListeners := []gwv1.Listener{
-							{
-								Name:     "test-listener",
-								Port:     80,
-								Protocol: gwv1.HTTPProtocolType,
-							},
-						}
-						httpr := buildHTTPRoute([]string{}, httpRouteRuleWithMatchesAndFilters, nil)
-
-						By("deploying stack", func() {
-							err := stack.DeployHTTP(ctx, nil, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec, lrcSpec, nil, true)
-							Expect(err).NotTo(HaveOccurred())
-						})
-
-						By("checking gateway status for lb dns name", func() {
-							dnsName = stack.GetLoadBalancerIngressHostName()
-							Expect(dnsName).ToNot(BeEmpty())
-						})
-
-						By("querying AWS loadbalancer from the dns name", func() {
-							var err error
-							lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
-							Expect(err).NotTo(HaveOccurred())
-							Expect(lbARN).ToNot(BeEmpty())
-						})
-
-						By("waiting until DNS name is available", func() {
-							err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
-							Expect(err).NotTo(HaveOccurred())
-						})
-
-						By("testing redirect with ReplaceFullPath", func() {
-							httpExp := httpexpect.New(tf.LoggerReporter, fmt.Sprintf("http://%v", dnsName))
-							httpExp.GET("/old-path").WithRedirectPolicy(httpexpect.DontFollowRedirects).Expect().
-								Status(301).
-								Header("Location").Equal("https://example.com:80/new-path")
-						})
-
-						By("testing redirect with ReplacePrefixMatch", func() {
-							httpExp := httpexpect.New(tf.LoggerReporter, fmt.Sprintf("http://%v", dnsName))
-							httpExp.GET("/api/v1/users").WithRedirectPolicy(httpexpect.DontFollowRedirects).Expect().
-								Status(302).
-								Header("Location").Equal("https://api.example.com:80/v2/*")
-						})
-
-						By("testing redirect with scheme and port change", func() {
-							httpExp := httpexpect.New(tf.LoggerReporter, fmt.Sprintf("http://%v", dnsName))
-							httpExp.GET("/secure").WithRedirectPolicy(httpexpect.DontFollowRedirects).Expect().
-								Status(302).
-								Header("Location").Equal("https://secure.example.com:8443/secure")
-						})
-					})
+			By("verifying HTTP load balancer listener", func() {
+				err := verifier.VerifyLoadBalancerListener(ctx, tf, lbARN, int32(gwListeners[0].Port), &verifier.ListenerExpectation{
+					ProtocolPort: "HTTP:80",
 				})
-
-				Context("with ALB instance target configuration with HTTPRoute specified source ip in listener rule configuration", func() {
-					BeforeEach(func() {})
-					It("should provision internet-facing load balancer resources", func() {
-						interf := elbv2gw.LoadBalancerSchemeInternetFacing
-						lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
-							Scheme: &interf,
-						}
-						tgSpec := elbv2gw.TargetGroupConfigurationSpec{}
-
-						matchIndex := []int{0, 2}
-						sourceIp := "10.0.0.0/8"
-						lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{
-							Conditions: []elbv2gw.ListenerRuleCondition{
-								{
-									SourceIPConfig: &elbv2gw.SourceIPConditionConfig{Values: []string{sourceIp}},
-									Field:          elbv2gw.ListenerRuleConditionField(elbv2model.RuleConditionFieldSourceIP),
-									MatchIndexes:   &matchIndex,
-								},
-							},
-						}
-						gwListeners := []gwv1.Listener{
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("verifying listener rules", func() {
+				err := verifier.VerifyLoadBalancerListenerRules(ctx, tf, lbARN, int32(gwListeners[0].Port), []verifier.ListenerRuleExpectation{
+					{
+						Conditions: []elbv2types.RuleCondition{
 							{
-								Name:     "test-listener",
-								Port:     80,
-								Protocol: gwv1.HTTPProtocolType,
+								Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
+								PathPatternConfig: &elbv2types.PathPatternConditionConfig{
+									Values: []string{testPathString},
+								},
 							},
-						}
-
-						httpr := buildHTTPRoute([]string{}, httpRouteRuleWithMultiMatchesInSingleRule, nil)
-
-						By("deploying stack", func() {
-							err := stack.DeployHTTP(ctx, nil, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec, lrcSpec, nil, true)
-
-							Expect(err).NotTo(HaveOccurred())
-						})
-
-						By("checking gateway status for lb dns name", func() {
-							dnsName = stack.GetLoadBalancerIngressHostName()
-							Expect(dnsName).ToNot(BeEmpty())
-						})
-
-						By("querying AWS loadbalancer from the dns name", func() {
-							var err error
-							lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
-							Expect(err).NotTo(HaveOccurred())
-							Expect(lbARN).ToNot(BeEmpty())
-						})
-
-						By("verifying AWS loadbalancer resources", func() {
-							nodeList, err := stack.GetWorkerNodes(ctx, tf)
-							Expect(err).ToNot(HaveOccurred())
-							expectedTargetGroups := []verifier.ExpectedTargetGroup{
-								{
-									Protocol:      "HTTP",
-									Port:          stack.albResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort,
-									NumTargets:    len(nodeList),
-									TargetType:    "instance",
-									TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
+						},
+						Actions: []elbv2types.Action{
+							{
+								Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
+								ForwardConfig: &elbv2types.ForwardActionConfig{
+									TargetGroups: []elbv2types.TargetGroupTuple{
+										{
+											TargetGroupArn: awssdk.String(testTargetGroupArn),
+											Weight:         awssdk.Int32(50),
+										},
+									},
 								},
-							}
-							err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
-								Type:         "application",
-								Scheme:       "internet-facing",
-								Listeners:    stack.albResourceStack.getListenersPortMap(),
-								TargetGroups: expectedTargetGroups,
-							})
-							Expect(err).NotTo(HaveOccurred())
-						})
-
-						By("verifying HTTP load balancer listener", func() {
-							err := verifier.VerifyLoadBalancerListener(ctx, tf, lbARN, int32(gwListeners[0].Port), &verifier.ListenerExpectation{
-								ProtocolPort: "HTTP:80",
-							})
-							Expect(err).NotTo(HaveOccurred())
-						})
-						By("verifying listener rules", func() {
-							err := verifier.VerifyLoadBalancerListenerRules(ctx, tf, lbARN, int32(gwListeners[0].Port), []verifier.ListenerRuleExpectation{
-								{
-									Conditions: []elbv2types.RuleCondition{
-										{
-											Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
-											PathPatternConfig: &elbv2types.PathPatternConditionConfig{
-												Values: []string{testPathString},
-											},
-										},
-										{
-											Field: awssdk.String(string(elbv2model.RuleConditionFieldSourceIP)),
-											SourceIpConfig: &elbv2types.SourceIpConditionConfig{
-												Values: []string{sourceIp},
-											},
-										},
-									},
-									Actions: []elbv2types.Action{
-										{
-											Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
-											ForwardConfig: &elbv2types.ForwardActionConfig{
-												TargetGroups: []elbv2types.TargetGroupTuple{
-													{
-														TargetGroupArn: awssdk.String(testTargetGroupArn),
-														Weight:         aws.Int32(1),
-													},
-												},
-											},
-										},
-									},
-									Priority: 1,
+							},
+						},
+						Priority: 1,
+					},
+					{
+						Conditions: []elbv2types.RuleCondition{
+							{
+								Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
+								PathPatternConfig: &elbv2types.PathPatternConditionConfig{
+									Values: []string{testPathString, fmt.Sprintf("%s/*", testPathString)},
 								},
-								{
-									Conditions: []elbv2types.RuleCondition{
-										{
-											Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
-											PathPatternConfig: &elbv2types.PathPatternConditionConfig{
-												Values: []string{testPathString, fmt.Sprintf("%s/*", testPathString)},
-											},
-										},
-										{
-											Field: awssdk.String(string(elbv2model.RuleConditionFieldHTTPRequestMethod)),
-											HttpRequestMethodConfig: &elbv2types.HttpRequestMethodConditionConfig{
-												Values: []string{
-													"GET",
-												},
-											},
-										},
+							},
+							{
+								Field: awssdk.String(string(elbv2model.RuleConditionFieldHTTPRequestMethod)),
+								HttpRequestMethodConfig: &elbv2types.HttpRequestMethodConditionConfig{
+									Values: []string{
+										"GET",
 									},
-									Actions: []elbv2types.Action{
-										{
-											Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
-											ForwardConfig: &elbv2types.ForwardActionConfig{
-												TargetGroups: []elbv2types.TargetGroupTuple{
-													{
-														TargetGroupArn: awssdk.String(testTargetGroupArn),
-														Weight:         aws.Int32(1),
-													},
-												},
-											},
-										},
-									},
-									Priority: 2,
 								},
-								{
-									Conditions: []elbv2types.RuleCondition{
-										{
-											Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
-											PathPatternConfig: &elbv2types.PathPatternConditionConfig{
-												Values: []string{testPathString, fmt.Sprintf("%s/*", testPathString)},
-											},
-										},
-										{
-											Field: awssdk.String(string(elbv2model.RuleConditionFieldHTTPHeader)),
-											HttpHeaderConfig: &elbv2types.HttpHeaderConditionConfig{
-												HttpHeaderName: awssdk.String(testHttpHeaderNameOne),
-												Values: []string{
-													testHttpHeaderValueOne,
-												},
-											},
-										},
-										{
-											Field: awssdk.String(string(elbv2model.RuleConditionFieldSourceIP)),
-											SourceIpConfig: &elbv2types.SourceIpConditionConfig{
-												Values: []string{sourceIp},
-											},
-										},
+							},
+							{
+								Field: awssdk.String(string(elbv2model.RuleConditionFieldHTTPHeader)),
+								HttpHeaderConfig: &elbv2types.HttpHeaderConditionConfig{
+									HttpHeaderName: awssdk.String(testHttpHeaderNameOne),
+									Values: []string{
+										testHttpHeaderValueOne,
 									},
-									Actions: []elbv2types.Action{
-										{
-											Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
-											ForwardConfig: &elbv2types.ForwardActionConfig{
-												TargetGroups: []elbv2types.TargetGroupTuple{
-													{
-														TargetGroupArn: awssdk.String(testTargetGroupArn),
-														Weight:         aws.Int32(1),
-													},
-												},
-											},
-										},
-									},
-									Priority: 3,
 								},
-							})
-							Expect(err).NotTo(HaveOccurred())
-						})
-						By("waiting for target group targets to be healthy", func() {
-							nodeList, err := stack.GetWorkerNodes(ctx, tf)
-							Expect(err).ToNot(HaveOccurred())
-							err = verifier.WaitUntilTargetsAreHealthy(ctx, tf, lbARN, len(nodeList))
-							Expect(err).NotTo(HaveOccurred())
-						})
-						By("waiting until DNS name is available", func() {
-							err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
-							Expect(err).NotTo(HaveOccurred())
-						})
-					})
+							},
+							{
+								Field: awssdk.String(string(elbv2model.RuleConditionFieldHTTPHeader)),
+								HttpHeaderConfig: &elbv2types.HttpHeaderConditionConfig{
+									HttpHeaderName: awssdk.String(testHttpHeaderNameTwo),
+									Values: []string{
+										testHttpHeaderValueTwo,
+									},
+								},
+							},
+						},
+						Actions: []elbv2types.Action{
+							{
+								Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
+								ForwardConfig: &elbv2types.ForwardActionConfig{
+									TargetGroups: []elbv2types.TargetGroupTuple{
+										{
+											TargetGroupArn: awssdk.String(testTargetGroupArn),
+											Weight:         awssdk.Int32(30),
+										},
+									},
+								},
+							},
+						},
+						Priority: 2,
+					},
+					{
+						Conditions: []elbv2types.RuleCondition{
+							{
+								Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
+								PathPatternConfig: &elbv2types.PathPatternConditionConfig{
+									Values: []string{testPathString, fmt.Sprintf("%s/*", testPathString)},
+								},
+							},
+							{
+								Field: awssdk.String(string(elbv2model.RuleConditionFieldQueryString)),
+								QueryStringConfig: &elbv2types.QueryStringConditionConfig{
+									Values: []elbv2types.QueryStringKeyValuePair{
+										{
+											Key:   awssdk.String(testQueryStringKeyOne),
+											Value: awssdk.String(testQueryStringValueOne),
+										},
+									},
+								},
+							},
+							{
+								Field: awssdk.String(string(elbv2model.RuleConditionFieldQueryString)),
+								QueryStringConfig: &elbv2types.QueryStringConditionConfig{
+									Values: []elbv2types.QueryStringKeyValuePair{
+										{
+											Key:   awssdk.String(testQueryStringKeyTwo),
+											Value: awssdk.String(testQueryStringValueTwo),
+										},
+									},
+								},
+							},
+						},
+						Actions: []elbv2types.Action{
+							{
+								Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
+								ForwardConfig: &elbv2types.ForwardActionConfig{
+									TargetGroups: []elbv2types.TargetGroupTuple{
+										{
+											TargetGroupArn: awssdk.String(testTargetGroupArn),
+											Weight:         awssdk.Int32(30),
+										},
+									},
+								},
+							},
+						},
+						Priority: 3,
+					},
 				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("waiting for target group targets to be healthy", func() {
+				nodeList, err := stack.GetWorkerNodes(ctx, tf)
+				Expect(err).ToNot(HaveOccurred())
+				err = verifier.WaitUntilTargetsAreHealthy(ctx, tf, lbARN, len(nodeList))
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("waiting until DNS name is available", func() {
+				err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("sending http request to the lb", func() {
+				url := fmt.Sprintf("http://%v%s", dnsName, testPathString)
+				err := tf.HTTPVerifier.VerifyURL(url, http.ResponseCodeMatches(200))
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
 
-				Context("with ALB instance target configuration with secure HTTPRoute", func() {
-					BeforeEach(func() {})
-					It("should provision internet-facing load balancer resources", func() {
-						if len(tf.Options.CertificateARNs) == 0 {
-							Skip("Skipping tests, certificates not specified")
-						}
-						interf := elbv2gw.LoadBalancerSchemeInternetFacing
-						lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
-							Scheme: &interf,
-						}
+	Context("with ALB instance target configuration with HTTPRoute specified filter", func() {
+		BeforeEach(func() {})
+		It("should provision internet-facing load balancer resources", func() {
+			interf := elbv2gw.LoadBalancerSchemeInternetFacing
+			lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
+				Scheme: &interf,
+			}
+			tgSpec := elbv2gw.TargetGroupConfigurationSpec{}
+			lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{}
+			gwListeners := []gwv1.Listener{
+				{
+					Name:     "test-listener",
+					Port:     80,
+					Protocol: gwv1.HTTPProtocolType,
+				},
+			}
+			httpr := buildHTTPRoute([]string{}, httpRouteRuleWithMatchesAndFilters, nil)
 
-						cert := strings.Split(tf.Options.CertificateARNs, ",")[0]
-						lsConfig := elbv2gw.ListenerConfiguration{
-							ProtocolPort:       "HTTPS:443",
-							DefaultCertificate: &cert,
-						}
-						lbcSpec.ListenerConfigurations = &[]elbv2gw.ListenerConfiguration{lsConfig}
-						tgSpec := elbv2gw.TargetGroupConfigurationSpec{}
-						lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{}
-						gwListeners := []gwv1.Listener{
-							{
-								Name:     "https443",
-								Port:     443,
-								Protocol: gwv1.HTTPSProtocolType,
-								Hostname: (*gwv1.Hostname)(awssdk.String(testHostname)),
-							},
-						}
-						httpr := buildHTTPRoute([]string{testHostname}, []gwv1.HTTPRouteRule{}, nil)
-						By("deploying stack", func() {
-							err := stack.DeployHTTP(ctx, nil, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec, lrcSpec, nil, true)
-							Expect(err).NotTo(HaveOccurred())
-						})
+			By("deploying stack", func() {
+				err := stack.DeployHTTP(ctx, nil, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec, lrcSpec, nil, true)
+				Expect(err).NotTo(HaveOccurred())
+			})
 
-						By("checking gateway status for lb dns name", func() {
-							dnsName = stack.GetLoadBalancerIngressHostName()
-							Expect(dnsName).ToNot(BeEmpty())
-						})
+			By("checking gateway status for lb dns name", func() {
+				dnsName = stack.GetLoadBalancerIngressHostName()
+				Expect(dnsName).ToNot(BeEmpty())
+			})
 
-						By("querying AWS loadbalancer from the dns name", func() {
-							var err error
-							lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
-							Expect(err).NotTo(HaveOccurred())
-							Expect(lbARN).ToNot(BeEmpty())
-						})
-						By("verifying AWS loadbalancer resources", func() {
-							nodeList, err := stack.GetWorkerNodes(ctx, tf)
-							Expect(err).ToNot(HaveOccurred())
+			By("querying AWS loadbalancer from the dns name", func() {
+				var err error
+				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(lbARN).ToNot(BeEmpty())
+			})
 
-							expectedTargetGroups := []verifier.ExpectedTargetGroup{
-								{
-									Protocol:      "HTTP",
-									Port:          stack.albResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort,
-									NumTargets:    len(nodeList),
-									TargetType:    "instance",
-									TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
-								},
-							}
-							err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
-								Type:         "application",
-								Scheme:       "internet-facing",
-								Listeners:    stack.albResourceStack.getListenersPortMap(),
-								TargetGroups: expectedTargetGroups,
-							})
-							Expect(err).NotTo(HaveOccurred())
-						})
-						By("verifying AWS load balancer listener", func() {
-							err := verifier.VerifyLoadBalancerListener(ctx, tf, lbARN, int32(gwListeners[0].Port), &verifier.ListenerExpectation{
-								ProtocolPort:          "HTTPS:443",
-								DefaultCertificateARN: awssdk.ToString(lsConfig.DefaultCertificate),
-								MutualAuthentication: &verifier.MutualAuthenticationExpectation{
-									Mode: "off",
-								},
-							})
-							Expect(err).NotTo(HaveOccurred())
-						})
-						By("waiting for target group targets to be healthy", func() {
-							nodeList, err := stack.GetWorkerNodes(ctx, tf)
-							Expect(err).ToNot(HaveOccurred())
-							err = verifier.WaitUntilTargetsAreHealthy(ctx, tf, lbARN, len(nodeList))
-							Expect(err).NotTo(HaveOccurred())
-						})
-						By("waiting until DNS name is available", func() {
-							err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
-							Expect(err).NotTo(HaveOccurred())
-						})
-						By("sending https request to the lb", func() {
-							url := fmt.Sprintf("https://%v/any-path", dnsName)
-							urlOptions := http.URLOptions{
-								InsecureSkipVerify: true,
-								HostHeader:         testHostname, // Set Host header
-							}
-							err := tf.HTTPVerifier.VerifyURLWithOptions(url, urlOptions, http.ResponseCodeMatches(200))
-							Expect(err).NotTo(HaveOccurred())
-						})
-					})
+			By("waiting until DNS name is available", func() {
+				err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("testing redirect with ReplaceFullPath", func() {
+				httpExp := httpexpect.New(tf.LoggerReporter, fmt.Sprintf("http://%v", dnsName))
+				httpExp.GET("/old-path").WithRedirectPolicy(httpexpect.DontFollowRedirects).Expect().
+					Status(301).
+					Header("Location").Equal("https://example.com:80/new-path")
+			})
+
+			By("testing redirect with ReplacePrefixMatch", func() {
+				httpExp := httpexpect.New(tf.LoggerReporter, fmt.Sprintf("http://%v", dnsName))
+				httpExp.GET("/api/v1/users").WithRedirectPolicy(httpexpect.DontFollowRedirects).Expect().
+					Status(302).
+					Header("Location").Equal("https://api.example.com:80/v2/*")
+			})
+
+			By("testing redirect with scheme and port change", func() {
+				httpExp := httpexpect.New(tf.LoggerReporter, fmt.Sprintf("http://%v", dnsName))
+				httpExp.GET("/secure").WithRedirectPolicy(httpexpect.DontFollowRedirects).Expect().
+					Status(302).
+					Header("Location").Equal("https://secure.example.com:8443/secure")
+			})
+		})
+	})
+
+	Context("with ALB instance target configuration with HTTPRoute specified source ip in listener rule configuration", func() {
+		BeforeEach(func() {})
+		It("should provision internet-facing load balancer resources", func() {
+			interf := elbv2gw.LoadBalancerSchemeInternetFacing
+			lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
+				Scheme: &interf,
+			}
+			tgSpec := elbv2gw.TargetGroupConfigurationSpec{}
+
+			matchIndex := []int{0, 2}
+			sourceIp := "10.0.0.0/8"
+			lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{
+				Conditions: []elbv2gw.ListenerRuleCondition{
+					{
+						SourceIPConfig: &elbv2gw.SourceIPConditionConfig{Values: []string{sourceIp}},
+						Field:          elbv2gw.ListenerRuleConditionField(elbv2model.RuleConditionFieldSourceIP),
+						MatchIndexes:   &matchIndex,
+					},
+				},
+			}
+			gwListeners := []gwv1.Listener{
+				{
+					Name:     "test-listener",
+					Port:     80,
+					Protocol: gwv1.HTTPProtocolType,
+				},
+			}
+
+			httpr := buildHTTPRoute([]string{}, httpRouteRuleWithMultiMatchesInSingleRule, nil)
+
+			By("deploying stack", func() {
+				err := stack.DeployHTTP(ctx, nil, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec, lrcSpec, nil, true)
+
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("checking gateway status for lb dns name", func() {
+				dnsName = stack.GetLoadBalancerIngressHostName()
+				Expect(dnsName).ToNot(BeEmpty())
+			})
+
+			By("querying AWS loadbalancer from the dns name", func() {
+				var err error
+				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(lbARN).ToNot(BeEmpty())
+			})
+
+			By("verifying AWS loadbalancer resources", func() {
+				nodeList, err := stack.GetWorkerNodes(ctx, tf)
+				Expect(err).ToNot(HaveOccurred())
+				expectedTargetGroups := []verifier.ExpectedTargetGroup{
+					{
+						Protocol:      "HTTP",
+						Port:          stack.albResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort,
+						NumTargets:    len(nodeList),
+						TargetType:    "instance",
+						TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
+					},
+				}
+				err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
+					Type:         "application",
+					Scheme:       "internet-facing",
+					Listeners:    stack.albResourceStack.getListenersPortMap(),
+					TargetGroups: expectedTargetGroups,
 				})
+				Expect(err).NotTo(HaveOccurred())
+			})
 
-				Context("with ALB instance target configuration with secure HTTPRoute and mutual authentication PASSTHROUGH mode", func() {
-					BeforeEach(func() {})
-					It("should provision internet-facing load balancer resources", func() {
-						if len(tf.Options.CertificateARNs) == 0 {
-							Skip("Skipping tests, certificates not specified")
-						}
-						interf := elbv2gw.LoadBalancerSchemeInternetFacing
-						lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
-							Scheme: &interf,
-						}
-
-						cert := strings.Split(tf.Options.CertificateARNs, ",")[0]
-						lsConfig := elbv2gw.ListenerConfiguration{
-							ProtocolPort:       "HTTPS:443",
-							DefaultCertificate: &cert,
-							MutualAuthentication: &elbv2gw.MutualAuthenticationAttributes{
-								Mode: "passthrough",
-							},
-						}
-						lbcSpec.ListenerConfigurations = &[]elbv2gw.ListenerConfiguration{lsConfig}
-						tgSpec := elbv2gw.TargetGroupConfigurationSpec{}
-						lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{}
-						gwListeners := []gwv1.Listener{
-							{
-								Name:     "https443",
-								Port:     443,
-								Protocol: gwv1.HTTPSProtocolType,
-								Hostname: (*gwv1.Hostname)(awssdk.String(testHostname)),
-							},
-						}
-						httpr := buildHTTPRoute([]string{testHostname}, []gwv1.HTTPRouteRule{}, nil)
-						By("deploying stack", func() {
-							err := stack.DeployHTTP(ctx, nil, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec, lrcSpec, nil, true)
-							Expect(err).NotTo(HaveOccurred())
-						})
-
-						By("checking gateway status for lb dns name", func() {
-							dnsName = stack.GetLoadBalancerIngressHostName()
-							Expect(dnsName).ToNot(BeEmpty())
-						})
-
-						By("querying AWS loadbalancer from the dns name", func() {
-							var err error
-							lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
-							Expect(err).NotTo(HaveOccurred())
-							Expect(lbARN).ToNot(BeEmpty())
-						})
-
-						By("verifying AWS loadbalancer resources", func() {
-							nodeList, err := stack.GetWorkerNodes(ctx, tf)
-							Expect(err).ToNot(HaveOccurred())
-							expectedTargetGroups := []verifier.ExpectedTargetGroup{
-								{
-									Protocol:      "HTTP",
-									Port:          stack.albResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort,
-									NumTargets:    len(nodeList),
-									TargetType:    "instance",
-									TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
-								},
-							}
-							err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
-								Type:         "application",
-								Scheme:       "internet-facing",
-								Listeners:    stack.albResourceStack.getListenersPortMap(),
-								TargetGroups: expectedTargetGroups,
-							})
-							Expect(err).NotTo(HaveOccurred())
-						})
-						By("verifying AWS load balancer listener", func() {
-							err := verifier.VerifyLoadBalancerListener(ctx, tf, lbARN, int32(gwListeners[0].Port), &verifier.ListenerExpectation{
-								ProtocolPort:          "HTTPS:443",
-								DefaultCertificateARN: awssdk.ToString(lsConfig.DefaultCertificate),
-								MutualAuthentication: &verifier.MutualAuthenticationExpectation{
-									Mode: "passthrough",
-								},
-							})
-							Expect(err).NotTo(HaveOccurred())
-						})
-						By("waiting for target group targets to be healthy", func() {
-							nodeList, err := stack.GetWorkerNodes(ctx, tf)
-							Expect(err).ToNot(HaveOccurred())
-							err = verifier.WaitUntilTargetsAreHealthy(ctx, tf, lbARN, len(nodeList))
-							Expect(err).NotTo(HaveOccurred())
-						})
-						By("waiting until DNS name is available", func() {
-							err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
-							Expect(err).NotTo(HaveOccurred())
-						})
-						By("sending https request to the lb", func() {
-							url := fmt.Sprintf("https://%v/any-path", dnsName)
-							urlOptions := http.URLOptions{
-								InsecureSkipVerify: true,
-								HostHeader:         testHostname, // Set Host header
-							}
-							err := tf.HTTPVerifier.VerifyURLWithOptions(url, urlOptions, http.ResponseCodeMatches(200))
-							Expect(err).NotTo(HaveOccurred())
-						})
-					})
+			By("verifying HTTP load balancer listener", func() {
+				err := verifier.VerifyLoadBalancerListener(ctx, tf, lbARN, int32(gwListeners[0].Port), &verifier.ListenerExpectation{
+					ProtocolPort: "HTTP:80",
 				})
-
-				Context("with ALB instance target configuration with secure HTTPRoute and authenticate cognito action", func() {
-					BeforeEach(func() {})
-					It("should provision internet-facing load balancer with authenticate-cognito action", func() {
-						if len(tf.Options.CertificateARNs) == 0 {
-							Skip("Skipping tests, certificates not specified")
-						}
-						// Skip test if Cognito options not provided (similar to certificate check)
-						if len(tf.Options.CognitoUserPoolArn) == 0 ||
-							len(tf.Options.CognitoUserPoolClientId) == 0 ||
-							len(tf.Options.CognitoUserPoolDomain) == 0 {
-							Skip("Skipping authenticate-cognito tests, Cognito configuration not specified")
-						}
-
-						// Setup HTTPS listener with certificate
-						interf := elbv2gw.LoadBalancerSchemeInternetFacing
-						lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
-							Scheme: &interf,
-						}
-						cert := strings.Split(tf.Options.CertificateARNs, ",")[0]
-						lsConfig := elbv2gw.ListenerConfiguration{
-							ProtocolPort:       "HTTPS:443",
-							DefaultCertificate: &cert,
-						}
-						lbcSpec.ListenerConfigurations = &[]elbv2gw.ListenerConfiguration{lsConfig}
-						tgSpec := elbv2gw.TargetGroupConfigurationSpec{}
-						gwListeners := []gwv1.Listener{
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("verifying listener rules", func() {
+				err := verifier.VerifyLoadBalancerListenerRules(ctx, tf, lbARN, int32(gwListeners[0].Port), []verifier.ListenerRuleExpectation{
+					{
+						Conditions: []elbv2types.RuleCondition{
 							{
-								Name:     "https443",
-								Port:     443,
-								Protocol: gwv1.HTTPSProtocolType,
-								Hostname: (*gwv1.Hostname)(awssdk.String(testHostname)),
+								Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
+								PathPatternConfig: &elbv2types.PathPatternConditionConfig{
+									Values: []string{testPathString},
+								},
 							},
-						}
-
-						// Create ListenerRuleConfiguration with real Cognito values
-						authenticateBehavior := elbv2gw.AuthenticateCognitoActionConditionalBehaviorEnumAuthenticate
-						lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{
-							Actions: []elbv2gw.Action{
-								{
-									Type: elbv2gw.ActionTypeAuthenticateCognito,
-									AuthenticateCognitoConfig: &elbv2gw.AuthenticateCognitoActionConfig{
-										UserPoolArn:      tf.Options.CognitoUserPoolArn,
-										UserPoolClientID: tf.Options.CognitoUserPoolClientId,
-										UserPoolDomain:   tf.Options.CognitoUserPoolDomain,
-										Scope:            awssdk.String("openid"),
-										AuthenticationRequestExtraParams: &map[string]string{
-											"key1": "value1",
+							{
+								Field: awssdk.String(string(elbv2model.RuleConditionFieldSourceIP)),
+								SourceIpConfig: &elbv2types.SourceIpConditionConfig{
+									Values: []string{sourceIp},
+								},
+							},
+						},
+						Actions: []elbv2types.Action{
+							{
+								Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
+								ForwardConfig: &elbv2types.ForwardActionConfig{
+									TargetGroups: []elbv2types.TargetGroupTuple{
+										{
+											TargetGroupArn: awssdk.String(testTargetGroupArn),
+											Weight:         aws.Int32(1),
 										},
-										OnUnauthenticatedRequest: &authenticateBehavior,
-										SessionCookieName:        awssdk.String("my-session-cookie"),
-										SessionTimeout:           awssdk.Int64(604800),
 									},
 								},
 							},
-						}
-						httpRouteRules := []gwv1.HTTPRouteRule{
+						},
+						Priority: 1,
+					},
+					{
+						Conditions: []elbv2types.RuleCondition{
 							{
-								BackendRefs: DefaultHttpRouteRuleBackendRefs,
-								Filters: []gwv1.HTTPRouteFilter{
+								Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
+								PathPatternConfig: &elbv2types.PathPatternConditionConfig{
+									Values: []string{testPathString, fmt.Sprintf("%s/*", testPathString)},
+								},
+							},
+							{
+								Field: awssdk.String(string(elbv2model.RuleConditionFieldHTTPRequestMethod)),
+								HttpRequestMethodConfig: &elbv2types.HttpRequestMethodConditionConfig{
+									Values: []string{
+										"GET",
+									},
+								},
+							},
+						},
+						Actions: []elbv2types.Action{
+							{
+								Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
+								ForwardConfig: &elbv2types.ForwardActionConfig{
+									TargetGroups: []elbv2types.TargetGroupTuple{
+										{
+											TargetGroupArn: awssdk.String(testTargetGroupArn),
+											Weight:         aws.Int32(1),
+										},
+									},
+								},
+							},
+						},
+						Priority: 2,
+					},
+					{
+						Conditions: []elbv2types.RuleCondition{
+							{
+								Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
+								PathPatternConfig: &elbv2types.PathPatternConditionConfig{
+									Values: []string{testPathString, fmt.Sprintf("%s/*", testPathString)},
+								},
+							},
+							{
+								Field: awssdk.String(string(elbv2model.RuleConditionFieldHTTPHeader)),
+								HttpHeaderConfig: &elbv2types.HttpHeaderConditionConfig{
+									HttpHeaderName: awssdk.String(testHttpHeaderNameOne),
+									Values: []string{
+										testHttpHeaderValueOne,
+									},
+								},
+							},
+							{
+								Field: awssdk.String(string(elbv2model.RuleConditionFieldSourceIP)),
+								SourceIpConfig: &elbv2types.SourceIpConditionConfig{
+									Values: []string{sourceIp},
+								},
+							},
+						},
+						Actions: []elbv2types.Action{
+							{
+								Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
+								ForwardConfig: &elbv2types.ForwardActionConfig{
+									TargetGroups: []elbv2types.TargetGroupTuple{
+										{
+											TargetGroupArn: awssdk.String(testTargetGroupArn),
+											Weight:         aws.Int32(1),
+										},
+									},
+								},
+							},
+						},
+						Priority: 3,
+					},
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("waiting for target group targets to be healthy", func() {
+				nodeList, err := stack.GetWorkerNodes(ctx, tf)
+				Expect(err).ToNot(HaveOccurred())
+				err = verifier.WaitUntilTargetsAreHealthy(ctx, tf, lbARN, len(nodeList))
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("waiting until DNS name is available", func() {
+				err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
+
+	Context("with ALB instance target configuration with secure HTTPRoute", func() {
+		BeforeEach(func() {})
+		It("should provision internet-facing load balancer resources", func() {
+			if len(tf.Options.CertificateARNs) == 0 {
+				Skip("Skipping tests, certificates not specified")
+			}
+			interf := elbv2gw.LoadBalancerSchemeInternetFacing
+			lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
+				Scheme: &interf,
+			}
+
+			cert := strings.Split(tf.Options.CertificateARNs, ",")[0]
+			lsConfig := elbv2gw.ListenerConfiguration{
+				ProtocolPort:       "HTTPS:443",
+				DefaultCertificate: &cert,
+			}
+			lbcSpec.ListenerConfigurations = &[]elbv2gw.ListenerConfiguration{lsConfig}
+			tgSpec := elbv2gw.TargetGroupConfigurationSpec{}
+			lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{}
+			gwListeners := []gwv1.Listener{
+				{
+					Name:     "https443",
+					Port:     443,
+					Protocol: gwv1.HTTPSProtocolType,
+					Hostname: (*gwv1.Hostname)(awssdk.String(testHostname)),
+				},
+			}
+			httpr := buildHTTPRoute([]string{testHostname}, []gwv1.HTTPRouteRule{}, nil)
+			By("deploying stack", func() {
+				err := stack.DeployHTTP(ctx, nil, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec, lrcSpec, nil, true)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("checking gateway status for lb dns name", func() {
+				dnsName = stack.GetLoadBalancerIngressHostName()
+				Expect(dnsName).ToNot(BeEmpty())
+			})
+
+			By("querying AWS loadbalancer from the dns name", func() {
+				var err error
+				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(lbARN).ToNot(BeEmpty())
+			})
+			By("verifying AWS loadbalancer resources", func() {
+				nodeList, err := stack.GetWorkerNodes(ctx, tf)
+				Expect(err).ToNot(HaveOccurred())
+
+				expectedTargetGroups := []verifier.ExpectedTargetGroup{
+					{
+						Protocol:      "HTTP",
+						Port:          stack.albResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort,
+						NumTargets:    len(nodeList),
+						TargetType:    "instance",
+						TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
+					},
+				}
+				err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
+					Type:         "application",
+					Scheme:       "internet-facing",
+					Listeners:    stack.albResourceStack.getListenersPortMap(),
+					TargetGroups: expectedTargetGroups,
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("verifying AWS load balancer listener", func() {
+				err := verifier.VerifyLoadBalancerListener(ctx, tf, lbARN, int32(gwListeners[0].Port), &verifier.ListenerExpectation{
+					ProtocolPort:          "HTTPS:443",
+					DefaultCertificateARN: awssdk.ToString(lsConfig.DefaultCertificate),
+					MutualAuthentication: &verifier.MutualAuthenticationExpectation{
+						Mode: "off",
+					},
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("waiting for target group targets to be healthy", func() {
+				nodeList, err := stack.GetWorkerNodes(ctx, tf)
+				Expect(err).ToNot(HaveOccurred())
+				err = verifier.WaitUntilTargetsAreHealthy(ctx, tf, lbARN, len(nodeList))
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("waiting until DNS name is available", func() {
+				err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("sending https request to the lb", func() {
+				url := fmt.Sprintf("https://%v/any-path", dnsName)
+				urlOptions := http.URLOptions{
+					InsecureSkipVerify: true,
+					HostHeader:         testHostname, // Set Host header
+				}
+				err := tf.HTTPVerifier.VerifyURLWithOptions(url, urlOptions, http.ResponseCodeMatches(200))
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
+
+	Context("with ALB instance target configuration with secure HTTPRoute and mutual authentication PASSTHROUGH mode", func() {
+		BeforeEach(func() {})
+		It("should provision internet-facing load balancer resources", func() {
+			if len(tf.Options.CertificateARNs) == 0 {
+				Skip("Skipping tests, certificates not specified")
+			}
+			interf := elbv2gw.LoadBalancerSchemeInternetFacing
+			lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
+				Scheme: &interf,
+			}
+
+			cert := strings.Split(tf.Options.CertificateARNs, ",")[0]
+			lsConfig := elbv2gw.ListenerConfiguration{
+				ProtocolPort:       "HTTPS:443",
+				DefaultCertificate: &cert,
+				MutualAuthentication: &elbv2gw.MutualAuthenticationAttributes{
+					Mode: "passthrough",
+				},
+			}
+			lbcSpec.ListenerConfigurations = &[]elbv2gw.ListenerConfiguration{lsConfig}
+			tgSpec := elbv2gw.TargetGroupConfigurationSpec{}
+			lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{}
+			gwListeners := []gwv1.Listener{
+				{
+					Name:     "https443",
+					Port:     443,
+					Protocol: gwv1.HTTPSProtocolType,
+					Hostname: (*gwv1.Hostname)(awssdk.String(testHostname)),
+				},
+			}
+			httpr := buildHTTPRoute([]string{testHostname}, []gwv1.HTTPRouteRule{}, nil)
+			By("deploying stack", func() {
+				err := stack.DeployHTTP(ctx, nil, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec, lrcSpec, nil, true)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("checking gateway status for lb dns name", func() {
+				dnsName = stack.GetLoadBalancerIngressHostName()
+				Expect(dnsName).ToNot(BeEmpty())
+			})
+
+			By("querying AWS loadbalancer from the dns name", func() {
+				var err error
+				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(lbARN).ToNot(BeEmpty())
+			})
+
+			By("verifying AWS loadbalancer resources", func() {
+				nodeList, err := stack.GetWorkerNodes(ctx, tf)
+				Expect(err).ToNot(HaveOccurred())
+				expectedTargetGroups := []verifier.ExpectedTargetGroup{
+					{
+						Protocol:      "HTTP",
+						Port:          stack.albResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort,
+						NumTargets:    len(nodeList),
+						TargetType:    "instance",
+						TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
+					},
+				}
+				err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
+					Type:         "application",
+					Scheme:       "internet-facing",
+					Listeners:    stack.albResourceStack.getListenersPortMap(),
+					TargetGroups: expectedTargetGroups,
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("verifying AWS load balancer listener", func() {
+				err := verifier.VerifyLoadBalancerListener(ctx, tf, lbARN, int32(gwListeners[0].Port), &verifier.ListenerExpectation{
+					ProtocolPort:          "HTTPS:443",
+					DefaultCertificateARN: awssdk.ToString(lsConfig.DefaultCertificate),
+					MutualAuthentication: &verifier.MutualAuthenticationExpectation{
+						Mode: "passthrough",
+					},
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("waiting for target group targets to be healthy", func() {
+				nodeList, err := stack.GetWorkerNodes(ctx, tf)
+				Expect(err).ToNot(HaveOccurred())
+				err = verifier.WaitUntilTargetsAreHealthy(ctx, tf, lbARN, len(nodeList))
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("waiting until DNS name is available", func() {
+				err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("sending https request to the lb", func() {
+				url := fmt.Sprintf("https://%v/any-path", dnsName)
+				urlOptions := http.URLOptions{
+					InsecureSkipVerify: true,
+					HostHeader:         testHostname, // Set Host header
+				}
+				err := tf.HTTPVerifier.VerifyURLWithOptions(url, urlOptions, http.ResponseCodeMatches(200))
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
+
+	Context("with ALB instance target configuration with secure HTTPRoute and authenticate cognito action", func() {
+		BeforeEach(func() {})
+		It("should provision internet-facing load balancer with authenticate-cognito action", func() {
+			if len(tf.Options.CertificateARNs) == 0 {
+				Skip("Skipping tests, certificates not specified")
+			}
+			// Skip test if Cognito options not provided (similar to certificate check)
+			if len(tf.Options.CognitoUserPoolArn) == 0 ||
+				len(tf.Options.CognitoUserPoolClientId) == 0 ||
+				len(tf.Options.CognitoUserPoolDomain) == 0 {
+				Skip("Skipping authenticate-cognito tests, Cognito configuration not specified")
+			}
+
+			// Setup HTTPS listener with certificate
+			interf := elbv2gw.LoadBalancerSchemeInternetFacing
+			lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
+				Scheme: &interf,
+			}
+			cert := strings.Split(tf.Options.CertificateARNs, ",")[0]
+			lsConfig := elbv2gw.ListenerConfiguration{
+				ProtocolPort:       "HTTPS:443",
+				DefaultCertificate: &cert,
+			}
+			lbcSpec.ListenerConfigurations = &[]elbv2gw.ListenerConfiguration{lsConfig}
+			tgSpec := elbv2gw.TargetGroupConfigurationSpec{}
+			gwListeners := []gwv1.Listener{
+				{
+					Name:     "https443",
+					Port:     443,
+					Protocol: gwv1.HTTPSProtocolType,
+					Hostname: (*gwv1.Hostname)(awssdk.String(testHostname)),
+				},
+			}
+
+			// Create ListenerRuleConfiguration with real Cognito values
+			authenticateBehavior := elbv2gw.AuthenticateCognitoActionConditionalBehaviorEnumAuthenticate
+			lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{
+				Actions: []elbv2gw.Action{
+					{
+						Type: elbv2gw.ActionTypeAuthenticateCognito,
+						AuthenticateCognitoConfig: &elbv2gw.AuthenticateCognitoActionConfig{
+							UserPoolArn:      tf.Options.CognitoUserPoolArn,
+							UserPoolClientID: tf.Options.CognitoUserPoolClientId,
+							UserPoolDomain:   tf.Options.CognitoUserPoolDomain,
+							Scope:            awssdk.String("openid"),
+							AuthenticationRequestExtraParams: &map[string]string{
+								"key1": "value1",
+							},
+							OnUnauthenticatedRequest: &authenticateBehavior,
+							SessionCookieName:        awssdk.String("my-session-cookie"),
+							SessionTimeout:           awssdk.Int64(604800),
+						},
+					},
+				},
+			}
+			httpRouteRules := []gwv1.HTTPRouteRule{
+				{
+					BackendRefs: DefaultHttpRouteRuleBackendRefs,
+					Filters: []gwv1.HTTPRouteFilter{
+						{
+							Type: gwv1.HTTPRouteFilterExtensionRef,
+							ExtensionRef: &gwv1.LocalObjectReference{
+								Name:  defaultLRConfigName,
+								Kind:  constants.ListenerRuleConfiguration,
+								Group: constants.ControllerCRDGroupVersion,
+							},
+						},
+					},
+				},
+			}
+			httpr := buildHTTPRoute([]string{testHostname}, httpRouteRules, &gwListeners[0].Name)
+
+			By("deploying stack", func() {
+				err := stack.DeployHTTP(ctx, nil, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec, lrcSpec, nil, false)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("checking gateway status for lb dns name", func() {
+				dnsName = stack.GetLoadBalancerIngressHostName()
+				Expect(dnsName).ToNot(BeEmpty())
+			})
+
+			By("querying AWS loadbalancer from the dns name", func() {
+				var err error
+				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(lbARN).ToNot(BeEmpty())
+			})
+
+			By("verifying AWS loadbalancer resources", func() {
+				nodeList, err := stack.GetWorkerNodes(ctx, tf)
+				Expect(err).ToNot(HaveOccurred())
+				expectedTargetGroups := []verifier.ExpectedTargetGroup{
+					{
+						Protocol:      "HTTP",
+						Port:          stack.albResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort,
+						NumTargets:    len(nodeList),
+						TargetType:    "instance",
+						TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
+					},
+				}
+				err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
+					Type:         "application",
+					Scheme:       "internet-facing",
+					Listeners:    stack.albResourceStack.getListenersPortMap(),
+					TargetGroups: expectedTargetGroups,
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("verifying AWS load balancer listener", func() {
+				err := verifier.VerifyLoadBalancerListener(ctx, tf, lbARN, int32(gwListeners[0].Port), &verifier.ListenerExpectation{
+					ProtocolPort:          "HTTPS:443",
+					DefaultCertificateARN: awssdk.ToString(lsConfig.DefaultCertificate),
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("verifying listener rules", func() {
+				err := verifier.VerifyLoadBalancerListenerRules(ctx, tf, lbARN, int32(gwListeners[0].Port), []verifier.ListenerRuleExpectation{
+					{
+						Conditions: []elbv2types.RuleCondition{
+							{
+								Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
+								PathPatternConfig: &elbv2types.PathPatternConditionConfig{
+									Values: []string{"/*"},
+								},
+							},
+							{
+								Field: awssdk.String(string(elbv2model.RuleConditionFieldHostHeader)),
+								HostHeaderConfig: &elbv2types.HostHeaderConditionConfig{
+									Values: []string{testHostname},
+								},
+							},
+						},
+						Actions: []elbv2types.Action{
+							{
+								Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeAuthenticateCognito),
+								AuthenticateCognitoConfig: &elbv2types.AuthenticateCognitoActionConfig{
+									UserPoolArn:      awssdk.String(tf.Options.CognitoUserPoolArn),
+									UserPoolClientId: awssdk.String(tf.Options.CognitoUserPoolClientId),
+									UserPoolDomain:   awssdk.String(tf.Options.CognitoUserPoolDomain),
+									Scope:            awssdk.String("openid"),
+									AuthenticationRequestExtraParams: map[string]string{
+										"key1": "value1",
+									},
+									OnUnauthenticatedRequest: elbv2types.AuthenticateCognitoActionConditionalBehaviorEnumAuthenticate,
+									SessionCookieName:        awssdk.String("my-session-cookie"),
+									SessionTimeout:           awssdk.Int64(604800),
+								},
+							},
+							{
+								Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
+								ForwardConfig: &elbv2types.ForwardActionConfig{
+									TargetGroups: []elbv2types.TargetGroupTuple{
+										{
+											TargetGroupArn: awssdk.String(testTargetGroupArn),
+											Weight:         awssdk.Int32(1),
+										},
+									},
+								},
+							},
+						},
+						Priority: 1,
+					},
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("waiting until DNS name is available", func() {
+				err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("verifying authenticate-cognito redirect for unauthenticated request", func() {
+				url := fmt.Sprintf("https://%v/any-path", dnsName)
+				urlOptions := http.URLOptions{
+					InsecureSkipVerify: true,
+					HostHeader:         testHostname,
+					FollowRedirects:    false, // Don't follow redirects automatically
+				}
+
+				// Expect 302 redirect to Cognito
+				err := tf.HTTPVerifier.VerifyURLWithOptions(url, urlOptions, http.ResponseCodeMatches(302))
+				Expect(err).NotTo(HaveOccurred())
+
+				// Verify redirect Location header contains Cognito domain
+				err = tf.HTTPVerifier.VerifyURLWithOptions(url, urlOptions,
+					http.ResponseHeaderContains("Location", tf.Options.CognitoUserPoolDomain))
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
+	Context("with ALB instance target configuration with secure HTTPRoute and authenticate oidc action", func() {
+		BeforeEach(func() {})
+		It("should provision internet-facing load balancer with authenticate-oidc action", func() {
+			if len(tf.Options.CertificateARNs) == 0 {
+				Skip("Skipping tests, certificates not specified")
+			}
+
+			// Generate random OIDC credentials for testing
+			oidcClientID, oidcClientSecret := GenerateOIDCCredentials()
+
+			// Setup HTTPS listener with certificate
+			interf := elbv2gw.LoadBalancerSchemeInternetFacing
+			lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
+				Scheme: &interf,
+			}
+			cert := strings.Split(tf.Options.CertificateARNs, ",")[0]
+			lsConfig := elbv2gw.ListenerConfiguration{
+				ProtocolPort:       "HTTPS:443",
+				DefaultCertificate: &cert,
+			}
+			lbcSpec.ListenerConfigurations = &[]elbv2gw.ListenerConfiguration{lsConfig}
+			tgSpec := elbv2gw.TargetGroupConfigurationSpec{}
+			gwListeners := []gwv1.Listener{
+				{
+					Name:     "https443",
+					Port:     443,
+					Protocol: gwv1.HTTPSProtocolType,
+					Hostname: (*gwv1.Hostname)(awssdk.String(testHostname)),
+				},
+			}
+
+			// Create Kubernetes Secret for OIDC credentials
+			oidcSecretName := "oidc-auth-secret"
+			// Generate random OIDC credentials for testing
+			oidcClientID, oidcClientSecret = GenerateOIDCCredentials()
+
+			oidcSecret := &testOIDCSecret{
+				name:         oidcSecretName,
+				clientId:     oidcClientID,
+				clientSecret: oidcClientSecret,
+			}
+			// Create ListenerRuleConfiguration with real Cognito values
+			authenticateBehavior := elbv2gw.AuthenticateOidcActionConditionalBehaviorEnumAuthenticate
+			lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{
+				Actions: []elbv2gw.Action{
+					{
+						Type: elbv2gw.ActionTypeAuthenticateOIDC,
+						AuthenticateOIDCConfig: &elbv2gw.AuthenticateOidcActionConfig{
+							Issuer:                testOidcIssuer,
+							AuthorizationEndpoint: testOidcAuthorizationEndpoint,
+							TokenEndpoint:         testOidcTokenEndpoint,
+							UserInfoEndpoint:      testOidcUserInfoEndpoint,
+							Secret: &elbv2gw.Secret{
+								Name: oidcSecretName,
+								// Namespace will default to same as ListenerRuleConfiguration
+							},
+							Scope: awssdk.String("openid profile email"),
+							AuthenticationRequestExtraParams: &map[string]string{
+								"prompt":  "login",
+								"display": "page",
+							},
+							OnUnauthenticatedRequest: &authenticateBehavior,
+							SessionCookieName:        awssdk.String("AWSELBAuthSessionCookie-OIDC"),
+							SessionTimeout:           awssdk.Int64(604800),
+						},
+					},
+				},
+			}
+			httpRouteRules := []gwv1.HTTPRouteRule{
+				{
+					BackendRefs: DefaultHttpRouteRuleBackendRefs,
+					Filters: []gwv1.HTTPRouteFilter{
+						{
+							Type: gwv1.HTTPRouteFilterExtensionRef,
+							ExtensionRef: &gwv1.LocalObjectReference{
+								Name:  defaultLRConfigName,
+								Kind:  constants.ListenerRuleConfiguration,
+								Group: constants.ControllerCRDGroupVersion,
+							},
+						},
+					},
+				},
+			}
+			httpr := buildHTTPRoute([]string{testHostname}, httpRouteRules, &gwListeners[0].Name)
+
+			By("deploying stack", func() {
+				err := stack.DeployHTTP(ctx, nil, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec, lrcSpec, oidcSecret, false)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("checking gateway status for lb dns name", func() {
+				dnsName = stack.GetLoadBalancerIngressHostName()
+				Expect(dnsName).ToNot(BeEmpty())
+			})
+
+			By("querying AWS loadbalancer from the dns name", func() {
+				var err error
+				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(lbARN).ToNot(BeEmpty())
+			})
+
+			By("verifying AWS loadbalancer resources", func() {
+				nodeList, err := stack.GetWorkerNodes(ctx, tf)
+				Expect(err).ToNot(HaveOccurred())
+
+				expectedTargetGroups := []verifier.ExpectedTargetGroup{
+					{
+						Protocol:      "HTTP",
+						Port:          stack.albResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort,
+						NumTargets:    len(nodeList),
+						TargetType:    "instance",
+						TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
+					},
+				}
+				err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
+					Type:         "application",
+					Scheme:       "internet-facing",
+					Listeners:    stack.albResourceStack.getListenersPortMap(),
+					TargetGroups: expectedTargetGroups,
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("verifying AWS load balancer listener", func() {
+				err := verifier.VerifyLoadBalancerListener(ctx, tf, lbARN, int32(gwListeners[0].Port), &verifier.ListenerExpectation{
+					ProtocolPort:          "HTTPS:443",
+					DefaultCertificateARN: awssdk.ToString(lsConfig.DefaultCertificate),
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("verifying listener rules with authenticate-oidc action", func() {
+				err := verifier.VerifyLoadBalancerListenerRules(ctx, tf, lbARN, int32(gwListeners[0].Port), []verifier.ListenerRuleExpectation{
+					{
+						Conditions: []elbv2types.RuleCondition{
+							{
+								Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
+								PathPatternConfig: &elbv2types.PathPatternConditionConfig{
+									Values: []string{"/*"},
+								},
+							},
+							{
+								Field: awssdk.String(string(elbv2model.RuleConditionFieldHostHeader)),
+								HostHeaderConfig: &elbv2types.HostHeaderConditionConfig{
+									Values: []string{testHostname},
+								},
+							},
+						},
+						Actions: []elbv2types.Action{
+							{
+								Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeAuthenticateOIDC),
+								AuthenticateOidcConfig: &elbv2types.AuthenticateOidcActionConfig{
+									Issuer:                  awssdk.String(testOidcIssuer),
+									AuthorizationEndpoint:   awssdk.String(testOidcAuthorizationEndpoint),
+									TokenEndpoint:           awssdk.String(testOidcTokenEndpoint),
+									UserInfoEndpoint:        awssdk.String(testOidcUserInfoEndpoint),
+									ClientId:                awssdk.String(oidcClientID),
+									UseExistingClientSecret: awssdk.Bool(true),
+									Scope:                   awssdk.String("openid profile email"),
+									AuthenticationRequestExtraParams: map[string]string{
+										"prompt":  "login",
+										"display": "page",
+									},
+									OnUnauthenticatedRequest: elbv2types.AuthenticateOidcActionConditionalBehaviorEnumAuthenticate,
+									SessionCookieName:        awssdk.String("AWSELBAuthSessionCookie-OIDC"),
+									SessionTimeout:           awssdk.Int64(604800),
+								},
+							},
+							{
+								Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
+								ForwardConfig: &elbv2types.ForwardActionConfig{
+									TargetGroups: []elbv2types.TargetGroupTuple{
+										{
+											TargetGroupArn: awssdk.String(testTargetGroupArn),
+											Weight:         awssdk.Int32(1),
+										},
+									},
+								},
+							},
+						},
+						Priority: 1,
+					},
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("waiting until DNS name is available", func() {
+				err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("verifying authenticate-oidc redirect for unauthenticated request", func() {
+				url := fmt.Sprintf("https://%v/any-path", dnsName)
+				urlOptions := http.URLOptions{
+					InsecureSkipVerify: true,
+					HostHeader:         testHostname,
+					FollowRedirects:    false, // Don't follow redirects automatically
+				}
+
+				// Expect 302 redirect to Cognito
+				err := tf.HTTPVerifier.VerifyURLWithOptions(url, urlOptions, http.ResponseCodeMatches(302))
+				Expect(err).NotTo(HaveOccurred())
+
+				// Verify redirect Location header contains Cognito domain
+				err = tf.HTTPVerifier.VerifyURLWithOptions(url, urlOptions,
+					http.ResponseHeaderContains("Location", testOidcAuthorizationEndpoint))
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
+
+	Context("with both basic and secure HTTPRoutes", func() {
+		BeforeEach(func() {})
+		It("should provision internet-facing load balancer with both HTTP and HTTPS endpoints", func() {
+			if len(tf.Options.CertificateARNs) == 0 {
+				Skip("Skipping tests, certificates not specified")
+			}
+
+			interf := elbv2gw.LoadBalancerSchemeInternetFacing
+			lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
+				Scheme: &interf,
+			}
+
+			// Configure both HTTP and HTTPS listeners
+			cert := strings.Split(tf.Options.CertificateARNs, ",")[0]
+			httpLsConfig := elbv2gw.ListenerConfiguration{
+				ProtocolPort: "HTTP:80",
+			}
+			httpsLsConfig := elbv2gw.ListenerConfiguration{
+				ProtocolPort:       "HTTPS:443",
+				DefaultCertificate: &cert,
+			}
+			lbcSpec.ListenerConfigurations = &[]elbv2gw.ListenerConfiguration{
+				httpLsConfig,
+				httpsLsConfig,
+			}
+
+			tgSpec := elbv2gw.TargetGroupConfigurationSpec{}
+			lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{}
+			gwListeners := []gwv1.Listener{
+				{
+					Name:     "http80",
+					Port:     80,
+					Protocol: gwv1.HTTPProtocolType,
+				},
+				{
+					Name:     "https443",
+					Port:     443,
+					Protocol: gwv1.HTTPSProtocolType,
+					Hostname: (*gwv1.Hostname)(awssdk.String(testHostname)),
+				},
+			}
+			httpr := buildHTTPRoute([]string{testHostname}, []gwv1.HTTPRouteRule{}, nil)
+
+			By("deploying stack", func() {
+				err := stack.DeployHTTP(ctx, nil, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec, lrcSpec, nil, true)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("checking gateway status for lb dns name", func() {
+				dnsName = stack.GetLoadBalancerIngressHostName()
+				Expect(dnsName).ToNot(BeEmpty())
+			})
+
+			By("querying AWS loadbalancer from the dns name", func() {
+				var err error
+				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(lbARN).ToNot(BeEmpty())
+			})
+
+			By("verifying AWS loadbalancer resources", func() {
+				nodeList, err := stack.GetWorkerNodes(ctx, tf)
+				Expect(err).ToNot(HaveOccurred())
+
+				expectedTargetGroups := []verifier.ExpectedTargetGroup{
+					{
+						Protocol:      "HTTP",
+						Port:          stack.albResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort,
+						NumTargets:    len(nodeList),
+						TargetType:    "instance",
+						TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
+					},
+				}
+				err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
+					Type:         "application",
+					Scheme:       "internet-facing",
+					Listeners:    stack.albResourceStack.getListenersPortMap(),
+					TargetGroups: expectedTargetGroups,
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			// Verify HTTP listener
+			By("verifying HTTP load balancer listener", func() {
+				err := verifier.VerifyLoadBalancerListener(ctx, tf, lbARN, int32(gwListeners[0].Port), &verifier.ListenerExpectation{
+					ProtocolPort: "HTTP:80",
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			// Verify HTTPS listener
+			By("verifying HTTPS load balancer listener", func() {
+				err := verifier.VerifyLoadBalancerListener(ctx, tf, lbARN, int32(gwListeners[1].Port), &verifier.ListenerExpectation{
+					ProtocolPort:          "HTTPS:443",
+					DefaultCertificateARN: awssdk.ToString(httpsLsConfig.DefaultCertificate),
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("waiting for target group targets to be healthy", func() {
+				nodeList, err := stack.GetWorkerNodes(ctx, tf)
+				Expect(err).ToNot(HaveOccurred())
+				err = verifier.WaitUntilTargetsAreHealthy(ctx, tf, lbARN, len(nodeList))
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("waiting until DNS name is available", func() {
+				err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			// Test HTTP endpoint
+			By("sending HTTP request to the lb", func() {
+				url := fmt.Sprintf("http://%v/any-path", dnsName)
+				urlOptions := http.URLOptions{
+					InsecureSkipVerify: true,
+					HostHeader:         testHostname, // Set Host header
+					Method:             "GET",
+				}
+				err := tf.HTTPVerifier.VerifyURLWithOptions(url, urlOptions, http.ResponseCodeMatches(200))
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			// Test HTTPS endpoint
+			By("sending HTTPS request to the lb", func() {
+				url := fmt.Sprintf("https://%v/any-path", dnsName)
+				urlOptions := http.URLOptions{
+					InsecureSkipVerify: true,
+					HostHeader:         testHostname, // Set Host header
+					Method:             "GET",
+				}
+				err := tf.HTTPVerifier.VerifyURLWithOptions(url, urlOptions, http.ResponseCodeMatches(200))
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
+
+	Context("with ALB instance target configuration with GRPC", func() {
+		It("should provision internet-facing load balancer resources", func() {
+			if len(tf.Options.CertificateARNs) == 0 {
+				Skip("Skipping tests, certificates not specified")
+			}
+
+			interf := elbv2gw.LoadBalancerSchemeInternetFacing
+			lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
+				Scheme: &interf,
+			}
+
+			// Use the first certificate from the provided list
+			cert := strings.Split(tf.Options.CertificateARNs, ",")[0]
+			lsConfig := elbv2gw.ListenerConfiguration{
+				ProtocolPort:       "HTTPS:443",
+				DefaultCertificate: &cert,
+			}
+			lbcSpec.ListenerConfigurations = &[]elbv2gw.ListenerConfiguration{lsConfig}
+			tgSpec := elbv2gw.TargetGroupConfigurationSpec{
+				DefaultConfiguration: elbv2gw.TargetGroupProps{},
+			}
+			lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{}
+			gwListeners := []gwv1.Listener{
+				{
+					Name:     "test-listener",
+					Port:     443,
+					Protocol: gwv1.HTTPSProtocolType,
+				},
+			}
+
+			grpcRouteRules := []gwv1.GRPCRouteRule{
+				{
+					BackendRefs: DefaultGrpcRouteRuleBackendRefs,
+				},
+				{
+					Matches: []gwv1.GRPCRouteMatch{
+						{
+							Headers: []gwv1.GRPCHeaderMatch{
+								{
+									Type:  (*gwv1.GRPCHeaderMatchType)(awssdk.String("Exact")),
+									Name:  "my-header",
+									Value: "my-header-value",
+								},
+							},
+						},
+					},
+					BackendRefs: []gwv1.GRPCBackendRef{
+						{
+							BackendRef: gwv1.BackendRef{
+								BackendObjectReference: gwv1.BackendObjectReference{
+									Name: grpcDefaultName + "-other",
+									Port: &defaultGrpcPort,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			grpcr := buildGRPCRoute([]string{}, grpcRouteRules, &gwListeners[0].Name)
+			By("deploying stack", func() {
+				err := stack.DeployGRPC(ctx, tf, gwListeners, []*gwv1.GRPCRoute{grpcr}, lbcSpec, tgSpec, lrcSpec, true)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("checking gateway status for lb dns name", func() {
+				time.Sleep(2 * time.Minute)
+				dnsName = stack.GetLoadBalancerIngressHostName()
+				Expect(dnsName).ToNot(BeEmpty())
+			})
+			By("querying AWS loadbalancer from the dns name", func() {
+				var err error
+				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(lbARN).ToNot(BeEmpty())
+			})
+
+			nodeList, err := stack.GetWorkerNodes(ctx, tf)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("verifying AWS loadbalancer resources", func() {
+				expectedTargetGroups := []verifier.ExpectedTargetGroup{
+					{
+						Protocol:      "HTTP",
+						Port:          stack.albResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort,
+						NumTargets:    len(nodeList),
+						TargetType:    "instance",
+						TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC_GRPC,
+					},
+					{
+						Protocol:      "HTTP",
+						Port:          stack.albResourceStack.commonStack.svcs[1].Spec.Ports[0].NodePort,
+						NumTargets:    len(nodeList),
+						TargetType:    "instance",
+						TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC_GRPC,
+					},
+				}
+				err := verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
+					Type:         "application",
+					Scheme:       "internet-facing",
+					Listeners:    stack.albResourceStack.getListenersPortMap(),
+					TargetGroups: expectedTargetGroups,
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("waiting for target group targets to be healthy", func() {
+				err := verifier.WaitUntilTargetsAreHealthy(ctx, tf, lbARN, len(nodeList))
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("waiting until DNS name is available", func() {
+				err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+			})
+			By("sending grpc request to the lb", func() {
+				c, err := generateGRPCClient(dnsName)
+				Expect(err).NotTo(HaveOccurred())
+				mdCtx := metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{"foo": "cat"}))
+				response, err := c.Echo(mdCtx, &echo.EchoRequest{Message: "Hello from E2E test"})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(response.Message).To(Equal("Hello from E2E test"))
+			})
+			By("sending grpc request with certain header must forward traffic to right backend", func() {
+				target := fmt.Sprintf("%s:443", dnsName)
+				tlsConfig := &tls.Config{
+					InsecureSkipVerify: true, // This skips all certificate verification, including expiry.
+				}
+
+				conn, err := grpc.NewClient(target, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
+				Expect(err).NotTo(HaveOccurred())
+				c := echo.NewEchoServiceClient(conn)
+
+				mdCtx := metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{"my-header": "my-header-value"}))
+				response, err := c.FixedResponse(mdCtx, &echo.FixedResponseRequest{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(response.Message).To(Equal("Hello World - Other"))
+			})
+			By("sending grpc request with header missing uses default service.", func() {
+				c, err := generateGRPCClient(dnsName)
+				Expect(err).NotTo(HaveOccurred())
+				mdCtx := metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{}))
+				response, err := c.FixedResponse(mdCtx, &echo.FixedResponseRequest{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(response.Message).To(Equal("Hello World"))
+			})
+			By("update grpc route to remove default rule", func() {
+
+				err = tf.K8sClient.Get(ctx, types.NamespacedName{Name: stack.albResourceStack.grpcrs[0].Name, Namespace: stack.albResourceStack.grpcrs[0].Namespace}, stack.albResourceStack.grpcrs[0])
+				Expect(err).NotTo(HaveOccurred())
+
+				stack.albResourceStack.grpcrs[0].Spec.Rules = []gwv1.GRPCRouteRule{
+					{
+						Matches: []gwv1.GRPCRouteMatch{
+							{
+								Headers: []gwv1.GRPCHeaderMatch{
 									{
-										Type: gwv1.HTTPRouteFilterExtensionRef,
-										ExtensionRef: &gwv1.LocalObjectReference{
-											Name:  defaultLRConfigName,
-											Kind:  constants.ListenerRuleConfiguration,
-											Group: constants.ControllerCRDGroupVersion,
-										},
+										Type:  (*gwv1.GRPCHeaderMatchType)(awssdk.String("Exact")),
+										Name:  "my-header",
+										Value: "my-header-value",
 									},
 								},
 							},
-						}
-						httpr := buildHTTPRoute([]string{testHostname}, httpRouteRules, &gwListeners[0].Name)
-
-						By("deploying stack", func() {
-							err := stack.DeployHTTP(ctx, nil, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec, lrcSpec, nil, false)
-							Expect(err).NotTo(HaveOccurred())
-						})
-
-						By("checking gateway status for lb dns name", func() {
-							dnsName = stack.GetLoadBalancerIngressHostName()
-							Expect(dnsName).ToNot(BeEmpty())
-						})
-
-						By("querying AWS loadbalancer from the dns name", func() {
-							var err error
-							lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
-							Expect(err).NotTo(HaveOccurred())
-							Expect(lbARN).ToNot(BeEmpty())
-						})
-
-						By("verifying AWS loadbalancer resources", func() {
-							nodeList, err := stack.GetWorkerNodes(ctx, tf)
-							Expect(err).ToNot(HaveOccurred())
-							expectedTargetGroups := []verifier.ExpectedTargetGroup{
-								{
-									Protocol:      "HTTP",
-									Port:          stack.albResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort,
-									NumTargets:    len(nodeList),
-									TargetType:    "instance",
-									TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
-								},
-							}
-							err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
-								Type:         "application",
-								Scheme:       "internet-facing",
-								Listeners:    stack.albResourceStack.getListenersPortMap(),
-								TargetGroups: expectedTargetGroups,
-							})
-							Expect(err).NotTo(HaveOccurred())
-						})
-						By("verifying AWS load balancer listener", func() {
-							err := verifier.VerifyLoadBalancerListener(ctx, tf, lbARN, int32(gwListeners[0].Port), &verifier.ListenerExpectation{
-								ProtocolPort:          "HTTPS:443",
-								DefaultCertificateARN: awssdk.ToString(lsConfig.DefaultCertificate),
-							})
-							Expect(err).NotTo(HaveOccurred())
-						})
-						By("verifying listener rules", func() {
-							err := verifier.VerifyLoadBalancerListenerRules(ctx, tf, lbARN, int32(gwListeners[0].Port), []verifier.ListenerRuleExpectation{
-								{
-									Conditions: []elbv2types.RuleCondition{
-										{
-											Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
-											PathPatternConfig: &elbv2types.PathPatternConditionConfig{
-												Values: []string{"/*"},
-											},
-										},
-										{
-											Field: awssdk.String(string(elbv2model.RuleConditionFieldHostHeader)),
-											HostHeaderConfig: &elbv2types.HostHeaderConditionConfig{
-												Values: []string{testHostname},
-											},
-										},
-									},
-									Actions: []elbv2types.Action{
-										{
-											Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeAuthenticateCognito),
-											AuthenticateCognitoConfig: &elbv2types.AuthenticateCognitoActionConfig{
-												UserPoolArn:      awssdk.String(tf.Options.CognitoUserPoolArn),
-												UserPoolClientId: awssdk.String(tf.Options.CognitoUserPoolClientId),
-												UserPoolDomain:   awssdk.String(tf.Options.CognitoUserPoolDomain),
-												Scope:            awssdk.String("openid"),
-												AuthenticationRequestExtraParams: map[string]string{
-													"key1": "value1",
-												},
-												OnUnauthenticatedRequest: elbv2types.AuthenticateCognitoActionConditionalBehaviorEnumAuthenticate,
-												SessionCookieName:        awssdk.String("my-session-cookie"),
-												SessionTimeout:           awssdk.Int64(604800),
-											},
-										},
-										{
-											Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
-											ForwardConfig: &elbv2types.ForwardActionConfig{
-												TargetGroups: []elbv2types.TargetGroupTuple{
-													{
-														TargetGroupArn: awssdk.String(testTargetGroupArn),
-														Weight:         awssdk.Int32(1),
-													},
-												},
-											},
-										},
-									},
-									Priority: 1,
-								},
-							})
-							Expect(err).NotTo(HaveOccurred())
-						})
-						By("waiting until DNS name is available", func() {
-							err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
-							Expect(err).NotTo(HaveOccurred())
-						})
-						By("verifying authenticate-cognito redirect for unauthenticated request", func() {
-							url := fmt.Sprintf("https://%v/any-path", dnsName)
-							urlOptions := http.URLOptions{
-								InsecureSkipVerify: true,
-								HostHeader:         testHostname,
-								FollowRedirects:    false, // Don't follow redirects automatically
-							}
-
-							// Expect 302 redirect to Cognito
-							err := tf.HTTPVerifier.VerifyURLWithOptions(url, urlOptions, http.ResponseCodeMatches(302))
-							Expect(err).NotTo(HaveOccurred())
-
-							// Verify redirect Location header contains Cognito domain
-							err = tf.HTTPVerifier.VerifyURLWithOptions(url, urlOptions,
-								http.ResponseHeaderContains("Location", tf.Options.CognitoUserPoolDomain))
-							Expect(err).NotTo(HaveOccurred())
-						})
-					})
-				})
-				Context("with ALB instance target configuration with secure HTTPRoute and authenticate oidc action", func() {
-					BeforeEach(func() {})
-					It("should provision internet-facing load balancer with authenticate-oidc action", func() {
-						if len(tf.Options.CertificateARNs) == 0 {
-							Skip("Skipping tests, certificates not specified")
-						}
-
-						// Generate random OIDC credentials for testing
-						oidcClientID, oidcClientSecret := GenerateOIDCCredentials()
-
-						// Setup HTTPS listener with certificate
-						interf := elbv2gw.LoadBalancerSchemeInternetFacing
-						lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
-							Scheme: &interf,
-						}
-						cert := strings.Split(tf.Options.CertificateARNs, ",")[0]
-						lsConfig := elbv2gw.ListenerConfiguration{
-							ProtocolPort:       "HTTPS:443",
-							DefaultCertificate: &cert,
-						}
-						lbcSpec.ListenerConfigurations = &[]elbv2gw.ListenerConfiguration{lsConfig}
-						tgSpec := elbv2gw.TargetGroupConfigurationSpec{}
-						gwListeners := []gwv1.Listener{
+						},
+						BackendRefs: []gwv1.GRPCBackendRef{
 							{
-								Name:     "https443",
-								Port:     443,
-								Protocol: gwv1.HTTPSProtocolType,
-								Hostname: (*gwv1.Hostname)(awssdk.String(testHostname)),
-							},
-						}
-
-						// Create Kubernetes Secret for OIDC credentials
-						oidcSecretName := "oidc-auth-secret"
-						// Generate random OIDC credentials for testing
-						oidcClientID, oidcClientSecret = GenerateOIDCCredentials()
-
-						oidcSecret := &testOIDCSecret{
-							name:         oidcSecretName,
-							clientId:     oidcClientID,
-							clientSecret: oidcClientSecret,
-						}
-						// Create ListenerRuleConfiguration with real Cognito values
-						authenticateBehavior := elbv2gw.AuthenticateOidcActionConditionalBehaviorEnumAuthenticate
-						lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{
-							Actions: []elbv2gw.Action{
-								{
-									Type: elbv2gw.ActionTypeAuthenticateOIDC,
-									AuthenticateOIDCConfig: &elbv2gw.AuthenticateOidcActionConfig{
-										Issuer:                testOidcIssuer,
-										AuthorizationEndpoint: testOidcAuthorizationEndpoint,
-										TokenEndpoint:         testOidcTokenEndpoint,
-										UserInfoEndpoint:      testOidcUserInfoEndpoint,
-										Secret: &elbv2gw.Secret{
-											Name: oidcSecretName,
-											// Namespace will default to same as ListenerRuleConfiguration
-										},
-										Scope: awssdk.String("openid profile email"),
-										AuthenticationRequestExtraParams: &map[string]string{
-											"prompt":  "login",
-											"display": "page",
-										},
-										OnUnauthenticatedRequest: &authenticateBehavior,
-										SessionCookieName:        awssdk.String("AWSELBAuthSessionCookie-OIDC"),
-										SessionTimeout:           awssdk.Int64(604800),
+								BackendRef: gwv1.BackendRef{
+									BackendObjectReference: gwv1.BackendObjectReference{
+										Name: grpcDefaultName + "-other",
+										Port: &defaultGrpcPort,
 									},
 								},
 							},
-						}
-						httpRouteRules := []gwv1.HTTPRouteRule{
+						},
+					},
+				}
+
+				err = stack.albResourceStack.updateGRPCRoute(ctx, tf, stack.albResourceStack.grpcrs[0])
+				Expect(err).NotTo(HaveOccurred())
+				// Wait for listener change to propagate.
+				time.Sleep(1 * time.Minute)
+			})
+			By("send grpc request with correct request header", func() {
+				c, err := generateGRPCClient(dnsName)
+				Expect(err).NotTo(HaveOccurred())
+				mdCtx := metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{"my-header": "my-header-value"}))
+				response, err := c.FixedResponse(mdCtx, &echo.FixedResponseRequest{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(response.Message).To(Equal("Hello World - Other"))
+			})
+			By("sending grpc request with header missing uses default service.", func() {
+				c, err := generateGRPCClient(dnsName)
+				Expect(err).NotTo(HaveOccurred())
+				mdCtx := metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{}))
+				_, err = c.FixedResponse(mdCtx, &echo.FixedResponseRequest{})
+				Expect(err).To(HaveOccurred())
+			})
+			By("update grpc route to route by service / method name. use invalid service", func() {
+
+				err = tf.K8sClient.Get(ctx, types.NamespacedName{Name: stack.albResourceStack.grpcrs[0].Name, Namespace: stack.albResourceStack.grpcrs[0].Namespace}, stack.albResourceStack.grpcrs[0])
+				Expect(err).NotTo(HaveOccurred())
+
+				stack.albResourceStack.grpcrs[0].Spec.Rules = []gwv1.GRPCRouteRule{
+					{
+						Matches: []gwv1.GRPCRouteMatch{
 							{
-								BackendRefs: DefaultHttpRouteRuleBackendRefs,
-								Filters: []gwv1.HTTPRouteFilter{
-									{
-										Type: gwv1.HTTPRouteFilterExtensionRef,
-										ExtensionRef: &gwv1.LocalObjectReference{
-											Name:  defaultLRConfigName,
-											Kind:  constants.ListenerRuleConfiguration,
-											Group: constants.ControllerCRDGroupVersion,
-										},
-									},
+								Method: &gwv1.GRPCMethodMatch{
+									Service: awssdk.String("com.example.FakeService"),
+									Method:  awssdk.String("FakeMethod"),
 								},
 							},
-						}
-						httpr := buildHTTPRoute([]string{testHostname}, httpRouteRules, &gwListeners[0].Name)
-
-						By("deploying stack", func() {
-							err := stack.DeployHTTP(ctx, nil, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec, lrcSpec, oidcSecret, false)
-							Expect(err).NotTo(HaveOccurred())
-						})
-
-						By("checking gateway status for lb dns name", func() {
-							dnsName = stack.GetLoadBalancerIngressHostName()
-							Expect(dnsName).ToNot(BeEmpty())
-						})
-
-						By("querying AWS loadbalancer from the dns name", func() {
-							var err error
-							lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
-							Expect(err).NotTo(HaveOccurred())
-							Expect(lbARN).ToNot(BeEmpty())
-						})
-
-						By("verifying AWS loadbalancer resources", func() {
-							nodeList, err := stack.GetWorkerNodes(ctx, tf)
-							Expect(err).ToNot(HaveOccurred())
-
-							expectedTargetGroups := []verifier.ExpectedTargetGroup{
-								{
-									Protocol:      "HTTP",
-									Port:          stack.albResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort,
-									NumTargets:    len(nodeList),
-									TargetType:    "instance",
-									TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
-								},
-							}
-							err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
-								Type:         "application",
-								Scheme:       "internet-facing",
-								Listeners:    stack.albResourceStack.getListenersPortMap(),
-								TargetGroups: expectedTargetGroups,
-							})
-							Expect(err).NotTo(HaveOccurred())
-						})
-						By("verifying AWS load balancer listener", func() {
-							err := verifier.VerifyLoadBalancerListener(ctx, tf, lbARN, int32(gwListeners[0].Port), &verifier.ListenerExpectation{
-								ProtocolPort:          "HTTPS:443",
-								DefaultCertificateARN: awssdk.ToString(lsConfig.DefaultCertificate),
-							})
-							Expect(err).NotTo(HaveOccurred())
-						})
-						By("verifying listener rules with authenticate-oidc action", func() {
-							err := verifier.VerifyLoadBalancerListenerRules(ctx, tf, lbARN, int32(gwListeners[0].Port), []verifier.ListenerRuleExpectation{
-								{
-									Conditions: []elbv2types.RuleCondition{
-										{
-											Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
-											PathPatternConfig: &elbv2types.PathPatternConditionConfig{
-												Values: []string{"/*"},
-											},
-										},
-										{
-											Field: awssdk.String(string(elbv2model.RuleConditionFieldHostHeader)),
-											HostHeaderConfig: &elbv2types.HostHeaderConditionConfig{
-												Values: []string{testHostname},
-											},
-										},
-									},
-									Actions: []elbv2types.Action{
-										{
-											Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeAuthenticateOIDC),
-											AuthenticateOidcConfig: &elbv2types.AuthenticateOidcActionConfig{
-												Issuer:                  awssdk.String(testOidcIssuer),
-												AuthorizationEndpoint:   awssdk.String(testOidcAuthorizationEndpoint),
-												TokenEndpoint:           awssdk.String(testOidcTokenEndpoint),
-												UserInfoEndpoint:        awssdk.String(testOidcUserInfoEndpoint),
-												ClientId:                awssdk.String(oidcClientID),
-												UseExistingClientSecret: awssdk.Bool(true),
-												Scope:                   awssdk.String("openid profile email"),
-												AuthenticationRequestExtraParams: map[string]string{
-													"prompt":  "login",
-													"display": "page",
-												},
-												OnUnauthenticatedRequest: elbv2types.AuthenticateOidcActionConditionalBehaviorEnumAuthenticate,
-												SessionCookieName:        awssdk.String("AWSELBAuthSessionCookie-OIDC"),
-												SessionTimeout:           awssdk.Int64(604800),
-											},
-										},
-										{
-											Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
-											ForwardConfig: &elbv2types.ForwardActionConfig{
-												TargetGroups: []elbv2types.TargetGroupTuple{
-													{
-														TargetGroupArn: awssdk.String(testTargetGroupArn),
-														Weight:         awssdk.Int32(1),
-													},
-												},
-											},
-										},
-									},
-									Priority: 1,
-								},
-							})
-							Expect(err).NotTo(HaveOccurred())
-						})
-						By("waiting until DNS name is available", func() {
-							err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
-							Expect(err).NotTo(HaveOccurred())
-						})
-						By("verifying authenticate-oidc redirect for unauthenticated request", func() {
-							url := fmt.Sprintf("https://%v/any-path", dnsName)
-							urlOptions := http.URLOptions{
-								InsecureSkipVerify: true,
-								HostHeader:         testHostname,
-								FollowRedirects:    false, // Don't follow redirects automatically
-							}
-
-							// Expect 302 redirect to Cognito
-							err := tf.HTTPVerifier.VerifyURLWithOptions(url, urlOptions, http.ResponseCodeMatches(302))
-							Expect(err).NotTo(HaveOccurred())
-
-							// Verify redirect Location header contains Cognito domain
-							err = tf.HTTPVerifier.VerifyURLWithOptions(url, urlOptions,
-								http.ResponseHeaderContains("Location", testOidcAuthorizationEndpoint))
-							Expect(err).NotTo(HaveOccurred())
-						})
-					})
-				})
-
-				Context("with both basic and secure HTTPRoutes", func() {
-					BeforeEach(func() {})
-					It("should provision internet-facing load balancer with both HTTP and HTTPS endpoints", func() {
-						if len(tf.Options.CertificateARNs) == 0 {
-							Skip("Skipping tests, certificates not specified")
-						}
-
-						interf := elbv2gw.LoadBalancerSchemeInternetFacing
-						lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
-							Scheme: &interf,
-						}
-
-						// Configure both HTTP and HTTPS listeners
-						cert := strings.Split(tf.Options.CertificateARNs, ",")[0]
-						httpLsConfig := elbv2gw.ListenerConfiguration{
-							ProtocolPort: "HTTP:80",
-						}
-						httpsLsConfig := elbv2gw.ListenerConfiguration{
-							ProtocolPort:       "HTTPS:443",
-							DefaultCertificate: &cert,
-						}
-						lbcSpec.ListenerConfigurations = &[]elbv2gw.ListenerConfiguration{
-							httpLsConfig,
-							httpsLsConfig,
-						}
-
-						tgSpec := elbv2gw.TargetGroupConfigurationSpec{}
-						lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{}
-						gwListeners := []gwv1.Listener{
+						},
+						BackendRefs: []gwv1.GRPCBackendRef{
 							{
-								Name:     "http80",
-								Port:     80,
-								Protocol: gwv1.HTTPProtocolType,
+								BackendRef: gwv1.BackendRef{
+									BackendObjectReference: gwv1.BackendObjectReference{
+										Name: grpcDefaultName + "-other",
+										Port: &defaultGrpcPort,
+									},
+								},
 							},
+						},
+					},
+				}
+
+				err = stack.albResourceStack.updateGRPCRoute(ctx, tf, stack.albResourceStack.grpcrs[0])
+				Expect(err).NotTo(HaveOccurred())
+				// Wait for listener change to propagate.
+				time.Sleep(1 * time.Minute)
+			})
+			By("sending grpc request should result in a failure.", func() {
+				c, err := generateGRPCClient(dnsName)
+				Expect(err).NotTo(HaveOccurred())
+				mdCtx := metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{}))
+				_, err = c.FixedResponse(mdCtx, &echo.FixedResponseRequest{})
+				Expect(err).To(HaveOccurred())
+			})
+			By("update grpc route to route by service / method name. filter by service", func() {
+
+				err = tf.K8sClient.Get(ctx, types.NamespacedName{Name: stack.albResourceStack.grpcrs[0].Name, Namespace: stack.albResourceStack.grpcrs[0].Namespace}, stack.albResourceStack.grpcrs[0])
+				Expect(err).NotTo(HaveOccurred())
+
+				stack.albResourceStack.grpcrs[0].Spec.Rules = []gwv1.GRPCRouteRule{
+					{
+						Matches: []gwv1.GRPCRouteMatch{
 							{
-								Name:     "https443",
-								Port:     443,
-								Protocol: gwv1.HTTPSProtocolType,
-								Hostname: (*gwv1.Hostname)(awssdk.String(testHostname)),
-							},
-						}
-						httpr := buildHTTPRoute([]string{testHostname}, []gwv1.HTTPRouteRule{}, nil)
-
-						By("deploying stack", func() {
-							err := stack.DeployHTTP(ctx, nil, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec, lrcSpec, nil, true)
-							Expect(err).NotTo(HaveOccurred())
-						})
-
-						By("checking gateway status for lb dns name", func() {
-							dnsName = stack.GetLoadBalancerIngressHostName()
-							Expect(dnsName).ToNot(BeEmpty())
-						})
-
-						By("querying AWS loadbalancer from the dns name", func() {
-							var err error
-							lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
-							Expect(err).NotTo(HaveOccurred())
-							Expect(lbARN).ToNot(BeEmpty())
-						})
-
-						By("verifying AWS loadbalancer resources", func() {
-							nodeList, err := stack.GetWorkerNodes(ctx, tf)
-							Expect(err).ToNot(HaveOccurred())
-
-							expectedTargetGroups := []verifier.ExpectedTargetGroup{
-								{
-									Protocol:      "HTTP",
-									Port:          stack.albResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort,
-									NumTargets:    len(nodeList),
-									TargetType:    "instance",
-									TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
+								Method: &gwv1.GRPCMethodMatch{
+									Service: awssdk.String("echo.EchoService"),
 								},
-							}
-							err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
-								Type:         "application",
-								Scheme:       "internet-facing",
-								Listeners:    stack.albResourceStack.getListenersPortMap(),
-								TargetGroups: expectedTargetGroups,
-							})
-							Expect(err).NotTo(HaveOccurred())
-						})
-
-						// Verify HTTP listener
-						By("verifying HTTP load balancer listener", func() {
-							err := verifier.VerifyLoadBalancerListener(ctx, tf, lbARN, int32(gwListeners[0].Port), &verifier.ListenerExpectation{
-								ProtocolPort: "HTTP:80",
-							})
-							Expect(err).NotTo(HaveOccurred())
-						})
-
-						// Verify HTTPS listener
-						By("verifying HTTPS load balancer listener", func() {
-							err := verifier.VerifyLoadBalancerListener(ctx, tf, lbARN, int32(gwListeners[1].Port), &verifier.ListenerExpectation{
-								ProtocolPort:          "HTTPS:443",
-								DefaultCertificateARN: awssdk.ToString(httpsLsConfig.DefaultCertificate),
-							})
-							Expect(err).NotTo(HaveOccurred())
-						})
-
-						By("waiting for target group targets to be healthy", func() {
-							nodeList, err := stack.GetWorkerNodes(ctx, tf)
-							Expect(err).ToNot(HaveOccurred())
-							err = verifier.WaitUntilTargetsAreHealthy(ctx, tf, lbARN, len(nodeList))
-							Expect(err).NotTo(HaveOccurred())
-						})
-
-						By("waiting until DNS name is available", func() {
-							err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
-							Expect(err).NotTo(HaveOccurred())
-						})
-
-						// Test HTTP endpoint
-						By("sending HTTP request to the lb", func() {
-							url := fmt.Sprintf("http://%v/any-path", dnsName)
-							urlOptions := http.URLOptions{
-								InsecureSkipVerify: true,
-								HostHeader:         testHostname, // Set Host header
-								Method:             "GET",
-							}
-							err := tf.HTTPVerifier.VerifyURLWithOptions(url, urlOptions, http.ResponseCodeMatches(200))
-							Expect(err).NotTo(HaveOccurred())
-						})
-
-						// Test HTTPS endpoint
-						By("sending HTTPS request to the lb", func() {
-							url := fmt.Sprintf("https://%v/any-path", dnsName)
-							urlOptions := http.URLOptions{
-								InsecureSkipVerify: true,
-								HostHeader:         testHostname, // Set Host header
-								Method:             "GET",
-							}
-							err := tf.HTTPVerifier.VerifyURLWithOptions(url, urlOptions, http.ResponseCodeMatches(200))
-							Expect(err).NotTo(HaveOccurred())
-						})
-					})
-				})
-
-				Context("with ALB instance target configuration with GRPC", func() {
-					It("should provision internet-facing load balancer resources", func() {
-						if len(tf.Options.CertificateARNs) == 0 {
-							Skip("Skipping tests, certificates not specified")
-						}
-
-						interf := elbv2gw.LoadBalancerSchemeInternetFacing
-						lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
-							Scheme: &interf,
-						}
-
-						// Use the first certificate from the provided list
-						cert := strings.Split(tf.Options.CertificateARNs, ",")[0]
-						lsConfig := elbv2gw.ListenerConfiguration{
-							ProtocolPort:       "HTTPS:443",
-							DefaultCertificate: &cert,
-						}
-						lbcSpec.ListenerConfigurations = &[]elbv2gw.ListenerConfiguration{lsConfig}
-						tgSpec := elbv2gw.TargetGroupConfigurationSpec{
-							DefaultConfiguration: elbv2gw.TargetGroupProps{},
-						}
-						lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{}
-						gwListeners := []gwv1.Listener{
+							},
+						},
+						BackendRefs: []gwv1.GRPCBackendRef{
 							{
-								Name:     "test-listener",
-								Port:     443,
-								Protocol: gwv1.HTTPSProtocolType,
+								BackendRef: gwv1.BackendRef{
+									BackendObjectReference: gwv1.BackendObjectReference{
+										Name: grpcDefaultName + "-other",
+										Port: &defaultGrpcPort,
+									},
+								},
 							},
-						}
+						},
+					},
+				}
 
-						grpcRouteRules := []gwv1.GRPCRouteRule{
+				err = stack.albResourceStack.updateGRPCRoute(ctx, tf, stack.albResourceStack.grpcrs[0])
+				Expect(err).NotTo(HaveOccurred())
+				// Wait for listener change to propagate.
+				time.Sleep(1 * time.Minute)
+			})
+			By("sending grpc request should work for both methods", func() {
+				c, err := generateGRPCClient(dnsName)
+				Expect(err).NotTo(HaveOccurred())
+				mdCtx := metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{}))
+				_, err = c.FixedResponse(mdCtx, &echo.FixedResponseRequest{})
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = c.Echo(mdCtx, &echo.EchoRequest{Message: "foo"})
+				Expect(err).ToNot(HaveOccurred())
+			})
+			By("update grpc route to route by service / method name. filter by service and method", func() {
+
+				err = tf.K8sClient.Get(ctx, types.NamespacedName{Name: stack.albResourceStack.grpcrs[0].Name, Namespace: stack.albResourceStack.grpcrs[0].Namespace}, stack.albResourceStack.grpcrs[0])
+				Expect(err).NotTo(HaveOccurred())
+
+				stack.albResourceStack.grpcrs[0].Spec.Rules = []gwv1.GRPCRouteRule{
+					{
+						Matches: []gwv1.GRPCRouteMatch{
 							{
-								BackendRefs: DefaultGrpcRouteRuleBackendRefs,
+								Method: &gwv1.GRPCMethodMatch{
+									Service: awssdk.String("echo.EchoService"),
+									Method:  awssdk.String("Echo"),
+								},
 							},
+						},
+						BackendRefs: []gwv1.GRPCBackendRef{
 							{
-								Matches: []gwv1.GRPCRouteMatch{
-									{
-										Headers: []gwv1.GRPCHeaderMatch{
-											{
-												Type:  (*gwv1.GRPCHeaderMatchType)(awssdk.String("Exact")),
-												Name:  "my-header",
-												Value: "my-header-value",
-											},
-										},
-									},
-								},
-								BackendRefs: []gwv1.GRPCBackendRef{
-									{
-										BackendRef: gwv1.BackendRef{
-											BackendObjectReference: gwv1.BackendObjectReference{
-												Name: grpcDefaultName + "-other",
-												Port: &defaultGrpcPort,
-											},
-										},
+								BackendRef: gwv1.BackendRef{
+									BackendObjectReference: gwv1.BackendObjectReference{
+										Name: grpcDefaultName + "-other",
+										Port: &defaultGrpcPort,
 									},
 								},
 							},
-						}
+						},
+					},
+				}
 
-						grpcr := buildGRPCRoute([]string{}, grpcRouteRules, &gwListeners[0].Name)
-						By("deploying stack", func() {
-							err := stack.DeployGRPC(ctx, tf, gwListeners, []*gwv1.GRPCRoute{grpcr}, lbcSpec, tgSpec, lrcSpec, true)
-							Expect(err).NotTo(HaveOccurred())
-						})
+				err = stack.albResourceStack.updateGRPCRoute(ctx, tf, stack.albResourceStack.grpcrs[0])
+				Expect(err).NotTo(HaveOccurred())
+				// Wait for listener change to propagate.
+				time.Sleep(1 * time.Minute)
+			})
+			By("sending grpc request should work for Echo method, should fail for FixedResponse", func() {
+				c, err := generateGRPCClient(dnsName)
+				Expect(err).NotTo(HaveOccurred())
+				mdCtx := metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{}))
+				_, err = c.FixedResponse(mdCtx, &echo.FixedResponseRequest{})
+				Expect(err).To(HaveOccurred())
 
-						By("checking gateway status for lb dns name", func() {
-							time.Sleep(2 * time.Minute)
-							dnsName = stack.GetLoadBalancerIngressHostName()
-							Expect(dnsName).ToNot(BeEmpty())
-						})
-						By("querying AWS loadbalancer from the dns name", func() {
-							var err error
-							lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
-							Expect(err).NotTo(HaveOccurred())
-							Expect(lbARN).ToNot(BeEmpty())
-						})
-
-						nodeList, err := stack.GetWorkerNodes(ctx, tf)
-						Expect(err).ToNot(HaveOccurred())
-
-						By("verifying AWS loadbalancer resources", func() {
-							expectedTargetGroups := []verifier.ExpectedTargetGroup{
-								{
-									Protocol:      "HTTP",
-									Port:          stack.albResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort,
-									NumTargets:    len(nodeList),
-									TargetType:    "instance",
-									TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC_GRPC,
-								},
-								{
-									Protocol:      "HTTP",
-									Port:          stack.albResourceStack.commonStack.svcs[1].Spec.Ports[0].NodePort,
-									NumTargets:    len(nodeList),
-									TargetType:    "instance",
-									TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC_GRPC,
-								},
-							}
-							err := verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
-								Type:         "application",
-								Scheme:       "internet-facing",
-								Listeners:    stack.albResourceStack.getListenersPortMap(),
-								TargetGroups: expectedTargetGroups,
-							})
-							Expect(err).NotTo(HaveOccurred())
-						})
-						By("waiting for target group targets to be healthy", func() {
-							err := verifier.WaitUntilTargetsAreHealthy(ctx, tf, lbARN, len(nodeList))
-							Expect(err).NotTo(HaveOccurred())
-						})
-						By("waiting until DNS name is available", func() {
-							err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
-							Expect(err).NotTo(HaveOccurred())
-						})
-						By("sending grpc request to the lb", func() {
-							c, err := generateGRPCClient(dnsName)
-							Expect(err).NotTo(HaveOccurred())
-							mdCtx := metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{"foo": "cat"}))
-							response, err := c.Echo(mdCtx, &echo.EchoRequest{Message: "Hello from E2E test"})
-							Expect(err).NotTo(HaveOccurred())
-							Expect(response.Message).To(Equal("Hello from E2E test"))
-						})
-						By("sending grpc request with certain header must forward traffic to right backend", func() {
-							target := fmt.Sprintf("%s:443", dnsName)
-							tlsConfig := &tls.Config{
-								InsecureSkipVerify: true, // This skips all certificate verification, including expiry.
-							}
-
-							conn, err := grpc.NewClient(target, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
-							Expect(err).NotTo(HaveOccurred())
-							c := echo.NewEchoServiceClient(conn)
-
-							mdCtx := metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{"my-header": "my-header-value"}))
-							response, err := c.FixedResponse(mdCtx, &echo.FixedResponseRequest{})
-							Expect(err).NotTo(HaveOccurred())
-							Expect(response.Message).To(Equal("Hello World - Other"))
-						})
-						By("sending grpc request with header missing uses default service.", func() {
-							c, err := generateGRPCClient(dnsName)
-							Expect(err).NotTo(HaveOccurred())
-							mdCtx := metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{}))
-							response, err := c.FixedResponse(mdCtx, &echo.FixedResponseRequest{})
-							Expect(err).NotTo(HaveOccurred())
-							Expect(response.Message).To(Equal("Hello World"))
-						})
-						By("update grpc route to remove default rule", func() {
-
-							err = tf.K8sClient.Get(ctx, types.NamespacedName{Name: stack.albResourceStack.grpcrs[0].Name, Namespace: stack.albResourceStack.grpcrs[0].Namespace}, stack.albResourceStack.grpcrs[0])
-							Expect(err).NotTo(HaveOccurred())
-
-							stack.albResourceStack.grpcrs[0].Spec.Rules = []gwv1.GRPCRouteRule{
-								{
-									Matches: []gwv1.GRPCRouteMatch{
-										{
-											Headers: []gwv1.GRPCHeaderMatch{
-												{
-													Type:  (*gwv1.GRPCHeaderMatchType)(awssdk.String("Exact")),
-													Name:  "my-header",
-													Value: "my-header-value",
-												},
-											},
-										},
-									},
-									BackendRefs: []gwv1.GRPCBackendRef{
-										{
-											BackendRef: gwv1.BackendRef{
-												BackendObjectReference: gwv1.BackendObjectReference{
-													Name: grpcDefaultName + "-other",
-													Port: &defaultGrpcPort,
-												},
-											},
-										},
-									},
-								},
-							}
-
-							err = stack.albResourceStack.updateGRPCRoute(ctx, tf, stack.albResourceStack.grpcrs[0])
-							Expect(err).NotTo(HaveOccurred())
-							// Wait for listener change to propagate.
-							time.Sleep(1 * time.Minute)
-						})
-						By("send grpc request with correct request header", func() {
-							c, err := generateGRPCClient(dnsName)
-							Expect(err).NotTo(HaveOccurred())
-							mdCtx := metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{"my-header": "my-header-value"}))
-							response, err := c.FixedResponse(mdCtx, &echo.FixedResponseRequest{})
-							Expect(err).NotTo(HaveOccurred())
-							Expect(response.Message).To(Equal("Hello World - Other"))
-						})
-						By("sending grpc request with header missing uses default service.", func() {
-							c, err := generateGRPCClient(dnsName)
-							Expect(err).NotTo(HaveOccurred())
-							mdCtx := metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{}))
-							_, err = c.FixedResponse(mdCtx, &echo.FixedResponseRequest{})
-							Expect(err).To(HaveOccurred())
-						})
-						By("update grpc route to route by service / method name. use invalid service", func() {
-
-							err = tf.K8sClient.Get(ctx, types.NamespacedName{Name: stack.albResourceStack.grpcrs[0].Name, Namespace: stack.albResourceStack.grpcrs[0].Namespace}, stack.albResourceStack.grpcrs[0])
-							Expect(err).NotTo(HaveOccurred())
-
-							stack.albResourceStack.grpcrs[0].Spec.Rules = []gwv1.GRPCRouteRule{
-								{
-									Matches: []gwv1.GRPCRouteMatch{
-										{
-											Method: &gwv1.GRPCMethodMatch{
-												Service: awssdk.String("com.example.FakeService"),
-												Method:  awssdk.String("FakeMethod"),
-											},
-										},
-									},
-									BackendRefs: []gwv1.GRPCBackendRef{
-										{
-											BackendRef: gwv1.BackendRef{
-												BackendObjectReference: gwv1.BackendObjectReference{
-													Name: grpcDefaultName + "-other",
-													Port: &defaultGrpcPort,
-												},
-											},
-										},
-									},
-								},
-							}
-
-							err = stack.albResourceStack.updateGRPCRoute(ctx, tf, stack.albResourceStack.grpcrs[0])
-							Expect(err).NotTo(HaveOccurred())
-							// Wait for listener change to propagate.
-							time.Sleep(1 * time.Minute)
-						})
-						By("sending grpc request should result in a failure.", func() {
-							c, err := generateGRPCClient(dnsName)
-							Expect(err).NotTo(HaveOccurred())
-							mdCtx := metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{}))
-							_, err = c.FixedResponse(mdCtx, &echo.FixedResponseRequest{})
-							Expect(err).To(HaveOccurred())
-						})
-						By("update grpc route to route by service / method name. filter by service", func() {
-
-							err = tf.K8sClient.Get(ctx, types.NamespacedName{Name: stack.albResourceStack.grpcrs[0].Name, Namespace: stack.albResourceStack.grpcrs[0].Namespace}, stack.albResourceStack.grpcrs[0])
-							Expect(err).NotTo(HaveOccurred())
-
-							stack.albResourceStack.grpcrs[0].Spec.Rules = []gwv1.GRPCRouteRule{
-								{
-									Matches: []gwv1.GRPCRouteMatch{
-										{
-											Method: &gwv1.GRPCMethodMatch{
-												Service: awssdk.String("echo.EchoService"),
-											},
-										},
-									},
-									BackendRefs: []gwv1.GRPCBackendRef{
-										{
-											BackendRef: gwv1.BackendRef{
-												BackendObjectReference: gwv1.BackendObjectReference{
-													Name: grpcDefaultName + "-other",
-													Port: &defaultGrpcPort,
-												},
-											},
-										},
-									},
-								},
-							}
-
-							err = stack.albResourceStack.updateGRPCRoute(ctx, tf, stack.albResourceStack.grpcrs[0])
-							Expect(err).NotTo(HaveOccurred())
-							// Wait for listener change to propagate.
-							time.Sleep(1 * time.Minute)
-						})
-						By("sending grpc request should work for both methods", func() {
-							c, err := generateGRPCClient(dnsName)
-							Expect(err).NotTo(HaveOccurred())
-							mdCtx := metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{}))
-							_, err = c.FixedResponse(mdCtx, &echo.FixedResponseRequest{})
-							Expect(err).ToNot(HaveOccurred())
-
-							_, err = c.Echo(mdCtx, &echo.EchoRequest{Message: "foo"})
-							Expect(err).ToNot(HaveOccurred())
-						})
-						By("update grpc route to route by service / method name. filter by service and method", func() {
-
-							err = tf.K8sClient.Get(ctx, types.NamespacedName{Name: stack.albResourceStack.grpcrs[0].Name, Namespace: stack.albResourceStack.grpcrs[0].Namespace}, stack.albResourceStack.grpcrs[0])
-							Expect(err).NotTo(HaveOccurred())
-
-							stack.albResourceStack.grpcrs[0].Spec.Rules = []gwv1.GRPCRouteRule{
-								{
-									Matches: []gwv1.GRPCRouteMatch{
-										{
-											Method: &gwv1.GRPCMethodMatch{
-												Service: awssdk.String("echo.EchoService"),
-												Method:  awssdk.String("Echo"),
-											},
-										},
-									},
-									BackendRefs: []gwv1.GRPCBackendRef{
-										{
-											BackendRef: gwv1.BackendRef{
-												BackendObjectReference: gwv1.BackendObjectReference{
-													Name: grpcDefaultName + "-other",
-													Port: &defaultGrpcPort,
-												},
-											},
-										},
-									},
-								},
-							}
-
-							err = stack.albResourceStack.updateGRPCRoute(ctx, tf, stack.albResourceStack.grpcrs[0])
-							Expect(err).NotTo(HaveOccurred())
-							// Wait for listener change to propagate.
-							time.Sleep(1 * time.Minute)
-						})
-						By("sending grpc request should work for Echo method, should fail for FixedResponse", func() {
-							c, err := generateGRPCClient(dnsName)
-							Expect(err).NotTo(HaveOccurred())
-							mdCtx := metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{}))
-							_, err = c.FixedResponse(mdCtx, &echo.FixedResponseRequest{})
-							Expect(err).To(HaveOccurred())
-
-							_, err = c.Echo(mdCtx, &echo.EchoRequest{Message: "foo"})
-							Expect(err).ToNot(HaveOccurred())
-						})
-
-			*/
+				_, err = c.Echo(mdCtx, &echo.EchoRequest{Message: "foo"})
+				Expect(err).ToNot(HaveOccurred())
+			})
+			By("confirming the route status", func() {
+				validationInfo := map[string]routeValidationInfo{
+					k8s.NamespacedName(stack.albResourceStack.grpcrs[0]).String(): {
+						parentGatewayName: stack.albResourceStack.commonStack.gw.Name,
+						listenerInfo: []listenerValidationInfo{
+							{
+								listenerName:       "test-listener",
+								parentKind:         "Gateway",
+								resolvedRefReason:  "Accepted",
+								resolvedRefsStatus: "True",
+								acceptedReason:     "Accepted",
+								acceptedStatus:     "True",
+							},
+						},
+					},
+				}
+				validateRouteStatus(tf, stack.albResourceStack.grpcrs, grpcRouteStatusConverter, validationInfo)
+			})
 		})
 	})
 })

--- a/test/e2e/gateway/alb_instance_target_test.go
+++ b/test/e2e/gateway/alb_instance_target_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	"strings"
 	"time"
 
@@ -143,35 +142,7 @@ var _ = Describe("test k8s alb gateway using instance targets reconciled by the 
 				Expect(err).NotTo(HaveOccurred())
 			})
 			By("confirming the route status", func() {
-				validationInfo := map[string]routeValidationInfo{
-					k8s.NamespacedName(stack.albResourceStack.httprs[0]).String(): {
-						parentGatewayName: stack.albResourceStack.commonStack.gw.Name,
-						listenerInfo: []listenerValidationInfo{
-							{
-								listenerName:       "test-listener",
-								parentKind:         "Gateway",
-								resolvedRefReason:  "Accepted",
-								resolvedRefsStatus: "True",
-								acceptedReason:     "Accepted",
-								acceptedStatus:     "True",
-							},
-						},
-					},
-					k8s.NamespacedName(stack.albResourceStack.httprs[1]).String(): {
-						parentGatewayName: stack.albResourceStack.commonStack.gw.Name,
-						listenerInfo: []listenerValidationInfo{
-							{
-								listenerName:       "other-ns",
-								parentKind:         "Gateway",
-								resolvedRefReason:  "RefNotPermitted",
-								resolvedRefsStatus: "False",
-								acceptedReason:     "RefNotPermitted",
-								acceptedStatus:     "False",
-							},
-						},
-					},
-				}
-				validateRouteStatus(tf, stack.albResourceStack.httprs, httpRouteStatusConverter, validationInfo)
+				validateHTTPRouteStatusNotPermitted(tf, stack)
 			})
 			By("deploying ref grant", func() {
 				err := auxiliaryStack.CreateReferenceGrants(ctx, tf, stack.albResourceStack.commonStack.ns)
@@ -213,35 +184,7 @@ var _ = Describe("test k8s alb gateway using instance targets reconciled by the 
 				Expect(err).NotTo(HaveOccurred())
 			})
 			By("confirming the http route status after ref grant is materialized", func() {
-				validationInfo := map[string]routeValidationInfo{
-					k8s.NamespacedName(stack.albResourceStack.httprs[0]).String(): {
-						parentGatewayName: stack.albResourceStack.commonStack.gw.Name,
-						listenerInfo: []listenerValidationInfo{
-							{
-								listenerName:       "test-listener",
-								parentKind:         "Gateway",
-								resolvedRefReason:  "Accepted",
-								resolvedRefsStatus: "True",
-								acceptedReason:     "Accepted",
-								acceptedStatus:     "True",
-							},
-						},
-					},
-					k8s.NamespacedName(stack.albResourceStack.httprs[1]).String(): {
-						parentGatewayName: stack.albResourceStack.commonStack.gw.Name,
-						listenerInfo: []listenerValidationInfo{
-							{
-								listenerName:       "other-ns",
-								parentKind:         "Gateway",
-								resolvedRefReason:  "Accepted",
-								resolvedRefsStatus: "True",
-								acceptedReason:     "Accepted",
-								acceptedStatus:     "True",
-							},
-						},
-					},
-				}
-				validateRouteStatus(tf, stack.albResourceStack.httprs, httpRouteStatusConverter, validationInfo)
+				validateHTTPRouteStatusPermitted(tf, stack)
 			})
 			By("removing ref grant", func() {
 				err := auxiliaryStack.DeleteReferenceGrants(ctx, tf)
@@ -255,35 +198,7 @@ var _ = Describe("test k8s alb gateway using instance targets reconciled by the 
 				Expect(err).NotTo(HaveOccurred())
 			})
 			By("confirming the route status", func() {
-				validationInfo := map[string]routeValidationInfo{
-					k8s.NamespacedName(stack.albResourceStack.httprs[0]).String(): {
-						parentGatewayName: stack.albResourceStack.commonStack.gw.Name,
-						listenerInfo: []listenerValidationInfo{
-							{
-								listenerName:       "test-listener",
-								parentKind:         "Gateway",
-								resolvedRefReason:  "Accepted",
-								resolvedRefsStatus: "True",
-								acceptedReason:     "Accepted",
-								acceptedStatus:     "True",
-							},
-						},
-					},
-					k8s.NamespacedName(stack.albResourceStack.httprs[1]).String(): {
-						parentGatewayName: stack.albResourceStack.commonStack.gw.Name,
-						listenerInfo: []listenerValidationInfo{
-							{
-								listenerName:       "other-ns",
-								parentKind:         "Gateway",
-								resolvedRefReason:  "RefNotPermitted",
-								resolvedRefsStatus: "False",
-								acceptedReason:     "RefNotPermitted",
-								acceptedStatus:     "False",
-							},
-						},
-					},
-				}
-				validateRouteStatus(tf, stack.albResourceStack.httprs, httpRouteStatusConverter, validationInfo)
+				validateHTTPRouteStatusNotPermitted(tf, stack)
 			})
 		})
 	})
@@ -1802,22 +1717,7 @@ var _ = Describe("test k8s alb gateway using instance targets reconciled by the 
 				Expect(err).ToNot(HaveOccurred())
 			})
 			By("confirming the route status", func() {
-				validationInfo := map[string]routeValidationInfo{
-					k8s.NamespacedName(stack.albResourceStack.grpcrs[0]).String(): {
-						parentGatewayName: stack.albResourceStack.commonStack.gw.Name,
-						listenerInfo: []listenerValidationInfo{
-							{
-								listenerName:       "test-listener",
-								parentKind:         "Gateway",
-								resolvedRefReason:  "Accepted",
-								resolvedRefsStatus: "True",
-								acceptedReason:     "Accepted",
-								acceptedStatus:     "True",
-							},
-						},
-					},
-				}
-				validateRouteStatus(tf, stack.albResourceStack.grpcrs, grpcRouteStatusConverter, validationInfo)
+				validateGRPCRouteStatus(tf, stack)
 			})
 		})
 	})

--- a/test/e2e/gateway/alb_instance_target_test.go
+++ b/test/e2e/gateway/alb_instance_target_test.go
@@ -2,25 +2,11 @@ package gateway
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
-	"strings"
-	"time"
-
-	awssdk "github.com/aws/aws-sdk-go-v2/aws"
-	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/gavv/httpexpect/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/metadata"
-	"k8s.io/apimachinery/pkg/types"
 	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
-	"sigs.k8s.io/aws-load-balancer-controller/pkg/gateway/constants"
-	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
-	"sigs.k8s.io/aws-load-balancer-controller/test/e2e/gateway/grpc/echo"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework/http"
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework/utils"
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework/verifier"
@@ -136,1577 +122,1602 @@ var _ = Describe("test k8s alb gateway using instance targets reconciled by the 
 				err := tf.HTTPVerifier.VerifyURL(url, http.ResponseCodeMatches(200))
 				Expect(err).NotTo(HaveOccurred())
 			})
-			By("cross-ns listener should return 503 as no ref grant is available", func() {
-				url := fmt.Sprintf("http://%v:5000/any-path", dnsName)
-				err := tf.HTTPVerifier.VerifyURL(url, http.ResponseCodeMatches(503))
-				Expect(err).NotTo(HaveOccurred())
-			})
-			By("deploying ref grant", func() {
-				err := auxiliaryStack.CreateReferenceGrants(ctx, tf, stack.albResourceStack.commonStack.ns)
-				Expect(err).NotTo(HaveOccurred())
-				// Give some time to have the listener get materialized.
-				time.Sleep(2 * time.Minute)
-			})
-			By("ensuring cross namespace is materialized", func() {
-				nodeList, err := stack.GetWorkerNodes(ctx, tf)
-				Expect(err).ToNot(HaveOccurred())
-				expectedTargetGroups := []verifier.ExpectedTargetGroup{
-					{
-						Protocol:      "HTTP",
-						Port:          stack.albResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort,
-						NumTargets:    len(nodeList),
-						TargetType:    "instance",
-						TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
-					},
-					{
-						Protocol:      "HTTP",
-						Port:          auxiliaryStack.svcs[0].Spec.Ports[0].NodePort,
-						NumTargets:    len(nodeList),
-						TargetType:    "instance",
-						TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
-					},
+			By("confirming the http routes have been updated with a valid status", func() {
+				for _, createdRoute := range stack.albResourceStack.httprs {
+					retrievedRoute := gwv1.HTTPRoute{}
+					err := tf.K8sClient.Get(ctx, k8s.NamespacedName(createdRoute), &retrievedRoute)
+					Expect(err).NotTo(HaveOccurred())
+					// We only have one listener attaching to the route.
+					Expect(len(retrievedRoute.Status.RouteStatus.Parents)).To(Equal(1))
+					fmt.Printf("---->%+v\n", retrievedRoute.Status.RouteStatus)
+					if createdRoute.Name == defaultName+"-otherns" {
+						Expect(string(retrievedRoute.Status.RouteStatus.Parents[0].ParentRef.Name)).To(Equal(stack.albResourceStack.commonStack.gw.Name))
+						Expect(retrievedRoute.Status.RouteStatus.Parents[0].ParentRef.Namespace).To(BeNil())
+						Expect(string(*retrievedRoute.Status.RouteStatus.Parents[0].ParentRef.SectionName)).To(Equal("other-ns"))
+						Expect(string(*retrievedRoute.Status.RouteStatus.Parents[0].ParentRef.Kind)).To(Equal("Gateway"))
+					} else {
+						Expect(string(retrievedRoute.Status.RouteStatus.Parents[0].ParentRef.Name)).To(Equal(stack.albResourceStack.commonStack.gw.Name))
+						Expect(retrievedRoute.Status.RouteStatus.Parents[0].ParentRef.Namespace).To(BeNil())
+						Expect(string(*retrievedRoute.Status.RouteStatus.Parents[0].ParentRef.SectionName)).To(Equal("test-listener"))
+						Expect(string(*retrievedRoute.Status.RouteStatus.Parents[0].ParentRef.Kind)).To(Equal("Gateway"))
+					}
+
 				}
-
-				err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
-					Type:         "application",
-					Scheme:       "internet-facing",
-					Listeners:    stack.albResourceStack.getListenersPortMap(),
-					TargetGroups: expectedTargetGroups,
-				})
-				Expect(err).NotTo(HaveOccurred())
 			})
-			By("sending http request cross namespace service", func() {
-				url := fmt.Sprintf("http://%v:5000/any-path", dnsName)
-				err := tf.HTTPVerifier.VerifyURL(url, http.ResponseCodeMatches(200))
-				Expect(err).NotTo(HaveOccurred())
-			})
-			By("removing ref grant", func() {
-				err := auxiliaryStack.DeleteReferenceGrants(ctx, tf)
-				Expect(err).NotTo(HaveOccurred())
-				// Give some time to have the reference grant to be deleted
-				time.Sleep(2 * time.Minute)
-			})
-			By("cross-ns listener should return 503 as no ref grant is available", func() {
-				url := fmt.Sprintf("http://%v:5000/any-path", dnsName)
-				err := tf.HTTPVerifier.VerifyURL(url, http.ResponseCodeMatches(503))
-				Expect(err).NotTo(HaveOccurred())
-			})
-		})
-	})
-
-	Context("with ALB instance target configuration with HTTPRoute specified matches", func() {
-		BeforeEach(func() {})
-		It("should provision internet-facing load balancer resources", func() {
-			interf := elbv2gw.LoadBalancerSchemeInternetFacing
-			lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
-				Scheme: &interf,
-			}
-			tgSpec := elbv2gw.TargetGroupConfigurationSpec{}
-			lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{}
-			gwListeners := []gwv1.Listener{
-				{
-					Name:     "test-listener",
-					Port:     80,
-					Protocol: gwv1.HTTPProtocolType,
-				},
-			}
-			httpr := buildHTTPRoute([]string{}, httpRouteRuleWithMatchesAndTargetGroupWeights, nil)
-
-			By("deploying stack", func() {
-				err := stack.DeployHTTP(ctx, nil, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec, lrcSpec, nil, true)
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			By("checking gateway status for lb dns name", func() {
-				dnsName = stack.GetLoadBalancerIngressHostName()
-				Expect(dnsName).ToNot(BeEmpty())
-			})
-
-			By("querying AWS loadbalancer from the dns name", func() {
-				var err error
-				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(lbARN).ToNot(BeEmpty())
-			})
-
-			By("verifying AWS loadbalancer resources", func() {
-				nodeList, err := stack.GetWorkerNodes(ctx, tf)
-				Expect(err).ToNot(HaveOccurred())
-				expectedTargetGroups := []verifier.ExpectedTargetGroup{
-					{
-						Protocol:      "HTTP",
-						Port:          stack.albResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort,
-						NumTargets:    len(nodeList),
-						TargetType:    "instance",
-						TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
-					},
-				}
-				err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
-					Type:         "application",
-					Scheme:       "internet-facing",
-					Listeners:    stack.albResourceStack.getListenersPortMap(),
-					TargetGroups: expectedTargetGroups,
-				})
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			By("verifying HTTP load balancer listener", func() {
-				err := verifier.VerifyLoadBalancerListener(ctx, tf, lbARN, int32(gwListeners[0].Port), &verifier.ListenerExpectation{
-					ProtocolPort: "HTTP:80",
-				})
-				Expect(err).NotTo(HaveOccurred())
-			})
-			By("verifying listener rules", func() {
-				err := verifier.VerifyLoadBalancerListenerRules(ctx, tf, lbARN, int32(gwListeners[0].Port), []verifier.ListenerRuleExpectation{
-					{
-						Conditions: []elbv2types.RuleCondition{
-							{
-								Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
-								PathPatternConfig: &elbv2types.PathPatternConditionConfig{
-									Values: []string{testPathString},
-								},
-							},
-						},
-						Actions: []elbv2types.Action{
-							{
-								Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
-								ForwardConfig: &elbv2types.ForwardActionConfig{
-									TargetGroups: []elbv2types.TargetGroupTuple{
-										{
-											TargetGroupArn: awssdk.String(testTargetGroupArn),
-											Weight:         awssdk.Int32(50),
-										},
-									},
-								},
-							},
-						},
-						Priority: 1,
-					},
-					{
-						Conditions: []elbv2types.RuleCondition{
-							{
-								Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
-								PathPatternConfig: &elbv2types.PathPatternConditionConfig{
-									Values: []string{testPathString, fmt.Sprintf("%s/*", testPathString)},
-								},
-							},
-							{
-								Field: awssdk.String(string(elbv2model.RuleConditionFieldHTTPRequestMethod)),
-								HttpRequestMethodConfig: &elbv2types.HttpRequestMethodConditionConfig{
-									Values: []string{
-										"GET",
-									},
-								},
-							},
-							{
-								Field: awssdk.String(string(elbv2model.RuleConditionFieldHTTPHeader)),
-								HttpHeaderConfig: &elbv2types.HttpHeaderConditionConfig{
-									HttpHeaderName: awssdk.String(testHttpHeaderNameOne),
-									Values: []string{
-										testHttpHeaderValueOne,
-									},
-								},
-							},
-							{
-								Field: awssdk.String(string(elbv2model.RuleConditionFieldHTTPHeader)),
-								HttpHeaderConfig: &elbv2types.HttpHeaderConditionConfig{
-									HttpHeaderName: awssdk.String(testHttpHeaderNameTwo),
-									Values: []string{
-										testHttpHeaderValueTwo,
-									},
-								},
-							},
-						},
-						Actions: []elbv2types.Action{
-							{
-								Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
-								ForwardConfig: &elbv2types.ForwardActionConfig{
-									TargetGroups: []elbv2types.TargetGroupTuple{
-										{
-											TargetGroupArn: awssdk.String(testTargetGroupArn),
-											Weight:         awssdk.Int32(30),
-										},
-									},
-								},
-							},
-						},
-						Priority: 2,
-					},
-					{
-						Conditions: []elbv2types.RuleCondition{
-							{
-								Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
-								PathPatternConfig: &elbv2types.PathPatternConditionConfig{
-									Values: []string{testPathString, fmt.Sprintf("%s/*", testPathString)},
-								},
-							},
-							{
-								Field: awssdk.String(string(elbv2model.RuleConditionFieldQueryString)),
-								QueryStringConfig: &elbv2types.QueryStringConditionConfig{
-									Values: []elbv2types.QueryStringKeyValuePair{
-										{
-											Key:   awssdk.String(testQueryStringKeyOne),
-											Value: awssdk.String(testQueryStringValueOne),
-										},
-									},
-								},
-							},
-							{
-								Field: awssdk.String(string(elbv2model.RuleConditionFieldQueryString)),
-								QueryStringConfig: &elbv2types.QueryStringConditionConfig{
-									Values: []elbv2types.QueryStringKeyValuePair{
-										{
-											Key:   awssdk.String(testQueryStringKeyTwo),
-											Value: awssdk.String(testQueryStringValueTwo),
-										},
-									},
-								},
-							},
-						},
-						Actions: []elbv2types.Action{
-							{
-								Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
-								ForwardConfig: &elbv2types.ForwardActionConfig{
-									TargetGroups: []elbv2types.TargetGroupTuple{
-										{
-											TargetGroupArn: awssdk.String(testTargetGroupArn),
-											Weight:         awssdk.Int32(30),
-										},
-									},
-								},
-							},
-						},
-						Priority: 3,
-					},
-				})
-				Expect(err).NotTo(HaveOccurred())
-			})
-			By("waiting for target group targets to be healthy", func() {
-				nodeList, err := stack.GetWorkerNodes(ctx, tf)
-				Expect(err).ToNot(HaveOccurred())
-				err = verifier.WaitUntilTargetsAreHealthy(ctx, tf, lbARN, len(nodeList))
-				Expect(err).NotTo(HaveOccurred())
-			})
-			By("waiting until DNS name is available", func() {
-				err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
-				Expect(err).NotTo(HaveOccurred())
-			})
-			By("sending http request to the lb", func() {
-				url := fmt.Sprintf("http://%v%s", dnsName, testPathString)
-				err := tf.HTTPVerifier.VerifyURL(url, http.ResponseCodeMatches(200))
-				Expect(err).NotTo(HaveOccurred())
-			})
-		})
-	})
-
-	Context("with ALB instance target configuration with HTTPRoute specified filter", func() {
-		BeforeEach(func() {})
-		It("should provision internet-facing load balancer resources", func() {
-			interf := elbv2gw.LoadBalancerSchemeInternetFacing
-			lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
-				Scheme: &interf,
-			}
-			tgSpec := elbv2gw.TargetGroupConfigurationSpec{}
-			lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{}
-			gwListeners := []gwv1.Listener{
-				{
-					Name:     "test-listener",
-					Port:     80,
-					Protocol: gwv1.HTTPProtocolType,
-				},
-			}
-			httpr := buildHTTPRoute([]string{}, httpRouteRuleWithMatchesAndFilters, nil)
-
-			By("deploying stack", func() {
-				err := stack.DeployHTTP(ctx, nil, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec, lrcSpec, nil, true)
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			By("checking gateway status for lb dns name", func() {
-				dnsName = stack.GetLoadBalancerIngressHostName()
-				Expect(dnsName).ToNot(BeEmpty())
-			})
-
-			By("querying AWS loadbalancer from the dns name", func() {
-				var err error
-				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(lbARN).ToNot(BeEmpty())
-			})
-
-			By("waiting until DNS name is available", func() {
-				err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			By("testing redirect with ReplaceFullPath", func() {
-				httpExp := httpexpect.New(tf.LoggerReporter, fmt.Sprintf("http://%v", dnsName))
-				httpExp.GET("/old-path").WithRedirectPolicy(httpexpect.DontFollowRedirects).Expect().
-					Status(301).
-					Header("Location").Equal("https://example.com:80/new-path")
-			})
-
-			By("testing redirect with ReplacePrefixMatch", func() {
-				httpExp := httpexpect.New(tf.LoggerReporter, fmt.Sprintf("http://%v", dnsName))
-				httpExp.GET("/api/v1/users").WithRedirectPolicy(httpexpect.DontFollowRedirects).Expect().
-					Status(302).
-					Header("Location").Equal("https://api.example.com:80/v2/*")
-			})
-
-			By("testing redirect with scheme and port change", func() {
-				httpExp := httpexpect.New(tf.LoggerReporter, fmt.Sprintf("http://%v", dnsName))
-				httpExp.GET("/secure").WithRedirectPolicy(httpexpect.DontFollowRedirects).Expect().
-					Status(302).
-					Header("Location").Equal("https://secure.example.com:8443/secure")
-			})
-		})
-	})
-
-	Context("with ALB instance target configuration with HTTPRoute specified source ip in listener rule configuration", func() {
-		BeforeEach(func() {})
-		It("should provision internet-facing load balancer resources", func() {
-			interf := elbv2gw.LoadBalancerSchemeInternetFacing
-			lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
-				Scheme: &interf,
-			}
-			tgSpec := elbv2gw.TargetGroupConfigurationSpec{}
-
-			matchIndex := []int{0, 2}
-			sourceIp := "10.0.0.0/8"
-			lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{
-				Conditions: []elbv2gw.ListenerRuleCondition{
-					{
-						SourceIPConfig: &elbv2gw.SourceIPConditionConfig{Values: []string{sourceIp}},
-						Field:          elbv2gw.ListenerRuleConditionField(elbv2model.RuleConditionFieldSourceIP),
-						MatchIndexes:   &matchIndex,
-					},
-				},
-			}
-			gwListeners := []gwv1.Listener{
-				{
-					Name:     "test-listener",
-					Port:     80,
-					Protocol: gwv1.HTTPProtocolType,
-				},
-			}
-
-			httpr := buildHTTPRoute([]string{}, httpRouteRuleWithMultiMatchesInSingleRule, nil)
-
-			By("deploying stack", func() {
-				err := stack.DeployHTTP(ctx, nil, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec, lrcSpec, nil, true)
-
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			By("checking gateway status for lb dns name", func() {
-				dnsName = stack.GetLoadBalancerIngressHostName()
-				Expect(dnsName).ToNot(BeEmpty())
-			})
-
-			By("querying AWS loadbalancer from the dns name", func() {
-				var err error
-				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(lbARN).ToNot(BeEmpty())
-			})
-
-			By("verifying AWS loadbalancer resources", func() {
-				nodeList, err := stack.GetWorkerNodes(ctx, tf)
-				Expect(err).ToNot(HaveOccurred())
-				expectedTargetGroups := []verifier.ExpectedTargetGroup{
-					{
-						Protocol:      "HTTP",
-						Port:          stack.albResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort,
-						NumTargets:    len(nodeList),
-						TargetType:    "instance",
-						TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
-					},
-				}
-				err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
-					Type:         "application",
-					Scheme:       "internet-facing",
-					Listeners:    stack.albResourceStack.getListenersPortMap(),
-					TargetGroups: expectedTargetGroups,
-				})
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			By("verifying HTTP load balancer listener", func() {
-				err := verifier.VerifyLoadBalancerListener(ctx, tf, lbARN, int32(gwListeners[0].Port), &verifier.ListenerExpectation{
-					ProtocolPort: "HTTP:80",
-				})
-				Expect(err).NotTo(HaveOccurred())
-			})
-			By("verifying listener rules", func() {
-				err := verifier.VerifyLoadBalancerListenerRules(ctx, tf, lbARN, int32(gwListeners[0].Port), []verifier.ListenerRuleExpectation{
-					{
-						Conditions: []elbv2types.RuleCondition{
-							{
-								Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
-								PathPatternConfig: &elbv2types.PathPatternConditionConfig{
-									Values: []string{testPathString},
-								},
-							},
-							{
-								Field: awssdk.String(string(elbv2model.RuleConditionFieldSourceIP)),
-								SourceIpConfig: &elbv2types.SourceIpConditionConfig{
-									Values: []string{sourceIp},
-								},
-							},
-						},
-						Actions: []elbv2types.Action{
-							{
-								Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
-								ForwardConfig: &elbv2types.ForwardActionConfig{
-									TargetGroups: []elbv2types.TargetGroupTuple{
-										{
-											TargetGroupArn: awssdk.String(testTargetGroupArn),
-											Weight:         aws.Int32(1),
-										},
-									},
-								},
-							},
-						},
-						Priority: 1,
-					},
-					{
-						Conditions: []elbv2types.RuleCondition{
-							{
-								Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
-								PathPatternConfig: &elbv2types.PathPatternConditionConfig{
-									Values: []string{testPathString, fmt.Sprintf("%s/*", testPathString)},
-								},
-							},
-							{
-								Field: awssdk.String(string(elbv2model.RuleConditionFieldHTTPRequestMethod)),
-								HttpRequestMethodConfig: &elbv2types.HttpRequestMethodConditionConfig{
-									Values: []string{
-										"GET",
-									},
-								},
-							},
-						},
-						Actions: []elbv2types.Action{
-							{
-								Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
-								ForwardConfig: &elbv2types.ForwardActionConfig{
-									TargetGroups: []elbv2types.TargetGroupTuple{
-										{
-											TargetGroupArn: awssdk.String(testTargetGroupArn),
-											Weight:         aws.Int32(1),
-										},
-									},
-								},
-							},
-						},
-						Priority: 2,
-					},
-					{
-						Conditions: []elbv2types.RuleCondition{
-							{
-								Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
-								PathPatternConfig: &elbv2types.PathPatternConditionConfig{
-									Values: []string{testPathString, fmt.Sprintf("%s/*", testPathString)},
-								},
-							},
-							{
-								Field: awssdk.String(string(elbv2model.RuleConditionFieldHTTPHeader)),
-								HttpHeaderConfig: &elbv2types.HttpHeaderConditionConfig{
-									HttpHeaderName: awssdk.String(testHttpHeaderNameOne),
-									Values: []string{
-										testHttpHeaderValueOne,
-									},
-								},
-							},
-							{
-								Field: awssdk.String(string(elbv2model.RuleConditionFieldSourceIP)),
-								SourceIpConfig: &elbv2types.SourceIpConditionConfig{
-									Values: []string{sourceIp},
-								},
-							},
-						},
-						Actions: []elbv2types.Action{
-							{
-								Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
-								ForwardConfig: &elbv2types.ForwardActionConfig{
-									TargetGroups: []elbv2types.TargetGroupTuple{
-										{
-											TargetGroupArn: awssdk.String(testTargetGroupArn),
-											Weight:         aws.Int32(1),
-										},
-									},
-								},
-							},
-						},
-						Priority: 3,
-					},
-				})
-				Expect(err).NotTo(HaveOccurred())
-			})
-			By("waiting for target group targets to be healthy", func() {
-				nodeList, err := stack.GetWorkerNodes(ctx, tf)
-				Expect(err).ToNot(HaveOccurred())
-				err = verifier.WaitUntilTargetsAreHealthy(ctx, tf, lbARN, len(nodeList))
-				Expect(err).NotTo(HaveOccurred())
-			})
-			By("waiting until DNS name is available", func() {
-				err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
-				Expect(err).NotTo(HaveOccurred())
-			})
-		})
-	})
-
-	Context("with ALB instance target configuration with secure HTTPRoute", func() {
-		BeforeEach(func() {})
-		It("should provision internet-facing load balancer resources", func() {
-			if len(tf.Options.CertificateARNs) == 0 {
-				Skip("Skipping tests, certificates not specified")
-			}
-			interf := elbv2gw.LoadBalancerSchemeInternetFacing
-			lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
-				Scheme: &interf,
-			}
-
-			cert := strings.Split(tf.Options.CertificateARNs, ",")[0]
-			lsConfig := elbv2gw.ListenerConfiguration{
-				ProtocolPort:       "HTTPS:443",
-				DefaultCertificate: &cert,
-			}
-			lbcSpec.ListenerConfigurations = &[]elbv2gw.ListenerConfiguration{lsConfig}
-			tgSpec := elbv2gw.TargetGroupConfigurationSpec{}
-			lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{}
-			gwListeners := []gwv1.Listener{
-				{
-					Name:     "https443",
-					Port:     443,
-					Protocol: gwv1.HTTPSProtocolType,
-					Hostname: (*gwv1.Hostname)(awssdk.String(testHostname)),
-				},
-			}
-			httpr := buildHTTPRoute([]string{testHostname}, []gwv1.HTTPRouteRule{}, nil)
-			By("deploying stack", func() {
-				err := stack.DeployHTTP(ctx, nil, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec, lrcSpec, nil, true)
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			By("checking gateway status for lb dns name", func() {
-				dnsName = stack.GetLoadBalancerIngressHostName()
-				Expect(dnsName).ToNot(BeEmpty())
-			})
-
-			By("querying AWS loadbalancer from the dns name", func() {
-				var err error
-				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(lbARN).ToNot(BeEmpty())
-			})
-			By("verifying AWS loadbalancer resources", func() {
-				nodeList, err := stack.GetWorkerNodes(ctx, tf)
-				Expect(err).ToNot(HaveOccurred())
-
-				expectedTargetGroups := []verifier.ExpectedTargetGroup{
-					{
-						Protocol:      "HTTP",
-						Port:          stack.albResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort,
-						NumTargets:    len(nodeList),
-						TargetType:    "instance",
-						TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
-					},
-				}
-				err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
-					Type:         "application",
-					Scheme:       "internet-facing",
-					Listeners:    stack.albResourceStack.getListenersPortMap(),
-					TargetGroups: expectedTargetGroups,
-				})
-				Expect(err).NotTo(HaveOccurred())
-			})
-			By("verifying AWS load balancer listener", func() {
-				err := verifier.VerifyLoadBalancerListener(ctx, tf, lbARN, int32(gwListeners[0].Port), &verifier.ListenerExpectation{
-					ProtocolPort:          "HTTPS:443",
-					DefaultCertificateARN: awssdk.ToString(lsConfig.DefaultCertificate),
-					MutualAuthentication: &verifier.MutualAuthenticationExpectation{
-						Mode: "off",
-					},
-				})
-				Expect(err).NotTo(HaveOccurred())
-			})
-			By("waiting for target group targets to be healthy", func() {
-				nodeList, err := stack.GetWorkerNodes(ctx, tf)
-				Expect(err).ToNot(HaveOccurred())
-				err = verifier.WaitUntilTargetsAreHealthy(ctx, tf, lbARN, len(nodeList))
-				Expect(err).NotTo(HaveOccurred())
-			})
-			By("waiting until DNS name is available", func() {
-				err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
-				Expect(err).NotTo(HaveOccurred())
-			})
-			By("sending https request to the lb", func() {
-				url := fmt.Sprintf("https://%v/any-path", dnsName)
-				urlOptions := http.URLOptions{
-					InsecureSkipVerify: true,
-					HostHeader:         testHostname, // Set Host header
-				}
-				err := tf.HTTPVerifier.VerifyURLWithOptions(url, urlOptions, http.ResponseCodeMatches(200))
-				Expect(err).NotTo(HaveOccurred())
-			})
-		})
-	})
-
-	Context("with ALB instance target configuration with secure HTTPRoute and mutual authentication PASSTHROUGH mode", func() {
-		BeforeEach(func() {})
-		It("should provision internet-facing load balancer resources", func() {
-			if len(tf.Options.CertificateARNs) == 0 {
-				Skip("Skipping tests, certificates not specified")
-			}
-			interf := elbv2gw.LoadBalancerSchemeInternetFacing
-			lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
-				Scheme: &interf,
-			}
-
-			cert := strings.Split(tf.Options.CertificateARNs, ",")[0]
-			lsConfig := elbv2gw.ListenerConfiguration{
-				ProtocolPort:       "HTTPS:443",
-				DefaultCertificate: &cert,
-				MutualAuthentication: &elbv2gw.MutualAuthenticationAttributes{
-					Mode: "passthrough",
-				},
-			}
-			lbcSpec.ListenerConfigurations = &[]elbv2gw.ListenerConfiguration{lsConfig}
-			tgSpec := elbv2gw.TargetGroupConfigurationSpec{}
-			lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{}
-			gwListeners := []gwv1.Listener{
-				{
-					Name:     "https443",
-					Port:     443,
-					Protocol: gwv1.HTTPSProtocolType,
-					Hostname: (*gwv1.Hostname)(awssdk.String(testHostname)),
-				},
-			}
-			httpr := buildHTTPRoute([]string{testHostname}, []gwv1.HTTPRouteRule{}, nil)
-			By("deploying stack", func() {
-				err := stack.DeployHTTP(ctx, nil, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec, lrcSpec, nil, true)
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			By("checking gateway status for lb dns name", func() {
-				dnsName = stack.GetLoadBalancerIngressHostName()
-				Expect(dnsName).ToNot(BeEmpty())
-			})
-
-			By("querying AWS loadbalancer from the dns name", func() {
-				var err error
-				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(lbARN).ToNot(BeEmpty())
-			})
-
-			By("verifying AWS loadbalancer resources", func() {
-				nodeList, err := stack.GetWorkerNodes(ctx, tf)
-				Expect(err).ToNot(HaveOccurred())
-				expectedTargetGroups := []verifier.ExpectedTargetGroup{
-					{
-						Protocol:      "HTTP",
-						Port:          stack.albResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort,
-						NumTargets:    len(nodeList),
-						TargetType:    "instance",
-						TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
-					},
-				}
-				err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
-					Type:         "application",
-					Scheme:       "internet-facing",
-					Listeners:    stack.albResourceStack.getListenersPortMap(),
-					TargetGroups: expectedTargetGroups,
-				})
-				Expect(err).NotTo(HaveOccurred())
-			})
-			By("verifying AWS load balancer listener", func() {
-				err := verifier.VerifyLoadBalancerListener(ctx, tf, lbARN, int32(gwListeners[0].Port), &verifier.ListenerExpectation{
-					ProtocolPort:          "HTTPS:443",
-					DefaultCertificateARN: awssdk.ToString(lsConfig.DefaultCertificate),
-					MutualAuthentication: &verifier.MutualAuthenticationExpectation{
-						Mode: "passthrough",
-					},
-				})
-				Expect(err).NotTo(HaveOccurred())
-			})
-			By("waiting for target group targets to be healthy", func() {
-				nodeList, err := stack.GetWorkerNodes(ctx, tf)
-				Expect(err).ToNot(HaveOccurred())
-				err = verifier.WaitUntilTargetsAreHealthy(ctx, tf, lbARN, len(nodeList))
-				Expect(err).NotTo(HaveOccurred())
-			})
-			By("waiting until DNS name is available", func() {
-				err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
-				Expect(err).NotTo(HaveOccurred())
-			})
-			By("sending https request to the lb", func() {
-				url := fmt.Sprintf("https://%v/any-path", dnsName)
-				urlOptions := http.URLOptions{
-					InsecureSkipVerify: true,
-					HostHeader:         testHostname, // Set Host header
-				}
-				err := tf.HTTPVerifier.VerifyURLWithOptions(url, urlOptions, http.ResponseCodeMatches(200))
-				Expect(err).NotTo(HaveOccurred())
-			})
-		})
-	})
-
-	Context("with ALB instance target configuration with secure HTTPRoute and authenticate cognito action", func() {
-		BeforeEach(func() {})
-		It("should provision internet-facing load balancer with authenticate-cognito action", func() {
-			if len(tf.Options.CertificateARNs) == 0 {
-				Skip("Skipping tests, certificates not specified")
-			}
-			// Skip test if Cognito options not provided (similar to certificate check)
-			if len(tf.Options.CognitoUserPoolArn) == 0 ||
-				len(tf.Options.CognitoUserPoolClientId) == 0 ||
-				len(tf.Options.CognitoUserPoolDomain) == 0 {
-				Skip("Skipping authenticate-cognito tests, Cognito configuration not specified")
-			}
-
-			// Setup HTTPS listener with certificate
-			interf := elbv2gw.LoadBalancerSchemeInternetFacing
-			lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
-				Scheme: &interf,
-			}
-			cert := strings.Split(tf.Options.CertificateARNs, ",")[0]
-			lsConfig := elbv2gw.ListenerConfiguration{
-				ProtocolPort:       "HTTPS:443",
-				DefaultCertificate: &cert,
-			}
-			lbcSpec.ListenerConfigurations = &[]elbv2gw.ListenerConfiguration{lsConfig}
-			tgSpec := elbv2gw.TargetGroupConfigurationSpec{}
-			gwListeners := []gwv1.Listener{
-				{
-					Name:     "https443",
-					Port:     443,
-					Protocol: gwv1.HTTPSProtocolType,
-					Hostname: (*gwv1.Hostname)(awssdk.String(testHostname)),
-				},
-			}
-
-			// Create ListenerRuleConfiguration with real Cognito values
-			authenticateBehavior := elbv2gw.AuthenticateCognitoActionConditionalBehaviorEnumAuthenticate
-			lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{
-				Actions: []elbv2gw.Action{
-					{
-						Type: elbv2gw.ActionTypeAuthenticateCognito,
-						AuthenticateCognitoConfig: &elbv2gw.AuthenticateCognitoActionConfig{
-							UserPoolArn:      tf.Options.CognitoUserPoolArn,
-							UserPoolClientID: tf.Options.CognitoUserPoolClientId,
-							UserPoolDomain:   tf.Options.CognitoUserPoolDomain,
-							Scope:            awssdk.String("openid"),
-							AuthenticationRequestExtraParams: &map[string]string{
-								"key1": "value1",
-							},
-							OnUnauthenticatedRequest: &authenticateBehavior,
-							SessionCookieName:        awssdk.String("my-session-cookie"),
-							SessionTimeout:           awssdk.Int64(604800),
-						},
-					},
-				},
-			}
-			httpRouteRules := []gwv1.HTTPRouteRule{
-				{
-					BackendRefs: DefaultHttpRouteRuleBackendRefs,
-					Filters: []gwv1.HTTPRouteFilter{
-						{
-							Type: gwv1.HTTPRouteFilterExtensionRef,
-							ExtensionRef: &gwv1.LocalObjectReference{
-								Name:  defaultLRConfigName,
-								Kind:  constants.ListenerRuleConfiguration,
-								Group: constants.ControllerCRDGroupVersion,
-							},
-						},
-					},
-				},
-			}
-			httpr := buildHTTPRoute([]string{testHostname}, httpRouteRules, &gwListeners[0].Name)
-
-			By("deploying stack", func() {
-				err := stack.DeployHTTP(ctx, nil, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec, lrcSpec, nil, false)
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			By("checking gateway status for lb dns name", func() {
-				dnsName = stack.GetLoadBalancerIngressHostName()
-				Expect(dnsName).ToNot(BeEmpty())
-			})
-
-			By("querying AWS loadbalancer from the dns name", func() {
-				var err error
-				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(lbARN).ToNot(BeEmpty())
-			})
-
-			By("verifying AWS loadbalancer resources", func() {
-				nodeList, err := stack.GetWorkerNodes(ctx, tf)
-				Expect(err).ToNot(HaveOccurred())
-				expectedTargetGroups := []verifier.ExpectedTargetGroup{
-					{
-						Protocol:      "HTTP",
-						Port:          stack.albResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort,
-						NumTargets:    len(nodeList),
-						TargetType:    "instance",
-						TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
-					},
-				}
-				err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
-					Type:         "application",
-					Scheme:       "internet-facing",
-					Listeners:    stack.albResourceStack.getListenersPortMap(),
-					TargetGroups: expectedTargetGroups,
-				})
-				Expect(err).NotTo(HaveOccurred())
-			})
-			By("verifying AWS load balancer listener", func() {
-				err := verifier.VerifyLoadBalancerListener(ctx, tf, lbARN, int32(gwListeners[0].Port), &verifier.ListenerExpectation{
-					ProtocolPort:          "HTTPS:443",
-					DefaultCertificateARN: awssdk.ToString(lsConfig.DefaultCertificate),
-				})
-				Expect(err).NotTo(HaveOccurred())
-			})
-			By("verifying listener rules", func() {
-				err := verifier.VerifyLoadBalancerListenerRules(ctx, tf, lbARN, int32(gwListeners[0].Port), []verifier.ListenerRuleExpectation{
-					{
-						Conditions: []elbv2types.RuleCondition{
-							{
-								Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
-								PathPatternConfig: &elbv2types.PathPatternConditionConfig{
-									Values: []string{"/*"},
-								},
-							},
-							{
-								Field: awssdk.String(string(elbv2model.RuleConditionFieldHostHeader)),
-								HostHeaderConfig: &elbv2types.HostHeaderConditionConfig{
-									Values: []string{testHostname},
-								},
-							},
-						},
-						Actions: []elbv2types.Action{
-							{
-								Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeAuthenticateCognito),
-								AuthenticateCognitoConfig: &elbv2types.AuthenticateCognitoActionConfig{
-									UserPoolArn:      awssdk.String(tf.Options.CognitoUserPoolArn),
-									UserPoolClientId: awssdk.String(tf.Options.CognitoUserPoolClientId),
-									UserPoolDomain:   awssdk.String(tf.Options.CognitoUserPoolDomain),
-									Scope:            awssdk.String("openid"),
-									AuthenticationRequestExtraParams: map[string]string{
-										"key1": "value1",
-									},
-									OnUnauthenticatedRequest: elbv2types.AuthenticateCognitoActionConditionalBehaviorEnumAuthenticate,
-									SessionCookieName:        awssdk.String("my-session-cookie"),
-									SessionTimeout:           awssdk.Int64(604800),
-								},
-							},
-							{
-								Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
-								ForwardConfig: &elbv2types.ForwardActionConfig{
-									TargetGroups: []elbv2types.TargetGroupTuple{
-										{
-											TargetGroupArn: awssdk.String(testTargetGroupArn),
-											Weight:         awssdk.Int32(1),
-										},
-									},
-								},
-							},
-						},
-						Priority: 1,
-					},
-				})
-				Expect(err).NotTo(HaveOccurred())
-			})
-			By("waiting until DNS name is available", func() {
-				err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
-				Expect(err).NotTo(HaveOccurred())
-			})
-			By("verifying authenticate-cognito redirect for unauthenticated request", func() {
-				url := fmt.Sprintf("https://%v/any-path", dnsName)
-				urlOptions := http.URLOptions{
-					InsecureSkipVerify: true,
-					HostHeader:         testHostname,
-					FollowRedirects:    false, // Don't follow redirects automatically
-				}
-
-				// Expect 302 redirect to Cognito
-				err := tf.HTTPVerifier.VerifyURLWithOptions(url, urlOptions, http.ResponseCodeMatches(302))
-				Expect(err).NotTo(HaveOccurred())
-
-				// Verify redirect Location header contains Cognito domain
-				err = tf.HTTPVerifier.VerifyURLWithOptions(url, urlOptions,
-					http.ResponseHeaderContains("Location", tf.Options.CognitoUserPoolDomain))
-				Expect(err).NotTo(HaveOccurred())
-			})
-		})
-	})
-	Context("with ALB instance target configuration with secure HTTPRoute and authenticate oidc action", func() {
-		BeforeEach(func() {})
-		It("should provision internet-facing load balancer with authenticate-oidc action", func() {
-			if len(tf.Options.CertificateARNs) == 0 {
-				Skip("Skipping tests, certificates not specified")
-			}
-
-			// Generate random OIDC credentials for testing
-			oidcClientID, oidcClientSecret := GenerateOIDCCredentials()
-
-			// Setup HTTPS listener with certificate
-			interf := elbv2gw.LoadBalancerSchemeInternetFacing
-			lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
-				Scheme: &interf,
-			}
-			cert := strings.Split(tf.Options.CertificateARNs, ",")[0]
-			lsConfig := elbv2gw.ListenerConfiguration{
-				ProtocolPort:       "HTTPS:443",
-				DefaultCertificate: &cert,
-			}
-			lbcSpec.ListenerConfigurations = &[]elbv2gw.ListenerConfiguration{lsConfig}
-			tgSpec := elbv2gw.TargetGroupConfigurationSpec{}
-			gwListeners := []gwv1.Listener{
-				{
-					Name:     "https443",
-					Port:     443,
-					Protocol: gwv1.HTTPSProtocolType,
-					Hostname: (*gwv1.Hostname)(awssdk.String(testHostname)),
-				},
-			}
-
-			// Create Kubernetes Secret for OIDC credentials
-			oidcSecretName := "oidc-auth-secret"
-			// Generate random OIDC credentials for testing
-			oidcClientID, oidcClientSecret = GenerateOIDCCredentials()
-
-			oidcSecret := &testOIDCSecret{
-				name:         oidcSecretName,
-				clientId:     oidcClientID,
-				clientSecret: oidcClientSecret,
-			}
-			// Create ListenerRuleConfiguration with real Cognito values
-			authenticateBehavior := elbv2gw.AuthenticateOidcActionConditionalBehaviorEnumAuthenticate
-			lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{
-				Actions: []elbv2gw.Action{
-					{
-						Type: elbv2gw.ActionTypeAuthenticateOIDC,
-						AuthenticateOIDCConfig: &elbv2gw.AuthenticateOidcActionConfig{
-							Issuer:                testOidcIssuer,
-							AuthorizationEndpoint: testOidcAuthorizationEndpoint,
-							TokenEndpoint:         testOidcTokenEndpoint,
-							UserInfoEndpoint:      testOidcUserInfoEndpoint,
-							Secret: &elbv2gw.Secret{
-								Name: oidcSecretName,
-								// Namespace will default to same as ListenerRuleConfiguration
-							},
-							Scope: awssdk.String("openid profile email"),
-							AuthenticationRequestExtraParams: &map[string]string{
-								"prompt":  "login",
-								"display": "page",
-							},
-							OnUnauthenticatedRequest: &authenticateBehavior,
-							SessionCookieName:        awssdk.String("AWSELBAuthSessionCookie-OIDC"),
-							SessionTimeout:           awssdk.Int64(604800),
-						},
-					},
-				},
-			}
-			httpRouteRules := []gwv1.HTTPRouteRule{
-				{
-					BackendRefs: DefaultHttpRouteRuleBackendRefs,
-					Filters: []gwv1.HTTPRouteFilter{
-						{
-							Type: gwv1.HTTPRouteFilterExtensionRef,
-							ExtensionRef: &gwv1.LocalObjectReference{
-								Name:  defaultLRConfigName,
-								Kind:  constants.ListenerRuleConfiguration,
-								Group: constants.ControllerCRDGroupVersion,
-							},
-						},
-					},
-				},
-			}
-			httpr := buildHTTPRoute([]string{testHostname}, httpRouteRules, &gwListeners[0].Name)
-
-			By("deploying stack", func() {
-				err := stack.DeployHTTP(ctx, nil, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec, lrcSpec, oidcSecret, false)
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			By("checking gateway status for lb dns name", func() {
-				dnsName = stack.GetLoadBalancerIngressHostName()
-				Expect(dnsName).ToNot(BeEmpty())
-			})
-
-			By("querying AWS loadbalancer from the dns name", func() {
-				var err error
-				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(lbARN).ToNot(BeEmpty())
-			})
-
-			By("verifying AWS loadbalancer resources", func() {
-				nodeList, err := stack.GetWorkerNodes(ctx, tf)
-				Expect(err).ToNot(HaveOccurred())
-
-				expectedTargetGroups := []verifier.ExpectedTargetGroup{
-					{
-						Protocol:      "HTTP",
-						Port:          stack.albResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort,
-						NumTargets:    len(nodeList),
-						TargetType:    "instance",
-						TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
-					},
-				}
-				err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
-					Type:         "application",
-					Scheme:       "internet-facing",
-					Listeners:    stack.albResourceStack.getListenersPortMap(),
-					TargetGroups: expectedTargetGroups,
-				})
-				Expect(err).NotTo(HaveOccurred())
-			})
-			By("verifying AWS load balancer listener", func() {
-				err := verifier.VerifyLoadBalancerListener(ctx, tf, lbARN, int32(gwListeners[0].Port), &verifier.ListenerExpectation{
-					ProtocolPort:          "HTTPS:443",
-					DefaultCertificateARN: awssdk.ToString(lsConfig.DefaultCertificate),
-				})
-				Expect(err).NotTo(HaveOccurred())
-			})
-			By("verifying listener rules with authenticate-oidc action", func() {
-				err := verifier.VerifyLoadBalancerListenerRules(ctx, tf, lbARN, int32(gwListeners[0].Port), []verifier.ListenerRuleExpectation{
-					{
-						Conditions: []elbv2types.RuleCondition{
-							{
-								Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
-								PathPatternConfig: &elbv2types.PathPatternConditionConfig{
-									Values: []string{"/*"},
-								},
-							},
-							{
-								Field: awssdk.String(string(elbv2model.RuleConditionFieldHostHeader)),
-								HostHeaderConfig: &elbv2types.HostHeaderConditionConfig{
-									Values: []string{testHostname},
-								},
-							},
-						},
-						Actions: []elbv2types.Action{
-							{
-								Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeAuthenticateOIDC),
-								AuthenticateOidcConfig: &elbv2types.AuthenticateOidcActionConfig{
-									Issuer:                  awssdk.String(testOidcIssuer),
-									AuthorizationEndpoint:   awssdk.String(testOidcAuthorizationEndpoint),
-									TokenEndpoint:           awssdk.String(testOidcTokenEndpoint),
-									UserInfoEndpoint:        awssdk.String(testOidcUserInfoEndpoint),
-									ClientId:                awssdk.String(oidcClientID),
-									UseExistingClientSecret: awssdk.Bool(true),
-									Scope:                   awssdk.String("openid profile email"),
-									AuthenticationRequestExtraParams: map[string]string{
-										"prompt":  "login",
-										"display": "page",
-									},
-									OnUnauthenticatedRequest: elbv2types.AuthenticateOidcActionConditionalBehaviorEnumAuthenticate,
-									SessionCookieName:        awssdk.String("AWSELBAuthSessionCookie-OIDC"),
-									SessionTimeout:           awssdk.Int64(604800),
-								},
-							},
-							{
-								Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
-								ForwardConfig: &elbv2types.ForwardActionConfig{
-									TargetGroups: []elbv2types.TargetGroupTuple{
-										{
-											TargetGroupArn: awssdk.String(testTargetGroupArn),
-											Weight:         awssdk.Int32(1),
-										},
-									},
-								},
-							},
-						},
-						Priority: 1,
-					},
-				})
-				Expect(err).NotTo(HaveOccurred())
-			})
-			By("waiting until DNS name is available", func() {
-				err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
-				Expect(err).NotTo(HaveOccurred())
-			})
-			By("verifying authenticate-oidc redirect for unauthenticated request", func() {
-				url := fmt.Sprintf("https://%v/any-path", dnsName)
-				urlOptions := http.URLOptions{
-					InsecureSkipVerify: true,
-					HostHeader:         testHostname,
-					FollowRedirects:    false, // Don't follow redirects automatically
-				}
-
-				// Expect 302 redirect to Cognito
-				err := tf.HTTPVerifier.VerifyURLWithOptions(url, urlOptions, http.ResponseCodeMatches(302))
-				Expect(err).NotTo(HaveOccurred())
-
-				// Verify redirect Location header contains Cognito domain
-				err = tf.HTTPVerifier.VerifyURLWithOptions(url, urlOptions,
-					http.ResponseHeaderContains("Location", testOidcAuthorizationEndpoint))
-				Expect(err).NotTo(HaveOccurred())
-			})
-		})
-	})
-
-	Context("with both basic and secure HTTPRoutes", func() {
-		BeforeEach(func() {})
-		It("should provision internet-facing load balancer with both HTTP and HTTPS endpoints", func() {
-			if len(tf.Options.CertificateARNs) == 0 {
-				Skip("Skipping tests, certificates not specified")
-			}
-
-			interf := elbv2gw.LoadBalancerSchemeInternetFacing
-			lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
-				Scheme: &interf,
-			}
-
-			// Configure both HTTP and HTTPS listeners
-			cert := strings.Split(tf.Options.CertificateARNs, ",")[0]
-			httpLsConfig := elbv2gw.ListenerConfiguration{
-				ProtocolPort: "HTTP:80",
-			}
-			httpsLsConfig := elbv2gw.ListenerConfiguration{
-				ProtocolPort:       "HTTPS:443",
-				DefaultCertificate: &cert,
-			}
-			lbcSpec.ListenerConfigurations = &[]elbv2gw.ListenerConfiguration{
-				httpLsConfig,
-				httpsLsConfig,
-			}
-
-			tgSpec := elbv2gw.TargetGroupConfigurationSpec{}
-			lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{}
-			gwListeners := []gwv1.Listener{
-				{
-					Name:     "http80",
-					Port:     80,
-					Protocol: gwv1.HTTPProtocolType,
-				},
-				{
-					Name:     "https443",
-					Port:     443,
-					Protocol: gwv1.HTTPSProtocolType,
-					Hostname: (*gwv1.Hostname)(awssdk.String(testHostname)),
-				},
-			}
-			httpr := buildHTTPRoute([]string{testHostname}, []gwv1.HTTPRouteRule{}, nil)
-
-			By("deploying stack", func() {
-				err := stack.DeployHTTP(ctx, nil, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec, lrcSpec, nil, true)
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			By("checking gateway status for lb dns name", func() {
-				dnsName = stack.GetLoadBalancerIngressHostName()
-				Expect(dnsName).ToNot(BeEmpty())
-			})
-
-			By("querying AWS loadbalancer from the dns name", func() {
-				var err error
-				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(lbARN).ToNot(BeEmpty())
-			})
-
-			By("verifying AWS loadbalancer resources", func() {
-				nodeList, err := stack.GetWorkerNodes(ctx, tf)
-				Expect(err).ToNot(HaveOccurred())
-
-				expectedTargetGroups := []verifier.ExpectedTargetGroup{
-					{
-						Protocol:      "HTTP",
-						Port:          stack.albResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort,
-						NumTargets:    len(nodeList),
-						TargetType:    "instance",
-						TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
-					},
-				}
-				err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
-					Type:         "application",
-					Scheme:       "internet-facing",
-					Listeners:    stack.albResourceStack.getListenersPortMap(),
-					TargetGroups: expectedTargetGroups,
-				})
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			// Verify HTTP listener
-			By("verifying HTTP load balancer listener", func() {
-				err := verifier.VerifyLoadBalancerListener(ctx, tf, lbARN, int32(gwListeners[0].Port), &verifier.ListenerExpectation{
-					ProtocolPort: "HTTP:80",
-				})
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			// Verify HTTPS listener
-			By("verifying HTTPS load balancer listener", func() {
-				err := verifier.VerifyLoadBalancerListener(ctx, tf, lbARN, int32(gwListeners[1].Port), &verifier.ListenerExpectation{
-					ProtocolPort:          "HTTPS:443",
-					DefaultCertificateARN: awssdk.ToString(httpsLsConfig.DefaultCertificate),
-				})
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			By("waiting for target group targets to be healthy", func() {
-				nodeList, err := stack.GetWorkerNodes(ctx, tf)
-				Expect(err).ToNot(HaveOccurred())
-				err = verifier.WaitUntilTargetsAreHealthy(ctx, tf, lbARN, len(nodeList))
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			By("waiting until DNS name is available", func() {
-				err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			// Test HTTP endpoint
-			By("sending HTTP request to the lb", func() {
-				url := fmt.Sprintf("http://%v/any-path", dnsName)
-				urlOptions := http.URLOptions{
-					InsecureSkipVerify: true,
-					HostHeader:         testHostname, // Set Host header
-					Method:             "GET",
-				}
-				err := tf.HTTPVerifier.VerifyURLWithOptions(url, urlOptions, http.ResponseCodeMatches(200))
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			// Test HTTPS endpoint
-			By("sending HTTPS request to the lb", func() {
-				url := fmt.Sprintf("https://%v/any-path", dnsName)
-				urlOptions := http.URLOptions{
-					InsecureSkipVerify: true,
-					HostHeader:         testHostname, // Set Host header
-					Method:             "GET",
-				}
-				err := tf.HTTPVerifier.VerifyURLWithOptions(url, urlOptions, http.ResponseCodeMatches(200))
-				Expect(err).NotTo(HaveOccurred())
-			})
-		})
-	})
-
-	Context("with ALB instance target configuration with GRPC", func() {
-		It("should provision internet-facing load balancer resources", func() {
-			if len(tf.Options.CertificateARNs) == 0 {
-				Skip("Skipping tests, certificates not specified")
-			}
-
-			interf := elbv2gw.LoadBalancerSchemeInternetFacing
-			lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
-				Scheme: &interf,
-			}
-
-			// Use the first certificate from the provided list
-			cert := strings.Split(tf.Options.CertificateARNs, ",")[0]
-			lsConfig := elbv2gw.ListenerConfiguration{
-				ProtocolPort:       "HTTPS:443",
-				DefaultCertificate: &cert,
-			}
-			lbcSpec.ListenerConfigurations = &[]elbv2gw.ListenerConfiguration{lsConfig}
-			tgSpec := elbv2gw.TargetGroupConfigurationSpec{
-				DefaultConfiguration: elbv2gw.TargetGroupProps{},
-			}
-			lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{}
-			gwListeners := []gwv1.Listener{
-				{
-					Name:     "test-listener",
-					Port:     443,
-					Protocol: gwv1.HTTPSProtocolType,
-				},
-			}
-
-			grpcRouteRules := []gwv1.GRPCRouteRule{
-				{
-					BackendRefs: DefaultGrpcRouteRuleBackendRefs,
-				},
-				{
-					Matches: []gwv1.GRPCRouteMatch{
-						{
-							Headers: []gwv1.GRPCHeaderMatch{
+			/*
+						By("cross-ns listener should return 503 as no ref grant is available", func() {
+							url := fmt.Sprintf("http://%v:5000/any-path", dnsName)
+							err := tf.HTTPVerifier.VerifyURL(url, http.ResponseCodeMatches(503))
+							Expect(err).NotTo(HaveOccurred())
+						})
+						By("deploying ref grant", func() {
+							err := auxiliaryStack.CreateReferenceGrants(ctx, tf, stack.albResourceStack.commonStack.ns)
+							Expect(err).NotTo(HaveOccurred())
+							// Give some time to have the listener get materialized.
+							time.Sleep(2 * time.Minute)
+						})
+						By("ensuring cross namespace is materialized", func() {
+							nodeList, err := stack.GetWorkerNodes(ctx, tf)
+							Expect(err).ToNot(HaveOccurred())
+							expectedTargetGroups := []verifier.ExpectedTargetGroup{
 								{
-									Type:  (*gwv1.GRPCHeaderMatchType)(awssdk.String("Exact")),
-									Name:  "my-header",
-									Value: "my-header-value",
+									Protocol:      "HTTP",
+									Port:          stack.albResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort,
+									NumTargets:    len(nodeList),
+									TargetType:    "instance",
+									TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
 								},
-							},
-						},
-					},
-					BackendRefs: []gwv1.GRPCBackendRef{
-						{
-							BackendRef: gwv1.BackendRef{
-								BackendObjectReference: gwv1.BackendObjectReference{
-									Name: grpcDefaultName + "-other",
-									Port: &defaultGrpcPort,
+								{
+									Protocol:      "HTTP",
+									Port:          auxiliaryStack.svcs[0].Spec.Ports[0].NodePort,
+									NumTargets:    len(nodeList),
+									TargetType:    "instance",
+									TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
 								},
-							},
-						},
-					},
-				},
-			}
+							}
 
-			grpcr := buildGRPCRoute([]string{}, grpcRouteRules, &gwListeners[0].Name)
-			By("deploying stack", func() {
-				err := stack.DeployGRPC(ctx, tf, gwListeners, []*gwv1.GRPCRoute{grpcr}, lbcSpec, tgSpec, lrcSpec, true)
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			By("checking gateway status for lb dns name", func() {
-				time.Sleep(2 * time.Minute)
-				dnsName = stack.GetLoadBalancerIngressHostName()
-				Expect(dnsName).ToNot(BeEmpty())
-			})
-			By("querying AWS loadbalancer from the dns name", func() {
-				var err error
-				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(lbARN).ToNot(BeEmpty())
-			})
-
-			nodeList, err := stack.GetWorkerNodes(ctx, tf)
-			Expect(err).ToNot(HaveOccurred())
-
-			By("verifying AWS loadbalancer resources", func() {
-				expectedTargetGroups := []verifier.ExpectedTargetGroup{
-					{
-						Protocol:      "HTTP",
-						Port:          stack.albResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort,
-						NumTargets:    len(nodeList),
-						TargetType:    "instance",
-						TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC_GRPC,
-					},
-					{
-						Protocol:      "HTTP",
-						Port:          stack.albResourceStack.commonStack.svcs[1].Spec.Ports[0].NodePort,
-						NumTargets:    len(nodeList),
-						TargetType:    "instance",
-						TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC_GRPC,
-					},
-				}
-				err := verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
-					Type:         "application",
-					Scheme:       "internet-facing",
-					Listeners:    stack.albResourceStack.getListenersPortMap(),
-					TargetGroups: expectedTargetGroups,
+							err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
+								Type:         "application",
+								Scheme:       "internet-facing",
+								Listeners:    stack.albResourceStack.getListenersPortMap(),
+								TargetGroups: expectedTargetGroups,
+							})
+							Expect(err).NotTo(HaveOccurred())
+						})
+						By("sending http request cross namespace service", func() {
+							url := fmt.Sprintf("http://%v:5000/any-path", dnsName)
+							err := tf.HTTPVerifier.VerifyURL(url, http.ResponseCodeMatches(200))
+							Expect(err).NotTo(HaveOccurred())
+						})
+						By("removing ref grant", func() {
+							err := auxiliaryStack.DeleteReferenceGrants(ctx, tf)
+							Expect(err).NotTo(HaveOccurred())
+							// Give some time to have the reference grant to be deleted
+							time.Sleep(2 * time.Minute)
+						})
+						By("cross-ns listener should return 503 as no ref grant is available", func() {
+							url := fmt.Sprintf("http://%v:5000/any-path", dnsName)
+							err := tf.HTTPVerifier.VerifyURL(url, http.ResponseCodeMatches(503))
+							Expect(err).NotTo(HaveOccurred())
+						})
+					})
 				})
-				Expect(err).NotTo(HaveOccurred())
-			})
-			By("waiting for target group targets to be healthy", func() {
-				err := verifier.WaitUntilTargetsAreHealthy(ctx, tf, lbARN, len(nodeList))
-				Expect(err).NotTo(HaveOccurred())
-			})
-			By("waiting until DNS name is available", func() {
-				err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
-				Expect(err).NotTo(HaveOccurred())
-			})
-			By("sending grpc request to the lb", func() {
-				c, err := generateGRPCClient(dnsName)
-				Expect(err).NotTo(HaveOccurred())
-				mdCtx := metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{"foo": "cat"}))
-				response, err := c.Echo(mdCtx, &echo.EchoRequest{Message: "Hello from E2E test"})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(response.Message).To(Equal("Hello from E2E test"))
-			})
-			By("sending grpc request with certain header must forward traffic to right backend", func() {
-				target := fmt.Sprintf("%s:443", dnsName)
-				tlsConfig := &tls.Config{
-					InsecureSkipVerify: true, // This skips all certificate verification, including expiry.
-				}
 
-				conn, err := grpc.NewClient(target, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
-				Expect(err).NotTo(HaveOccurred())
-				c := echo.NewEchoServiceClient(conn)
-
-				mdCtx := metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{"my-header": "my-header-value"}))
-				response, err := c.FixedResponse(mdCtx, &echo.FixedResponseRequest{})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(response.Message).To(Equal("Hello World - Other"))
-			})
-			By("sending grpc request with header missing uses default service.", func() {
-				c, err := generateGRPCClient(dnsName)
-				Expect(err).NotTo(HaveOccurred())
-				mdCtx := metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{}))
-				response, err := c.FixedResponse(mdCtx, &echo.FixedResponseRequest{})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(response.Message).To(Equal("Hello World"))
-			})
-			By("update grpc route to remove default rule", func() {
-
-				err = tf.K8sClient.Get(ctx, types.NamespacedName{Name: stack.albResourceStack.grpcrs[0].Name, Namespace: stack.albResourceStack.grpcrs[0].Namespace}, stack.albResourceStack.grpcrs[0])
-				Expect(err).NotTo(HaveOccurred())
-
-				stack.albResourceStack.grpcrs[0].Spec.Rules = []gwv1.GRPCRouteRule{
-					{
-						Matches: []gwv1.GRPCRouteMatch{
+				Context("with ALB instance target configuration with HTTPRoute specified matches", func() {
+					BeforeEach(func() {})
+					It("should provision internet-facing load balancer resources", func() {
+						interf := elbv2gw.LoadBalancerSchemeInternetFacing
+						lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
+							Scheme: &interf,
+						}
+						tgSpec := elbv2gw.TargetGroupConfigurationSpec{}
+						lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{}
+						gwListeners := []gwv1.Listener{
 							{
-								Headers: []gwv1.GRPCHeaderMatch{
+								Name:     "test-listener",
+								Port:     80,
+								Protocol: gwv1.HTTPProtocolType,
+							},
+						}
+						httpr := buildHTTPRoute([]string{}, httpRouteRuleWithMatchesAndTargetGroupWeights, nil)
+
+						By("deploying stack", func() {
+							err := stack.DeployHTTP(ctx, nil, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec, lrcSpec, nil, true)
+							Expect(err).NotTo(HaveOccurred())
+						})
+
+						By("checking gateway status for lb dns name", func() {
+							dnsName = stack.GetLoadBalancerIngressHostName()
+							Expect(dnsName).ToNot(BeEmpty())
+						})
+
+						By("querying AWS loadbalancer from the dns name", func() {
+							var err error
+							lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(lbARN).ToNot(BeEmpty())
+						})
+
+						By("verifying AWS loadbalancer resources", func() {
+							nodeList, err := stack.GetWorkerNodes(ctx, tf)
+							Expect(err).ToNot(HaveOccurred())
+							expectedTargetGroups := []verifier.ExpectedTargetGroup{
+								{
+									Protocol:      "HTTP",
+									Port:          stack.albResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort,
+									NumTargets:    len(nodeList),
+									TargetType:    "instance",
+									TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
+								},
+							}
+							err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
+								Type:         "application",
+								Scheme:       "internet-facing",
+								Listeners:    stack.albResourceStack.getListenersPortMap(),
+								TargetGroups: expectedTargetGroups,
+							})
+							Expect(err).NotTo(HaveOccurred())
+						})
+
+						By("verifying HTTP load balancer listener", func() {
+							err := verifier.VerifyLoadBalancerListener(ctx, tf, lbARN, int32(gwListeners[0].Port), &verifier.ListenerExpectation{
+								ProtocolPort: "HTTP:80",
+							})
+							Expect(err).NotTo(HaveOccurred())
+						})
+						By("verifying listener rules", func() {
+							err := verifier.VerifyLoadBalancerListenerRules(ctx, tf, lbARN, int32(gwListeners[0].Port), []verifier.ListenerRuleExpectation{
+								{
+									Conditions: []elbv2types.RuleCondition{
+										{
+											Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
+											PathPatternConfig: &elbv2types.PathPatternConditionConfig{
+												Values: []string{testPathString},
+											},
+										},
+									},
+									Actions: []elbv2types.Action{
+										{
+											Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
+											ForwardConfig: &elbv2types.ForwardActionConfig{
+												TargetGroups: []elbv2types.TargetGroupTuple{
+													{
+														TargetGroupArn: awssdk.String(testTargetGroupArn),
+														Weight:         awssdk.Int32(50),
+													},
+												},
+											},
+										},
+									},
+									Priority: 1,
+								},
+								{
+									Conditions: []elbv2types.RuleCondition{
+										{
+											Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
+											PathPatternConfig: &elbv2types.PathPatternConditionConfig{
+												Values: []string{testPathString, fmt.Sprintf("%s/*", testPathString)},
+											},
+										},
+										{
+											Field: awssdk.String(string(elbv2model.RuleConditionFieldHTTPRequestMethod)),
+											HttpRequestMethodConfig: &elbv2types.HttpRequestMethodConditionConfig{
+												Values: []string{
+													"GET",
+												},
+											},
+										},
+										{
+											Field: awssdk.String(string(elbv2model.RuleConditionFieldHTTPHeader)),
+											HttpHeaderConfig: &elbv2types.HttpHeaderConditionConfig{
+												HttpHeaderName: awssdk.String(testHttpHeaderNameOne),
+												Values: []string{
+													testHttpHeaderValueOne,
+												},
+											},
+										},
+										{
+											Field: awssdk.String(string(elbv2model.RuleConditionFieldHTTPHeader)),
+											HttpHeaderConfig: &elbv2types.HttpHeaderConditionConfig{
+												HttpHeaderName: awssdk.String(testHttpHeaderNameTwo),
+												Values: []string{
+													testHttpHeaderValueTwo,
+												},
+											},
+										},
+									},
+									Actions: []elbv2types.Action{
+										{
+											Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
+											ForwardConfig: &elbv2types.ForwardActionConfig{
+												TargetGroups: []elbv2types.TargetGroupTuple{
+													{
+														TargetGroupArn: awssdk.String(testTargetGroupArn),
+														Weight:         awssdk.Int32(30),
+													},
+												},
+											},
+										},
+									},
+									Priority: 2,
+								},
+								{
+									Conditions: []elbv2types.RuleCondition{
+										{
+											Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
+											PathPatternConfig: &elbv2types.PathPatternConditionConfig{
+												Values: []string{testPathString, fmt.Sprintf("%s/*", testPathString)},
+											},
+										},
+										{
+											Field: awssdk.String(string(elbv2model.RuleConditionFieldQueryString)),
+											QueryStringConfig: &elbv2types.QueryStringConditionConfig{
+												Values: []elbv2types.QueryStringKeyValuePair{
+													{
+														Key:   awssdk.String(testQueryStringKeyOne),
+														Value: awssdk.String(testQueryStringValueOne),
+													},
+												},
+											},
+										},
+										{
+											Field: awssdk.String(string(elbv2model.RuleConditionFieldQueryString)),
+											QueryStringConfig: &elbv2types.QueryStringConditionConfig{
+												Values: []elbv2types.QueryStringKeyValuePair{
+													{
+														Key:   awssdk.String(testQueryStringKeyTwo),
+														Value: awssdk.String(testQueryStringValueTwo),
+													},
+												},
+											},
+										},
+									},
+									Actions: []elbv2types.Action{
+										{
+											Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
+											ForwardConfig: &elbv2types.ForwardActionConfig{
+												TargetGroups: []elbv2types.TargetGroupTuple{
+													{
+														TargetGroupArn: awssdk.String(testTargetGroupArn),
+														Weight:         awssdk.Int32(30),
+													},
+												},
+											},
+										},
+									},
+									Priority: 3,
+								},
+							})
+							Expect(err).NotTo(HaveOccurred())
+						})
+						By("waiting for target group targets to be healthy", func() {
+							nodeList, err := stack.GetWorkerNodes(ctx, tf)
+							Expect(err).ToNot(HaveOccurred())
+							err = verifier.WaitUntilTargetsAreHealthy(ctx, tf, lbARN, len(nodeList))
+							Expect(err).NotTo(HaveOccurred())
+						})
+						By("waiting until DNS name is available", func() {
+							err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
+							Expect(err).NotTo(HaveOccurred())
+						})
+						By("sending http request to the lb", func() {
+							url := fmt.Sprintf("http://%v%s", dnsName, testPathString)
+							err := tf.HTTPVerifier.VerifyURL(url, http.ResponseCodeMatches(200))
+							Expect(err).NotTo(HaveOccurred())
+						})
+					})
+				})
+
+				Context("with ALB instance target configuration with HTTPRoute specified filter", func() {
+					BeforeEach(func() {})
+					It("should provision internet-facing load balancer resources", func() {
+						interf := elbv2gw.LoadBalancerSchemeInternetFacing
+						lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
+							Scheme: &interf,
+						}
+						tgSpec := elbv2gw.TargetGroupConfigurationSpec{}
+						lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{}
+						gwListeners := []gwv1.Listener{
+							{
+								Name:     "test-listener",
+								Port:     80,
+								Protocol: gwv1.HTTPProtocolType,
+							},
+						}
+						httpr := buildHTTPRoute([]string{}, httpRouteRuleWithMatchesAndFilters, nil)
+
+						By("deploying stack", func() {
+							err := stack.DeployHTTP(ctx, nil, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec, lrcSpec, nil, true)
+							Expect(err).NotTo(HaveOccurred())
+						})
+
+						By("checking gateway status for lb dns name", func() {
+							dnsName = stack.GetLoadBalancerIngressHostName()
+							Expect(dnsName).ToNot(BeEmpty())
+						})
+
+						By("querying AWS loadbalancer from the dns name", func() {
+							var err error
+							lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(lbARN).ToNot(BeEmpty())
+						})
+
+						By("waiting until DNS name is available", func() {
+							err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
+							Expect(err).NotTo(HaveOccurred())
+						})
+
+						By("testing redirect with ReplaceFullPath", func() {
+							httpExp := httpexpect.New(tf.LoggerReporter, fmt.Sprintf("http://%v", dnsName))
+							httpExp.GET("/old-path").WithRedirectPolicy(httpexpect.DontFollowRedirects).Expect().
+								Status(301).
+								Header("Location").Equal("https://example.com:80/new-path")
+						})
+
+						By("testing redirect with ReplacePrefixMatch", func() {
+							httpExp := httpexpect.New(tf.LoggerReporter, fmt.Sprintf("http://%v", dnsName))
+							httpExp.GET("/api/v1/users").WithRedirectPolicy(httpexpect.DontFollowRedirects).Expect().
+								Status(302).
+								Header("Location").Equal("https://api.example.com:80/v2/*")
+						})
+
+						By("testing redirect with scheme and port change", func() {
+							httpExp := httpexpect.New(tf.LoggerReporter, fmt.Sprintf("http://%v", dnsName))
+							httpExp.GET("/secure").WithRedirectPolicy(httpexpect.DontFollowRedirects).Expect().
+								Status(302).
+								Header("Location").Equal("https://secure.example.com:8443/secure")
+						})
+					})
+				})
+
+				Context("with ALB instance target configuration with HTTPRoute specified source ip in listener rule configuration", func() {
+					BeforeEach(func() {})
+					It("should provision internet-facing load balancer resources", func() {
+						interf := elbv2gw.LoadBalancerSchemeInternetFacing
+						lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
+							Scheme: &interf,
+						}
+						tgSpec := elbv2gw.TargetGroupConfigurationSpec{}
+
+						matchIndex := []int{0, 2}
+						sourceIp := "10.0.0.0/8"
+						lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{
+							Conditions: []elbv2gw.ListenerRuleCondition{
+								{
+									SourceIPConfig: &elbv2gw.SourceIPConditionConfig{Values: []string{sourceIp}},
+									Field:          elbv2gw.ListenerRuleConditionField(elbv2model.RuleConditionFieldSourceIP),
+									MatchIndexes:   &matchIndex,
+								},
+							},
+						}
+						gwListeners := []gwv1.Listener{
+							{
+								Name:     "test-listener",
+								Port:     80,
+								Protocol: gwv1.HTTPProtocolType,
+							},
+						}
+
+						httpr := buildHTTPRoute([]string{}, httpRouteRuleWithMultiMatchesInSingleRule, nil)
+
+						By("deploying stack", func() {
+							err := stack.DeployHTTP(ctx, nil, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec, lrcSpec, nil, true)
+
+							Expect(err).NotTo(HaveOccurred())
+						})
+
+						By("checking gateway status for lb dns name", func() {
+							dnsName = stack.GetLoadBalancerIngressHostName()
+							Expect(dnsName).ToNot(BeEmpty())
+						})
+
+						By("querying AWS loadbalancer from the dns name", func() {
+							var err error
+							lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(lbARN).ToNot(BeEmpty())
+						})
+
+						By("verifying AWS loadbalancer resources", func() {
+							nodeList, err := stack.GetWorkerNodes(ctx, tf)
+							Expect(err).ToNot(HaveOccurred())
+							expectedTargetGroups := []verifier.ExpectedTargetGroup{
+								{
+									Protocol:      "HTTP",
+									Port:          stack.albResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort,
+									NumTargets:    len(nodeList),
+									TargetType:    "instance",
+									TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
+								},
+							}
+							err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
+								Type:         "application",
+								Scheme:       "internet-facing",
+								Listeners:    stack.albResourceStack.getListenersPortMap(),
+								TargetGroups: expectedTargetGroups,
+							})
+							Expect(err).NotTo(HaveOccurred())
+						})
+
+						By("verifying HTTP load balancer listener", func() {
+							err := verifier.VerifyLoadBalancerListener(ctx, tf, lbARN, int32(gwListeners[0].Port), &verifier.ListenerExpectation{
+								ProtocolPort: "HTTP:80",
+							})
+							Expect(err).NotTo(HaveOccurred())
+						})
+						By("verifying listener rules", func() {
+							err := verifier.VerifyLoadBalancerListenerRules(ctx, tf, lbARN, int32(gwListeners[0].Port), []verifier.ListenerRuleExpectation{
+								{
+									Conditions: []elbv2types.RuleCondition{
+										{
+											Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
+											PathPatternConfig: &elbv2types.PathPatternConditionConfig{
+												Values: []string{testPathString},
+											},
+										},
+										{
+											Field: awssdk.String(string(elbv2model.RuleConditionFieldSourceIP)),
+											SourceIpConfig: &elbv2types.SourceIpConditionConfig{
+												Values: []string{sourceIp},
+											},
+										},
+									},
+									Actions: []elbv2types.Action{
+										{
+											Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
+											ForwardConfig: &elbv2types.ForwardActionConfig{
+												TargetGroups: []elbv2types.TargetGroupTuple{
+													{
+														TargetGroupArn: awssdk.String(testTargetGroupArn),
+														Weight:         aws.Int32(1),
+													},
+												},
+											},
+										},
+									},
+									Priority: 1,
+								},
+								{
+									Conditions: []elbv2types.RuleCondition{
+										{
+											Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
+											PathPatternConfig: &elbv2types.PathPatternConditionConfig{
+												Values: []string{testPathString, fmt.Sprintf("%s/*", testPathString)},
+											},
+										},
+										{
+											Field: awssdk.String(string(elbv2model.RuleConditionFieldHTTPRequestMethod)),
+											HttpRequestMethodConfig: &elbv2types.HttpRequestMethodConditionConfig{
+												Values: []string{
+													"GET",
+												},
+											},
+										},
+									},
+									Actions: []elbv2types.Action{
+										{
+											Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
+											ForwardConfig: &elbv2types.ForwardActionConfig{
+												TargetGroups: []elbv2types.TargetGroupTuple{
+													{
+														TargetGroupArn: awssdk.String(testTargetGroupArn),
+														Weight:         aws.Int32(1),
+													},
+												},
+											},
+										},
+									},
+									Priority: 2,
+								},
+								{
+									Conditions: []elbv2types.RuleCondition{
+										{
+											Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
+											PathPatternConfig: &elbv2types.PathPatternConditionConfig{
+												Values: []string{testPathString, fmt.Sprintf("%s/*", testPathString)},
+											},
+										},
+										{
+											Field: awssdk.String(string(elbv2model.RuleConditionFieldHTTPHeader)),
+											HttpHeaderConfig: &elbv2types.HttpHeaderConditionConfig{
+												HttpHeaderName: awssdk.String(testHttpHeaderNameOne),
+												Values: []string{
+													testHttpHeaderValueOne,
+												},
+											},
+										},
+										{
+											Field: awssdk.String(string(elbv2model.RuleConditionFieldSourceIP)),
+											SourceIpConfig: &elbv2types.SourceIpConditionConfig{
+												Values: []string{sourceIp},
+											},
+										},
+									},
+									Actions: []elbv2types.Action{
+										{
+											Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
+											ForwardConfig: &elbv2types.ForwardActionConfig{
+												TargetGroups: []elbv2types.TargetGroupTuple{
+													{
+														TargetGroupArn: awssdk.String(testTargetGroupArn),
+														Weight:         aws.Int32(1),
+													},
+												},
+											},
+										},
+									},
+									Priority: 3,
+								},
+							})
+							Expect(err).NotTo(HaveOccurred())
+						})
+						By("waiting for target group targets to be healthy", func() {
+							nodeList, err := stack.GetWorkerNodes(ctx, tf)
+							Expect(err).ToNot(HaveOccurred())
+							err = verifier.WaitUntilTargetsAreHealthy(ctx, tf, lbARN, len(nodeList))
+							Expect(err).NotTo(HaveOccurred())
+						})
+						By("waiting until DNS name is available", func() {
+							err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
+							Expect(err).NotTo(HaveOccurred())
+						})
+					})
+				})
+
+				Context("with ALB instance target configuration with secure HTTPRoute", func() {
+					BeforeEach(func() {})
+					It("should provision internet-facing load balancer resources", func() {
+						if len(tf.Options.CertificateARNs) == 0 {
+							Skip("Skipping tests, certificates not specified")
+						}
+						interf := elbv2gw.LoadBalancerSchemeInternetFacing
+						lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
+							Scheme: &interf,
+						}
+
+						cert := strings.Split(tf.Options.CertificateARNs, ",")[0]
+						lsConfig := elbv2gw.ListenerConfiguration{
+							ProtocolPort:       "HTTPS:443",
+							DefaultCertificate: &cert,
+						}
+						lbcSpec.ListenerConfigurations = &[]elbv2gw.ListenerConfiguration{lsConfig}
+						tgSpec := elbv2gw.TargetGroupConfigurationSpec{}
+						lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{}
+						gwListeners := []gwv1.Listener{
+							{
+								Name:     "https443",
+								Port:     443,
+								Protocol: gwv1.HTTPSProtocolType,
+								Hostname: (*gwv1.Hostname)(awssdk.String(testHostname)),
+							},
+						}
+						httpr := buildHTTPRoute([]string{testHostname}, []gwv1.HTTPRouteRule{}, nil)
+						By("deploying stack", func() {
+							err := stack.DeployHTTP(ctx, nil, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec, lrcSpec, nil, true)
+							Expect(err).NotTo(HaveOccurred())
+						})
+
+						By("checking gateway status for lb dns name", func() {
+							dnsName = stack.GetLoadBalancerIngressHostName()
+							Expect(dnsName).ToNot(BeEmpty())
+						})
+
+						By("querying AWS loadbalancer from the dns name", func() {
+							var err error
+							lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(lbARN).ToNot(BeEmpty())
+						})
+						By("verifying AWS loadbalancer resources", func() {
+							nodeList, err := stack.GetWorkerNodes(ctx, tf)
+							Expect(err).ToNot(HaveOccurred())
+
+							expectedTargetGroups := []verifier.ExpectedTargetGroup{
+								{
+									Protocol:      "HTTP",
+									Port:          stack.albResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort,
+									NumTargets:    len(nodeList),
+									TargetType:    "instance",
+									TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
+								},
+							}
+							err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
+								Type:         "application",
+								Scheme:       "internet-facing",
+								Listeners:    stack.albResourceStack.getListenersPortMap(),
+								TargetGroups: expectedTargetGroups,
+							})
+							Expect(err).NotTo(HaveOccurred())
+						})
+						By("verifying AWS load balancer listener", func() {
+							err := verifier.VerifyLoadBalancerListener(ctx, tf, lbARN, int32(gwListeners[0].Port), &verifier.ListenerExpectation{
+								ProtocolPort:          "HTTPS:443",
+								DefaultCertificateARN: awssdk.ToString(lsConfig.DefaultCertificate),
+								MutualAuthentication: &verifier.MutualAuthenticationExpectation{
+									Mode: "off",
+								},
+							})
+							Expect(err).NotTo(HaveOccurred())
+						})
+						By("waiting for target group targets to be healthy", func() {
+							nodeList, err := stack.GetWorkerNodes(ctx, tf)
+							Expect(err).ToNot(HaveOccurred())
+							err = verifier.WaitUntilTargetsAreHealthy(ctx, tf, lbARN, len(nodeList))
+							Expect(err).NotTo(HaveOccurred())
+						})
+						By("waiting until DNS name is available", func() {
+							err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
+							Expect(err).NotTo(HaveOccurred())
+						})
+						By("sending https request to the lb", func() {
+							url := fmt.Sprintf("https://%v/any-path", dnsName)
+							urlOptions := http.URLOptions{
+								InsecureSkipVerify: true,
+								HostHeader:         testHostname, // Set Host header
+							}
+							err := tf.HTTPVerifier.VerifyURLWithOptions(url, urlOptions, http.ResponseCodeMatches(200))
+							Expect(err).NotTo(HaveOccurred())
+						})
+					})
+				})
+
+				Context("with ALB instance target configuration with secure HTTPRoute and mutual authentication PASSTHROUGH mode", func() {
+					BeforeEach(func() {})
+					It("should provision internet-facing load balancer resources", func() {
+						if len(tf.Options.CertificateARNs) == 0 {
+							Skip("Skipping tests, certificates not specified")
+						}
+						interf := elbv2gw.LoadBalancerSchemeInternetFacing
+						lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
+							Scheme: &interf,
+						}
+
+						cert := strings.Split(tf.Options.CertificateARNs, ",")[0]
+						lsConfig := elbv2gw.ListenerConfiguration{
+							ProtocolPort:       "HTTPS:443",
+							DefaultCertificate: &cert,
+							MutualAuthentication: &elbv2gw.MutualAuthenticationAttributes{
+								Mode: "passthrough",
+							},
+						}
+						lbcSpec.ListenerConfigurations = &[]elbv2gw.ListenerConfiguration{lsConfig}
+						tgSpec := elbv2gw.TargetGroupConfigurationSpec{}
+						lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{}
+						gwListeners := []gwv1.Listener{
+							{
+								Name:     "https443",
+								Port:     443,
+								Protocol: gwv1.HTTPSProtocolType,
+								Hostname: (*gwv1.Hostname)(awssdk.String(testHostname)),
+							},
+						}
+						httpr := buildHTTPRoute([]string{testHostname}, []gwv1.HTTPRouteRule{}, nil)
+						By("deploying stack", func() {
+							err := stack.DeployHTTP(ctx, nil, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec, lrcSpec, nil, true)
+							Expect(err).NotTo(HaveOccurred())
+						})
+
+						By("checking gateway status for lb dns name", func() {
+							dnsName = stack.GetLoadBalancerIngressHostName()
+							Expect(dnsName).ToNot(BeEmpty())
+						})
+
+						By("querying AWS loadbalancer from the dns name", func() {
+							var err error
+							lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(lbARN).ToNot(BeEmpty())
+						})
+
+						By("verifying AWS loadbalancer resources", func() {
+							nodeList, err := stack.GetWorkerNodes(ctx, tf)
+							Expect(err).ToNot(HaveOccurred())
+							expectedTargetGroups := []verifier.ExpectedTargetGroup{
+								{
+									Protocol:      "HTTP",
+									Port:          stack.albResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort,
+									NumTargets:    len(nodeList),
+									TargetType:    "instance",
+									TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
+								},
+							}
+							err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
+								Type:         "application",
+								Scheme:       "internet-facing",
+								Listeners:    stack.albResourceStack.getListenersPortMap(),
+								TargetGroups: expectedTargetGroups,
+							})
+							Expect(err).NotTo(HaveOccurred())
+						})
+						By("verifying AWS load balancer listener", func() {
+							err := verifier.VerifyLoadBalancerListener(ctx, tf, lbARN, int32(gwListeners[0].Port), &verifier.ListenerExpectation{
+								ProtocolPort:          "HTTPS:443",
+								DefaultCertificateARN: awssdk.ToString(lsConfig.DefaultCertificate),
+								MutualAuthentication: &verifier.MutualAuthenticationExpectation{
+									Mode: "passthrough",
+								},
+							})
+							Expect(err).NotTo(HaveOccurred())
+						})
+						By("waiting for target group targets to be healthy", func() {
+							nodeList, err := stack.GetWorkerNodes(ctx, tf)
+							Expect(err).ToNot(HaveOccurred())
+							err = verifier.WaitUntilTargetsAreHealthy(ctx, tf, lbARN, len(nodeList))
+							Expect(err).NotTo(HaveOccurred())
+						})
+						By("waiting until DNS name is available", func() {
+							err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
+							Expect(err).NotTo(HaveOccurred())
+						})
+						By("sending https request to the lb", func() {
+							url := fmt.Sprintf("https://%v/any-path", dnsName)
+							urlOptions := http.URLOptions{
+								InsecureSkipVerify: true,
+								HostHeader:         testHostname, // Set Host header
+							}
+							err := tf.HTTPVerifier.VerifyURLWithOptions(url, urlOptions, http.ResponseCodeMatches(200))
+							Expect(err).NotTo(HaveOccurred())
+						})
+					})
+				})
+
+				Context("with ALB instance target configuration with secure HTTPRoute and authenticate cognito action", func() {
+					BeforeEach(func() {})
+					It("should provision internet-facing load balancer with authenticate-cognito action", func() {
+						if len(tf.Options.CertificateARNs) == 0 {
+							Skip("Skipping tests, certificates not specified")
+						}
+						// Skip test if Cognito options not provided (similar to certificate check)
+						if len(tf.Options.CognitoUserPoolArn) == 0 ||
+							len(tf.Options.CognitoUserPoolClientId) == 0 ||
+							len(tf.Options.CognitoUserPoolDomain) == 0 {
+							Skip("Skipping authenticate-cognito tests, Cognito configuration not specified")
+						}
+
+						// Setup HTTPS listener with certificate
+						interf := elbv2gw.LoadBalancerSchemeInternetFacing
+						lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
+							Scheme: &interf,
+						}
+						cert := strings.Split(tf.Options.CertificateARNs, ",")[0]
+						lsConfig := elbv2gw.ListenerConfiguration{
+							ProtocolPort:       "HTTPS:443",
+							DefaultCertificate: &cert,
+						}
+						lbcSpec.ListenerConfigurations = &[]elbv2gw.ListenerConfiguration{lsConfig}
+						tgSpec := elbv2gw.TargetGroupConfigurationSpec{}
+						gwListeners := []gwv1.Listener{
+							{
+								Name:     "https443",
+								Port:     443,
+								Protocol: gwv1.HTTPSProtocolType,
+								Hostname: (*gwv1.Hostname)(awssdk.String(testHostname)),
+							},
+						}
+
+						// Create ListenerRuleConfiguration with real Cognito values
+						authenticateBehavior := elbv2gw.AuthenticateCognitoActionConditionalBehaviorEnumAuthenticate
+						lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{
+							Actions: []elbv2gw.Action{
+								{
+									Type: elbv2gw.ActionTypeAuthenticateCognito,
+									AuthenticateCognitoConfig: &elbv2gw.AuthenticateCognitoActionConfig{
+										UserPoolArn:      tf.Options.CognitoUserPoolArn,
+										UserPoolClientID: tf.Options.CognitoUserPoolClientId,
+										UserPoolDomain:   tf.Options.CognitoUserPoolDomain,
+										Scope:            awssdk.String("openid"),
+										AuthenticationRequestExtraParams: &map[string]string{
+											"key1": "value1",
+										},
+										OnUnauthenticatedRequest: &authenticateBehavior,
+										SessionCookieName:        awssdk.String("my-session-cookie"),
+										SessionTimeout:           awssdk.Int64(604800),
+									},
+								},
+							},
+						}
+						httpRouteRules := []gwv1.HTTPRouteRule{
+							{
+								BackendRefs: DefaultHttpRouteRuleBackendRefs,
+								Filters: []gwv1.HTTPRouteFilter{
 									{
-										Type:  (*gwv1.GRPCHeaderMatchType)(awssdk.String("Exact")),
-										Name:  "my-header",
-										Value: "my-header-value",
+										Type: gwv1.HTTPRouteFilterExtensionRef,
+										ExtensionRef: &gwv1.LocalObjectReference{
+											Name:  defaultLRConfigName,
+											Kind:  constants.ListenerRuleConfiguration,
+											Group: constants.ControllerCRDGroupVersion,
+										},
 									},
 								},
 							},
-						},
-						BackendRefs: []gwv1.GRPCBackendRef{
+						}
+						httpr := buildHTTPRoute([]string{testHostname}, httpRouteRules, &gwListeners[0].Name)
+
+						By("deploying stack", func() {
+							err := stack.DeployHTTP(ctx, nil, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec, lrcSpec, nil, false)
+							Expect(err).NotTo(HaveOccurred())
+						})
+
+						By("checking gateway status for lb dns name", func() {
+							dnsName = stack.GetLoadBalancerIngressHostName()
+							Expect(dnsName).ToNot(BeEmpty())
+						})
+
+						By("querying AWS loadbalancer from the dns name", func() {
+							var err error
+							lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(lbARN).ToNot(BeEmpty())
+						})
+
+						By("verifying AWS loadbalancer resources", func() {
+							nodeList, err := stack.GetWorkerNodes(ctx, tf)
+							Expect(err).ToNot(HaveOccurred())
+							expectedTargetGroups := []verifier.ExpectedTargetGroup{
+								{
+									Protocol:      "HTTP",
+									Port:          stack.albResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort,
+									NumTargets:    len(nodeList),
+									TargetType:    "instance",
+									TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
+								},
+							}
+							err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
+								Type:         "application",
+								Scheme:       "internet-facing",
+								Listeners:    stack.albResourceStack.getListenersPortMap(),
+								TargetGroups: expectedTargetGroups,
+							})
+							Expect(err).NotTo(HaveOccurred())
+						})
+						By("verifying AWS load balancer listener", func() {
+							err := verifier.VerifyLoadBalancerListener(ctx, tf, lbARN, int32(gwListeners[0].Port), &verifier.ListenerExpectation{
+								ProtocolPort:          "HTTPS:443",
+								DefaultCertificateARN: awssdk.ToString(lsConfig.DefaultCertificate),
+							})
+							Expect(err).NotTo(HaveOccurred())
+						})
+						By("verifying listener rules", func() {
+							err := verifier.VerifyLoadBalancerListenerRules(ctx, tf, lbARN, int32(gwListeners[0].Port), []verifier.ListenerRuleExpectation{
+								{
+									Conditions: []elbv2types.RuleCondition{
+										{
+											Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
+											PathPatternConfig: &elbv2types.PathPatternConditionConfig{
+												Values: []string{"/*"},
+											},
+										},
+										{
+											Field: awssdk.String(string(elbv2model.RuleConditionFieldHostHeader)),
+											HostHeaderConfig: &elbv2types.HostHeaderConditionConfig{
+												Values: []string{testHostname},
+											},
+										},
+									},
+									Actions: []elbv2types.Action{
+										{
+											Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeAuthenticateCognito),
+											AuthenticateCognitoConfig: &elbv2types.AuthenticateCognitoActionConfig{
+												UserPoolArn:      awssdk.String(tf.Options.CognitoUserPoolArn),
+												UserPoolClientId: awssdk.String(tf.Options.CognitoUserPoolClientId),
+												UserPoolDomain:   awssdk.String(tf.Options.CognitoUserPoolDomain),
+												Scope:            awssdk.String("openid"),
+												AuthenticationRequestExtraParams: map[string]string{
+													"key1": "value1",
+												},
+												OnUnauthenticatedRequest: elbv2types.AuthenticateCognitoActionConditionalBehaviorEnumAuthenticate,
+												SessionCookieName:        awssdk.String("my-session-cookie"),
+												SessionTimeout:           awssdk.Int64(604800),
+											},
+										},
+										{
+											Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
+											ForwardConfig: &elbv2types.ForwardActionConfig{
+												TargetGroups: []elbv2types.TargetGroupTuple{
+													{
+														TargetGroupArn: awssdk.String(testTargetGroupArn),
+														Weight:         awssdk.Int32(1),
+													},
+												},
+											},
+										},
+									},
+									Priority: 1,
+								},
+							})
+							Expect(err).NotTo(HaveOccurred())
+						})
+						By("waiting until DNS name is available", func() {
+							err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
+							Expect(err).NotTo(HaveOccurred())
+						})
+						By("verifying authenticate-cognito redirect for unauthenticated request", func() {
+							url := fmt.Sprintf("https://%v/any-path", dnsName)
+							urlOptions := http.URLOptions{
+								InsecureSkipVerify: true,
+								HostHeader:         testHostname,
+								FollowRedirects:    false, // Don't follow redirects automatically
+							}
+
+							// Expect 302 redirect to Cognito
+							err := tf.HTTPVerifier.VerifyURLWithOptions(url, urlOptions, http.ResponseCodeMatches(302))
+							Expect(err).NotTo(HaveOccurred())
+
+							// Verify redirect Location header contains Cognito domain
+							err = tf.HTTPVerifier.VerifyURLWithOptions(url, urlOptions,
+								http.ResponseHeaderContains("Location", tf.Options.CognitoUserPoolDomain))
+							Expect(err).NotTo(HaveOccurred())
+						})
+					})
+				})
+				Context("with ALB instance target configuration with secure HTTPRoute and authenticate oidc action", func() {
+					BeforeEach(func() {})
+					It("should provision internet-facing load balancer with authenticate-oidc action", func() {
+						if len(tf.Options.CertificateARNs) == 0 {
+							Skip("Skipping tests, certificates not specified")
+						}
+
+						// Generate random OIDC credentials for testing
+						oidcClientID, oidcClientSecret := GenerateOIDCCredentials()
+
+						// Setup HTTPS listener with certificate
+						interf := elbv2gw.LoadBalancerSchemeInternetFacing
+						lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
+							Scheme: &interf,
+						}
+						cert := strings.Split(tf.Options.CertificateARNs, ",")[0]
+						lsConfig := elbv2gw.ListenerConfiguration{
+							ProtocolPort:       "HTTPS:443",
+							DefaultCertificate: &cert,
+						}
+						lbcSpec.ListenerConfigurations = &[]elbv2gw.ListenerConfiguration{lsConfig}
+						tgSpec := elbv2gw.TargetGroupConfigurationSpec{}
+						gwListeners := []gwv1.Listener{
 							{
-								BackendRef: gwv1.BackendRef{
-									BackendObjectReference: gwv1.BackendObjectReference{
-										Name: grpcDefaultName + "-other",
-										Port: &defaultGrpcPort,
+								Name:     "https443",
+								Port:     443,
+								Protocol: gwv1.HTTPSProtocolType,
+								Hostname: (*gwv1.Hostname)(awssdk.String(testHostname)),
+							},
+						}
+
+						// Create Kubernetes Secret for OIDC credentials
+						oidcSecretName := "oidc-auth-secret"
+						// Generate random OIDC credentials for testing
+						oidcClientID, oidcClientSecret = GenerateOIDCCredentials()
+
+						oidcSecret := &testOIDCSecret{
+							name:         oidcSecretName,
+							clientId:     oidcClientID,
+							clientSecret: oidcClientSecret,
+						}
+						// Create ListenerRuleConfiguration with real Cognito values
+						authenticateBehavior := elbv2gw.AuthenticateOidcActionConditionalBehaviorEnumAuthenticate
+						lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{
+							Actions: []elbv2gw.Action{
+								{
+									Type: elbv2gw.ActionTypeAuthenticateOIDC,
+									AuthenticateOIDCConfig: &elbv2gw.AuthenticateOidcActionConfig{
+										Issuer:                testOidcIssuer,
+										AuthorizationEndpoint: testOidcAuthorizationEndpoint,
+										TokenEndpoint:         testOidcTokenEndpoint,
+										UserInfoEndpoint:      testOidcUserInfoEndpoint,
+										Secret: &elbv2gw.Secret{
+											Name: oidcSecretName,
+											// Namespace will default to same as ListenerRuleConfiguration
+										},
+										Scope: awssdk.String("openid profile email"),
+										AuthenticationRequestExtraParams: &map[string]string{
+											"prompt":  "login",
+											"display": "page",
+										},
+										OnUnauthenticatedRequest: &authenticateBehavior,
+										SessionCookieName:        awssdk.String("AWSELBAuthSessionCookie-OIDC"),
+										SessionTimeout:           awssdk.Int64(604800),
 									},
 								},
 							},
-						},
-					},
-				}
-
-				err = stack.albResourceStack.updateGRPCRoute(ctx, tf, stack.albResourceStack.grpcrs[0])
-				Expect(err).NotTo(HaveOccurred())
-				// Wait for listener change to propagate.
-				time.Sleep(1 * time.Minute)
-			})
-			By("send grpc request with correct request header", func() {
-				c, err := generateGRPCClient(dnsName)
-				Expect(err).NotTo(HaveOccurred())
-				mdCtx := metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{"my-header": "my-header-value"}))
-				response, err := c.FixedResponse(mdCtx, &echo.FixedResponseRequest{})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(response.Message).To(Equal("Hello World - Other"))
-			})
-			By("sending grpc request with header missing uses default service.", func() {
-				c, err := generateGRPCClient(dnsName)
-				Expect(err).NotTo(HaveOccurred())
-				mdCtx := metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{}))
-				_, err = c.FixedResponse(mdCtx, &echo.FixedResponseRequest{})
-				Expect(err).To(HaveOccurred())
-			})
-			By("update grpc route to route by service / method name. use invalid service", func() {
-
-				err = tf.K8sClient.Get(ctx, types.NamespacedName{Name: stack.albResourceStack.grpcrs[0].Name, Namespace: stack.albResourceStack.grpcrs[0].Namespace}, stack.albResourceStack.grpcrs[0])
-				Expect(err).NotTo(HaveOccurred())
-
-				stack.albResourceStack.grpcrs[0].Spec.Rules = []gwv1.GRPCRouteRule{
-					{
-						Matches: []gwv1.GRPCRouteMatch{
+						}
+						httpRouteRules := []gwv1.HTTPRouteRule{
 							{
-								Method: &gwv1.GRPCMethodMatch{
-									Service: awssdk.String("com.example.FakeService"),
-									Method:  awssdk.String("FakeMethod"),
-								},
-							},
-						},
-						BackendRefs: []gwv1.GRPCBackendRef{
-							{
-								BackendRef: gwv1.BackendRef{
-									BackendObjectReference: gwv1.BackendObjectReference{
-										Name: grpcDefaultName + "-other",
-										Port: &defaultGrpcPort,
+								BackendRefs: DefaultHttpRouteRuleBackendRefs,
+								Filters: []gwv1.HTTPRouteFilter{
+									{
+										Type: gwv1.HTTPRouteFilterExtensionRef,
+										ExtensionRef: &gwv1.LocalObjectReference{
+											Name:  defaultLRConfigName,
+											Kind:  constants.ListenerRuleConfiguration,
+											Group: constants.ControllerCRDGroupVersion,
+										},
 									},
 								},
 							},
-						},
-					},
-				}
+						}
+						httpr := buildHTTPRoute([]string{testHostname}, httpRouteRules, &gwListeners[0].Name)
 
-				err = stack.albResourceStack.updateGRPCRoute(ctx, tf, stack.albResourceStack.grpcrs[0])
-				Expect(err).NotTo(HaveOccurred())
-				// Wait for listener change to propagate.
-				time.Sleep(1 * time.Minute)
-			})
-			By("sending grpc request should result in a failure.", func() {
-				c, err := generateGRPCClient(dnsName)
-				Expect(err).NotTo(HaveOccurred())
-				mdCtx := metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{}))
-				_, err = c.FixedResponse(mdCtx, &echo.FixedResponseRequest{})
-				Expect(err).To(HaveOccurred())
-			})
-			By("update grpc route to route by service / method name. filter by service", func() {
+						By("deploying stack", func() {
+							err := stack.DeployHTTP(ctx, nil, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec, lrcSpec, oidcSecret, false)
+							Expect(err).NotTo(HaveOccurred())
+						})
 
-				err = tf.K8sClient.Get(ctx, types.NamespacedName{Name: stack.albResourceStack.grpcrs[0].Name, Namespace: stack.albResourceStack.grpcrs[0].Namespace}, stack.albResourceStack.grpcrs[0])
-				Expect(err).NotTo(HaveOccurred())
+						By("checking gateway status for lb dns name", func() {
+							dnsName = stack.GetLoadBalancerIngressHostName()
+							Expect(dnsName).ToNot(BeEmpty())
+						})
 
-				stack.albResourceStack.grpcrs[0].Spec.Rules = []gwv1.GRPCRouteRule{
-					{
-						Matches: []gwv1.GRPCRouteMatch{
-							{
-								Method: &gwv1.GRPCMethodMatch{
-									Service: awssdk.String("echo.EchoService"),
+						By("querying AWS loadbalancer from the dns name", func() {
+							var err error
+							lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(lbARN).ToNot(BeEmpty())
+						})
+
+						By("verifying AWS loadbalancer resources", func() {
+							nodeList, err := stack.GetWorkerNodes(ctx, tf)
+							Expect(err).ToNot(HaveOccurred())
+
+							expectedTargetGroups := []verifier.ExpectedTargetGroup{
+								{
+									Protocol:      "HTTP",
+									Port:          stack.albResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort,
+									NumTargets:    len(nodeList),
+									TargetType:    "instance",
+									TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
 								},
-							},
-						},
-						BackendRefs: []gwv1.GRPCBackendRef{
+							}
+							err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
+								Type:         "application",
+								Scheme:       "internet-facing",
+								Listeners:    stack.albResourceStack.getListenersPortMap(),
+								TargetGroups: expectedTargetGroups,
+							})
+							Expect(err).NotTo(HaveOccurred())
+						})
+						By("verifying AWS load balancer listener", func() {
+							err := verifier.VerifyLoadBalancerListener(ctx, tf, lbARN, int32(gwListeners[0].Port), &verifier.ListenerExpectation{
+								ProtocolPort:          "HTTPS:443",
+								DefaultCertificateARN: awssdk.ToString(lsConfig.DefaultCertificate),
+							})
+							Expect(err).NotTo(HaveOccurred())
+						})
+						By("verifying listener rules with authenticate-oidc action", func() {
+							err := verifier.VerifyLoadBalancerListenerRules(ctx, tf, lbARN, int32(gwListeners[0].Port), []verifier.ListenerRuleExpectation{
+								{
+									Conditions: []elbv2types.RuleCondition{
+										{
+											Field: awssdk.String(string(elbv2model.RuleConditionFieldPathPattern)),
+											PathPatternConfig: &elbv2types.PathPatternConditionConfig{
+												Values: []string{"/*"},
+											},
+										},
+										{
+											Field: awssdk.String(string(elbv2model.RuleConditionFieldHostHeader)),
+											HostHeaderConfig: &elbv2types.HostHeaderConditionConfig{
+												Values: []string{testHostname},
+											},
+										},
+									},
+									Actions: []elbv2types.Action{
+										{
+											Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeAuthenticateOIDC),
+											AuthenticateOidcConfig: &elbv2types.AuthenticateOidcActionConfig{
+												Issuer:                  awssdk.String(testOidcIssuer),
+												AuthorizationEndpoint:   awssdk.String(testOidcAuthorizationEndpoint),
+												TokenEndpoint:           awssdk.String(testOidcTokenEndpoint),
+												UserInfoEndpoint:        awssdk.String(testOidcUserInfoEndpoint),
+												ClientId:                awssdk.String(oidcClientID),
+												UseExistingClientSecret: awssdk.Bool(true),
+												Scope:                   awssdk.String("openid profile email"),
+												AuthenticationRequestExtraParams: map[string]string{
+													"prompt":  "login",
+													"display": "page",
+												},
+												OnUnauthenticatedRequest: elbv2types.AuthenticateOidcActionConditionalBehaviorEnumAuthenticate,
+												SessionCookieName:        awssdk.String("AWSELBAuthSessionCookie-OIDC"),
+												SessionTimeout:           awssdk.Int64(604800),
+											},
+										},
+										{
+											Type: elbv2types.ActionTypeEnum(elbv2model.ActionTypeForward),
+											ForwardConfig: &elbv2types.ForwardActionConfig{
+												TargetGroups: []elbv2types.TargetGroupTuple{
+													{
+														TargetGroupArn: awssdk.String(testTargetGroupArn),
+														Weight:         awssdk.Int32(1),
+													},
+												},
+											},
+										},
+									},
+									Priority: 1,
+								},
+							})
+							Expect(err).NotTo(HaveOccurred())
+						})
+						By("waiting until DNS name is available", func() {
+							err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
+							Expect(err).NotTo(HaveOccurred())
+						})
+						By("verifying authenticate-oidc redirect for unauthenticated request", func() {
+							url := fmt.Sprintf("https://%v/any-path", dnsName)
+							urlOptions := http.URLOptions{
+								InsecureSkipVerify: true,
+								HostHeader:         testHostname,
+								FollowRedirects:    false, // Don't follow redirects automatically
+							}
+
+							// Expect 302 redirect to Cognito
+							err := tf.HTTPVerifier.VerifyURLWithOptions(url, urlOptions, http.ResponseCodeMatches(302))
+							Expect(err).NotTo(HaveOccurred())
+
+							// Verify redirect Location header contains Cognito domain
+							err = tf.HTTPVerifier.VerifyURLWithOptions(url, urlOptions,
+								http.ResponseHeaderContains("Location", testOidcAuthorizationEndpoint))
+							Expect(err).NotTo(HaveOccurred())
+						})
+					})
+				})
+
+				Context("with both basic and secure HTTPRoutes", func() {
+					BeforeEach(func() {})
+					It("should provision internet-facing load balancer with both HTTP and HTTPS endpoints", func() {
+						if len(tf.Options.CertificateARNs) == 0 {
+							Skip("Skipping tests, certificates not specified")
+						}
+
+						interf := elbv2gw.LoadBalancerSchemeInternetFacing
+						lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
+							Scheme: &interf,
+						}
+
+						// Configure both HTTP and HTTPS listeners
+						cert := strings.Split(tf.Options.CertificateARNs, ",")[0]
+						httpLsConfig := elbv2gw.ListenerConfiguration{
+							ProtocolPort: "HTTP:80",
+						}
+						httpsLsConfig := elbv2gw.ListenerConfiguration{
+							ProtocolPort:       "HTTPS:443",
+							DefaultCertificate: &cert,
+						}
+						lbcSpec.ListenerConfigurations = &[]elbv2gw.ListenerConfiguration{
+							httpLsConfig,
+							httpsLsConfig,
+						}
+
+						tgSpec := elbv2gw.TargetGroupConfigurationSpec{}
+						lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{}
+						gwListeners := []gwv1.Listener{
 							{
-								BackendRef: gwv1.BackendRef{
-									BackendObjectReference: gwv1.BackendObjectReference{
-										Name: grpcDefaultName + "-other",
-										Port: &defaultGrpcPort,
+								Name:     "http80",
+								Port:     80,
+								Protocol: gwv1.HTTPProtocolType,
+							},
+							{
+								Name:     "https443",
+								Port:     443,
+								Protocol: gwv1.HTTPSProtocolType,
+								Hostname: (*gwv1.Hostname)(awssdk.String(testHostname)),
+							},
+						}
+						httpr := buildHTTPRoute([]string{testHostname}, []gwv1.HTTPRouteRule{}, nil)
+
+						By("deploying stack", func() {
+							err := stack.DeployHTTP(ctx, nil, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec, lrcSpec, nil, true)
+							Expect(err).NotTo(HaveOccurred())
+						})
+
+						By("checking gateway status for lb dns name", func() {
+							dnsName = stack.GetLoadBalancerIngressHostName()
+							Expect(dnsName).ToNot(BeEmpty())
+						})
+
+						By("querying AWS loadbalancer from the dns name", func() {
+							var err error
+							lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(lbARN).ToNot(BeEmpty())
+						})
+
+						By("verifying AWS loadbalancer resources", func() {
+							nodeList, err := stack.GetWorkerNodes(ctx, tf)
+							Expect(err).ToNot(HaveOccurred())
+
+							expectedTargetGroups := []verifier.ExpectedTargetGroup{
+								{
+									Protocol:      "HTTP",
+									Port:          stack.albResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort,
+									NumTargets:    len(nodeList),
+									TargetType:    "instance",
+									TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC,
+								},
+							}
+							err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
+								Type:         "application",
+								Scheme:       "internet-facing",
+								Listeners:    stack.albResourceStack.getListenersPortMap(),
+								TargetGroups: expectedTargetGroups,
+							})
+							Expect(err).NotTo(HaveOccurred())
+						})
+
+						// Verify HTTP listener
+						By("verifying HTTP load balancer listener", func() {
+							err := verifier.VerifyLoadBalancerListener(ctx, tf, lbARN, int32(gwListeners[0].Port), &verifier.ListenerExpectation{
+								ProtocolPort: "HTTP:80",
+							})
+							Expect(err).NotTo(HaveOccurred())
+						})
+
+						// Verify HTTPS listener
+						By("verifying HTTPS load balancer listener", func() {
+							err := verifier.VerifyLoadBalancerListener(ctx, tf, lbARN, int32(gwListeners[1].Port), &verifier.ListenerExpectation{
+								ProtocolPort:          "HTTPS:443",
+								DefaultCertificateARN: awssdk.ToString(httpsLsConfig.DefaultCertificate),
+							})
+							Expect(err).NotTo(HaveOccurred())
+						})
+
+						By("waiting for target group targets to be healthy", func() {
+							nodeList, err := stack.GetWorkerNodes(ctx, tf)
+							Expect(err).ToNot(HaveOccurred())
+							err = verifier.WaitUntilTargetsAreHealthy(ctx, tf, lbARN, len(nodeList))
+							Expect(err).NotTo(HaveOccurred())
+						})
+
+						By("waiting until DNS name is available", func() {
+							err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
+							Expect(err).NotTo(HaveOccurred())
+						})
+
+						// Test HTTP endpoint
+						By("sending HTTP request to the lb", func() {
+							url := fmt.Sprintf("http://%v/any-path", dnsName)
+							urlOptions := http.URLOptions{
+								InsecureSkipVerify: true,
+								HostHeader:         testHostname, // Set Host header
+								Method:             "GET",
+							}
+							err := tf.HTTPVerifier.VerifyURLWithOptions(url, urlOptions, http.ResponseCodeMatches(200))
+							Expect(err).NotTo(HaveOccurred())
+						})
+
+						// Test HTTPS endpoint
+						By("sending HTTPS request to the lb", func() {
+							url := fmt.Sprintf("https://%v/any-path", dnsName)
+							urlOptions := http.URLOptions{
+								InsecureSkipVerify: true,
+								HostHeader:         testHostname, // Set Host header
+								Method:             "GET",
+							}
+							err := tf.HTTPVerifier.VerifyURLWithOptions(url, urlOptions, http.ResponseCodeMatches(200))
+							Expect(err).NotTo(HaveOccurred())
+						})
+					})
+				})
+
+				Context("with ALB instance target configuration with GRPC", func() {
+					It("should provision internet-facing load balancer resources", func() {
+						if len(tf.Options.CertificateARNs) == 0 {
+							Skip("Skipping tests, certificates not specified")
+						}
+
+						interf := elbv2gw.LoadBalancerSchemeInternetFacing
+						lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
+							Scheme: &interf,
+						}
+
+						// Use the first certificate from the provided list
+						cert := strings.Split(tf.Options.CertificateARNs, ",")[0]
+						lsConfig := elbv2gw.ListenerConfiguration{
+							ProtocolPort:       "HTTPS:443",
+							DefaultCertificate: &cert,
+						}
+						lbcSpec.ListenerConfigurations = &[]elbv2gw.ListenerConfiguration{lsConfig}
+						tgSpec := elbv2gw.TargetGroupConfigurationSpec{
+							DefaultConfiguration: elbv2gw.TargetGroupProps{},
+						}
+						lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{}
+						gwListeners := []gwv1.Listener{
+							{
+								Name:     "test-listener",
+								Port:     443,
+								Protocol: gwv1.HTTPSProtocolType,
+							},
+						}
+
+						grpcRouteRules := []gwv1.GRPCRouteRule{
+							{
+								BackendRefs: DefaultGrpcRouteRuleBackendRefs,
+							},
+							{
+								Matches: []gwv1.GRPCRouteMatch{
+									{
+										Headers: []gwv1.GRPCHeaderMatch{
+											{
+												Type:  (*gwv1.GRPCHeaderMatchType)(awssdk.String("Exact")),
+												Name:  "my-header",
+												Value: "my-header-value",
+											},
+										},
+									},
+								},
+								BackendRefs: []gwv1.GRPCBackendRef{
+									{
+										BackendRef: gwv1.BackendRef{
+											BackendObjectReference: gwv1.BackendObjectReference{
+												Name: grpcDefaultName + "-other",
+												Port: &defaultGrpcPort,
+											},
+										},
 									},
 								},
 							},
-						},
-					},
-				}
+						}
 
-				err = stack.albResourceStack.updateGRPCRoute(ctx, tf, stack.albResourceStack.grpcrs[0])
-				Expect(err).NotTo(HaveOccurred())
-				// Wait for listener change to propagate.
-				time.Sleep(1 * time.Minute)
-			})
-			By("sending grpc request should work for both methods", func() {
-				c, err := generateGRPCClient(dnsName)
-				Expect(err).NotTo(HaveOccurred())
-				mdCtx := metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{}))
-				_, err = c.FixedResponse(mdCtx, &echo.FixedResponseRequest{})
-				Expect(err).ToNot(HaveOccurred())
+						grpcr := buildGRPCRoute([]string{}, grpcRouteRules, &gwListeners[0].Name)
+						By("deploying stack", func() {
+							err := stack.DeployGRPC(ctx, tf, gwListeners, []*gwv1.GRPCRoute{grpcr}, lbcSpec, tgSpec, lrcSpec, true)
+							Expect(err).NotTo(HaveOccurred())
+						})
 
-				_, err = c.Echo(mdCtx, &echo.EchoRequest{Message: "foo"})
-				Expect(err).ToNot(HaveOccurred())
-			})
-			By("update grpc route to route by service / method name. filter by service and method", func() {
+						By("checking gateway status for lb dns name", func() {
+							time.Sleep(2 * time.Minute)
+							dnsName = stack.GetLoadBalancerIngressHostName()
+							Expect(dnsName).ToNot(BeEmpty())
+						})
+						By("querying AWS loadbalancer from the dns name", func() {
+							var err error
+							lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(lbARN).ToNot(BeEmpty())
+						})
 
-				err = tf.K8sClient.Get(ctx, types.NamespacedName{Name: stack.albResourceStack.grpcrs[0].Name, Namespace: stack.albResourceStack.grpcrs[0].Namespace}, stack.albResourceStack.grpcrs[0])
-				Expect(err).NotTo(HaveOccurred())
+						nodeList, err := stack.GetWorkerNodes(ctx, tf)
+						Expect(err).ToNot(HaveOccurred())
 
-				stack.albResourceStack.grpcrs[0].Spec.Rules = []gwv1.GRPCRouteRule{
-					{
-						Matches: []gwv1.GRPCRouteMatch{
-							{
-								Method: &gwv1.GRPCMethodMatch{
-									Service: awssdk.String("echo.EchoService"),
-									Method:  awssdk.String("Echo"),
+						By("verifying AWS loadbalancer resources", func() {
+							expectedTargetGroups := []verifier.ExpectedTargetGroup{
+								{
+									Protocol:      "HTTP",
+									Port:          stack.albResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort,
+									NumTargets:    len(nodeList),
+									TargetType:    "instance",
+									TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC_GRPC,
 								},
-							},
-						},
-						BackendRefs: []gwv1.GRPCBackendRef{
-							{
-								BackendRef: gwv1.BackendRef{
-									BackendObjectReference: gwv1.BackendObjectReference{
-										Name: grpcDefaultName + "-other",
-										Port: &defaultGrpcPort,
+								{
+									Protocol:      "HTTP",
+									Port:          stack.albResourceStack.commonStack.svcs[1].Spec.Ports[0].NodePort,
+									NumTargets:    len(nodeList),
+									TargetType:    "instance",
+									TargetGroupHC: DEFAULT_ALB_TARGET_GROUP_HC_GRPC,
+								},
+							}
+							err := verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
+								Type:         "application",
+								Scheme:       "internet-facing",
+								Listeners:    stack.albResourceStack.getListenersPortMap(),
+								TargetGroups: expectedTargetGroups,
+							})
+							Expect(err).NotTo(HaveOccurred())
+						})
+						By("waiting for target group targets to be healthy", func() {
+							err := verifier.WaitUntilTargetsAreHealthy(ctx, tf, lbARN, len(nodeList))
+							Expect(err).NotTo(HaveOccurred())
+						})
+						By("waiting until DNS name is available", func() {
+							err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
+							Expect(err).NotTo(HaveOccurred())
+						})
+						By("sending grpc request to the lb", func() {
+							c, err := generateGRPCClient(dnsName)
+							Expect(err).NotTo(HaveOccurred())
+							mdCtx := metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{"foo": "cat"}))
+							response, err := c.Echo(mdCtx, &echo.EchoRequest{Message: "Hello from E2E test"})
+							Expect(err).NotTo(HaveOccurred())
+							Expect(response.Message).To(Equal("Hello from E2E test"))
+						})
+						By("sending grpc request with certain header must forward traffic to right backend", func() {
+							target := fmt.Sprintf("%s:443", dnsName)
+							tlsConfig := &tls.Config{
+								InsecureSkipVerify: true, // This skips all certificate verification, including expiry.
+							}
+
+							conn, err := grpc.NewClient(target, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
+							Expect(err).NotTo(HaveOccurred())
+							c := echo.NewEchoServiceClient(conn)
+
+							mdCtx := metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{"my-header": "my-header-value"}))
+							response, err := c.FixedResponse(mdCtx, &echo.FixedResponseRequest{})
+							Expect(err).NotTo(HaveOccurred())
+							Expect(response.Message).To(Equal("Hello World - Other"))
+						})
+						By("sending grpc request with header missing uses default service.", func() {
+							c, err := generateGRPCClient(dnsName)
+							Expect(err).NotTo(HaveOccurred())
+							mdCtx := metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{}))
+							response, err := c.FixedResponse(mdCtx, &echo.FixedResponseRequest{})
+							Expect(err).NotTo(HaveOccurred())
+							Expect(response.Message).To(Equal("Hello World"))
+						})
+						By("update grpc route to remove default rule", func() {
+
+							err = tf.K8sClient.Get(ctx, types.NamespacedName{Name: stack.albResourceStack.grpcrs[0].Name, Namespace: stack.albResourceStack.grpcrs[0].Namespace}, stack.albResourceStack.grpcrs[0])
+							Expect(err).NotTo(HaveOccurred())
+
+							stack.albResourceStack.grpcrs[0].Spec.Rules = []gwv1.GRPCRouteRule{
+								{
+									Matches: []gwv1.GRPCRouteMatch{
+										{
+											Headers: []gwv1.GRPCHeaderMatch{
+												{
+													Type:  (*gwv1.GRPCHeaderMatchType)(awssdk.String("Exact")),
+													Name:  "my-header",
+													Value: "my-header-value",
+												},
+											},
+										},
+									},
+									BackendRefs: []gwv1.GRPCBackendRef{
+										{
+											BackendRef: gwv1.BackendRef{
+												BackendObjectReference: gwv1.BackendObjectReference{
+													Name: grpcDefaultName + "-other",
+													Port: &defaultGrpcPort,
+												},
+											},
+										},
 									},
 								},
-							},
-						},
-					},
-				}
+							}
 
-				err = stack.albResourceStack.updateGRPCRoute(ctx, tf, stack.albResourceStack.grpcrs[0])
-				Expect(err).NotTo(HaveOccurred())
-				// Wait for listener change to propagate.
-				time.Sleep(1 * time.Minute)
-			})
-			By("sending grpc request should work for Echo method, should fail for FixedResponse", func() {
-				c, err := generateGRPCClient(dnsName)
-				Expect(err).NotTo(HaveOccurred())
-				mdCtx := metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{}))
-				_, err = c.FixedResponse(mdCtx, &echo.FixedResponseRequest{})
-				Expect(err).To(HaveOccurred())
+							err = stack.albResourceStack.updateGRPCRoute(ctx, tf, stack.albResourceStack.grpcrs[0])
+							Expect(err).NotTo(HaveOccurred())
+							// Wait for listener change to propagate.
+							time.Sleep(1 * time.Minute)
+						})
+						By("send grpc request with correct request header", func() {
+							c, err := generateGRPCClient(dnsName)
+							Expect(err).NotTo(HaveOccurred())
+							mdCtx := metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{"my-header": "my-header-value"}))
+							response, err := c.FixedResponse(mdCtx, &echo.FixedResponseRequest{})
+							Expect(err).NotTo(HaveOccurred())
+							Expect(response.Message).To(Equal("Hello World - Other"))
+						})
+						By("sending grpc request with header missing uses default service.", func() {
+							c, err := generateGRPCClient(dnsName)
+							Expect(err).NotTo(HaveOccurred())
+							mdCtx := metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{}))
+							_, err = c.FixedResponse(mdCtx, &echo.FixedResponseRequest{})
+							Expect(err).To(HaveOccurred())
+						})
+						By("update grpc route to route by service / method name. use invalid service", func() {
 
-				_, err = c.Echo(mdCtx, &echo.EchoRequest{Message: "foo"})
-				Expect(err).ToNot(HaveOccurred())
-			})
+							err = tf.K8sClient.Get(ctx, types.NamespacedName{Name: stack.albResourceStack.grpcrs[0].Name, Namespace: stack.albResourceStack.grpcrs[0].Namespace}, stack.albResourceStack.grpcrs[0])
+							Expect(err).NotTo(HaveOccurred())
+
+							stack.albResourceStack.grpcrs[0].Spec.Rules = []gwv1.GRPCRouteRule{
+								{
+									Matches: []gwv1.GRPCRouteMatch{
+										{
+											Method: &gwv1.GRPCMethodMatch{
+												Service: awssdk.String("com.example.FakeService"),
+												Method:  awssdk.String("FakeMethod"),
+											},
+										},
+									},
+									BackendRefs: []gwv1.GRPCBackendRef{
+										{
+											BackendRef: gwv1.BackendRef{
+												BackendObjectReference: gwv1.BackendObjectReference{
+													Name: grpcDefaultName + "-other",
+													Port: &defaultGrpcPort,
+												},
+											},
+										},
+									},
+								},
+							}
+
+							err = stack.albResourceStack.updateGRPCRoute(ctx, tf, stack.albResourceStack.grpcrs[0])
+							Expect(err).NotTo(HaveOccurred())
+							// Wait for listener change to propagate.
+							time.Sleep(1 * time.Minute)
+						})
+						By("sending grpc request should result in a failure.", func() {
+							c, err := generateGRPCClient(dnsName)
+							Expect(err).NotTo(HaveOccurred())
+							mdCtx := metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{}))
+							_, err = c.FixedResponse(mdCtx, &echo.FixedResponseRequest{})
+							Expect(err).To(HaveOccurred())
+						})
+						By("update grpc route to route by service / method name. filter by service", func() {
+
+							err = tf.K8sClient.Get(ctx, types.NamespacedName{Name: stack.albResourceStack.grpcrs[0].Name, Namespace: stack.albResourceStack.grpcrs[0].Namespace}, stack.albResourceStack.grpcrs[0])
+							Expect(err).NotTo(HaveOccurred())
+
+							stack.albResourceStack.grpcrs[0].Spec.Rules = []gwv1.GRPCRouteRule{
+								{
+									Matches: []gwv1.GRPCRouteMatch{
+										{
+											Method: &gwv1.GRPCMethodMatch{
+												Service: awssdk.String("echo.EchoService"),
+											},
+										},
+									},
+									BackendRefs: []gwv1.GRPCBackendRef{
+										{
+											BackendRef: gwv1.BackendRef{
+												BackendObjectReference: gwv1.BackendObjectReference{
+													Name: grpcDefaultName + "-other",
+													Port: &defaultGrpcPort,
+												},
+											},
+										},
+									},
+								},
+							}
+
+							err = stack.albResourceStack.updateGRPCRoute(ctx, tf, stack.albResourceStack.grpcrs[0])
+							Expect(err).NotTo(HaveOccurred())
+							// Wait for listener change to propagate.
+							time.Sleep(1 * time.Minute)
+						})
+						By("sending grpc request should work for both methods", func() {
+							c, err := generateGRPCClient(dnsName)
+							Expect(err).NotTo(HaveOccurred())
+							mdCtx := metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{}))
+							_, err = c.FixedResponse(mdCtx, &echo.FixedResponseRequest{})
+							Expect(err).ToNot(HaveOccurred())
+
+							_, err = c.Echo(mdCtx, &echo.EchoRequest{Message: "foo"})
+							Expect(err).ToNot(HaveOccurred())
+						})
+						By("update grpc route to route by service / method name. filter by service and method", func() {
+
+							err = tf.K8sClient.Get(ctx, types.NamespacedName{Name: stack.albResourceStack.grpcrs[0].Name, Namespace: stack.albResourceStack.grpcrs[0].Namespace}, stack.albResourceStack.grpcrs[0])
+							Expect(err).NotTo(HaveOccurred())
+
+							stack.albResourceStack.grpcrs[0].Spec.Rules = []gwv1.GRPCRouteRule{
+								{
+									Matches: []gwv1.GRPCRouteMatch{
+										{
+											Method: &gwv1.GRPCMethodMatch{
+												Service: awssdk.String("echo.EchoService"),
+												Method:  awssdk.String("Echo"),
+											},
+										},
+									},
+									BackendRefs: []gwv1.GRPCBackendRef{
+										{
+											BackendRef: gwv1.BackendRef{
+												BackendObjectReference: gwv1.BackendObjectReference{
+													Name: grpcDefaultName + "-other",
+													Port: &defaultGrpcPort,
+												},
+											},
+										},
+									},
+								},
+							}
+
+							err = stack.albResourceStack.updateGRPCRoute(ctx, tf, stack.albResourceStack.grpcrs[0])
+							Expect(err).NotTo(HaveOccurred())
+							// Wait for listener change to propagate.
+							time.Sleep(1 * time.Minute)
+						})
+						By("sending grpc request should work for Echo method, should fail for FixedResponse", func() {
+							c, err := generateGRPCClient(dnsName)
+							Expect(err).NotTo(HaveOccurred())
+							mdCtx := metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{}))
+							_, err = c.FixedResponse(mdCtx, &echo.FixedResponseRequest{})
+							Expect(err).To(HaveOccurred())
+
+							_, err = c.Echo(mdCtx, &echo.EchoRequest{Message: "foo"})
+							Expect(err).ToNot(HaveOccurred())
+						})
+
+			*/
 		})
 	})
 })

--- a/test/e2e/gateway/alb_ip_target_test.go
+++ b/test/e2e/gateway/alb_ip_target_test.go
@@ -36,9 +36,9 @@ var _ = Describe("test k8s alb gateway using ip targets reconciled by the aws lo
 		lbARN          string
 	)
 	BeforeEach(func() {
-		if !tf.Options.EnableGatewayTests {
-			Skip("Skipping gateway tests")
-		}
+		//if !tf.Options.EnableGatewayTests {
+		Skip("Skipping gateway tests")
+		//}
 		ctx = context.Background()
 		stack = ALBTestStack{}
 		auxiliaryStack = nil

--- a/test/e2e/gateway/alb_ip_target_test.go
+++ b/test/e2e/gateway/alb_ip_target_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	"strings"
 	"time"
 
@@ -139,35 +138,7 @@ var _ = Describe("test k8s alb gateway using ip targets reconciled by the aws lo
 				Expect(err).NotTo(HaveOccurred())
 			})
 			By("confirming the route status", func() {
-				validationInfo := map[string]routeValidationInfo{
-					k8s.NamespacedName(stack.albResourceStack.httprs[0]).String(): {
-						parentGatewayName: stack.albResourceStack.commonStack.gw.Name,
-						listenerInfo: []listenerValidationInfo{
-							{
-								listenerName:       "test-listener",
-								parentKind:         "Gateway",
-								resolvedRefReason:  "Accepted",
-								resolvedRefsStatus: "True",
-								acceptedReason:     "Accepted",
-								acceptedStatus:     "True",
-							},
-						},
-					},
-					k8s.NamespacedName(stack.albResourceStack.httprs[1]).String(): {
-						parentGatewayName: stack.albResourceStack.commonStack.gw.Name,
-						listenerInfo: []listenerValidationInfo{
-							{
-								listenerName:       "other-ns",
-								parentKind:         "Gateway",
-								resolvedRefReason:  "RefNotPermitted",
-								resolvedRefsStatus: "False",
-								acceptedReason:     "RefNotPermitted",
-								acceptedStatus:     "False",
-							},
-						},
-					},
-				}
-				validateRouteStatus(tf, stack.albResourceStack.httprs, httpRouteStatusConverter, validationInfo)
+				validateHTTPRouteStatusNotPermitted(tf, stack)
 			})
 			By("deploying ref grant", func() {
 				err := auxiliaryStack.CreateReferenceGrants(ctx, tf, stack.albResourceStack.commonStack.ns)
@@ -207,35 +178,7 @@ var _ = Describe("test k8s alb gateway using ip targets reconciled by the aws lo
 				Expect(err).NotTo(HaveOccurred())
 			})
 			By("confirming the http route status after ref grant is materialized", func() {
-				validationInfo := map[string]routeValidationInfo{
-					k8s.NamespacedName(stack.albResourceStack.httprs[0]).String(): {
-						parentGatewayName: stack.albResourceStack.commonStack.gw.Name,
-						listenerInfo: []listenerValidationInfo{
-							{
-								listenerName:       "test-listener",
-								parentKind:         "Gateway",
-								resolvedRefReason:  "Accepted",
-								resolvedRefsStatus: "True",
-								acceptedReason:     "Accepted",
-								acceptedStatus:     "True",
-							},
-						},
-					},
-					k8s.NamespacedName(stack.albResourceStack.httprs[1]).String(): {
-						parentGatewayName: stack.albResourceStack.commonStack.gw.Name,
-						listenerInfo: []listenerValidationInfo{
-							{
-								listenerName:       "other-ns",
-								parentKind:         "Gateway",
-								resolvedRefReason:  "Accepted",
-								resolvedRefsStatus: "True",
-								acceptedReason:     "Accepted",
-								acceptedStatus:     "True",
-							},
-						},
-					},
-				}
-				validateRouteStatus(tf, stack.albResourceStack.httprs, httpRouteStatusConverter, validationInfo)
+				validateHTTPRouteStatusPermitted(tf, stack)
 			})
 			By("removing ref grant", func() {
 				err := auxiliaryStack.DeleteReferenceGrants(ctx, tf)
@@ -249,35 +192,7 @@ var _ = Describe("test k8s alb gateway using ip targets reconciled by the aws lo
 				Expect(err).NotTo(HaveOccurred())
 			})
 			By("confirming the route status", func() {
-				validationInfo := map[string]routeValidationInfo{
-					k8s.NamespacedName(stack.albResourceStack.httprs[0]).String(): {
-						parentGatewayName: stack.albResourceStack.commonStack.gw.Name,
-						listenerInfo: []listenerValidationInfo{
-							{
-								listenerName:       "test-listener",
-								parentKind:         "Gateway",
-								resolvedRefReason:  "Accepted",
-								resolvedRefsStatus: "True",
-								acceptedReason:     "Accepted",
-								acceptedStatus:     "True",
-							},
-						},
-					},
-					k8s.NamespacedName(stack.albResourceStack.httprs[1]).String(): {
-						parentGatewayName: stack.albResourceStack.commonStack.gw.Name,
-						listenerInfo: []listenerValidationInfo{
-							{
-								listenerName:       "other-ns",
-								parentKind:         "Gateway",
-								resolvedRefReason:  "RefNotPermitted",
-								resolvedRefsStatus: "False",
-								acceptedReason:     "RefNotPermitted",
-								acceptedStatus:     "False",
-							},
-						},
-					},
-				}
-				validateRouteStatus(tf, stack.albResourceStack.httprs, httpRouteStatusConverter, validationInfo)
+				validateHTTPRouteStatusNotPermitted(tf, stack)
 			})
 		})
 	})
@@ -1863,22 +1778,7 @@ var _ = Describe("test k8s alb gateway using ip targets reconciled by the aws lo
 				Expect(err).ToNot(HaveOccurred())
 			})
 			By("confirming the route status", func() {
-				validationInfo := map[string]routeValidationInfo{
-					k8s.NamespacedName(stack.albResourceStack.grpcrs[0]).String(): {
-						parentGatewayName: stack.albResourceStack.commonStack.gw.Name,
-						listenerInfo: []listenerValidationInfo{
-							{
-								listenerName:       "test-listener",
-								parentKind:         "Gateway",
-								resolvedRefReason:  "Accepted",
-								resolvedRefsStatus: "True",
-								acceptedReason:     "Accepted",
-								acceptedStatus:     "True",
-							},
-						},
-					},
-				}
-				validateRouteStatus(tf, stack.albResourceStack.grpcrs, grpcRouteStatusConverter, validationInfo)
+				validateGRPCRouteStatus(tf, stack)
 			})
 		})
 	})

--- a/test/e2e/gateway/alb_ip_target_test.go
+++ b/test/e2e/gateway/alb_ip_target_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	"strings"
 	"time"
 
@@ -36,9 +37,9 @@ var _ = Describe("test k8s alb gateway using ip targets reconciled by the aws lo
 		lbARN          string
 	)
 	BeforeEach(func() {
-		//if !tf.Options.EnableGatewayTests {
-		Skip("Skipping gateway tests")
-		//}
+		if !tf.Options.EnableGatewayTests {
+			Skip("Skipping gateway tests")
+		}
 		ctx = context.Background()
 		stack = ALBTestStack{}
 		auxiliaryStack = nil
@@ -137,6 +138,37 @@ var _ = Describe("test k8s alb gateway using ip targets reconciled by the aws lo
 				err := tf.HTTPVerifier.VerifyURL(url, http.ResponseCodeMatches(503))
 				Expect(err).NotTo(HaveOccurred())
 			})
+			By("confirming the route status", func() {
+				validationInfo := map[string]routeValidationInfo{
+					k8s.NamespacedName(stack.albResourceStack.httprs[0]).String(): {
+						parentGatewayName: stack.albResourceStack.commonStack.gw.Name,
+						listenerInfo: []listenerValidationInfo{
+							{
+								listenerName:       "test-listener",
+								parentKind:         "Gateway",
+								resolvedRefReason:  "Accepted",
+								resolvedRefsStatus: "True",
+								acceptedReason:     "Accepted",
+								acceptedStatus:     "True",
+							},
+						},
+					},
+					k8s.NamespacedName(stack.albResourceStack.httprs[1]).String(): {
+						parentGatewayName: stack.albResourceStack.commonStack.gw.Name,
+						listenerInfo: []listenerValidationInfo{
+							{
+								listenerName:       "other-ns",
+								parentKind:         "Gateway",
+								resolvedRefReason:  "RefNotPermitted",
+								resolvedRefsStatus: "False",
+								acceptedReason:     "RefNotPermitted",
+								acceptedStatus:     "False",
+							},
+						},
+					},
+				}
+				validateRouteStatus(tf, stack.albResourceStack.httprs, httpRouteStatusConverter, validationInfo)
+			})
 			By("deploying ref grant", func() {
 				err := auxiliaryStack.CreateReferenceGrants(ctx, tf, stack.albResourceStack.commonStack.ns)
 				Expect(err).NotTo(HaveOccurred())
@@ -174,6 +206,37 @@ var _ = Describe("test k8s alb gateway using ip targets reconciled by the aws lo
 				err := tf.HTTPVerifier.VerifyURL(url, http.ResponseCodeMatches(200))
 				Expect(err).NotTo(HaveOccurred())
 			})
+			By("confirming the http route status after ref grant is materialized", func() {
+				validationInfo := map[string]routeValidationInfo{
+					k8s.NamespacedName(stack.albResourceStack.httprs[0]).String(): {
+						parentGatewayName: stack.albResourceStack.commonStack.gw.Name,
+						listenerInfo: []listenerValidationInfo{
+							{
+								listenerName:       "test-listener",
+								parentKind:         "Gateway",
+								resolvedRefReason:  "Accepted",
+								resolvedRefsStatus: "True",
+								acceptedReason:     "Accepted",
+								acceptedStatus:     "True",
+							},
+						},
+					},
+					k8s.NamespacedName(stack.albResourceStack.httprs[1]).String(): {
+						parentGatewayName: stack.albResourceStack.commonStack.gw.Name,
+						listenerInfo: []listenerValidationInfo{
+							{
+								listenerName:       "other-ns",
+								parentKind:         "Gateway",
+								resolvedRefReason:  "Accepted",
+								resolvedRefsStatus: "True",
+								acceptedReason:     "Accepted",
+								acceptedStatus:     "True",
+							},
+						},
+					},
+				}
+				validateRouteStatus(tf, stack.albResourceStack.httprs, httpRouteStatusConverter, validationInfo)
+			})
 			By("removing ref grant", func() {
 				err := auxiliaryStack.DeleteReferenceGrants(ctx, tf)
 				Expect(err).NotTo(HaveOccurred())
@@ -184,6 +247,37 @@ var _ = Describe("test k8s alb gateway using ip targets reconciled by the aws lo
 				url := fmt.Sprintf("http://%v:5000/any-path", dnsName)
 				err := tf.HTTPVerifier.VerifyURL(url, http.ResponseCodeMatches(503))
 				Expect(err).NotTo(HaveOccurred())
+			})
+			By("confirming the route status", func() {
+				validationInfo := map[string]routeValidationInfo{
+					k8s.NamespacedName(stack.albResourceStack.httprs[0]).String(): {
+						parentGatewayName: stack.albResourceStack.commonStack.gw.Name,
+						listenerInfo: []listenerValidationInfo{
+							{
+								listenerName:       "test-listener",
+								parentKind:         "Gateway",
+								resolvedRefReason:  "Accepted",
+								resolvedRefsStatus: "True",
+								acceptedReason:     "Accepted",
+								acceptedStatus:     "True",
+							},
+						},
+					},
+					k8s.NamespacedName(stack.albResourceStack.httprs[1]).String(): {
+						parentGatewayName: stack.albResourceStack.commonStack.gw.Name,
+						listenerInfo: []listenerValidationInfo{
+							{
+								listenerName:       "other-ns",
+								parentKind:         "Gateway",
+								resolvedRefReason:  "RefNotPermitted",
+								resolvedRefsStatus: "False",
+								acceptedReason:     "RefNotPermitted",
+								acceptedStatus:     "False",
+							},
+						},
+					},
+				}
+				validateRouteStatus(tf, stack.albResourceStack.httprs, httpRouteStatusConverter, validationInfo)
 			})
 		})
 	})
@@ -1767,6 +1861,24 @@ var _ = Describe("test k8s alb gateway using ip targets reconciled by the aws lo
 
 				_, err = c.Echo(mdCtx, &echo.EchoRequest{Message: "foo"})
 				Expect(err).ToNot(HaveOccurred())
+			})
+			By("confirming the route status", func() {
+				validationInfo := map[string]routeValidationInfo{
+					k8s.NamespacedName(stack.albResourceStack.grpcrs[0]).String(): {
+						parentGatewayName: stack.albResourceStack.commonStack.gw.Name,
+						listenerInfo: []listenerValidationInfo{
+							{
+								listenerName:       "test-listener",
+								parentKind:         "Gateway",
+								resolvedRefReason:  "Accepted",
+								resolvedRefsStatus: "True",
+								acceptedReason:     "Accepted",
+								acceptedStatus:     "True",
+							},
+						},
+					},
+				}
+				validateRouteStatus(tf, stack.albResourceStack.grpcrs, grpcRouteStatusConverter, validationInfo)
 			})
 		})
 	})

--- a/test/e2e/gateway/alb_test_helper.go
+++ b/test/e2e/gateway/alb_test_helper.go
@@ -8,7 +8,9 @@ import (
 	"google.golang.org/grpc/credentials"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	"sigs.k8s.io/aws-load-balancer-controller/test/e2e/gateway/grpc/echo"
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -104,4 +106,24 @@ func generateGRPCClient(dnsName string) (echo.EchoServiceClient, error) {
 		return nil, err
 	}
 	return echo.NewEchoServiceClient(conn), nil
+}
+
+func httpRouteStatusConverter(tf *framework.Framework, i interface{}) (gwv1.RouteStatus, types.NamespacedName, error) {
+	httpR := i.(*gwv1.HTTPRoute)
+	retrievedRoute := gwv1.HTTPRoute{}
+	err := tf.K8sClient.Get(context.Background(), k8s.NamespacedName(httpR), &retrievedRoute)
+	if err != nil {
+		return gwv1.RouteStatus{}, types.NamespacedName{}, err
+	}
+	return retrievedRoute.Status.RouteStatus, k8s.NamespacedName(&retrievedRoute), nil
+}
+
+func grpcRouteStatusConverter(tf *framework.Framework, i interface{}) (gwv1.RouteStatus, types.NamespacedName, error) {
+	grpcR := i.(*gwv1.GRPCRoute)
+	retrievedRoute := gwv1.GRPCRoute{}
+	err := tf.K8sClient.Get(context.Background(), k8s.NamespacedName(grpcR), &retrievedRoute)
+	if err != nil {
+		return gwv1.RouteStatus{}, types.NamespacedName{}, err
+	}
+	return retrievedRoute.Status.RouteStatus, k8s.NamespacedName(&retrievedRoute), nil
 }

--- a/test/e2e/gateway/alb_test_helper.go
+++ b/test/e2e/gateway/alb_test_helper.go
@@ -108,6 +108,89 @@ func generateGRPCClient(dnsName string) (echo.EchoServiceClient, error) {
 	return echo.NewEchoServiceClient(conn), nil
 }
 
+func validateHTTPRouteStatusNotPermitted(tf *framework.Framework, stack ALBTestStack) {
+	validationInfo := map[string]routeValidationInfo{
+		k8s.NamespacedName(stack.albResourceStack.httprs[0]).String(): {
+			parentGatewayName: stack.albResourceStack.commonStack.gw.Name,
+			listenerInfo: []listenerValidationInfo{
+				{
+					listenerName:       "test-listener",
+					parentKind:         "Gateway",
+					resolvedRefReason:  "Accepted",
+					resolvedRefsStatus: "True",
+					acceptedReason:     "Accepted",
+					acceptedStatus:     "True",
+				},
+			},
+		},
+		k8s.NamespacedName(stack.albResourceStack.httprs[1]).String(): {
+			parentGatewayName: stack.albResourceStack.commonStack.gw.Name,
+			listenerInfo: []listenerValidationInfo{
+				{
+					listenerName:       "other-ns",
+					parentKind:         "Gateway",
+					resolvedRefReason:  "RefNotPermitted",
+					resolvedRefsStatus: "False",
+					acceptedReason:     "RefNotPermitted",
+					acceptedStatus:     "False",
+				},
+			},
+		},
+	}
+	validateRouteStatus(tf, stack.albResourceStack.httprs, httpRouteStatusConverter, validationInfo)
+}
+
+func validateHTTPRouteStatusPermitted(tf *framework.Framework, stack ALBTestStack) {
+	validationInfo := map[string]routeValidationInfo{
+		k8s.NamespacedName(stack.albResourceStack.httprs[0]).String(): {
+			parentGatewayName: stack.albResourceStack.commonStack.gw.Name,
+			listenerInfo: []listenerValidationInfo{
+				{
+					listenerName:       "test-listener",
+					parentKind:         "Gateway",
+					resolvedRefReason:  "Accepted",
+					resolvedRefsStatus: "True",
+					acceptedReason:     "Accepted",
+					acceptedStatus:     "True",
+				},
+			},
+		},
+		k8s.NamespacedName(stack.albResourceStack.httprs[1]).String(): {
+			parentGatewayName: stack.albResourceStack.commonStack.gw.Name,
+			listenerInfo: []listenerValidationInfo{
+				{
+					listenerName:       "other-ns",
+					parentKind:         "Gateway",
+					resolvedRefReason:  "Accepted",
+					resolvedRefsStatus: "True",
+					acceptedReason:     "Accepted",
+					acceptedStatus:     "True",
+				},
+			},
+		},
+	}
+	validateRouteStatus(tf, stack.albResourceStack.httprs, httpRouteStatusConverter, validationInfo)
+}
+
+func validateGRPCRouteStatus(tf *framework.Framework, stack ALBTestStack) {
+	validationInfo := map[string]routeValidationInfo{
+		k8s.NamespacedName(stack.albResourceStack.grpcrs[0]).String(): {
+			parentGatewayName: stack.albResourceStack.commonStack.gw.Name,
+			listenerInfo: []listenerValidationInfo{
+				{
+					listenerName:       "test-listener",
+					parentKind:         "Gateway",
+					resolvedRefReason:  "Accepted",
+					resolvedRefsStatus: "True",
+					acceptedReason:     "Accepted",
+					acceptedStatus:     "True",
+				},
+			},
+		},
+	}
+	validateRouteStatus(tf, stack.albResourceStack.grpcrs, grpcRouteStatusConverter, validationInfo)
+}
+
 func httpRouteStatusConverter(tf *framework.Framework, i interface{}) (gwv1.RouteStatus, types.NamespacedName, error) {
 	httpR := i.(*gwv1.HTTPRoute)
 	retrievedRoute := gwv1.HTTPRoute{}

--- a/test/e2e/gateway/nlb_instance_target_test.go
+++ b/test/e2e/gateway/nlb_instance_target_test.go
@@ -23,9 +23,9 @@ var _ = Describe("test nlb gateway using instance targets reconciled by the aws 
 		lbARN          string
 	)
 	BeforeEach(func() {
-		if !tf.Options.EnableGatewayTests {
-			Skip("Skipping gateway tests")
-		}
+		//if !tf.Options.EnableGatewayTests {
+		Skip("Skipping gateway tests")
+		//}
 		ctx = context.Background()
 		stack = NLBTestStack{}
 		auxiliaryStack = nil

--- a/test/e2e/gateway/nlb_instance_target_test.go
+++ b/test/e2e/gateway/nlb_instance_target_test.go
@@ -6,7 +6,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
-	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework/http"
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework/utils"
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework/verifier"
@@ -157,65 +156,7 @@ var _ = Describe("test nlb gateway using instance targets reconciled by the aws 
 				Expect(err).NotTo(HaveOccurred())
 			})
 			By("confirming the route status", func() {
-				tcpRouteListenerInfo := []listenerValidationInfo{
-					{
-						listenerName:       "port80",
-						parentKind:         "Gateway",
-						resolvedRefReason:  "Accepted",
-						resolvedRefsStatus: "True",
-						acceptedReason:     "Accepted",
-						acceptedStatus:     "True",
-					},
-				}
-
-				if hasTLS {
-					tcpRouteListenerInfo = append(tcpRouteListenerInfo, listenerValidationInfo{
-						listenerName:       "port443",
-						parentKind:         "Gateway",
-						resolvedRefReason:  "Accepted",
-						resolvedRefsStatus: "True",
-						acceptedReason:     "Accepted",
-						acceptedStatus:     "True",
-					})
-				}
-
-				tcpValidationInfo := map[string]routeValidationInfo{
-					k8s.NamespacedName(stack.nlbResourceStack.tcprs[0]).String(): {
-						parentGatewayName: stack.nlbResourceStack.commonStack.gw.Name,
-						listenerInfo:      tcpRouteListenerInfo,
-					},
-					k8s.NamespacedName(stack.nlbResourceStack.tcprs[1]).String(): {
-						parentGatewayName: stack.nlbResourceStack.commonStack.gw.Name,
-						listenerInfo: []listenerValidationInfo{
-							{
-								listenerName:       "other-ns",
-								parentKind:         "Gateway",
-								resolvedRefReason:  "RefNotPermitted",
-								resolvedRefsStatus: "False",
-								acceptedReason:     "RefNotPermitted",
-								acceptedStatus:     "False",
-							},
-						},
-					},
-				}
-
-				udpValidationInfo := map[string]routeValidationInfo{
-					k8s.NamespacedName(stack.nlbResourceStack.udprs[0]).String(): {
-						parentGatewayName: stack.nlbResourceStack.commonStack.gw.Name,
-						listenerInfo: []listenerValidationInfo{
-							{
-								listenerName:       "port8080",
-								parentKind:         "Gateway",
-								resolvedRefReason:  "Accepted",
-								resolvedRefsStatus: "True",
-								acceptedReason:     "Accepted",
-								acceptedStatus:     "True",
-							},
-						},
-					},
-				}
-				validateRouteStatus(tf, stack.nlbResourceStack.tcprs, tcpRouteStatusConverter, tcpValidationInfo)
-				validateRouteStatus(tf, stack.nlbResourceStack.udprs, udpRouteStatusConverter, udpValidationInfo)
+				validateL4RouteStatusNotPermitted(tf, stack, hasTLS)
 			})
 			By("deploying ref grant", func() {
 				err := auxiliaryStack.CreateReferenceGrants(ctx, tf, stack.nlbResourceStack.commonStack.ns)
@@ -287,66 +228,7 @@ var _ = Describe("test nlb gateway using instance targets reconciled by the aws 
 				Expect(err).NotTo(HaveOccurred())
 			})
 			By("confirming the route status", func() {
-
-				tcpRouteListenerInfo := []listenerValidationInfo{
-					{
-						listenerName:       "port80",
-						parentKind:         "Gateway",
-						resolvedRefReason:  "Accepted",
-						resolvedRefsStatus: "True",
-						acceptedReason:     "Accepted",
-						acceptedStatus:     "True",
-					},
-				}
-
-				if hasTLS {
-					tcpRouteListenerInfo = append(tcpRouteListenerInfo, listenerValidationInfo{
-						listenerName:       "port443",
-						parentKind:         "Gateway",
-						resolvedRefReason:  "Accepted",
-						resolvedRefsStatus: "True",
-						acceptedReason:     "Accepted",
-						acceptedStatus:     "True",
-					})
-				}
-
-				tcpValidationInfo := map[string]routeValidationInfo{
-					k8s.NamespacedName(stack.nlbResourceStack.tcprs[0]).String(): {
-						parentGatewayName: stack.nlbResourceStack.commonStack.gw.Name,
-						listenerInfo:      tcpRouteListenerInfo,
-					},
-					k8s.NamespacedName(stack.nlbResourceStack.tcprs[1]).String(): {
-						parentGatewayName: stack.nlbResourceStack.commonStack.gw.Name,
-						listenerInfo: []listenerValidationInfo{
-							{
-								listenerName:       "other-ns",
-								parentKind:         "Gateway",
-								resolvedRefReason:  "Accepted",
-								resolvedRefsStatus: "True",
-								acceptedReason:     "Accepted",
-								acceptedStatus:     "True",
-							},
-						},
-					},
-				}
-
-				udpValidationInfo := map[string]routeValidationInfo{
-					k8s.NamespacedName(stack.nlbResourceStack.udprs[0]).String(): {
-						parentGatewayName: stack.nlbResourceStack.commonStack.gw.Name,
-						listenerInfo: []listenerValidationInfo{
-							{
-								listenerName:       "port8080",
-								parentKind:         "Gateway",
-								resolvedRefReason:  "Accepted",
-								resolvedRefsStatus: "True",
-								acceptedReason:     "Accepted",
-								acceptedStatus:     "True",
-							},
-						},
-					},
-				}
-				validateRouteStatus(tf, stack.nlbResourceStack.tcprs, tcpRouteStatusConverter, tcpValidationInfo)
-				validateRouteStatus(tf, stack.nlbResourceStack.udprs, udpRouteStatusConverter, udpValidationInfo)
+				validateL4RouteStatusPermitted(tf, stack, hasTLS)
 			})
 			By("removing ref grant", func() {
 				err := auxiliaryStack.DeleteReferenceGrants(ctx, tf)
@@ -408,66 +290,7 @@ var _ = Describe("test nlb gateway using instance targets reconciled by the aws 
 				Expect(err).NotTo(HaveOccurred())
 			})
 			By("confirming the route status", func() {
-
-				tcpRouteListenerInfo := []listenerValidationInfo{
-					{
-						listenerName:       "port80",
-						parentKind:         "Gateway",
-						resolvedRefReason:  "Accepted",
-						resolvedRefsStatus: "True",
-						acceptedReason:     "Accepted",
-						acceptedStatus:     "True",
-					},
-				}
-
-				if hasTLS {
-					tcpRouteListenerInfo = append(tcpRouteListenerInfo, listenerValidationInfo{
-						listenerName:       "port443",
-						parentKind:         "Gateway",
-						resolvedRefReason:  "Accepted",
-						resolvedRefsStatus: "True",
-						acceptedReason:     "Accepted",
-						acceptedStatus:     "True",
-					})
-				}
-
-				tcpValidationInfo := map[string]routeValidationInfo{
-					k8s.NamespacedName(stack.nlbResourceStack.tcprs[0]).String(): {
-						parentGatewayName: stack.nlbResourceStack.commonStack.gw.Name,
-						listenerInfo:      tcpRouteListenerInfo,
-					},
-					k8s.NamespacedName(stack.nlbResourceStack.tcprs[1]).String(): {
-						parentGatewayName: stack.nlbResourceStack.commonStack.gw.Name,
-						listenerInfo: []listenerValidationInfo{
-							{
-								listenerName:       "other-ns",
-								parentKind:         "Gateway",
-								resolvedRefReason:  "RefNotPermitted",
-								resolvedRefsStatus: "False",
-								acceptedReason:     "RefNotPermitted",
-								acceptedStatus:     "False",
-							},
-						},
-					},
-				}
-
-				udpValidationInfo := map[string]routeValidationInfo{
-					k8s.NamespacedName(stack.nlbResourceStack.udprs[0]).String(): {
-						parentGatewayName: stack.nlbResourceStack.commonStack.gw.Name,
-						listenerInfo: []listenerValidationInfo{
-							{
-								listenerName:       "port8080",
-								parentKind:         "Gateway",
-								resolvedRefReason:  "Accepted",
-								resolvedRefsStatus: "True",
-								acceptedReason:     "Accepted",
-								acceptedStatus:     "True",
-							},
-						},
-					},
-				}
-				validateRouteStatus(tf, stack.nlbResourceStack.tcprs, tcpRouteStatusConverter, tcpValidationInfo)
-				validateRouteStatus(tf, stack.nlbResourceStack.udprs, udpRouteStatusConverter, udpValidationInfo)
+				validateL4RouteStatusNotPermitted(tf, stack, hasTLS)
 			})
 		})
 	})

--- a/test/e2e/gateway/nlb_ip_target_test.go
+++ b/test/e2e/gateway/nlb_ip_target_test.go
@@ -23,9 +23,9 @@ var _ = Describe("test nlb gateway using ip targets reconciled by the aws load b
 		lbARN          string
 	)
 	BeforeEach(func() {
-		if !tf.Options.EnableGatewayTests {
-			Skip("Skipping gateway tests")
-		}
+		//if !tf.Options.EnableGatewayTests {
+		Skip("Skipping gateway tests")
+		//}
 		ctx = context.Background()
 		stack = NLBTestStack{}
 		auxiliaryStack = nil

--- a/test/e2e/gateway/nlb_ip_target_test.go
+++ b/test/e2e/gateway/nlb_ip_target_test.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework/http"
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework/utils"
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework/verifier"
@@ -23,9 +24,9 @@ var _ = Describe("test nlb gateway using ip targets reconciled by the aws load b
 		lbARN          string
 	)
 	BeforeEach(func() {
-		//if !tf.Options.EnableGatewayTests {
-		Skip("Skipping gateway tests")
-		//}
+		if !tf.Options.EnableGatewayTests {
+			Skip("Skipping gateway tests")
+		}
 		ctx = context.Background()
 		stack = NLBTestStack{}
 		auxiliaryStack = nil
@@ -158,6 +159,67 @@ var _ = Describe("test nlb gateway using ip targets reconciled by the aws load b
 					err := tf.UDPVerifier.VerifyUDP(endpoint)
 					Expect(err).NotTo(HaveOccurred())
 				})
+				By("confirming the route status", func() {
+					tcpRouteListenerInfo := []listenerValidationInfo{
+						{
+							listenerName:       "port80",
+							parentKind:         "Gateway",
+							resolvedRefReason:  "Accepted",
+							resolvedRefsStatus: "True",
+							acceptedReason:     "Accepted",
+							acceptedStatus:     "True",
+						},
+					}
+
+					if hasTLS {
+						tcpRouteListenerInfo = append(tcpRouteListenerInfo, listenerValidationInfo{
+							listenerName:       "port443",
+							parentKind:         "Gateway",
+							resolvedRefReason:  "Accepted",
+							resolvedRefsStatus: "True",
+							acceptedReason:     "Accepted",
+							acceptedStatus:     "True",
+						})
+					}
+
+					tcpValidationInfo := map[string]routeValidationInfo{
+						k8s.NamespacedName(stack.nlbResourceStack.tcprs[0]).String(): {
+							parentGatewayName: stack.nlbResourceStack.commonStack.gw.Name,
+							listenerInfo:      tcpRouteListenerInfo,
+						},
+						k8s.NamespacedName(stack.nlbResourceStack.tcprs[1]).String(): {
+							parentGatewayName: stack.nlbResourceStack.commonStack.gw.Name,
+							listenerInfo: []listenerValidationInfo{
+								{
+									listenerName:       "other-ns",
+									parentKind:         "Gateway",
+									resolvedRefReason:  "RefNotPermitted",
+									resolvedRefsStatus: "False",
+									acceptedReason:     "RefNotPermitted",
+									acceptedStatus:     "False",
+								},
+							},
+						},
+					}
+
+					udpValidationInfo := map[string]routeValidationInfo{
+						k8s.NamespacedName(stack.nlbResourceStack.udprs[0]).String(): {
+							parentGatewayName: stack.nlbResourceStack.commonStack.gw.Name,
+							listenerInfo: []listenerValidationInfo{
+								{
+									listenerName:       "port8080",
+									parentKind:         "Gateway",
+									resolvedRefReason:  "Accepted",
+									resolvedRefsStatus: "True",
+									acceptedReason:     "Accepted",
+									acceptedStatus:     "True",
+								},
+							},
+						},
+					}
+					validateRouteStatus(tf, stack.nlbResourceStack.tcprs, tcpRouteStatusConverter, tcpValidationInfo)
+					validateRouteStatus(tf, stack.nlbResourceStack.udprs, udpRouteStatusConverter, udpValidationInfo)
+				})
 				By("deploying ref grant", func() {
 					err := auxiliaryStack.CreateReferenceGrants(ctx, tf, stack.nlbResourceStack.commonStack.ns)
 					Expect(err).NotTo(HaveOccurred())
@@ -219,6 +281,68 @@ var _ = Describe("test nlb gateway using ip targets reconciled by the aws load b
 					})
 					Expect(err).NotTo(HaveOccurred())
 				})
+				By("confirming the route status", func() {
+
+					tcpRouteListenerInfo := []listenerValidationInfo{
+						{
+							listenerName:       "port80",
+							parentKind:         "Gateway",
+							resolvedRefReason:  "Accepted",
+							resolvedRefsStatus: "True",
+							acceptedReason:     "Accepted",
+							acceptedStatus:     "True",
+						},
+					}
+
+					if hasTLS {
+						tcpRouteListenerInfo = append(tcpRouteListenerInfo, listenerValidationInfo{
+							listenerName:       "port443",
+							parentKind:         "Gateway",
+							resolvedRefReason:  "Accepted",
+							resolvedRefsStatus: "True",
+							acceptedReason:     "Accepted",
+							acceptedStatus:     "True",
+						})
+					}
+
+					tcpValidationInfo := map[string]routeValidationInfo{
+						k8s.NamespacedName(stack.nlbResourceStack.tcprs[0]).String(): {
+							parentGatewayName: stack.nlbResourceStack.commonStack.gw.Name,
+							listenerInfo:      tcpRouteListenerInfo,
+						},
+						k8s.NamespacedName(stack.nlbResourceStack.tcprs[1]).String(): {
+							parentGatewayName: stack.nlbResourceStack.commonStack.gw.Name,
+							listenerInfo: []listenerValidationInfo{
+								{
+									listenerName:       "other-ns",
+									parentKind:         "Gateway",
+									resolvedRefReason:  "Accepted",
+									resolvedRefsStatus: "True",
+									acceptedReason:     "Accepted",
+									acceptedStatus:     "True",
+								},
+							},
+						},
+					}
+
+					udpValidationInfo := map[string]routeValidationInfo{
+						k8s.NamespacedName(stack.nlbResourceStack.udprs[0]).String(): {
+							parentGatewayName: stack.nlbResourceStack.commonStack.gw.Name,
+							listenerInfo: []listenerValidationInfo{
+								{
+									listenerName:       "port8080",
+									parentKind:         "Gateway",
+									resolvedRefReason:  "Accepted",
+									resolvedRefsStatus: "True",
+									acceptedReason:     "Accepted",
+									acceptedStatus:     "True",
+								},
+							},
+						},
+					}
+					validateRouteStatus(tf, stack.nlbResourceStack.tcprs, tcpRouteStatusConverter, tcpValidationInfo)
+					validateRouteStatus(tf, stack.nlbResourceStack.udprs, udpRouteStatusConverter, udpValidationInfo)
+				})
 				By("removing ref grant", func() {
 					err := auxiliaryStack.DeleteReferenceGrants(ctx, tf)
 					Expect(err).NotTo(HaveOccurred())
@@ -270,6 +394,67 @@ var _ = Describe("test nlb gateway using ip targets reconciled by the aws load b
 						TargetGroups: expectedTargetGroups,
 					})
 					Expect(err).NotTo(HaveOccurred())
+				})
+				By("confirming the route status", func() {
+					tcpRouteListenerInfo := []listenerValidationInfo{
+						{
+							listenerName:       "port80",
+							parentKind:         "Gateway",
+							resolvedRefReason:  "Accepted",
+							resolvedRefsStatus: "True",
+							acceptedReason:     "Accepted",
+							acceptedStatus:     "True",
+						},
+					}
+
+					if hasTLS {
+						tcpRouteListenerInfo = append(tcpRouteListenerInfo, listenerValidationInfo{
+							listenerName:       "port443",
+							parentKind:         "Gateway",
+							resolvedRefReason:  "Accepted",
+							resolvedRefsStatus: "True",
+							acceptedReason:     "Accepted",
+							acceptedStatus:     "True",
+						})
+					}
+
+					tcpValidationInfo := map[string]routeValidationInfo{
+						k8s.NamespacedName(stack.nlbResourceStack.tcprs[0]).String(): {
+							parentGatewayName: stack.nlbResourceStack.commonStack.gw.Name,
+							listenerInfo:      tcpRouteListenerInfo,
+						},
+						k8s.NamespacedName(stack.nlbResourceStack.tcprs[1]).String(): {
+							parentGatewayName: stack.nlbResourceStack.commonStack.gw.Name,
+							listenerInfo: []listenerValidationInfo{
+								{
+									listenerName:       "other-ns",
+									parentKind:         "Gateway",
+									resolvedRefReason:  "RefNotPermitted",
+									resolvedRefsStatus: "False",
+									acceptedReason:     "RefNotPermitted",
+									acceptedStatus:     "False",
+								},
+							},
+						},
+					}
+
+					udpValidationInfo := map[string]routeValidationInfo{
+						k8s.NamespacedName(stack.nlbResourceStack.udprs[0]).String(): {
+							parentGatewayName: stack.nlbResourceStack.commonStack.gw.Name,
+							listenerInfo: []listenerValidationInfo{
+								{
+									listenerName:       "port8080",
+									parentKind:         "Gateway",
+									resolvedRefReason:  "Accepted",
+									resolvedRefsStatus: "True",
+									acceptedReason:     "Accepted",
+									acceptedStatus:     "True",
+								},
+							},
+						},
+					}
+					validateRouteStatus(tf, stack.nlbResourceStack.tcprs, tcpRouteStatusConverter, tcpValidationInfo)
+					validateRouteStatus(tf, stack.nlbResourceStack.udprs, udpRouteStatusConverter, udpValidationInfo)
 				})
 			})
 		})

--- a/test/e2e/gateway/nlb_test_helper.go
+++ b/test/e2e/gateway/nlb_test_helper.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwalpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
@@ -97,4 +99,24 @@ func (s *NLBTestStack) GetWorkerNodes(ctx context.Context, f *framework.Framewor
 		}
 	}
 	return nodeList, nil
+}
+
+func tcpRouteStatusConverter(tf *framework.Framework, i interface{}) (gwv1.RouteStatus, types.NamespacedName, error) {
+	tcpR := i.(*gwalpha2.TCPRoute)
+	retrievedRoute := gwalpha2.TCPRoute{}
+	err := tf.K8sClient.Get(context.Background(), k8s.NamespacedName(tcpR), &retrievedRoute)
+	if err != nil {
+		return gwv1.RouteStatus{}, types.NamespacedName{}, err
+	}
+	return retrievedRoute.Status.RouteStatus, k8s.NamespacedName(&retrievedRoute), nil
+}
+
+func udpRouteStatusConverter(tf *framework.Framework, i interface{}) (gwv1.RouteStatus, types.NamespacedName, error) {
+	udpR := i.(*gwalpha2.UDPRoute)
+	retrievedRoute := gwalpha2.UDPRoute{}
+	err := tf.K8sClient.Get(context.Background(), k8s.NamespacedName(udpR), &retrievedRoute)
+	if err != nil {
+		return gwv1.RouteStatus{}, types.NamespacedName{}, err
+	}
+	return retrievedRoute.Status.RouteStatus, k8s.NamespacedName(&retrievedRoute), nil
 }

--- a/test/e2e/gateway/route_validator.go
+++ b/test/e2e/gateway/route_validator.go
@@ -1,0 +1,55 @@
+package gateway
+
+import (
+	"fmt"
+	"github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/aws-load-balancer-controller/test/framework"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+type routeValidationInfo struct {
+	parentGatewayName string
+	listenerInfo      []listenerValidationInfo
+}
+
+type listenerValidationInfo struct {
+	listenerName       string
+	parentKind         string
+	resolvedRefsStatus string
+	resolvedRefReason  string
+	acceptedStatus     string
+	acceptedReason     string
+}
+
+func validateRouteStatus[R any](tf *framework.Framework, routes []R, routeStatusConverter func(*framework.Framework, interface{}) (gwv1.RouteStatus, types.NamespacedName, error), validationMap map[string]routeValidationInfo) {
+	for _, createdRoute := range routes {
+		rs, nsn, err := routeStatusConverter(tf, createdRoute)
+		Expect(err).NotTo(HaveOccurred())
+		info := validationMap[nsn.String()]
+		for _, pr := range rs.Parents {
+			Expect(string(pr.ParentRef.Name)).To(Equal(info.parentGatewayName))
+			var found bool
+			for _, listener := range info.listenerInfo {
+				if listener.listenerName == string(*pr.ParentRef.SectionName) {
+					found = true
+					Expect(string(*pr.ParentRef.Kind)).To(Equal(listener.parentKind))
+					for _, cond := range pr.Conditions {
+						if cond.Type == string(gwv1.RouteConditionResolvedRefs) {
+							Expect(string(cond.Status)).To(Equal(listener.resolvedRefsStatus))
+							Expect(cond.Reason).To(Equal(listener.resolvedRefReason))
+						} else if cond.Type == string(gwv1.RouteReasonAccepted) {
+							Expect(string(cond.Status)).To(Equal(listener.acceptedStatus))
+							Expect(cond.Reason).To(Equal(listener.acceptedReason))
+						} else {
+							ginkgo.Fail(fmt.Sprintf("Unexpected condition type: %s", cond.Type))
+						}
+					}
+					break
+				}
+			}
+			Expect(found).To(BeTrue())
+		}
+	}
+}

--- a/test/e2e/gateway/route_validator.go
+++ b/test/e2e/gateway/route_validator.go
@@ -39,7 +39,7 @@ func validateRouteStatus[R any](tf *framework.Framework, routes []R, routeStatus
 						if cond.Type == string(gwv1.RouteConditionResolvedRefs) {
 							Expect(string(cond.Status)).To(Equal(listener.resolvedRefsStatus))
 							Expect(cond.Reason).To(Equal(listener.resolvedRefReason))
-						} else if cond.Type == string(gwv1.RouteReasonAccepted) {
+						} else if cond.Type == string(gwv1.RouteConditionAccepted) {
 							Expect(string(cond.Status)).To(Equal(listener.acceptedStatus))
 							Expect(cond.Reason).To(Equal(listener.acceptedReason))
 						} else {


### PR DESCRIPTION
### Description

Validates that UDP, TCP, HTTP, and GRPC routes get the route status successfully updated. A couple scenarios that were tested:

- Initial status set works
- Status is properly set for missing Reference Grant.
- Status is updated when Reference Grant is corrected.
- Status is updated yet again, once Reference Grant is destroyed.
- Validates that route statuses are independent when one route attaches to multiple Gateway listeners.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
