### PR TITLE
handle invalid yaml when generating helm crd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,8 @@ crds: manifests
 	$(MOVE_GATEWAY_CRDS)
 	$(KUSTOMIZE) build config/crd > helm/aws-load-balancer-controller/crds/crds.yaml
 	$(KUSTOMIZE) build config/crd/gateway > config/crd/gateway/gateway-crds.yaml
+	echo '---' > config/crd/gateway/gateway-crds.yaml
+	$(KUSTOMIZE) build config/crd/gateway >> config/crd/gateway/gateway-crds.yaml
 	$(COPY_GATEWAY_CRDS_TO_HELM)
 
 # Run go fmt against code

--- a/apis/gateway/v1beta1/loadbalancerconfig_types.go
+++ b/apis/gateway/v1beta1/loadbalancerconfig_types.go
@@ -245,10 +245,6 @@ type LoadBalancerConfigurationSpec struct {
 	// +optional
 	SourceRanges *[]string `json:"sourceRanges,omitempty"`
 
-	// vpcId is the ID of the VPC for the load balancer.
-	// +optional
-	VpcId *string `json:"vpcId,omitempty"`
-
 	// LoadBalancerAttributes defines the attribute of LB
 	// +optional
 	LoadBalancerAttributes []LoadBalancerAttribute `json:"loadBalancerAttributes,omitempty"`

--- a/apis/gateway/v1beta1/zz_generated.deepcopy.go
+++ b/apis/gateway/v1beta1/zz_generated.deepcopy.go
@@ -697,11 +697,6 @@ func (in *LoadBalancerConfigurationSpec) DeepCopyInto(out *LoadBalancerConfigura
 			copy(*out, *in)
 		}
 	}
-	if in.VpcId != nil {
-		in, out := &in.VpcId, &out.VpcId
-		*out = new(string)
-		**out = **in
-	}
 	if in.LoadBalancerAttributes != nil {
 		in, out := &in.LoadBalancerAttributes, &out.LoadBalancerAttributes
 		*out = make([]LoadBalancerAttribute, len(*in))

--- a/config/crd/gateway/gateway-crds.yaml
+++ b/config/crd/gateway/gateway-crds.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/config/crd/gateway/gateway-crds.yaml
+++ b/config/crd/gateway/gateway-crds.yaml
@@ -700,9 +700,6 @@ spec:
                   type: string
                 description: Tags the AWS Tags on all related resources to the gateway.
                 type: object
-              vpcId:
-                description: vpcId is the ID of the VPC for the load balancer.
-                type: string
               wafV2:
                 description: WAFv2 define the AWS WAFv2 settings for a Gateway [Application
                   Load Balancer]

--- a/config/crd/gateway/gateway.k8s.aws_loadbalancerconfigurations.yaml
+++ b/config/crd/gateway/gateway.k8s.aws_loadbalancerconfigurations.yaml
@@ -301,9 +301,6 @@ spec:
                   type: string
                 description: Tags the AWS Tags on all related resources to the gateway.
                 type: object
-              vpcId:
-                description: vpcId is the ID of the VPC for the load balancer.
-                type: string
               wafV2:
                 description: WAFv2 define the AWS WAFv2 settings for a Gateway [Application
                   Load Balancer]

--- a/helm/aws-load-balancer-controller/crds/gateway-crds.yaml
+++ b/helm/aws-load-balancer-controller/crds/gateway-crds.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/helm/aws-load-balancer-controller/crds/gateway-crds.yaml
+++ b/helm/aws-load-balancer-controller/crds/gateway-crds.yaml
@@ -700,9 +700,6 @@ spec:
                   type: string
                 description: Tags the AWS Tags on all related resources to the gateway.
                 type: object
-              vpcId:
-                description: vpcId is the ID of the VPC for the load balancer.
-                type: string
               wafV2:
                 description: WAFv2 define the AWS WAFv2 settings for a Gateway [Application
                   Load Balancer]

--- a/pkg/gateway/lb_config_merger.go
+++ b/pkg/gateway/lb_config_merger.go
@@ -154,12 +154,6 @@ func (merger *loadBalancerConfigMergerImpl) performTakeOneMerges(merged *elbv2gw
 		merged.SourceRanges = lowPriority.Spec.SourceRanges
 	}
 
-	if highPriority.Spec.VpcId != nil {
-		merged.VpcId = highPriority.Spec.VpcId
-	} else {
-		merged.VpcId = lowPriority.Spec.VpcId
-	}
-
 	if highPriority.Spec.EnableICMP != nil {
 		merged.EnableICMP = highPriority.Spec.EnableICMP
 	} else {

--- a/pkg/gateway/lb_config_merger_test.go
+++ b/pkg/gateway/lb_config_merger_test.go
@@ -50,7 +50,6 @@ func Test_Merge(t *testing.T) {
 					SecurityGroups:        &[]string{"sg1", "sg2", "s3"},
 					SecurityGroupPrefixes: &[]string{"pl1"},
 					SourceRanges:          &[]string{"127.0.0.0/20"},
-					VpcId:                 awssdk.String("vpc-1234"),
 					ListenerConfigurations: &[]elbv2gw.ListenerConfiguration{
 						{
 							ProtocolPort:       "pp1",
@@ -91,7 +90,6 @@ func Test_Merge(t *testing.T) {
 					SecurityGroups:        &[]string{"sg1", "sg2", "s3"},
 					SecurityGroupPrefixes: &[]string{"pl1"},
 					SourceRanges:          &[]string{"127.0.0.0/20"},
-					VpcId:                 awssdk.String("vpc-1234"),
 					ListenerConfigurations: &[]elbv2gw.ListenerConfiguration{
 						{
 							ProtocolPort:       "pp1",
@@ -134,7 +132,6 @@ func Test_Merge(t *testing.T) {
 					SecurityGroups:        &[]string{"sg1", "sg2", "s3"},
 					SecurityGroupPrefixes: &[]string{"pl1"},
 					SourceRanges:          &[]string{"127.0.0.0/20"},
-					VpcId:                 awssdk.String("vpc-1234"),
 					ListenerConfigurations: &[]elbv2gw.ListenerConfiguration{
 						{
 							ProtocolPort:       "pp1",
@@ -175,7 +172,6 @@ func Test_Merge(t *testing.T) {
 					SecurityGroups:        &[]string{"sg1", "sg2", "s3"},
 					SecurityGroupPrefixes: &[]string{"pl1"},
 					SourceRanges:          &[]string{"127.0.0.0/20"},
-					VpcId:                 awssdk.String("vpc-1234"),
 					ListenerConfigurations: &[]elbv2gw.ListenerConfiguration{
 						{
 							ProtocolPort:       "pp1",
@@ -222,7 +218,6 @@ func Test_Merge(t *testing.T) {
 					SecurityGroups:        &[]string{"sg1"},
 					SecurityGroupPrefixes: &[]string{"pl1"},
 					SourceRanges:          &[]string{"127.0.0.0/20"},
-					VpcId:                 awssdk.String("vpc-gw-class"),
 					ListenerConfigurations: &[]elbv2gw.ListenerConfiguration{
 						{
 							ProtocolPort:       "pp1-gwclass",
@@ -270,7 +265,6 @@ func Test_Merge(t *testing.T) {
 					SecurityGroups:        &[]string{"sg1-gw"},
 					SecurityGroupPrefixes: &[]string{"pl1-gw"},
 					SourceRanges:          &[]string{"127.0.0.10/20"},
-					VpcId:                 awssdk.String("vpc-gw"),
 					ListenerConfigurations: &[]elbv2gw.ListenerConfiguration{
 						{
 							ProtocolPort:       "pp1-gw",
@@ -321,7 +315,6 @@ func Test_Merge(t *testing.T) {
 					SecurityGroups:        &[]string{"sg1"},
 					SecurityGroupPrefixes: &[]string{"pl1"},
 					SourceRanges:          &[]string{"127.0.0.0/20"},
-					VpcId:                 awssdk.String("vpc-gw-class"),
 					ListenerConfigurations: &[]elbv2gw.ListenerConfiguration{
 						{
 							ProtocolPort:       "pp1-common",
@@ -385,7 +378,6 @@ func Test_Merge(t *testing.T) {
 					SecurityGroups:        &[]string{"sg1"},
 					SecurityGroupPrefixes: &[]string{"pl1"},
 					SourceRanges:          &[]string{"127.0.0.0/20"},
-					VpcId:                 awssdk.String("vpc-gw-class"),
 					ListenerConfigurations: &[]elbv2gw.ListenerConfiguration{
 						{
 							ProtocolPort:       "pp1-gwclass",
@@ -433,7 +425,6 @@ func Test_Merge(t *testing.T) {
 					SecurityGroups:        &[]string{"sg1-gw"},
 					SecurityGroupPrefixes: &[]string{"pl1-gw"},
 					SourceRanges:          &[]string{"127.0.0.10/20"},
-					VpcId:                 awssdk.String("vpc-gw"),
 					ListenerConfigurations: &[]elbv2gw.ListenerConfiguration{
 						{
 							ProtocolPort:       "pp1-gw",
@@ -481,7 +472,6 @@ func Test_Merge(t *testing.T) {
 					SecurityGroups:        &[]string{"sg1-gw"},
 					SecurityGroupPrefixes: &[]string{"pl1-gw"},
 					SourceRanges:          &[]string{"127.0.0.10/20"},
-					VpcId:                 awssdk.String("vpc-gw"),
 					ListenerConfigurations: &[]elbv2gw.ListenerConfiguration{
 						{
 							ProtocolPort:       "pp1-common",


### PR DESCRIPTION
### Issue

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4310

### Description

Adds the yaml delimiter.

Validated it works:
```
nixozach@80a997300bd5 aws-load-balancer-controller % make crds                                            
/Users/nixozach/go/bin/controller-gen "crd:crdVersions=v1" rbac:roleName=controller-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
yq eval '.metadata.name = "webhook"' -i config/webhook/manifests.yaml
mv config/crd/bases/gateway.k8s.aws_* config/crd/gateway/
/opt/homebrew/bin/kustomize build config/crd > helm/aws-load-balancer-controller/crds/crds.yaml
/opt/homebrew/bin/kustomize build config/crd/gateway > config/crd/gateway/gateway-crds.yaml
echo '---' > config/crd/gateway/gateway-crds.yaml
/opt/homebrew/bin/kustomize build config/crd/gateway >> config/crd/gateway/gateway-crds.yaml
cp config/crd/gateway/gateway-crds.yaml helm/aws-load-balancer-controller/crds/gateway-crds.yaml
nixozach@80a997300bd5 aws-load-balancer-controller % kubectl apply -f config/crd/gateway/gateway-crds.yaml
customresourcedefinition.apiextensions.k8s.io/listenerruleconfigurations.gateway.k8s.aws unchanged
customresourcedefinition.apiextensions.k8s.io/loadbalancerconfigurations.gateway.k8s.aws unchanged
customresourcedefinition.apiextensions.k8s.io/targetgroupconfigurations.gateway.k8s.aws unchanged
```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
