### PR TITLE
fix sorting when comparing listener rule differences

### DIFF
--- a/pkg/deploy/elbv2/listener_manager.go
+++ b/pkg/deploy/elbv2/listener_manager.go
@@ -296,7 +296,7 @@ func (m *defaultListenerManager) isSDKListenerSettingsDrifted(lsSpec elbv2model.
 	if string(lsSpec.Protocol) != string(sdkLS.Listener.Protocol) {
 		return true
 	}
-	if !cmp.Equal(desiredDefaultActions, sdkLS.Listener.DefaultActions, elbv2equality.CompareOptionForActions()) {
+	if !cmp.Equal(desiredDefaultActions, sdkLS.Listener.DefaultActions, elbv2equality.CompareOptionForActions(desiredDefaultActions, sdkLS.Listener.DefaultActions)) {
 		return true
 	}
 	if !cmp.Equal(desiredDefaultCerts, sdkLS.Listener.Certificates, elbv2equality.CompareOptionForCertificates()) {

--- a/pkg/deploy/elbv2/listener_rule_synthesizer.go
+++ b/pkg/deploy/elbv2/listener_rule_synthesizer.go
@@ -167,8 +167,10 @@ func (s *listenerRuleSynthesizer) matchResAndSDKListenerRules(resLRs []*elbv2mod
 		found := false
 		for i := 0; i < len(unmatchedSDKLRs); i++ {
 			sdkLR := unmatchedSDKLRs[i]
-			if cmp.Equal(resLRDesiredActionsAndConditionsPair.desiredActions, sdkLR.ListenerRule.Actions, elbv2equality.CompareOptionForActions()) &&
-				cmp.Equal(resLRDesiredActionsAndConditionsPair.desiredConditions, sdkLR.ListenerRule.Conditions, elbv2equality.CompareOptionForRuleConditions()) {
+
+			actionsEqual := cmp.Equal(resLRDesiredActionsAndConditionsPair.desiredActions, sdkLR.ListenerRule.Actions, elbv2equality.CompareOptionForActions(resLRDesiredActionsAndConditionsPair.desiredActions, sdkLR.ListenerRule.Actions))
+			conditionsEqual := cmp.Equal(resLRDesiredActionsAndConditionsPair.desiredConditions, sdkLR.ListenerRule.Conditions, elbv2equality.CompareOptionForRuleConditions(resLRDesiredActionsAndConditionsPair.desiredConditions, sdkLR.ListenerRule.Conditions))
+			if actionsEqual && conditionsEqual {
 				sdkLRPriority, _ := strconv.ParseInt(awssdk.ToString(sdkLR.ListenerRule.Priority), 10, 64)
 				if resLR.Spec.Priority != int32(sdkLRPriority) {
 					matchedResAndSDKLRsBySettings = append(matchedResAndSDKLRsBySettings, resAndSDKListenerRulePair{

--- a/pkg/equality/elbv2/compare_option_for_actions.go
+++ b/pkg/equality/elbv2/compare_option_for_actions.go
@@ -87,7 +87,10 @@ func CompareOptionForAction() cmp.Option {
 }
 
 // CompareOptionForActions returns the compare option for action slice.
-func CompareOptionForActions() cmp.Option {
+// IMPORTANT:
+// When changing the types compared (e.g. the input to the function)
+// ensure to update cmpopts.SortSlices to reflect the new type, otherwise sorting silently doesn't work.
+func CompareOptionForActions(_, _ []elbv2types.Action) cmp.Option {
 	return cmp.Options{
 		cmpopts.EquateEmpty(),
 		cmpopts.IgnoreUnexported(elbv2types.AuthenticateCognitoActionConfig{}),

--- a/pkg/equality/elbv2/compare_option_for_actions_test.go
+++ b/pkg/equality/elbv2/compare_option_for_actions_test.go
@@ -1667,7 +1667,7 @@ func TestCompareOptionForActions(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := cmp.Equal(tt.args.lhs, tt.args.rhs, CompareOptionForActions())
+			got := cmp.Equal(tt.args.lhs, tt.args.rhs, CompareOptionForActions(nil, nil))
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/equality/elbv2/compare_option_for_rule_conditions.go
+++ b/pkg/equality/elbv2/compare_option_for_rule_conditions.go
@@ -21,11 +21,16 @@ func CompareOptionForRuleCondition() cmp.Option {
 	}
 }
 
+// https://github.com/google/go-cmp/issues/273
+
 // CompareOptionForRuleConditions returns the compare option for rule conditions slice.
-func CompareOptionForRuleConditions() cmp.Option {
+// IMPORTANT:
+// When changing the types compared (e.g. the input to the function)
+// ensure to update cmpopts.SortSlices to reflect the new type, otherwise sorting silently doesn't work.
+func CompareOptionForRuleConditions(_, _ []elbv2types.RuleCondition) cmp.Option {
 	return cmp.Options{
 		cmpopts.EquateEmpty(),
-		cmpopts.SortSlices(func(lhs *elbv2types.RuleCondition, rhs *elbv2types.RuleCondition) bool {
+		cmpopts.SortSlices(func(lhs elbv2types.RuleCondition, rhs elbv2types.RuleCondition) bool {
 			return awssdk.ToString(lhs.Field) < awssdk.ToString(rhs.Field)
 		}),
 		CompareOptionForRuleCondition(),

--- a/pkg/equality/elbv2/compare_option_for_rule_conditions_test.go
+++ b/pkg/equality/elbv2/compare_option_for_rule_conditions_test.go
@@ -1,0 +1,90 @@
+package elbv2
+
+import (
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_CompareOptionForRuleConditions(t *testing.T) {
+	testCase := []struct {
+		name                 string
+		desiredRuleCondition []types.RuleCondition
+		actualRuleCondition  []types.RuleCondition
+		expected             bool
+	}{
+		{
+			name: "equal",
+			desiredRuleCondition: []types.RuleCondition{
+				{
+					Field: awssdk.String("host-header"),
+					HostHeaderConfig: &types.HostHeaderConditionConfig{
+						Values: []string{"h1"},
+					},
+				},
+				{
+					Field: awssdk.String("path-pattern"),
+					PathPatternConfig: &types.PathPatternConditionConfig{
+						Values: []string{"path-pattern"},
+					},
+				},
+			},
+			actualRuleCondition: []types.RuleCondition{
+				{
+					Field: awssdk.String("host-header"),
+					HostHeaderConfig: &types.HostHeaderConditionConfig{
+						Values: []string{"h1"},
+					},
+				},
+				{
+					Field: awssdk.String("path-pattern"),
+					PathPatternConfig: &types.PathPatternConditionConfig{
+						Values: []string{"path-pattern"},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "equal - different order",
+			desiredRuleCondition: []types.RuleCondition{
+				{
+					Field: awssdk.String("host-header"),
+					HostHeaderConfig: &types.HostHeaderConditionConfig{
+						Values: []string{"h1"},
+					},
+				},
+				{
+					Field: awssdk.String("path-pattern"),
+					PathPatternConfig: &types.PathPatternConditionConfig{
+						Values: []string{"path-pattern"},
+					},
+				},
+			},
+			actualRuleCondition: []types.RuleCondition{
+				{
+					Field: awssdk.String("path-pattern"),
+					PathPatternConfig: &types.PathPatternConditionConfig{
+						Values: []string{"path-pattern"},
+					},
+				},
+				{
+					Field: awssdk.String("host-header"),
+					HostHeaderConfig: &types.HostHeaderConditionConfig{
+						Values: []string{"h1"},
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCase {
+		t.Run(tc.name, func(t *testing.T) {
+			conditionsEqual := cmp.Equal(tc.desiredRuleCondition, tc.actualRuleCondition, CompareOptionForRuleConditions(nil, nil))
+			assert.Equal(t, tc.expected, conditionsEqual)
+		})
+	}
+}


### PR DESCRIPTION
### Description

Anytime the Ingress reconcilation process runs, it can potentially modify _all_ ALB rules. This is because in v2.12.0 we broke the listener rule conditions sorting, which prevented semantically similar configurations to be detected as drifted. As listener rule conditions can be returned in any order, the reconcilation process could potentially say a configuration like:

```
				{
					Field: awssdk.String("host-header"),
					HostHeaderConfig: &types.HostHeaderConditionConfig{
						Values: []string{"h1"},
					},
				},
				{
					Field: awssdk.String("path-pattern"),
					PathPatternConfig: &types.PathPatternConditionConfig{
						Values: []string{"path-pattern"},
					},
				},
```

is not equal to

```
				{
					Field: awssdk.String("path-pattern"),
					PathPatternConfig: &types.PathPatternConditionConfig{
						Values: []string{"path-pattern"},
					},
				},
				{
					Field: awssdk.String("host-header"),
					HostHeaderConfig: &types.HostHeaderConditionConfig{
						Values: []string{"h1"},
					},
				},
```

The root cause that broke the sorting is that we started using the actual condition / action objects in the array, rather than a pointer. e.g. originally the code was comparing arrays of `[]*elbv2types.RuleCondition`, but it v2.12 this was refactored to compare arrays of `[]elbv2types.RuleCondition` while the compartator was still expecting a  `*elbv2types.RuleCondition`. I fixed the comparator to use the right type. Also, I added some compile time checks and warnings to ensure this doesn't happen again.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
