### PR TITLE
Implement support for URL and Host Header Rewrite for Application Load Balancer

### DIFF
--- a/docs/guide/tasks/url_rewrite.md
+++ b/docs/guide/tasks/url_rewrite.md
@@ -1,0 +1,126 @@
+# URL rewrite
+
+URL rewrite enables request URLs to be transformed before the request reaches your backend services.
+
+Consider the following scenario:
+
+- An ingress exposes two services:
+  - An API service exposed at path prefix `/api/`.
+  - A users service exposed at path prefix `/users/`.
+- These service **do not expect** the `/api/` or `/users/` prefixes in the request path.
+
+For this scenario, URL rewrite would be used to remove the leading `/api/` and `/users/` from the request paths.
+
+Example ingress manifest:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: default
+  name: ingress
+  annotations:
+    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-west-2:xxxx:certificate/xxxxxx
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
+    alb.ingress.kubernetes.io/ssl-redirect: "443"
+
+    # Add transform to users-service to remove "/users/" prefix from paths
+    alb.ingress.kubernetes.io/transforms.users-service: >
+      [
+        {
+          "type": "url-rewrite",
+          "urlRewriteConfig": {
+            "rewrites": [{
+              "regex": "^/users/(.+)$",
+              "replace": "/$1"
+            }]
+          }
+        }
+      ]
+    # Add transform to api-service to remove "/api/" prefix from paths
+    alb.ingress.kubernetes.io/transforms.api-service: >
+      [
+        {
+          "type": "url-rewrite",
+          "urlRewriteConfig": {
+            "rewrites": [{
+              "regex": "^/api/(.+)$",
+              "replace": "/$1"
+            }]
+          }
+        }
+      ]
+spec:
+  ingressClassName: alb
+  rules:
+    - http:
+        paths:
+          - path: /users/
+            pathType: Prefix
+            backend:
+              service:
+                name: users-service
+                port:
+                  number: 80
+          - path: /api/
+            pathType: Prefix
+            backend:
+              service:
+                name: api-service
+                port:
+                  number: 80
+          - path: /*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: default-service
+                port:
+                  number: 80
+```
+
+## Host header rewrite
+
+To rewrite from `api.example.com` to `example.com`:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: default
+  name: ingress
+  annotations:
+    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-west-2:xxxx:certificate/xxxxxx
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
+    alb.ingress.kubernetes.io/ssl-redirect: "443"
+
+    # add transform to api-service to replace "api.example.com" hostname with "example.com"
+    alb.ingress.kubernetes.io/transforms.api-service: >
+      [
+        {
+          "type": "host-header-rewrite",
+          "hostHeaderRewriteConfig": {
+            "rewrites": [{
+              "regex": "^api\\.example\\.com$",
+              "replace": "example.com"
+            }]
+          }
+        }
+      ]
+spec:
+  ingressClassName: alb
+  rules:
+    - host: api.example.com
+      http:
+        paths:
+          - path: /*
+            pathType: Prefix
+            backend:
+              service:
+                name: api-service
+                port:
+                  number: 80
+```
+
+## Additional resources
+
+- [`alb.ingress.kubernetes.io/transforms.${transforms-name}` annotation documentation](../../ingress/annotations#transforms)

--- a/go.mod
+++ b/go.mod
@@ -3,21 +3,21 @@ module sigs.k8s.io/aws-load-balancer-controller
 go 1.24.6
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.36.3
+	github.com/aws/aws-sdk-go-v2 v1.39.2
 	github.com/aws/aws-sdk-go-v2/config v1.27.27
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.27
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.11
 	github.com/aws/aws-sdk-go-v2/service/acm v1.28.4
 	github.com/aws/aws-sdk-go-v2/service/appmesh v1.27.7
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.173.0
-	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.45.0
+	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.51.0
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.23.3
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.31.7
 	github.com/aws/aws-sdk-go-v2/service/shield v1.27.3
 	github.com/aws/aws-sdk-go-v2/service/sts v1.30.3
 	github.com/aws/aws-sdk-go-v2/service/wafregional v1.23.3
 	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.51.4
-	github.com/aws/smithy-go v1.22.2
+	github.com/aws/smithy-go v1.23.0
 	github.com/evanphx/json-patch v5.9.11+incompatible
 	github.com/gavv/httpexpect/v2 v2.9.0
 	github.com/go-logr/logr v1.4.3
@@ -60,8 +60,8 @@ require (
 	github.com/ajg/form v1.5.1 // indirect
 	github.com/andybalholm/brotli v1.0.4 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.34 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.34 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.9 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.9 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.11.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.17 // indirect

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3d
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/aws/aws-sdk-go-v2 v1.36.3 h1:mJoei2CxPutQVxaATCzDUjcZEjVRdpsiiXi2o38yqWM=
 github.com/aws/aws-sdk-go-v2 v1.36.3/go.mod h1:LLXuLpgzEbD766Z5ECcRmi8AzSwfZItDtmABVkRLGzg=
+github.com/aws/aws-sdk-go-v2 v1.39.2 h1:EJLg8IdbzgeD7xgvZ+I8M1e0fL0ptn/M47lianzth0I=
+github.com/aws/aws-sdk-go-v2 v1.39.2/go.mod h1:sDioUELIUO9Znk23YVmIk86/9DOpkbyyVb1i/gUNFXY=
 github.com/aws/aws-sdk-go-v2/config v1.27.27 h1:HdqgGt1OAP0HkEDDShEl0oSYa9ZZBSOmKpdpsDMdO90=
 github.com/aws/aws-sdk-go-v2/config v1.27.27/go.mod h1:MVYamCg76dFNINkZFu4n4RjDixhVr51HLj4ErWzrVwg=
 github.com/aws/aws-sdk-go-v2/credentials v1.17.27 h1:2raNba6gr2IfA0eqqiP2XiQ0UVOpGPgDSi0I9iAP+UI=
@@ -39,8 +41,12 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.11 h1:KreluoV8FZDEtI6Co2xuNk
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.11/go.mod h1:SeSUYBLsMYFoRvHE0Tjvn7kbxaUhl75CJi1sbfhMxkU=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.34 h1:ZK5jHhnrioRkUNOc+hOgQKlUL5JeC3S6JgLxtQ+Rm0Q=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.34/go.mod h1:p4VfIceZokChbA9FzMbRGz5OV+lekcVtHlPKEO0gSZY=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.9 h1:se2vOWGD3dWQUtfn4wEjRQJb1HK1XsNIt825gskZ970=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.9/go.mod h1:hijCGH2VfbZQxqCDN7bwz/4dzxV+hkyhjawAtdPWKZA=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.34 h1:SZwFm17ZUNNg5Np0ioo/gq8Mn6u9w19Mri8DnJ15Jf0=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.34/go.mod h1:dFZsC0BLo346mvKQLWmoJxT+Sjp+qcVR1tRVHQGOH9Q=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.9 h1:6RBnKZLkJM4hQ+kN6E7yWFveOTg8NLPHAkqrs4ZPlTU=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.9/go.mod h1:V9rQKRmK7AWuEsOMnHzKj8WyrIir1yUJbZxDuZLFvXI=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.0 h1:hT8rVHwugYE2lEfdFE0QWVo81lF7jMrYJVDWI+f+VxU=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.0/go.mod h1:8tu/lYfQfFe6IGnaOdrpVgEL2IrrDOf6/m9RQum4NkY=
 github.com/aws/aws-sdk-go-v2/service/acm v1.28.4 h1:wiW1Y6/1lysA0eJZRq0I53YYKuV9MNAzL15z2eZRlEE=
@@ -51,6 +57,8 @@ github.com/aws/aws-sdk-go-v2/service/ec2 v1.173.0 h1:ta62lid9JkIpKZtZZXSj6rP2AqY
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.173.0/go.mod h1:o6QDjdVKpP5EF0dp/VlvqckzuSDATr1rLdHt3A5m0YY=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.45.0 h1:RB7V8wT9ypjE/YJVBgKjoydTOh4IFoqceGiKxFH70mY=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.45.0/go.mod h1:xnCC3vFBfOKpU6PcsCKL2ktgBTZfOwTGxj6V8/X3IS4=
+github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.51.0 h1:Zy1yjx+R6cR4pAwzFFJ8nWJh4ri8I44H76PDJ77tcJo=
+github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.51.0/go.mod h1:RuZwE3p8IrWqK1kZhwH2TymlHLPuiI/taBMb8vrD39Q=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.11.3 h1:dT3MqvGhSoaIhRseqw2I0yH81l7wiR2vjs57O51EAm8=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.11.3/go.mod h1:GlAeCkHwugxdHaueRr4nhPuY+WW+gR8UjlcqzPr1SPI=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.17 h1:HGErhhrxZlQ044RiM+WdoZxp0p+EGM62y3L6pwA4olE=
@@ -73,6 +81,8 @@ github.com/aws/aws-sdk-go-v2/service/wafv2 v1.51.4 h1:1khBA5uryBRJoCb4G2iR5RT06B
 github.com/aws/aws-sdk-go-v2/service/wafv2 v1.51.4/go.mod h1:QpFImaPGKNwa+MiZ+oo6LbV1PVQBapc0CnrAMRScoxM=
 github.com/aws/smithy-go v1.22.2 h1:6D9hW43xKFrRx/tXXfAlIZc4JI+yQe6snnWcQyxSyLQ=
 github.com/aws/smithy-go v1.22.2/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
+github.com/aws/smithy-go v1.23.0 h1:8n6I3gXzWJB2DxBDnfxgBaSX6oe0d/t10qGz7OKqMCE=
+github.com/aws/smithy-go v1.23.0/go.mod h1:t1ufH5HMublsJYulve2RKmHDC15xu1f26kHCp/HgceI=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ nav:
       - Tasks:
           - Cognito Authentication: guide/tasks/cognito_authentication.md
           - SSL Redirect: guide/tasks/ssl_redirect.md
+          - URL Rewrite: guide/tasks/url_rewrite.md
       - Use Cases:
         - NLB TLS Termination: guide/use_cases/nlb_tls_termination/index.md
         - Externally Managed Load Balancer: guide/use_cases/self_managed_lb/index.md

--- a/pkg/annotations/constants.go
+++ b/pkg/annotations/constants.go
@@ -75,6 +75,7 @@ const (
 	IngressSuffixFrontendNlHealthCheckbUnhealthyThresholdCount = "frontend-nlb-healthcheck-unhealthy-threshold-count"
 	IngressSuffixFrontendNlbHealthCheckSuccessCodes            = "frontend-nlb-healthcheck-success-codes"
 	IngressSuffixFrontendNlbTags                               = "frontend-nlb-tags"
+	IngressSuffixUseRegexPathMatch                             = "use-regex-path-match"
 
 	// NLB annotation suffixes
 	// prefixes service.beta.kubernetes.io, service.kubernetes.io

--- a/pkg/deploy/elbv2/listener_rule_synthesizer_test.go
+++ b/pkg/deploy/elbv2/listener_rule_synthesizer_test.go
@@ -478,6 +478,415 @@ func Test_matchResAndSDKListenerRules(t *testing.T) {
 			wantErr: nil,
 		},
 		{
+			name: "all listener rules settings including transforms has match but not priority",
+			args: args{
+				resLRs: []*elbv2model.ListenerRule{
+					{
+						ResourceMeta: coremodel.NewResourceMeta(stack, "AWS::ElasticLoadBalancingV2::ListenerRule", "id-1"),
+						Spec: elbv2model.ListenerRuleSpec{
+							Priority: 3,
+							Actions: []elbv2model.Action{
+								{
+									Type: "forward",
+									ForwardConfig: &elbv2model.ForwardActionConfig{
+										TargetGroups: []elbv2model.TargetGroupTuple{
+											{
+												TargetGroupARN: core.LiteralStringToken("foo1-tg"),
+											},
+										},
+									},
+								},
+							},
+							Conditions: []elbv2model.RuleCondition{
+								{
+									Field: "path-pattern",
+									PathPatternConfig: &elbv2model.PathPatternConditionConfig{
+										Values: []string{"/foo1"},
+									},
+								},
+							},
+							Transforms: []elbv2model.Transform{
+								{
+									Type: elbv2model.TransformTypeUrlRewrite,
+									UrlRewriteConfig: &elbv2model.RewriteConfigObject{
+										Rewrites: []elbv2model.RewriteConfig{
+											{
+												Regex:   "/path1/(.*)",
+												Replace: "/newpath1/$1",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						ResourceMeta: coremodel.NewResourceMeta(stack, "AWS::ElasticLoadBalancingV2::ListenerRule", "id-1"),
+						Spec: elbv2model.ListenerRuleSpec{
+							Priority: 2,
+							Actions: []elbv2model.Action{
+								{
+									Type: "forward",
+									ForwardConfig: &elbv2model.ForwardActionConfig{
+										TargetGroups: []elbv2model.TargetGroupTuple{
+											{
+												TargetGroupARN: core.LiteralStringToken("foo2-tg"),
+											},
+										},
+									},
+								},
+							},
+							Conditions: []elbv2model.RuleCondition{
+								{
+									Field: "path-pattern",
+									PathPatternConfig: &elbv2model.PathPatternConditionConfig{
+										Values: []string{"/foo2"},
+									},
+								},
+							},
+							Transforms: []elbv2model.Transform{
+								{
+									Type: elbv2model.TransformTypeUrlRewrite,
+									UrlRewriteConfig: &elbv2model.RewriteConfigObject{
+										Rewrites: []elbv2model.RewriteConfig{
+											{
+												Regex:   "/path2/(.*)",
+												Replace: "/newpath2/$1",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						ResourceMeta: coremodel.NewResourceMeta(stack, "AWS::ElasticLoadBalancingV2::ListenerRule", "id-1"),
+						Spec: elbv2model.ListenerRuleSpec{
+							Priority: 1,
+							Actions: []elbv2model.Action{
+								{
+									Type: "forward",
+									ForwardConfig: &elbv2model.ForwardActionConfig{
+										TargetGroups: []elbv2model.TargetGroupTuple{
+											{
+												TargetGroupARN: core.LiteralStringToken("foo3-tg"),
+											},
+										},
+									},
+								},
+							},
+							Conditions: []elbv2model.RuleCondition{
+								{
+									Field: "path-pattern",
+									PathPatternConfig: &elbv2model.PathPatternConditionConfig{
+										Values: []string{"/foo3"},
+									},
+								},
+							},
+							Transforms: []elbv2model.Transform{
+								{
+									Type: elbv2model.TransformTypeUrlRewrite,
+									UrlRewriteConfig: &elbv2model.RewriteConfigObject{
+										Rewrites: []elbv2model.RewriteConfig{
+											{
+												Regex:   "/path3/(.*)",
+												Replace: "/newpath3/$1",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				sdkLRs: []ListenerRuleWithTags{
+					{
+						ListenerRule: &elbv2types.Rule{
+							RuleArn:  awssdk.String("arn-1"),
+							Priority: awssdk.String("1"),
+							Actions: []elbv2types.Action{
+								{
+									Type: elbv2types.ActionTypeEnumForward,
+									ForwardConfig: &elbv2types.ForwardActionConfig{
+										TargetGroups: []elbv2types.TargetGroupTuple{
+											{
+												TargetGroupArn: awssdk.String("foo1-tg"),
+											},
+										},
+									},
+								},
+							},
+							Conditions: []elbv2types.RuleCondition{
+								{
+									Field: awssdk.String("path-pattern"),
+									PathPatternConfig: &elbv2types.PathPatternConditionConfig{
+										Values: []string{"/foo1"},
+									},
+								},
+							},
+							Transforms: []elbv2types.RuleTransform{
+								{
+									Type: elbv2types.TransformTypeEnumUrlRewrite,
+									UrlRewriteConfig: &elbv2types.UrlRewriteConfig{
+										Rewrites: []elbv2types.RewriteConfig{
+											{
+												Regex:   awssdk.String("/path1/(.*)"),
+												Replace: awssdk.String("/newpath1/$1"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						ListenerRule: &elbv2types.Rule{
+							RuleArn:  awssdk.String("arn-2"),
+							Priority: awssdk.String("2"),
+							Actions: []elbv2types.Action{
+								{
+									Type: elbv2types.ActionTypeEnumForward,
+									ForwardConfig: &elbv2types.ForwardActionConfig{
+										TargetGroups: []elbv2types.TargetGroupTuple{
+											{
+												TargetGroupArn: awssdk.String("foo2-tg"),
+											},
+										},
+									},
+								},
+							},
+							Conditions: []elbv2types.RuleCondition{
+								{
+									Field: awssdk.String("path-pattern"),
+									PathPatternConfig: &elbv2types.PathPatternConditionConfig{
+										Values: []string{"/foo2"},
+									},
+								},
+							},
+							Transforms: []elbv2types.RuleTransform{
+								{
+									Type: elbv2types.TransformTypeEnumUrlRewrite,
+									UrlRewriteConfig: &elbv2types.UrlRewriteConfig{
+										Rewrites: []elbv2types.RewriteConfig{
+											{
+												Regex:   awssdk.String("/path2/(.*)"),
+												Replace: awssdk.String("/newpath2/$1"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						ListenerRule: &elbv2types.Rule{
+							RuleArn:  awssdk.String("arn-3"),
+							Priority: awssdk.String("3"),
+							Actions: []elbv2types.Action{
+								{
+									Type: elbv2types.ActionTypeEnumForward,
+									ForwardConfig: &elbv2types.ForwardActionConfig{
+										TargetGroups: []elbv2types.TargetGroupTuple{
+											{
+												TargetGroupArn: awssdk.String("foo3-tg"),
+											},
+										},
+									},
+								},
+							},
+							Conditions: []elbv2types.RuleCondition{
+								{
+									Field: awssdk.String("path-pattern"),
+									PathPatternConfig: &elbv2types.PathPatternConditionConfig{
+										Values: []string{"/foo3"},
+									},
+								},
+							},
+							Transforms: []elbv2types.RuleTransform{
+								{
+									Type: elbv2types.TransformTypeEnumUrlRewrite,
+									UrlRewriteConfig: &elbv2types.UrlRewriteConfig{
+										Rewrites: []elbv2types.RewriteConfig{
+											{
+												Regex:   awssdk.String("/path3/(.*)"),
+												Replace: awssdk.String("/newpath3/$1"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []resAndSDKListenerRulePair{
+				{
+					resLR: &elbv2model.ListenerRule{
+						ResourceMeta: coremodel.NewResourceMeta(stack, "AWS::ElasticLoadBalancingV2::ListenerRule", "id-1"),
+						Spec: elbv2model.ListenerRuleSpec{
+							Priority: 3,
+							Actions: []elbv2model.Action{
+								{
+									Type: "forward",
+									ForwardConfig: &elbv2model.ForwardActionConfig{
+										TargetGroups: []elbv2model.TargetGroupTuple{
+											{
+												TargetGroupARN: core.LiteralStringToken("foo1-tg"),
+											},
+										},
+									},
+								},
+							},
+							Conditions: []elbv2model.RuleCondition{
+								{
+									Field: "path-pattern",
+									PathPatternConfig: &elbv2model.PathPatternConditionConfig{
+										Values: []string{"/foo1"},
+									},
+								},
+							},
+							Transforms: []elbv2model.Transform{
+								{
+									Type: elbv2model.TransformTypeUrlRewrite,
+									UrlRewriteConfig: &elbv2model.RewriteConfigObject{
+										Rewrites: []elbv2model.RewriteConfig{
+											{
+												Regex:   "/path1/(.*)",
+												Replace: "/newpath1/$1",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					sdkLR: ListenerRuleWithTags{
+						ListenerRule: &elbv2types.Rule{
+							RuleArn:  awssdk.String("arn-1"),
+							Priority: awssdk.String("1"),
+							Actions: []elbv2types.Action{
+								{
+									Type: elbv2types.ActionTypeEnumForward,
+									ForwardConfig: &elbv2types.ForwardActionConfig{
+										TargetGroups: []elbv2types.TargetGroupTuple{
+											{
+												TargetGroupArn: awssdk.String("foo1-tg"),
+											},
+										},
+									},
+								},
+							},
+							Conditions: []elbv2types.RuleCondition{
+								{
+									Field: awssdk.String("path-pattern"),
+									PathPatternConfig: &elbv2types.PathPatternConditionConfig{
+										Values: []string{"/foo1"},
+									},
+								},
+							},
+							Transforms: []elbv2types.RuleTransform{
+								{
+									Type: elbv2types.TransformTypeEnumUrlRewrite,
+									UrlRewriteConfig: &elbv2types.UrlRewriteConfig{
+										Rewrites: []elbv2types.RewriteConfig{
+											{
+												Regex:   awssdk.String("/path1/(.*)"),
+												Replace: awssdk.String("/newpath1/$1"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					resLR: &elbv2model.ListenerRule{
+						ResourceMeta: coremodel.NewResourceMeta(stack, "AWS::ElasticLoadBalancingV2::ListenerRule", "id-1"),
+						Spec: elbv2model.ListenerRuleSpec{
+							Priority: 1,
+							Actions: []elbv2model.Action{
+								{
+									Type: "forward",
+									ForwardConfig: &elbv2model.ForwardActionConfig{
+										TargetGroups: []elbv2model.TargetGroupTuple{
+											{
+												TargetGroupARN: core.LiteralStringToken("foo3-tg"),
+											},
+										},
+									},
+								},
+							},
+							Conditions: []elbv2model.RuleCondition{
+								{
+									Field: "path-pattern",
+									PathPatternConfig: &elbv2model.PathPatternConditionConfig{
+										Values: []string{"/foo3"},
+									},
+								},
+							},
+							Transforms: []elbv2model.Transform{
+								{
+									Type: elbv2model.TransformTypeUrlRewrite,
+									UrlRewriteConfig: &elbv2model.RewriteConfigObject{
+										Rewrites: []elbv2model.RewriteConfig{
+											{
+												Regex:   "/path3/(.*)",
+												Replace: "/newpath3/$1",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					sdkLR: ListenerRuleWithTags{
+						ListenerRule: &elbv2types.Rule{
+							RuleArn:  awssdk.String("arn-3"),
+							Priority: awssdk.String("3"),
+							Actions: []elbv2types.Action{
+								{
+									Type: elbv2types.ActionTypeEnumForward,
+									ForwardConfig: &elbv2types.ForwardActionConfig{
+										TargetGroups: []elbv2types.TargetGroupTuple{
+											{
+												TargetGroupArn: awssdk.String("foo3-tg"),
+											},
+										},
+									},
+								},
+							},
+							Conditions: []elbv2types.RuleCondition{
+								{
+									Field: awssdk.String("path-pattern"),
+									PathPatternConfig: &elbv2types.PathPatternConditionConfig{
+										Values: []string{"/foo3"},
+									},
+								},
+							},
+							Transforms: []elbv2types.RuleTransform{
+								{
+									Type: elbv2types.TransformTypeEnumUrlRewrite,
+									UrlRewriteConfig: &elbv2types.UrlRewriteConfig{
+										Rewrites: []elbv2types.RewriteConfig{
+											{
+												Regex:   awssdk.String("/path3/(.*)"),
+												Replace: awssdk.String("/newpath3/$1"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want1:   nil,
+			want2:   nil,
+			want3:   nil,
+			wantErr: nil,
+		},
+		{
 			name: "some listener rules settings has match but not priority, some listener rules priority match but not settings",
 			args: args{
 				resLRs: []*elbv2model.ListenerRule{
@@ -1260,12 +1669,12 @@ func Test_matchResAndSDKListenerRules(t *testing.T) {
 				elbv2Client:  elbv2Client,
 				featureGates: featureGates,
 			}
-			resLRDesiredActionsAndConditionsPairs := make(map[*elbv2model.ListenerRule]*resLRDesiredActionsAndConditionsPair, len(tt.args.resLRs))
+			resLRDesiredRuleConfigs := make(map[*elbv2model.ListenerRule]*resLRDesiredRuleConfig, len(tt.args.resLRs))
 			for _, resLR := range tt.args.resLRs {
-				resLRDesiredActionsAndConditionsPair, _ := buildResLRDesiredActionsAndConditionsPair(resLR, featureGates)
-				resLRDesiredActionsAndConditionsPairs[resLR] = resLRDesiredActionsAndConditionsPair
+				resLRDesiredRuleConfig, _ := buildResLRDesiredRuleConfig(resLR, featureGates)
+				resLRDesiredRuleConfigs[resLR] = resLRDesiredRuleConfig
 			}
-			got, got1, got2, got3, err := s.matchResAndSDKListenerRules(tt.args.resLRs, tt.args.sdkLRs, resLRDesiredActionsAndConditionsPairs)
+			got, got1, got2, got3, err := s.matchResAndSDKListenerRules(tt.args.resLRs, tt.args.sdkLRs, resLRDesiredRuleConfigs)
 			if tt.wantErr != nil {
 				assert.EqualError(t, err, tt.wantErr.Error())
 			} else {

--- a/pkg/equality/elbv2/compare_option_for_transform.go
+++ b/pkg/equality/elbv2/compare_option_for_transform.go
@@ -1,0 +1,27 @@
+package elbv2
+
+import (
+	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func CompareOptionForTransform() cmp.Option {
+	return cmp.Options{
+		cmpopts.IgnoreUnexported(elbv2types.RuleTransform{}),
+		cmpopts.IgnoreUnexported(elbv2types.HostHeaderRewriteConfig{}),
+		cmpopts.IgnoreUnexported(elbv2types.UrlRewriteConfig{}),
+		cmpopts.IgnoreUnexported(elbv2types.RewriteConfig{}),
+	}
+}
+
+// CompareOptionForTransforms returns the compare option for transforms slice.
+func CompareOptionForTransforms(_, _ []elbv2types.RuleTransform) cmp.Option {
+	return cmp.Options{
+		cmpopts.EquateEmpty(),
+		cmpopts.SortSlices(func(lhs elbv2types.RuleTransform, rhs elbv2types.RuleTransform) bool {
+			return string(lhs.Type) < string(rhs.Type)
+		}),
+		CompareOptionForTransform(),
+	}
+}

--- a/pkg/equality/elbv2/compare_option_for_transform_test.go
+++ b/pkg/equality/elbv2/compare_option_for_transform_test.go
@@ -1,0 +1,301 @@
+package elbv2
+
+import (
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestCompareOptionForTransforms(t *testing.T) {
+	type args struct {
+		lhs []elbv2types.RuleTransform
+		rhs []elbv2types.RuleTransform
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "empty transforms should be equal",
+			args: args{
+				lhs: []elbv2types.RuleTransform{},
+				rhs: []elbv2types.RuleTransform{},
+			},
+			want: true,
+		},
+		{
+			name: "nil transforms should be equal to empty transforms",
+			args: args{
+				lhs: nil,
+				rhs: []elbv2types.RuleTransform{},
+			},
+			want: true,
+		},
+		{
+			name: "transforms with same url-rewrite config should be equal",
+			args: args{
+				lhs: []elbv2types.RuleTransform{
+					{
+						Type: elbv2types.TransformTypeEnum("url-rewrite"),
+						UrlRewriteConfig: &elbv2types.UrlRewriteConfig{
+							Rewrites: []elbv2types.RewriteConfig{
+								{
+									Regex:   awssdk.String("/foo(.*)"),
+									Replace: awssdk.String("/bar$1"),
+								},
+							},
+						},
+					},
+				},
+				rhs: []elbv2types.RuleTransform{
+					{
+						Type: elbv2types.TransformTypeEnum("url-rewrite"),
+						UrlRewriteConfig: &elbv2types.UrlRewriteConfig{
+							Rewrites: []elbv2types.RewriteConfig{
+								{
+									Regex:   awssdk.String("/foo(.*)"),
+									Replace: awssdk.String("/bar$1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "transforms with same host-header-rewrite config should be equal",
+			args: args{
+				lhs: []elbv2types.RuleTransform{
+					{
+						Type: elbv2types.TransformTypeEnum("host-header-rewrite"),
+						HostHeaderRewriteConfig: &elbv2types.HostHeaderRewriteConfig{
+							Rewrites: []elbv2types.RewriteConfig{
+								{
+									Regex:   awssdk.String("example.com"),
+									Replace: awssdk.String("example.org"),
+								},
+							},
+						},
+					},
+				},
+				rhs: []elbv2types.RuleTransform{
+					{
+						Type: elbv2types.TransformTypeEnum("host-header-rewrite"),
+						HostHeaderRewriteConfig: &elbv2types.HostHeaderRewriteConfig{
+							Rewrites: []elbv2types.RewriteConfig{
+								{
+									Regex:   awssdk.String("example.com"),
+									Replace: awssdk.String("example.org"),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "transforms with different types should not be equal",
+			args: args{
+				lhs: []elbv2types.RuleTransform{
+					{
+						Type: elbv2types.TransformTypeEnum("url-rewrite"),
+						UrlRewriteConfig: &elbv2types.UrlRewriteConfig{
+							Rewrites: []elbv2types.RewriteConfig{
+								{
+									Regex:   awssdk.String("/foo(.*)"),
+									Replace: awssdk.String("/bar$1"),
+								},
+							},
+						},
+					},
+				},
+				rhs: []elbv2types.RuleTransform{
+					{
+						Type: elbv2types.TransformTypeEnum("host-header-rewrite"),
+						HostHeaderRewriteConfig: &elbv2types.HostHeaderRewriteConfig{
+							Rewrites: []elbv2types.RewriteConfig{
+								{
+									Regex:   awssdk.String("example.com"),
+									Replace: awssdk.String("example.org"),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "transforms with different url-rewrite config should not be equal",
+			args: args{
+				lhs: []elbv2types.RuleTransform{
+					{
+						Type: elbv2types.TransformTypeEnum("url-rewrite"),
+						UrlRewriteConfig: &elbv2types.UrlRewriteConfig{
+							Rewrites: []elbv2types.RewriteConfig{
+								{
+									Regex:   awssdk.String("/foo(.*)"),
+									Replace: awssdk.String("/bar$1"),
+								},
+							},
+						},
+					},
+				},
+				rhs: []elbv2types.RuleTransform{
+					{
+						Type: elbv2types.TransformTypeEnum("url-rewrite"),
+						UrlRewriteConfig: &elbv2types.UrlRewriteConfig{
+							Rewrites: []elbv2types.RewriteConfig{
+								{
+									Regex:   awssdk.String("/foo(.*)"),
+									Replace: awssdk.String("/baz$1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "transforms with different host-header-rewrite config should not be equal",
+			args: args{
+				lhs: []elbv2types.RuleTransform{
+					{
+						Type: elbv2types.TransformTypeEnum("host-header-rewrite"),
+						HostHeaderRewriteConfig: &elbv2types.HostHeaderRewriteConfig{
+							Rewrites: []elbv2types.RewriteConfig{
+								{
+									Regex:   awssdk.String("example.com"),
+									Replace: awssdk.String("example.org"),
+								},
+							},
+						},
+					},
+				},
+				rhs: []elbv2types.RuleTransform{
+					{
+						Type: elbv2types.TransformTypeEnum("host-header-rewrite"),
+						HostHeaderRewriteConfig: &elbv2types.HostHeaderRewriteConfig{
+							Rewrites: []elbv2types.RewriteConfig{
+								{
+									Regex:   awssdk.String("example.com"),
+									Replace: awssdk.String("example.net"),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "transforms with different number of transforms should not be equal",
+			args: args{
+				lhs: []elbv2types.RuleTransform{
+					{
+						Type: elbv2types.TransformTypeEnum("url-rewrite"),
+						UrlRewriteConfig: &elbv2types.UrlRewriteConfig{
+							Rewrites: []elbv2types.RewriteConfig{
+								{
+									Regex:   awssdk.String("/foo(.*)"),
+									Replace: awssdk.String("/bar$1"),
+								},
+							},
+						},
+					},
+				},
+				rhs: []elbv2types.RuleTransform{
+					{
+						Type: elbv2types.TransformTypeEnum("url-rewrite"),
+						UrlRewriteConfig: &elbv2types.UrlRewriteConfig{
+							Rewrites: []elbv2types.RewriteConfig{
+								{
+									Regex:   awssdk.String("/foo(.*)"),
+									Replace: awssdk.String("/bar$1"),
+								},
+							},
+						},
+					},
+					{
+						Type: elbv2types.TransformTypeEnum("host-header-rewrite"),
+						HostHeaderRewriteConfig: &elbv2types.HostHeaderRewriteConfig{
+							Rewrites: []elbv2types.RewriteConfig{
+								{
+									Regex:   awssdk.String("example.com"),
+									Replace: awssdk.String("example.org"),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "transforms with same configs but different order should be equal",
+			args: args{
+				lhs: []elbv2types.RuleTransform{
+					{
+						Type: elbv2types.TransformTypeEnum("url-rewrite"),
+						UrlRewriteConfig: &elbv2types.UrlRewriteConfig{
+							Rewrites: []elbv2types.RewriteConfig{
+								{
+									Regex:   awssdk.String("/foo(.*)"),
+									Replace: awssdk.String("/bar$1"),
+								},
+							},
+						},
+					},
+					{
+						Type: elbv2types.TransformTypeEnum("host-header-rewrite"),
+						HostHeaderRewriteConfig: &elbv2types.HostHeaderRewriteConfig{
+							Rewrites: []elbv2types.RewriteConfig{
+								{
+									Regex:   awssdk.String("example.com"),
+									Replace: awssdk.String("example.org"),
+								},
+							},
+						},
+					},
+				},
+				rhs: []elbv2types.RuleTransform{
+					{
+						Type: elbv2types.TransformTypeEnum("host-header-rewrite"),
+						HostHeaderRewriteConfig: &elbv2types.HostHeaderRewriteConfig{
+							Rewrites: []elbv2types.RewriteConfig{
+								{
+									Regex:   awssdk.String("example.com"),
+									Replace: awssdk.String("example.org"),
+								},
+							},
+						},
+					},
+					{
+						Type: elbv2types.TransformTypeEnum("url-rewrite"),
+						UrlRewriteConfig: &elbv2types.UrlRewriteConfig{
+							Rewrites: []elbv2types.RewriteConfig{
+								{
+									Regex:   awssdk.String("/foo(.*)"),
+									Replace: awssdk.String("/bar$1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cmp.Equal(tt.args.lhs, tt.args.rhs, CompareOptionForTransforms(nil, nil))
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/ingress/model_build_listener_rules.go
+++ b/pkg/ingress/model_build_listener_rules.go
@@ -3,6 +3,7 @@ package ingress
 import (
 	"context"
 	"fmt"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
 	"sort"
 	"strings"
 
@@ -36,11 +37,15 @@ func (t *defaultModelBuildTask) buildListenerRules(ctx context.Context, lsARN co
 				if err != nil {
 					return errors.Wrapf(err, "ingress: %v", k8s.NamespacedName(ing.Ing))
 				}
-				conditions, err := t.buildRuleConditions(ctx, rule, path, enhancedBackend)
+				conditions, err := t.buildRuleConditions(ctx, ing, rule, path, enhancedBackend)
 				if err != nil {
 					return errors.Wrapf(err, "ingress: %v", k8s.NamespacedName(ing.Ing))
 				}
 				actions, err := t.buildActions(ctx, protocol, ing, enhancedBackend)
+				if err != nil {
+					return errors.Wrapf(err, "ingress: %v", k8s.NamespacedName(ing.Ing))
+				}
+				transforms, err := t.buildTransforms(ctx, enhancedBackend)
 				if err != nil {
 					return errors.Wrapf(err, "ingress: %v", k8s.NamespacedName(ing.Ing))
 				}
@@ -51,6 +56,7 @@ func (t *defaultModelBuildTask) buildListenerRules(ctx context.Context, lsARN co
 				rules = append(rules, Rule{
 					Conditions: conditions,
 					Actions:    actions,
+					Transforms: transforms,
 					Tags:       tags,
 				})
 			}
@@ -69,6 +75,7 @@ func (t *defaultModelBuildTask) buildListenerRules(ctx context.Context, lsARN co
 			Priority:    priority,
 			Conditions:  rule.Conditions,
 			Actions:     rule.Actions,
+			Transforms:  rule.Transforms,
 			Tags:        rule.Tags,
 		})
 		priority += 1
@@ -119,19 +126,26 @@ func (t *defaultModelBuildTask) classifyIngressPathsByType(paths []networking.HT
 	return exactPaths, prefixPaths, implementationSpecificPaths, nil
 }
 
-func (t *defaultModelBuildTask) buildRuleConditions(ctx context.Context, rule networking.IngressRule,
+func (t *defaultModelBuildTask) buildRuleConditions(ctx context.Context, ing ClassifiedIngress, rule networking.IngressRule,
 	path networking.HTTPIngressPath, backend EnhancedBackend) ([]elbv2model.RuleCondition, error) {
-	var hosts []string
+	// Glob syntax with wildcards (`*` and `?`)
+	var hostValues []string
+	// Regex syntax
+	var hostRegexValues []string
 	if rule.Host != "" {
-		hosts = append(hosts, rule.Host)
+		hostValues = append(hostValues, rule.Host)
 	}
-	var paths []string
+	// Glob syntax with wildcards (`*` and `?`)
+	var pathValues []string
+	// Regex syntax
+	var pathRegexValues []string
 	if path.Path != "" {
-		pathPatterns, err := t.buildPathPatterns(path.Path, path.PathType)
+		pathValuePatterns, pathRegexValuesPatterns, err := t.buildPathPatterns(ing, path.Path, path.PathType)
 		if err != nil {
 			return nil, err
 		}
-		paths = append(paths, pathPatterns...)
+		pathValues = append(pathValues, pathValuePatterns...)
+		pathRegexValues = append(pathRegexValues, pathRegexValuesPatterns...)
 	}
 	var conditions []elbv2model.RuleCondition
 	for _, condition := range backend.Conditions {
@@ -140,12 +154,22 @@ func (t *defaultModelBuildTask) buildRuleConditions(ctx context.Context, rule ne
 			if condition.HostHeaderConfig == nil {
 				return nil, errors.New("missing HostHeaderConfig")
 			}
-			hosts = append(hosts, condition.HostHeaderConfig.Values...)
+			if len(condition.HostHeaderConfig.Values) > 0 {
+				hostValues = append(hostValues, condition.HostHeaderConfig.Values...)
+			}
+			if len(condition.HostHeaderConfig.RegexValues) > 0 {
+				hostRegexValues = append(hostRegexValues, condition.HostHeaderConfig.RegexValues...)
+			}
 		case RuleConditionFieldPathPattern:
 			if condition.PathPatternConfig == nil {
 				return nil, errors.New("missing PathPatternConfig")
 			}
-			paths = append(paths, condition.PathPatternConfig.Values...)
+			if len(condition.PathPatternConfig.Values) > 0 {
+				pathValues = append(pathValues, condition.PathPatternConfig.Values...)
+			}
+			if len(condition.PathPatternConfig.RegexValues) > 0 {
+				pathRegexValues = append(pathRegexValues, condition.PathPatternConfig.RegexValues...)
+			}
 		case RuleConditionFieldHTTPHeader:
 			httpHeaderCondition, err := t.buildHTTPHeaderCondition(ctx, condition)
 			if err != nil {
@@ -172,48 +196,77 @@ func (t *defaultModelBuildTask) buildRuleConditions(ctx context.Context, rule ne
 			conditions = append(conditions, sourceIPCondition)
 		}
 	}
-	if len(hosts) != 0 {
-		conditions = append(conditions, t.buildHostHeaderCondition(ctx, hosts))
+
+	// Using client-side validation to enforce that host-name and path-pattern conditions use either Values or RegexValues, never both
+	// This error is easy to make with LBC since these can be specified as conditions annotations or as host/path rules
+	// but the resulting API error is hard to debug!
+	if len(hostValues) != 0 && len(hostRegexValues) != 0 {
+		return nil, errors.Errorf("host condition must specify exactly one of Values and RegexValues, got both Values %s and RegexValues %s", hostValues, hostRegexValues)
 	}
-	if len(paths) != 0 {
-		conditions = append(conditions, t.buildPathPatternCondition(ctx, paths))
+	if len(pathValues) != 0 && len(pathRegexValues) != 0 {
+		return nil, errors.Errorf("path condition must specify exactly one of Values and RegexValues, got both Values %s and RegexValues %s", pathValues, pathRegexValues)
+	}
+
+	if len(hostValues) != 0 {
+		conditions = append(conditions, t.buildHostHeaderValuesCondition(ctx, hostValues))
+	}
+	if len(hostRegexValues) != 0 {
+		conditions = append(conditions, t.buildHostHeaderRegexValuesCondition(ctx, hostRegexValues))
+	}
+	if len(pathValues) != 0 {
+		conditions = append(conditions, t.buildPathValuesCondition(ctx, pathValues))
+	}
+	if len(pathRegexValues) != 0 {
+		conditions = append(conditions, t.buildPathRegexValuesCondition(ctx, pathRegexValues))
 	}
 	if len(conditions) == 0 {
-		conditions = append(conditions, t.buildPathPatternCondition(ctx, []string{"/*"}))
+		conditions = append(conditions, t.buildPathValuesCondition(ctx, []string{"/*"}))
 	}
 	return conditions, nil
 }
 
 // buildPathPatterns will build ELBv2's path patterns for given path and pathType.
-func (t *defaultModelBuildTask) buildPathPatterns(path string, pathType *networking.PathType) ([]string, error) {
+func (t *defaultModelBuildTask) buildPathPatterns(ing ClassifiedIngress, path string, pathType *networking.PathType) ([]string, []string, error) {
 	normalizedPathType := networking.PathTypeImplementationSpecific
 	if pathType != nil {
 		normalizedPathType = *pathType
 	}
 	switch normalizedPathType {
 	case networking.PathTypeImplementationSpecific:
-		return t.buildPathPatternsForImplementationSpecificPathType(path)
+		return t.buildPathPatternsForImplementationSpecificPathType(ing, path)
 	case networking.PathTypeExact:
 		return t.buildPathPatternsForExactPathType(path)
 	case networking.PathTypePrefix:
 		return t.buildPathPatternsForPrefixPathType(path)
 	default:
-		return nil, errors.Errorf("unsupported pathType: %v", normalizedPathType)
+		return nil, nil, errors.Errorf("unsupported pathType: %v", normalizedPathType)
 	}
 }
 
 // buildPathPatternsForImplementationSpecificPathType will build path patterns for implementationSpecific pathType.
-func (t *defaultModelBuildTask) buildPathPatternsForImplementationSpecificPathType(path string) ([]string, error) {
-	return []string{path}, nil
+func (t *defaultModelBuildTask) buildPathPatternsForImplementationSpecificPathType(ing ClassifiedIngress, path string) ([]string, []string, error) {
+	useRegexPathMatch, err := t.getUseRegexPathMatch(ing)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if useRegexPathMatch {
+		// Strip first character (leading `/`)
+		// because kubernetes requires paths to start with a `/`, but not required for regex
+		return []string{}, []string{path[1:]}, nil
+	}
+
+	return []string{path}, []string{}, nil
 }
 
 // buildPathPatternsForExactPathType will build path patterns for exact pathType.
 // exact path shouldn't contains any wildcards.
-func (t *defaultModelBuildTask) buildPathPatternsForExactPathType(path string) ([]string, error) {
+func (t *defaultModelBuildTask) buildPathPatternsForExactPathType(path string) ([]string, []string, error) {
 	if strings.ContainsAny(path, "*?") {
-		return nil, errors.Errorf("exact path shouldn't contain wildcards: %v", path)
+		return nil, nil, errors.Errorf("exact path shouldn't contain wildcards: %v", path)
 	}
-	return []string{path}, nil
+	return []string{path}, []string{}, nil
 }
 
 // buildPathPatternsForPrefixPathType will build path patterns for prefix pathType.
@@ -221,16 +274,16 @@ func (t *defaultModelBuildTask) buildPathPatternsForExactPathType(path string) (
 // with prefixType type, both "/foo" or "/foo/" should matches path like "/foo" or "/foo/" or "/foo/bar".
 // for above case, we'll generate two path pattern: "/foo/" and "/foo/*".
 // an special case is "/", which matches all paths, thus we generate the path pattern as "/*"
-func (t *defaultModelBuildTask) buildPathPatternsForPrefixPathType(path string) ([]string, error) {
+func (t *defaultModelBuildTask) buildPathPatternsForPrefixPathType(path string) ([]string, []string, error) {
 	if path == "/" {
-		return []string{"/*"}, nil
+		return []string{"/*"}, []string{}, nil
 	}
 	if strings.ContainsAny(path, "*?") {
-		return nil, errors.Errorf("prefix path shouldn't contain wildcards: %v", path)
+		return nil, nil, errors.Errorf("prefix path shouldn't contain wildcards: %v", path)
 	}
 
 	normalizedPath := strings.TrimSuffix(path, "/")
-	return []string{normalizedPath, normalizedPath + "/*"}, nil
+	return []string{normalizedPath, normalizedPath + "/*"}, []string{}, nil
 }
 
 func (t *defaultModelBuildTask) buildHTTPHeaderCondition(_ context.Context, condition RuleCondition) (elbv2model.RuleCondition, error) {
@@ -241,6 +294,7 @@ func (t *defaultModelBuildTask) buildHTTPHeaderCondition(_ context.Context, cond
 		Field: elbv2model.RuleConditionFieldHTTPHeader,
 		HTTPHeaderConfig: &elbv2model.HTTPHeaderConditionConfig{
 			HTTPHeaderName: condition.HTTPHeaderConfig.HTTPHeaderName,
+			RegexValues:    condition.HTTPHeaderConfig.RegexValues,
 			Values:         condition.HTTPHeaderConfig.Values,
 		},
 	}, nil
@@ -289,20 +343,38 @@ func (t *defaultModelBuildTask) buildSourceIPCondition(_ context.Context, condit
 	}, nil
 }
 
-func (t *defaultModelBuildTask) buildHostHeaderCondition(_ context.Context, hosts []string) elbv2model.RuleCondition {
+func (t *defaultModelBuildTask) buildHostHeaderValuesCondition(_ context.Context, hostValues []string) elbv2model.RuleCondition {
 	return elbv2model.RuleCondition{
 		Field: elbv2model.RuleConditionFieldHostHeader,
 		HostHeaderConfig: &elbv2model.HostHeaderConditionConfig{
-			Values: hosts,
+			Values: hostValues,
 		},
 	}
 }
 
-func (t *defaultModelBuildTask) buildPathPatternCondition(_ context.Context, paths []string) elbv2model.RuleCondition {
+func (t *defaultModelBuildTask) buildHostHeaderRegexValuesCondition(_ context.Context, hostRegexValues []string) elbv2model.RuleCondition {
+	return elbv2model.RuleCondition{
+		Field: elbv2model.RuleConditionFieldHostHeader,
+		HostHeaderConfig: &elbv2model.HostHeaderConditionConfig{
+			RegexValues: hostRegexValues,
+		},
+	}
+}
+
+func (t *defaultModelBuildTask) buildPathValuesCondition(_ context.Context, pathValues []string) elbv2model.RuleCondition {
 	return elbv2model.RuleCondition{
 		Field: elbv2model.RuleConditionFieldPathPattern,
 		PathPatternConfig: &elbv2model.PathPatternConditionConfig{
-			Values: paths,
+			Values: pathValues,
+		},
+	}
+}
+
+func (t *defaultModelBuildTask) buildPathRegexValuesCondition(_ context.Context, pathRegexValues []string) elbv2model.RuleCondition {
+	return elbv2model.RuleCondition{
+		Field: elbv2model.RuleConditionFieldPathPattern,
+		PathPatternConfig: &elbv2model.PathPatternConditionConfig{
+			RegexValues: pathRegexValues,
 		},
 	}
 }
@@ -314,4 +386,67 @@ func (t *defaultModelBuildTask) buildListenerRuleTags(_ context.Context, ing Cla
 	}
 
 	return algorithm.MergeStringMap(t.defaultTags, ingTags), nil
+}
+
+// Get whether to use regex path match for ImplementationSpecific path specs
+func (t *defaultModelBuildTask) getUseRegexPathMatch(ing ClassifiedIngress) (bool, error) {
+	var useRegexPathMatch bool
+	exists, err := t.annotationParser.ParseBoolAnnotation(annotations.IngressSuffixUseRegexPathMatch, &useRegexPathMatch, ing.Ing.Annotations)
+
+	if err != nil {
+		return false, err
+	}
+
+	if !exists {
+		// Default to `false`, which is the existing behavior
+		return false, nil
+	}
+
+	return useRegexPathMatch, nil
+}
+
+// buildTransforms builds the transforms for a listener rule from the enhanced backend
+func (t *defaultModelBuildTask) buildTransforms(_ context.Context, backend EnhancedBackend) ([]elbv2model.Transform, error) {
+	transforms := make([]elbv2model.Transform, 0)
+	for _, transform := range backend.Transforms {
+		switch transform.Type {
+		case TransformTypeHostHeaderRewrite:
+			if transform.HostHeaderRewriteConfig == nil {
+				return nil, errors.New("missing hostHeaderRewriteConfig")
+			}
+			var rewrites []elbv2model.RewriteConfig
+			for _, rewrite := range transform.HostHeaderRewriteConfig.Rewrites {
+				rewrites = append(rewrites, elbv2model.RewriteConfig{
+					Regex:   rewrite.Regex,
+					Replace: rewrite.Replace,
+				})
+			}
+			transforms = append(transforms, elbv2model.Transform{
+				Type: elbv2model.TransformTypeHostHeaderRewrite,
+				HostHeaderRewriteConfig: &elbv2model.RewriteConfigObject{
+					Rewrites: rewrites,
+				},
+			})
+		case TransformTypeUrlRewrite:
+			if transform.UrlRewriteConfig == nil {
+				return nil, errors.New("missing urlRewriteConfig")
+			}
+			var rewrites []elbv2model.RewriteConfig
+			for _, rewrite := range transform.UrlRewriteConfig.Rewrites {
+				rewrites = append(rewrites, elbv2model.RewriteConfig{
+					Regex:   rewrite.Regex,
+					Replace: rewrite.Replace,
+				})
+			}
+			transforms = append(transforms, elbv2model.Transform{
+				Type: elbv2model.TransformTypeUrlRewrite,
+				UrlRewriteConfig: &elbv2model.RewriteConfigObject{
+					Rewrites: rewrites,
+				},
+			})
+		default:
+			return nil, errors.Errorf("unknown transform type: %v", transform.Type)
+		}
+	}
+	return transforms, nil
 }

--- a/pkg/ingress/rule_optimizer.go
+++ b/pkg/ingress/rule_optimizer.go
@@ -12,6 +12,7 @@ import (
 type Rule struct {
 	Conditions []elbv2model.RuleCondition
 	Actions    []elbv2model.Action
+	Transforms []elbv2model.Transform
 	Tags       map[string]string
 }
 

--- a/pkg/model/elbv2/listener_rule.go
+++ b/pkg/model/elbv2/listener_rule.go
@@ -55,16 +55,24 @@ const (
 
 // Information for a host header condition.
 type HostHeaderConditionConfig struct {
-	// One or more host names.
-	Values []string `json:"values"`
+	// One or more regex expressions for request host header.
+	// +optional
+	RegexValues []string `json:"regexValues,omitempty"`
+	// One or more value expressions for request host header.
+	// +optional
+	Values []string `json:"values,omitempty"`
 }
 
 // Information for an HTTP header condition.
 type HTTPHeaderConditionConfig struct {
 	// The name of the HTTP header field.
 	HTTPHeaderName string `json:"httpHeaderName"`
-	// One or more strings to compare against the value of the HTTP header.
-	Values []string `json:"values"`
+	// One or more regex matches for request HTTP headers.
+	// +optional
+	RegexValues []string `json:"regexValues,omitempty"`
+	// One or more value matches for request HTTP headers.
+	// +optional
+	Values []string `json:"values,omitempty"`
 }
 
 // Information for an HTTP method condition.
@@ -75,8 +83,12 @@ type HTTPRequestMethodConditionConfig struct {
 
 // Information about a path pattern condition.
 type PathPatternConditionConfig struct {
-	// One or more path patterns to compare against the request URL.
-	Values []string `json:"values"`
+	// One or more regex matches for request URL path.
+	// +optional
+	RegexValues []string `json:"regexValues,omitempty"`
+	// One or more value matches for request URL path.
+	// +optional
+	Values []string `json:"values,omitempty"`
 }
 
 // Information about a key/value pair.
@@ -125,6 +137,36 @@ type RuleCondition struct {
 	SourceIPConfig *SourceIPConditionConfig `json:"sourceIPConfig,omitempty"`
 }
 
+type TransformType string
+
+const (
+	TransformTypeUrlRewrite        TransformType = "url-rewrite"
+	TransformTypeHostHeaderRewrite TransformType = "host-header-rewrite"
+)
+
+type RewriteConfig struct {
+	// Regex expression
+	Regex string `json:"regex"`
+	// Replacement expression
+	Replace string `json:"replace"`
+}
+
+type RewriteConfigObject struct {
+	// Rewrites for the transform
+	Rewrites []RewriteConfig `json:"rewrites"`
+}
+
+type Transform struct {
+	// The type of transform
+	Type TransformType `json:"type"`
+	// Information for a host header rewrite.
+	// +optional
+	HostHeaderRewriteConfig *RewriteConfigObject `json:"hostHeaderRewriteConfig,omitempty"`
+	// Information for a URL rewrite.
+	// +optional
+	UrlRewriteConfig *RewriteConfigObject `json:"urlRewriteConfig,omitempty"`
+}
+
 // ListenerRuleSpec defines the desired state of ListenerRule
 type ListenerRuleSpec struct {
 	// The Amazon Resource Name (ARN) of the listener.
@@ -135,6 +177,9 @@ type ListenerRuleSpec struct {
 	Actions []Action `json:"actions"`
 	// The conditions.
 	Conditions []RuleCondition `json:"conditions"`
+	// The transforms.
+	// +optional
+	Transforms []Transform `json:"transforms,omitempty"`
 	// The tags.
 	// +optional
 	Tags map[string]string `json:"tags,omitempty"`


### PR DESCRIPTION
Implement support for URL and Host Header Rewrite for Application Load Balancer

# Motivation

This PR adds AWS Load Balancer Controller support for 1/ URL and Host Header Rewrite, and 2/ regex rule conditions.

* See documentation: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/rule-transforms.html
* See launch announcement: https://aws.amazon.com/about-aws/whats-new/2025/10/application-load-balancer-url-header-rewrite/
* See blog: https://aws.amazon.com/blogs/networking-and-content-delivery/introducing-url-and-host-header-rewrite-with-aws-application-load-balancers/

# Usage in LBC

## Transforms

Added `alb.ingress.kubernetes.io/transforms.${transforms-name}` annotation, which provides a method for specifying transforms on Ingress spec.

Example transform to remove the leading `/api/` from request paths:

```yaml
alb.ingress.kubernetes.io/transforms.my-service: >
    [
        {
            "type": "url-rewrite",
            "urlRewriteConfig": {
                "rewrites": [
                    {
                        "regex": "^\\/api\\/(.+)$",
                        "replace": "/$1"
                    }
                ]
            }
        }
    ]
```

Example transform to replace `example.com` with `example.org` from request host headers:

```yaml
alb.ingress.kubernetes.io/transforms.my-service: >
    [
        {
            "type": "host-header-rewrite",
            "hostHeaderRewriteConfig": {
                "rewrites": [
                    {
                        "regex": "^(.+)\\.example\\.com$",
                        "replace": "$1.example.org"
                    }
                ]
            }
        }
    ]
```

## Regex rule conditions (annotations)

Extended `alb.ingress.kubernetes.io/conditions.${conditions-name}` to support new `regexValues` property.

HTTP header condition using regex values:

```yaml
alb.ingress.kubernetes.io/conditions.my-service: >
    [{ "field": "http-header", "httpHeaderConfig": { "httpHeaderName": "User-Agent", "regexValues": [ ".+Chrome.+" ] } }]
```

Path condition using regex values:

```yaml
alb.ingress.kubernetes.io/conditions.my-service: >
    [{ "field": "path-pattern", "pathPatternConfig": { "regexValues": [ "^/api/?(.*)$" ] } }]
```

Host header condition using regex values:

```yaml
alb.ingress.kubernetes.io/conditions.my-service: >
    [{ "field": "host-header", "hostHeaderConfig": { "regexValues": [ "^(.+)\\.example\\.com" ] } }]
```

## Regex rule conditions (ingress spec)

Added `alb.ingress.kubernetes.io/use-regex-path-match` annotation, which configures whether HTTP paths in the Ingress specification should be evaluated using regex.

* This configuration only applies to HTTP paths using `pathType: ImplementationSpecific`. HTTP paths using `pathType: Exact` or `pathType: Prefix` are not affected by this annotation.
* A leading `/` must precede the regex. The leading `/` will be removed from the regex.

Annotation:

```yaml
alb.ingress.kubernetes.io/use-regex-path-match: "true"
```

Ingress rule path:

```yaml
-   path: "/^/api/(.+)$"
    pathType: ImplementationSpecific
    backend:
        service:
        name: service-2048
        port:
            number: 80
```

With this configuration, the rule condition regex value will be `^/api/(.+)$` as the leading `/` is removed from the regex.

# Details

* Implement support for RegexValues in conditions annotation
* Implement support for RegexValues in ingress spec paths
    * Add `alb.ingress.kubernetes.io/use-regex-path-match` annotation
    * Update `buildPathPatternsForImplementationSpecificPathType` to treat spec path as regex when annotation is "true"
* Implement transforms annotation
    * Implement `buildTransforms` to get transforms from `transforms.${svc-name}` annotation
    * Implement `buildSDKTransforms` to marshall transforms
    * Add interface for transforms model
    * Update enhanced backend, `ListenerRuleManager`, `buildListenerRules`, `matchResAndSDKListenerRules` to handle transforms
    * Rename `resLRDesiredActionsAndConditionsPair` to `resLRDesiredRuleConfig`, extend to support transforms property
    * Update `matchResAndSDKListenerRules` and related helpers to support transforms property
    * Implement `CompareOptionForTransform` to compare transforms objects
    * Add and update unit tests
* Misc
    * Add documentation for URL Rewrite
    * Add client-side validation to prevent mixing Values and RegexValues for host-name and path-pattern conditions
    * Remove leading slash from regex rule path
    * Implement host regex value support

# Issues

* https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/142
* https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/835
* https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/1133
* https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/1571
* https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2082
* https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2428

# Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
  - Previously did manual tests, doing some more final testing now
- [x] Made sure the title of the PR is a good description that can go into the release notes

## BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [x] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:
