### PR TITLE
re-enable tls tests with new certs

### DIFF
--- a/scripts/ci_e2e_test.sh
+++ b/scripts/ci_e2e_test.sh
@@ -206,9 +206,9 @@ test_controller_image() {
   S3_BUCKET=${S3_BUCKET:-"lb-controller-e2e-${AWS_ACCOUNT_ID}"}
   CERTIFICATE_ARN_PREFIX=arn:aws:acm:${AWS_REGION}:${AWS_ACCOUNT_ID}:certificate
   echo "updated the CERT_IDs"
-  CERT_ID1="d39a65e5-44f6-4734-9034-6c82ae7df73b"
-  CERT_ID2="35d7e09b-c4a9-447e-ba8c-7f9f29b77c8f"
-  CERT_ID3="f44d1a16-409a-4937-a420-b42dab2d384a"
+  CERT_ID1="bfd3d659-90b9-489b-8961-6bf448492726"
+  CERT_ID2="c9f12ef2-4bd6-4c0f-ac9d-94f7683042a7"
+  CERT_ID3="10b8651f-708d-4a26-941a-db784610cd6e"
   CERTIFICATE_ARNS=${CERTIFICATE_ARNS:-"${CERTIFICATE_ARN_PREFIX}/${CERT_ID1},${CERTIFICATE_ARN_PREFIX}/${CERT_ID2},${CERTIFICATE_ARN_PREFIX}/${CERT_ID3}"}
   echo "creating s3 bucket $S3_BUCKET"
   aws s3api create-bucket --bucket $S3_BUCKET --region $AWS_REGION --create-bucket-configuration LocationConstraint=$AWS_REGION || true


### PR DESCRIPTION
reverts https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4358/files by replacing the old cert ids with the newly generated certs in https://github.com/kubernetes/k8s.io/issues/8552