### PR TITLE
[feat gw-api]return multiple types in listener status

### DIFF
--- a/controllers/gateway/route_reconciler.go
+++ b/controllers/gateway/route_reconciler.go
@@ -435,11 +435,12 @@ func areConditionsEqual(oldConditions, newConditions []metav1.Condition) bool {
 			return false
 		}
 
-		// Compare condition fields, ignore LastTransitionTime and ObservedGeneration
+		// Compare condition fields, ignore LastTransitionTime
 		if oldCondition.Type != newCondition.Type ||
 			oldCondition.Status != newCondition.Status ||
 			oldCondition.Reason != newCondition.Reason ||
-			oldCondition.Message != newCondition.Message {
+			oldCondition.Message != newCondition.Message ||
+			oldCondition.ObservedGeneration != newCondition.ObservedGeneration {
 			return false
 		}
 	}

--- a/controllers/gateway/route_reconciler_test.go
+++ b/controllers/gateway/route_reconciler_test.go
@@ -1,6 +1,9 @@
 package gateway
 
 import (
+	"testing"
+	"time"
+
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -11,8 +14,6 @@ import (
 	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
-	"testing"
-	"time"
 )
 
 func TestDeferredReconcilerConstructor(t *testing.T) {
@@ -671,7 +672,7 @@ func Test_areConditionsEqual(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "different conditions on ObservedGeneration - true",
+			name: "different conditions on ObservedGeneration - false",
 			oldCon: []metav1.Condition{
 				{
 					Type:               string(gwv1.RouteConditionAccepted),
@@ -694,7 +695,7 @@ func Test_areConditionsEqual(t *testing.T) {
 					Status: metav1.ConditionTrue,
 				},
 			},
-			expected: true,
+			expected: false,
 		},
 	}
 

--- a/controllers/gateway/utils_test.go
+++ b/controllers/gateway/utils_test.go
@@ -486,6 +486,13 @@ func Test_prepareGatewayConditionUpdate(t *testing.T) {
 							Reason:             "other reason2",
 							Message:            "other message2",
 						},
+						{
+							Type:               string(gwv1.GatewayConditionAccepted),
+							Status:             metav1.ConditionTrue,
+							ObservedGeneration: 0,
+							Reason:             "other reason",
+							Message:            "other message",
+						},
 					},
 				},
 			},
@@ -493,6 +500,7 @@ func Test_prepareGatewayConditionUpdate(t *testing.T) {
 			newStatus:           metav1.ConditionTrue,
 			reason:              "other reason",
 			message:             "other message",
+			expected:            true,
 		},
 		{
 			name: "target condition found",

--- a/pkg/gateway/constants/controller_constants.go
+++ b/pkg/gateway/constants/controller_constants.go
@@ -76,6 +76,12 @@ const (
 
 // constant for status update
 const (
-	GatewayAcceptedFalseMessage = "Gateway is not accepted because there is an invalid listener."
-	ListenerAcceptedMessage     = "Listener is accepted"
+	GatewayAcceptedFalseMessage      = "Gateway is not accepted because there is an invalid listener."
+	GatewayProgrammedPendingMessage  = "Waiting for load balancer to be active."
+	ListenerAcceptedMessage          = "Listener is accepted."
+	ListenerNotAcceptedMessage       = "Listener is not accepted."
+	ListenerNoConflictMessage        = "Listener has no conflict."
+	ListenerProgrammedMessage        = "Listener is programmed."
+	ListenerResolvedRefMessage       = "Listener has all refs resolved."
+	ListenerPendingProgrammedMessage = "Listener is pending to be programmed."
 )


### PR DESCRIPTION
### Description
- during conformance tests, found it requires listener status to return all Accepted/Programmed/ResolvedRefs types before continuing test cases, and we were only returning one type -> basically changed return value for buildListenerStatus 
- listener status Programmed=true when load balancer is provisioned and listener is accepted
- route status update was ignoring ObservedGeneration before

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
Screenshot of programmed = pending when lb is under provision
<img width="562" height="547" alt="Screenshot 2025-10-23 at 2 43 43 PM" src="https://github.com/user-attachments/assets/22c4ceea-07d2-4493-82f0-756314309850" />

Screenshot of programmed = true when lb is provisioned
<img width="555" height="544" alt="Screenshot 2025-10-23 at 3 29 00 PM" src="https://github.com/user-attachments/assets/b883e8dc-3a72-4d7f-8c23-3d3b887d4b51" />


- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
