### PR TITLE
[feat gw-api]update gateway status based on observation generation

### DIFF
--- a/controllers/gateway/gateway_controller.go
+++ b/controllers/gateway/gateway_controller.go
@@ -440,6 +440,8 @@ func (r *gatewayReconciler) updateGatewayStatusFailure(ctx context.Context, gw *
 			gw.Status.Listeners = ListenerStatuses
 			needPatch = true
 		}
+		gwProgrammedNeedPatch := r.gatewayConditionUpdater(gw, string(gwv1.GatewayConditionProgrammed), metav1.ConditionFalse, string(gwv1.GatewayConditionProgrammed), errMessage)
+		needPatch = needPatch || gwProgrammedNeedPatch
 	}
 
 	if needPatch {

--- a/controllers/gateway/utils.go
+++ b/controllers/gateway/utils.go
@@ -79,8 +79,9 @@ func updateGatewayClassAcceptedCondition(ctx context.Context, k8sClient client.C
 		storedStatus := gwClass.Status.Conditions[indxToUpdate].Status
 		storedMessage := gwClass.Status.Conditions[indxToUpdate].Message
 		storedReason := gwClass.Status.Conditions[indxToUpdate].Reason
+		storedObservedGeneration := gwClass.Status.Conditions[indxToUpdate].ObservedGeneration
 
-		if storedStatus == newStatus && storedMessage == message && storedReason == reason {
+		if storedStatus == newStatus && storedMessage == message && storedReason == reason && storedObservedGeneration == gwClass.Generation {
 			return nil
 		}
 
@@ -99,7 +100,6 @@ func updateGatewayClassAcceptedCondition(ctx context.Context, k8sClient client.C
 
 // prepareGatewayConditionUpdate inserts the necessary data into the condition field of the gateway. The caller should patch the corresponding gateway. Returns false when no change was performed.
 func prepareGatewayConditionUpdate(gw *gwv1.Gateway, targetConditionType string, newStatus metav1.ConditionStatus, reason string, message string) bool {
-
 	indxToUpdate := -1
 	var derivedCondition metav1.Condition
 	for i, condition := range gw.Status.Conditions {
@@ -114,7 +114,7 @@ func prepareGatewayConditionUpdate(gw *gwv1.Gateway, targetConditionType string,
 	truncatedMessage := truncateMessage(message)
 
 	if indxToUpdate != -1 {
-		if derivedCondition.Status != newStatus || derivedCondition.Message != truncatedMessage || derivedCondition.Reason != reason {
+		if derivedCondition.Status != newStatus || derivedCondition.Message != truncatedMessage || derivedCondition.Reason != reason || derivedCondition.ObservedGeneration != gw.Generation {
 			gw.Status.Conditions[indxToUpdate].LastTransitionTime = metav1.NewTime(time.Now())
 			gw.Status.Conditions[indxToUpdate].ObservedGeneration = gw.Generation
 			gw.Status.Conditions[indxToUpdate].Status = newStatus

--- a/controllers/gateway/utils_test.go
+++ b/controllers/gateway/utils_test.go
@@ -3,6 +3,10 @@ package gateway
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -11,9 +15,6 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/testutils"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
-	"strconv"
-	"testing"
-	"time"
 )
 
 func Test_updateGatewayClassLastProcessedConfig(t *testing.T) {
@@ -167,14 +168,14 @@ func Test_updateGatewayClassAcceptedCondition(t *testing.T) {
 						{
 							Type:               "other condition",
 							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 1000,
+							ObservedGeneration: 100,
 							Reason:             "other reason",
 							Message:            "other message",
 						},
 						{
 							Type:               string(gwv1.GatewayClassReasonAccepted),
 							Status:             metav1.ConditionFalse,
-							ObservedGeneration: 1000,
+							ObservedGeneration: 100,
 							Reason:             "",
 							Message:            "",
 						},
@@ -185,7 +186,7 @@ func Test_updateGatewayClassAcceptedCondition(t *testing.T) {
 				{
 					Type:               "other condition",
 					Status:             metav1.ConditionTrue,
-					ObservedGeneration: 1000,
+					ObservedGeneration: 100,
 					Reason:             "other reason",
 					Message:            "other message",
 				},
@@ -213,14 +214,14 @@ func Test_updateGatewayClassAcceptedCondition(t *testing.T) {
 						{
 							Type:               "other condition",
 							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 1000,
+							ObservedGeneration: 100,
 							Reason:             "other reason",
 							Message:            "other message",
 						},
 						{
 							Type:               string(gwv1.GatewayClassReasonAccepted),
 							Status:             metav1.ConditionFalse,
-							ObservedGeneration: 1000,
+							ObservedGeneration: 100,
 							Reason:             "",
 							Message:            "",
 						},
@@ -231,7 +232,7 @@ func Test_updateGatewayClassAcceptedCondition(t *testing.T) {
 				{
 					Type:               "other condition",
 					Status:             metav1.ConditionTrue,
-					ObservedGeneration: 1000,
+					ObservedGeneration: 100,
 					Reason:             "other reason",
 					Message:            "other message",
 				},
@@ -259,14 +260,14 @@ func Test_updateGatewayClassAcceptedCondition(t *testing.T) {
 						{
 							Type:               "other condition",
 							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 1000,
+							ObservedGeneration: 100,
 							Reason:             "other reason",
 							Message:            "other message",
 						},
 						{
 							Type:               string(gwv1.GatewayClassReasonAccepted),
 							Status:             metav1.ConditionFalse,
-							ObservedGeneration: 1000,
+							ObservedGeneration: 100,
 							Reason:             "reason",
 							Message:            "msg",
 						},
@@ -277,14 +278,106 @@ func Test_updateGatewayClassAcceptedCondition(t *testing.T) {
 				{
 					Type:               "other condition",
 					Status:             metav1.ConditionTrue,
-					ObservedGeneration: 1000,
+					ObservedGeneration: 100,
 					Reason:             "other reason",
 					Message:            "other message",
 				},
 				{
 					Type:               string(gwv1.GatewayClassReasonAccepted),
 					Status:             metav1.ConditionFalse,
-					ObservedGeneration: 1000,
+					ObservedGeneration: 100,
+					Reason:             "reason",
+					Message:            "msg",
+				},
+			},
+		},
+		{
+			name:    "update observation generation in Accepted condition result in patch",
+			status:  metav1.ConditionFalse,
+			reason:  "reason",
+			message: "msg",
+			gwClass: gwv1.GatewayClass{
+				ObjectMeta: v1.ObjectMeta{
+					Name:       "gwclass-flip",
+					Generation: 100,
+				},
+				Status: gwv1.GatewayClassStatus{
+					Conditions: []v1.Condition{
+						{
+							Type:               "other condition",
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: 100,
+							Reason:             "other reason",
+							Message:            "other message",
+						},
+						{
+							Type:               string(gwv1.GatewayClassReasonAccepted),
+							Status:             metav1.ConditionFalse,
+							ObservedGeneration: 99,
+							Reason:             "reason",
+							Message:            "msg",
+						},
+					},
+				},
+			},
+			expectedConditions: []v1.Condition{
+				{
+					Type:               "other condition",
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: 100,
+					Reason:             "other reason",
+					Message:            "other message",
+				},
+				{
+					Type:               string(gwv1.GatewayClassReasonAccepted),
+					Status:             metav1.ConditionFalse,
+					ObservedGeneration: 100,
+					Reason:             "reason",
+					Message:            "msg",
+				},
+			},
+		},
+		{
+			name:    "update observation generation in other conditions result in no patch",
+			status:  metav1.ConditionFalse,
+			reason:  "reason",
+			message: "msg",
+			gwClass: gwv1.GatewayClass{
+				ObjectMeta: v1.ObjectMeta{
+					Name:       "gwclass-flip",
+					Generation: 100,
+				},
+				Status: gwv1.GatewayClassStatus{
+					Conditions: []v1.Condition{
+						{
+							Type:               "other condition",
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: 99,
+							Reason:             "other reason",
+							Message:            "other message",
+						},
+						{
+							Type:               string(gwv1.GatewayClassReasonAccepted),
+							Status:             metav1.ConditionFalse,
+							ObservedGeneration: 100,
+							Reason:             "reason",
+							Message:            "msg",
+						},
+					},
+				},
+			},
+			expectedConditions: []v1.Condition{
+				{
+					Type:               "other condition",
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: 99,
+					Reason:             "other reason",
+					Message:            "other message",
+				},
+				{
+					Type:               string(gwv1.GatewayClassReasonAccepted),
+					Status:             metav1.ConditionFalse,
+					ObservedGeneration: 100,
 					Reason:             "reason",
 					Message:            "msg",
 				},
@@ -412,20 +505,21 @@ func Test_prepareGatewayConditionUpdate(t *testing.T) {
 						{
 							Type:               "other condition",
 							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 1000,
+							ObservedGeneration: 50,
 							Reason:             "other reason",
 							Message:            "other message",
 						},
 						{
-							Type:    string(gwv1.GatewayConditionAccepted),
-							Status:  metav1.ConditionFalse,
-							Reason:  "other reason",
-							Message: "other message",
+							Type:               string(gwv1.GatewayConditionAccepted),
+							Status:             metav1.ConditionFalse,
+							ObservedGeneration: 50,
+							Reason:             "other reason",
+							Message:            "other message",
 						},
 						{
 							Type:               "other condition2",
 							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 1001,
+							ObservedGeneration: 50,
 							Reason:             "other reason2",
 							Message:            "other message2",
 						},
@@ -441,7 +535,7 @@ func Test_prepareGatewayConditionUpdate(t *testing.T) {
 						{
 							Type:               "other condition",
 							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 1000,
+							ObservedGeneration: 50,
 							Reason:             "other reason",
 							Message:            "other message",
 						},
@@ -455,7 +549,7 @@ func Test_prepareGatewayConditionUpdate(t *testing.T) {
 						{
 							Type:               "other condition2",
 							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 1001,
+							ObservedGeneration: 50,
 							Reason:             "other reason2",
 							Message:            "other message2",
 						},
@@ -479,20 +573,21 @@ func Test_prepareGatewayConditionUpdate(t *testing.T) {
 						{
 							Type:               "other condition",
 							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 1000,
+							ObservedGeneration: 50,
 							Reason:             "other reason",
 							Message:            "other message",
 						},
 						{
-							Type:    string(gwv1.GatewayConditionAccepted),
-							Status:  metav1.ConditionFalse,
-							Reason:  "other reason",
-							Message: "other message",
+							Type:               string(gwv1.GatewayConditionAccepted),
+							Status:             metav1.ConditionFalse,
+							ObservedGeneration: 50,
+							Reason:             "other reason",
+							Message:            "other message",
 						},
 						{
 							Type:               "other condition2",
 							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 1001,
+							ObservedGeneration: 50,
 							Reason:             "other reason2",
 							Message:            "other message2",
 						},
@@ -508,7 +603,7 @@ func Test_prepareGatewayConditionUpdate(t *testing.T) {
 						{
 							Type:               "other condition",
 							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 1000,
+							ObservedGeneration: 50,
 							Reason:             "other reason",
 							Message:            "other message",
 						},
@@ -522,7 +617,7 @@ func Test_prepareGatewayConditionUpdate(t *testing.T) {
 						{
 							Type:               "other condition2",
 							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 1001,
+							ObservedGeneration: 50,
 							Reason:             "other reason2",
 							Message:            "other message2",
 						},
@@ -546,7 +641,7 @@ func Test_prepareGatewayConditionUpdate(t *testing.T) {
 						{
 							Type:               "other condition",
 							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 1000,
+							ObservedGeneration: 50,
 							Reason:             "other reason",
 							Message:            "other message",
 						},
@@ -555,12 +650,12 @@ func Test_prepareGatewayConditionUpdate(t *testing.T) {
 							Status:             metav1.ConditionTrue,
 							Reason:             "new reason",
 							Message:            "new message",
-							ObservedGeneration: 1000,
+							ObservedGeneration: 50,
 						},
 						{
 							Type:               "other condition2",
 							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 1001,
+							ObservedGeneration: 50,
 							Reason:             "other reason2",
 							Message:            "other message2",
 						},
@@ -576,7 +671,7 @@ func Test_prepareGatewayConditionUpdate(t *testing.T) {
 						{
 							Type:               "other condition",
 							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 1000,
+							ObservedGeneration: 50,
 							Reason:             "other reason",
 							Message:            "other message",
 						},
@@ -585,12 +680,12 @@ func Test_prepareGatewayConditionUpdate(t *testing.T) {
 							Status:             metav1.ConditionTrue,
 							Reason:             "new reason",
 							Message:            "new message",
-							ObservedGeneration: 1000,
+							ObservedGeneration: 50,
 						},
 						{
 							Type:               "other condition2",
 							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 1001,
+							ObservedGeneration: 50,
 							Reason:             "other reason2",
 							Message:            "other message2",
 						},
@@ -613,7 +708,7 @@ func Test_prepareGatewayConditionUpdate(t *testing.T) {
 						{
 							Type:               "other condition",
 							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 1000,
+							ObservedGeneration: 50,
 							Reason:             "other reason",
 							Message:            "other message",
 						},
@@ -622,12 +717,12 @@ func Test_prepareGatewayConditionUpdate(t *testing.T) {
 							Status:             metav1.ConditionTrue,
 							Reason:             "other reason",
 							Message:            truncatedString,
-							ObservedGeneration: 1000,
+							ObservedGeneration: 50,
 						},
 						{
 							Type:               "other condition2",
 							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 1001,
+							ObservedGeneration: 50,
 							Reason:             "other reason2",
 							Message:            "other message2",
 						},
@@ -643,7 +738,7 @@ func Test_prepareGatewayConditionUpdate(t *testing.T) {
 						{
 							Type:               "other condition",
 							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 1000,
+							ObservedGeneration: 50,
 							Reason:             "other reason",
 							Message:            "other message",
 						},
@@ -652,12 +747,12 @@ func Test_prepareGatewayConditionUpdate(t *testing.T) {
 							Status:             metav1.ConditionTrue,
 							Reason:             "other reason",
 							Message:            truncatedString,
-							ObservedGeneration: 1000,
+							ObservedGeneration: 50,
 						},
 						{
 							Type:               "other condition2",
 							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 1001,
+							ObservedGeneration: 50,
 							Reason:             "other reason2",
 							Message:            "other message2",
 						},


### PR DESCRIPTION
### Description
Those changes are found during conformance testing
- we were not updating observation generation for gateway status 
- we were not updating Programmed Status when needed

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
PASSED 
  - GatewayObservedGenerationBump
  - GatewayInvalidRouteKind
  - GatewayClassObservedGenerationBump
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
