### PR TITLE
support comma in string pars value

### DIFF
--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -965,6 +965,15 @@ Custom attributes to LoadBalancers and TargetGroups can be controlled with follo
             ```
             alb.ingress.kubernetes.io/listener-attributes.HTTP-80: routing.http.response.server.enabled=true
             ```
+        - Add Access-Control-Allow-Headers header value (with comma)
+            ```
+            alb.ingress.kubernetes.io/listener-attributes.HTTPS-443: "routing.http.response.access_control_allow_headers.header_value=exampleValue\\,anotherExampleValue"
+            ```
+            or
+            ```
+            alb.ingress.kubernetes.io/listener-attributes.HTTPS-443: routing.http.response.access_control_allow_headers.header_value=exampleValue\,anotherExampleValue
+            ```      
+            both result Access-Control-Allow-Headers header value: exampleValue,anotherExampleValue
 
 
 ## Resource Tags

--- a/pkg/annotations/parser_test.go
+++ b/pkg/annotations/parser_test.go
@@ -2,8 +2,9 @@ package annotations
 
 import (
 	"errors"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_annotationParser_ParseStringAnnotation(t *testing.T) {
@@ -275,6 +276,22 @@ func Test_serviceAnnotationParser_ParseStringMapAnnotation(t *testing.T) {
 				"key1":             "value1",
 				"key2":             "value2",
 				"key3/with-slash":  "value3",
+				"key4/empty-value": "",
+			},
+		},
+		{
+			name:   "multiple values",
+			prefix: "p.co",
+			suffix: "sfx",
+			annotations: map[string]string{
+				"first-value": "1",
+				"p.co/sfx":    "key1=value1\\,valueOne, key2= value2, key3/with-slash=value3\\,valueThree, key4/empty-value=",
+			},
+			wantExist: true,
+			wantValue: map[string]string{
+				"key1":             "value1,valueOne",
+				"key2":             "value2",
+				"key3/with-slash":  "value3,valueThree",
 				"key4/empty-value": "",
 			},
 		},


### PR DESCRIPTION
### Issue

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4363

### Description
- escape comma in string map parsing logic (we are having same escape pattern for gateway multi header value, so decide to be consistent here)
- update doc for instructions

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
```
 alb.ingress.kubernetes.io/listener-attributes.HTTPS-443: routing.http.response.access_control_allow_headers.header_value=testHeader\,anotherNewValue
```
<img width="552" height="362" alt="Screenshot 2025-10-03 at 2 09 53 PM" src="https://github.com/user-attachments/assets/daa856bd-5d4c-4f5b-b8cc-668537515b62" />

---
Doc update
<img width="776" height="453" alt="Screenshot 2025-10-03 at 1 48 40 PM" src="https://github.com/user-attachments/assets/dd65c610-4502-46f8-be80-efe9401550d3" />


- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
