### PR TITLE
Fix EIP Allocations annotation in docs

### DIFF
--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -85,7 +85,7 @@ You can add annotations to kubernetes Ingress and Service objects to customize t
 | [alb.ingress.kubernetes.io/frontend-nlb-healthcheck-unhealthy-threshold-count](#frontend-nlb-healthcheck-unhealthy-threshold-count) | integer                     |3| Ingress | N/A           |
 | [alb.ingress.kubernetes.io/frontend-nlb-healthcheck-success-codes](#frontend-nlb-healthcheck-success-codes) | string                                     |200| Ingress | N/A           |
 | [alb.ingress.kubernetes.io/frontend-nlb-tags](#frontend-nlb-tags) | stringMap | N/A | Ingress | Exclusive |
-| [alb.ingress.kubernetes.io/frontend-nlb-eip-allocation](#frontend-nlb-eip-allocation) | stringList                                     |200| Ingress | N/A           |
+| [alb.ingress.kubernetes.io/frontend-nlb-eip-allocations](#frontend-nlb-eip-allocations) | stringList                                     |200| Ingress | N/A           |
 
 ## IngressGroup
 IngressGroup feature enables you to group multiple Ingress resources together.
@@ -1344,7 +1344,7 @@ When this option is set to true, the controller will automatically provision a N
         alb.ingress.kubernetes.io/frontend-nlb-tags: Environment=prod,Team=platform
         ```
 
-- <a name="frontend-nlb-eip-allocation">`alb.ingress.kubernetes.io/frontend-nlb-eip-allocation`</a> specifies a list of [elastic IP address](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html) configuration for an internet-facing NLB.
+- <a name="frontend-nlb-eip-allocations">`alb.ingress.kubernetes.io/frontend-nlb-eip-allocations`</a> specifies a list of [elastic IP address](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html) configuration for an internet-facing NLB.
 
     !!!note
         - This configuration is optional, and you can use it to assign static IP addresses to your NLB
@@ -1353,5 +1353,5 @@ When this option is set to true, the controller will automatically provision a N
 
     !!!example
         ```
-        alb.ingress.kubernetes.io/frontend-nlb-eip-allocation: eipalloc-xyz, eipalloc-zzz
+        alb.ingress.kubernetes.io/frontend-nlb-eip-allocations: eipalloc-xyz, eipalloc-zzz
         ```


### PR DESCRIPTION
### Issue

The docs are incorrect, the annotation is `alb.ingress.kubernetes.io/frontend-nlb-eip-allocations`, not `alb.ingress.kubernetes.io/frontend-nlb-eip-allocation`.

### Description
Updated the docs to reflect the correct annotation

### Checklist
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Made sure the title of the PR is a good description that can go into the release notes