### PR TITLE
[gw api] add disable security group flag to lb config for gateway users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,5 @@ scripts/aws_sdk_model_override/*
 /gomock_reflect*
 config/crd/bases/gateway.k8s.aws_listenerruleconfigurations.yaml
 config/crd/bases/gateway.k8s.aws_loadbalancerconfigurations.yaml
+config/crd/bases/aga.k8s.aws_globalaccelerators.yaml
 config/crd/bases/gateway.k8s.aws_targetgroupconfigurations.yaml

--- a/apis/gateway/v1beta1/loadbalancerconfig_types.go
+++ b/apis/gateway/v1beta1/loadbalancerconfig_types.go
@@ -233,6 +233,11 @@ type LoadBalancerConfigurationSpec struct {
 	// +optional
 	ListenerConfigurations *[]ListenerConfiguration `json:"listenerConfigurations,omitempty"`
 
+	// disableSecurityGroup provisions a load balancer with no security groups.
+	// Allows an NLB to be provisioned with no security groups.
+	// [Network Load Balancer]
+	DisableSecurityGroup *bool `json:"disableSecurityGroup,omitempty"`
+
 	// securityGroups an optional list of security group ids or names to apply to the LB
 	// +optional
 	SecurityGroups *[]string `json:"securityGroups,omitempty"`

--- a/apis/gateway/v1beta1/zz_generated.deepcopy.go
+++ b/apis/gateway/v1beta1/zz_generated.deepcopy.go
@@ -670,6 +670,11 @@ func (in *LoadBalancerConfigurationSpec) DeepCopyInto(out *LoadBalancerConfigura
 			}
 		}
 	}
+	if in.DisableSecurityGroup != nil {
+		in, out := &in.DisableSecurityGroup, &out.DisableSecurityGroup
+		*out = new(bool)
+		**out = **in
+	}
 	if in.SecurityGroups != nil {
 		in, out := &in.SecurityGroups, &out.SecurityGroups
 		*out = new([]string)

--- a/config/crd/gateway/gateway-crds.yaml
+++ b/config/crd/gateway/gateway-crds.yaml
@@ -449,6 +449,12 @@ spec:
                   customerOwnedIpv4Pool [Application LoadBalancer]
                   is the ID of the customer-owned address for Application Load Balancers on Outposts pool.
                 type: string
+              disableSecurityGroup:
+                description: |-
+                  disableSecurityGroup provisions a load balancer with no security groups.
+                  Allows an NLB to be provisioned with no security groups.
+                  [Network Load Balancer]
+                type: boolean
               enableICMP:
                 description: |-
                   EnableICMP [Network LoadBalancer]

--- a/config/crd/gateway/gateway.k8s.aws_loadbalancerconfigurations.yaml
+++ b/config/crd/gateway/gateway.k8s.aws_loadbalancerconfigurations.yaml
@@ -50,6 +50,12 @@ spec:
                   customerOwnedIpv4Pool [Application LoadBalancer]
                   is the ID of the customer-owned address for Application Load Balancers on Outposts pool.
                 type: string
+              disableSecurityGroup:
+                description: |-
+                  disableSecurityGroup provisions a load balancer with no security groups.
+                  Allows an NLB to be provisioned with no security groups.
+                  [Network Load Balancer]
+                type: boolean
               enableICMP:
                 description: |-
                   EnableICMP [Network LoadBalancer]

--- a/helm/aws-load-balancer-controller/crds/gateway-crds.yaml
+++ b/helm/aws-load-balancer-controller/crds/gateway-crds.yaml
@@ -449,6 +449,12 @@ spec:
                   customerOwnedIpv4Pool [Application LoadBalancer]
                   is the ID of the customer-owned address for Application Load Balancers on Outposts pool.
                 type: string
+              disableSecurityGroup:
+                description: |-
+                  disableSecurityGroup provisions a load balancer with no security groups.
+                  Allows an NLB to be provisioned with no security groups.
+                  [Network Load Balancer]
+                type: boolean
               enableICMP:
                 description: |-
                   EnableICMP [Network LoadBalancer]

--- a/pkg/gateway/lb_config_merger.go
+++ b/pkg/gateway/lb_config_merger.go
@@ -177,4 +177,10 @@ func (merger *loadBalancerConfigMergerImpl) performTakeOneMerges(merged *elbv2gw
 	} else {
 		merged.ShieldAdvanced = lowPriority.Spec.ShieldAdvanced
 	}
+
+	if highPriority.Spec.DisableSecurityGroup != nil {
+		merged.DisableSecurityGroup = highPriority.Spec.DisableSecurityGroup
+	} else {
+		merged.DisableSecurityGroup = lowPriority.Spec.DisableSecurityGroup
+	}
 }

--- a/pkg/gateway/model/base_model_builder.go
+++ b/pkg/gateway/model/base_model_builder.go
@@ -45,7 +45,7 @@ func NewModelBuilder(subnetsResolver networking.SubnetsResolver,
 
 	gwTagHelper := newTagHelper(sets.New(lbcConfig.ExternalManagedTags...), lbcConfig.DefaultTags, featureGates.Enabled(config.EnableDefaultTagsLowPriority))
 	subnetBuilder := newSubnetModelBuilder(loadBalancerType, trackingProvider, subnetsResolver, elbv2TaggingManager)
-	sgBuilder := newSecurityGroupBuilder(gwTagHelper, clusterName, enableBackendSG, sgResolver, backendSGProvider, logger)
+	sgBuilder := newSecurityGroupBuilder(gwTagHelper, clusterName, loadBalancerType, enableBackendSG, sgResolver, backendSGProvider, logger)
 	lbBuilder := newLoadBalancerBuilder(loadBalancerType, gwTagHelper, clusterName)
 	tgConfigConstructor := config2.NewTargetGroupConfigConstructor()
 
@@ -163,7 +163,7 @@ func (baseBuilder *baseModelBuilder) Build(ctx context.Context, gw *gwv1.Gateway
 
 	/* Security Groups */
 
-	securityGroups, err := baseBuilder.securityGroupBuilder.buildSecurityGroups(ctx, stack, lbConf, gw, routes, ipAddressType)
+	securityGroups, err := baseBuilder.securityGroupBuilder.buildSecurityGroups(ctx, stack, lbConf, gw, ipAddressType)
 
 	if err != nil {
 		return nil, nil, nil, false, nil, err


### PR DESCRIPTION
### Description

This ports over a behavior from the Service API which allows users to provision NLBs with no security groups attached. This only applies to NLB gateways, as ALB most always have an SG attached.

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
