### PR TITLE
feat(helm): support templating in service account annotations

### DIFF
--- a/helm/aws-load-balancer-controller/templates/serviceaccount.yaml
+++ b/helm/aws-load-balancer-controller/templates/serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "aws-load-balancer-controller.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- with .Values.serviceAccount.imagePullSecrets }}


### PR DESCRIPTION
Enables Helm template functions in serviceAccount.annotations.
Allowing dynamic values like AWS account IDs for [EKS IRSA role ARNs](https://docs.aws.amazon.com/eks/latest/userguide/associate-service-account-role.html).

### Issue

Have to provide my own service account when deploying the aws-laod-balancer-controller chart because I have to template the AWS account IDs for EKS IRSA role ARNs.

### Description

Helm template functions in serviceAccount.annotations

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
