### PR TITLE
Add generic tag processing system for controllers

### DIFF
--- a/pkg/aga/model_build_accelerator.go
+++ b/pkg/aga/model_build_accelerator.go
@@ -23,9 +23,9 @@ type acceleratorBuilder interface {
 }
 
 // NewAcceleratorBuilder constructs new acceleratorBuilder
-func NewAcceleratorBuilder(trackingProvider tracking.Provider, clusterName string, defaultTags map[string]string, externalManagedTags []string) acceleratorBuilder {
+func NewAcceleratorBuilder(trackingProvider tracking.Provider, clusterName string, defaultTags map[string]string, externalManagedTags []string, additionalTagsOverrideDefaultTags bool) acceleratorBuilder {
 	externalManagedTagsSet := sets.New(externalManagedTags...)
-	tagHelper := newTagHelper(externalManagedTagsSet, defaultTags)
+	tagHelper := newTagHelper(externalManagedTagsSet, defaultTags, additionalTagsOverrideDefaultTags)
 
 	return &defaultAcceleratorBuilder{
 		trackingProvider: trackingProvider,
@@ -121,7 +121,7 @@ func (b *defaultAcceleratorBuilder) buildAcceleratorIPAddressType(_ context.Cont
 
 func (b *defaultAcceleratorBuilder) buildAcceleratorTags(_ context.Context, stack core.Stack, ga *agaapi.GlobalAccelerator) (map[string]string, error) {
 	// Get tags from tag helper (includes default tags and user-specified tags)
-	tags, err := b.tagHelper.getAcceleratorTags(ga)
+	tags, err := b.tagHelper.getAcceleratorTags(*ga)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/aga/model_build_accelerator_test.go
+++ b/pkg/aga/model_build_accelerator_test.go
@@ -329,7 +329,9 @@ func Test_defaultAcceleratorBuilder_buildAcceleratorTags(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			builder := NewAcceleratorBuilder(trackingProvider, tt.clusterName, tt.defaultTags, tt.externalManagedTags)
+			// Use true for "user tags override default tags" test case
+			additionalTagsOverrideDefaultTags := tt.name == "user tags override default tags"
+			builder := NewAcceleratorBuilder(trackingProvider, tt.clusterName, tt.defaultTags, tt.externalManagedTags, additionalTagsOverrideDefaultTags)
 			b := builder.(*defaultAcceleratorBuilder)
 
 			stack := core.NewDefaultStack(core.StackID{Namespace: "test", Name: "test"})
@@ -495,7 +497,7 @@ func Test_defaultAcceleratorBuilder_Build(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			builder := NewAcceleratorBuilder(trackingProvider, tt.clusterName, tt.defaultTags, tt.externalManagedTags)
+			builder := NewAcceleratorBuilder(trackingProvider, tt.clusterName, tt.defaultTags, tt.externalManagedTags, false)
 
 			got, err := builder.Build(context.Background(), stack, tt.ga)
 

--- a/pkg/aga/model_builder.go
+++ b/pkg/aga/model_builder.go
@@ -58,7 +58,7 @@ func (b *defaultModelBuilder) Build(ctx context.Context, ga *agaapi.GlobalAccele
 	stack := core.NewDefaultStack(core.StackID(k8s.NamespacedName(ga)))
 
 	// Create fresh builder instances for each reconciliation
-	acceleratorBuilder := NewAcceleratorBuilder(b.trackingProvider, b.clusterName, b.defaultTags, b.externalManagedTags)
+	acceleratorBuilder := NewAcceleratorBuilder(b.trackingProvider, b.clusterName, b.defaultTags, b.externalManagedTags, b.featureGates.Enabled(config.EnableDefaultTagsLowPriority))
 	// TODO
 	// listenerBuilder := NewListenerBuilder()
 	// endpointGroupBuilder := NewEndpointGroupBuilder()

--- a/pkg/aga/tag_adapters.go
+++ b/pkg/aga/tag_adapters.go
@@ -1,0 +1,21 @@
+package aga
+
+import (
+	agaapi "sigs.k8s.io/aws-load-balancer-controller/apis/aga/v1beta1"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/shared_utils"
+)
+
+// GlobalAcceleratorTagProvider adapts GlobalAccelerator to implement TagProvider
+type GlobalAcceleratorTagProvider struct {
+	ga agaapi.GlobalAccelerator
+}
+
+// NewGlobalAcceleratorTagProvider creates a new GlobalAcceleratorTagProvider
+func NewGlobalAcceleratorTagProvider(ga agaapi.GlobalAccelerator) shared_utils.TagProvider {
+	return &GlobalAcceleratorTagProvider{ga: ga}
+}
+
+// GetTags returns the tags from the GlobalAccelerator spec
+func (g GlobalAcceleratorTagProvider) GetTags() *map[string]string {
+	return g.ga.Spec.Tags
+}

--- a/pkg/aga/tag_helper.go
+++ b/pkg/aga/tag_helper.go
@@ -1,49 +1,31 @@
 package aga
 
 import (
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	agaapi "sigs.k8s.io/aws-load-balancer-controller/apis/aga/v1beta1"
-	"sigs.k8s.io/aws-load-balancer-controller/pkg/algorithm"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/shared_utils"
 )
 
 type tagHelper interface {
-	getAcceleratorTags(ga *agaapi.GlobalAccelerator) (map[string]string, error)
+	getAcceleratorTags(ga agaapi.GlobalAccelerator) (map[string]string, error)
 }
 
 type tagHelperImpl struct {
-	externalManagedTags sets.Set[string]
-	defaultTags         map[string]string
+	sharedHelper shared_utils.TagHelper
 }
 
-func newTagHelper(externalManagedTags sets.Set[string], defaultTags map[string]string) tagHelper {
+func newTagHelper(externalManagedTags sets.Set[string], defaultTags map[string]string, additionalTagsOverrideDefaultTags bool) tagHelper {
+	config := shared_utils.TagHelperConfig{
+		ExternalManagedTags:               externalManagedTags,
+		DefaultTags:                       defaultTags,
+		AdditionalTagsOverrideDefaultTags: additionalTagsOverrideDefaultTags,
+	}
 	return &tagHelperImpl{
-		externalManagedTags: externalManagedTags,
-		defaultTags:         defaultTags,
+		sharedHelper: shared_utils.NewTagHelper(config),
 	}
 }
 
-func (t *tagHelperImpl) getAcceleratorTags(ga *agaapi.GlobalAccelerator) (map[string]string, error) {
-	gaTags := make(map[string]string)
-
-	if ga.Spec.Tags != nil {
-		for k, v := range *ga.Spec.Tags {
-			gaTags[k] = v
-		}
-	}
-
-	if err := t.validateTagCollisionWithExternalManagedTags(gaTags); err != nil {
-		return nil, err
-	}
-
-	return algorithm.MergeStringMap(gaTags, t.defaultTags), nil
-}
-
-func (t *tagHelperImpl) validateTagCollisionWithExternalManagedTags(tags map[string]string) error {
-	for tagKey := range tags {
-		if t.externalManagedTags.Has(tagKey) {
-			return errors.Errorf("external managed tag key %v cannot be specified", tagKey)
-		}
-	}
-	return nil
+func (t *tagHelperImpl) getAcceleratorTags(ga agaapi.GlobalAccelerator) (map[string]string, error) {
+	provider := NewGlobalAcceleratorTagProvider(ga)
+	return t.sharedHelper.ProcessTags(provider)
 }

--- a/pkg/aga/tag_helper_test.go
+++ b/pkg/aga/tag_helper_test.go
@@ -10,16 +10,17 @@ import (
 
 func Test_tagHelperImpl_getAcceleratorTags(t *testing.T) {
 	tests := []struct {
-		name                string
-		ga                  *agaapi.GlobalAccelerator
-		externalManagedTags []string
-		defaultTags         map[string]string
-		want                map[string]string
-		wantErr             bool
+		name                   string
+		ga                     agaapi.GlobalAccelerator
+		externalManagedTags    []string
+		defaultTags            map[string]string
+		defaultTagsLowPriority bool
+		want                   map[string]string
+		wantErr                bool
 	}{
 		{
 			name: "no tags specified",
-			ga: &agaapi.GlobalAccelerator{
+			ga: agaapi.GlobalAccelerator{
 				Spec: agaapi.GlobalAcceleratorSpec{},
 			},
 			externalManagedTags: []string{},
@@ -35,7 +36,7 @@ func Test_tagHelperImpl_getAcceleratorTags(t *testing.T) {
 		},
 		{
 			name: "user tags specified",
-			ga: &agaapi.GlobalAccelerator{
+			ga: agaapi.GlobalAccelerator{
 				Spec: agaapi.GlobalAcceleratorSpec{
 					Tags: &map[string]string{
 						"Application": "my-app",
@@ -43,7 +44,8 @@ func Test_tagHelperImpl_getAcceleratorTags(t *testing.T) {
 					},
 				},
 			},
-			externalManagedTags: []string{},
+			externalManagedTags:    []string{},
+			defaultTagsLowPriority: false,
 			defaultTags: map[string]string{
 				"Environment": "test",
 				"Team":        "platform",
@@ -58,7 +60,7 @@ func Test_tagHelperImpl_getAcceleratorTags(t *testing.T) {
 		},
 		{
 			name: "user tags override default tags",
-			ga: &agaapi.GlobalAccelerator{
+			ga: agaapi.GlobalAccelerator{
 				Spec: agaapi.GlobalAcceleratorSpec{
 					Tags: &map[string]string{
 						"Environment": "production",
@@ -66,7 +68,8 @@ func Test_tagHelperImpl_getAcceleratorTags(t *testing.T) {
 					},
 				},
 			},
-			externalManagedTags: []string{},
+			externalManagedTags:    []string{},
+			defaultTagsLowPriority: true,
 			defaultTags: map[string]string{
 				"Environment": "test",
 				"Team":        "platform",
@@ -80,7 +83,7 @@ func Test_tagHelperImpl_getAcceleratorTags(t *testing.T) {
 		},
 		{
 			name: "external managed tags configured but not specified by user",
-			ga: &agaapi.GlobalAccelerator{
+			ga: agaapi.GlobalAccelerator{
 				Spec: agaapi.GlobalAcceleratorSpec{
 					Tags: &map[string]string{
 						"Application": "my-app",
@@ -88,7 +91,8 @@ func Test_tagHelperImpl_getAcceleratorTags(t *testing.T) {
 					},
 				},
 			},
-			externalManagedTags: []string{"ExternalTag", "ManagedByTeam"},
+			externalManagedTags:    []string{"ExternalTag", "ManagedByTeam"},
+			defaultTagsLowPriority: false,
 			defaultTags: map[string]string{
 				"Environment": "test",
 			},
@@ -101,7 +105,7 @@ func Test_tagHelperImpl_getAcceleratorTags(t *testing.T) {
 		},
 		{
 			name: "external managed tags specified by user should cause error",
-			ga: &agaapi.GlobalAccelerator{
+			ga: agaapi.GlobalAccelerator{
 				Spec: agaapi.GlobalAcceleratorSpec{
 					Tags: &map[string]string{
 						"Application":   "my-app",
@@ -110,7 +114,8 @@ func Test_tagHelperImpl_getAcceleratorTags(t *testing.T) {
 					},
 				},
 			},
-			externalManagedTags: []string{"ExternalTag", "ManagedByTeam"},
+			externalManagedTags:    []string{"ExternalTag", "ManagedByTeam"},
+			defaultTagsLowPriority: false,
 			defaultTags: map[string]string{
 				"Environment": "test",
 			},
@@ -119,7 +124,7 @@ func Test_tagHelperImpl_getAcceleratorTags(t *testing.T) {
 		},
 		{
 			name: "single external managed tag specified by user should cause error",
-			ga: &agaapi.GlobalAccelerator{
+			ga: agaapi.GlobalAccelerator{
 				Spec: agaapi.GlobalAcceleratorSpec{
 					Tags: &map[string]string{
 						"Application": "my-app",
@@ -127,7 +132,8 @@ func Test_tagHelperImpl_getAcceleratorTags(t *testing.T) {
 					},
 				},
 			},
-			externalManagedTags: []string{"ExternalTag", "ManagedByTeam"},
+			externalManagedTags:    []string{"ExternalTag", "ManagedByTeam"},
+			defaultTagsLowPriority: false,
 			defaultTags: map[string]string{
 				"Environment": "test",
 			},
@@ -136,15 +142,16 @@ func Test_tagHelperImpl_getAcceleratorTags(t *testing.T) {
 		},
 		{
 			name: "empty default tags",
-			ga: &agaapi.GlobalAccelerator{
+			ga: agaapi.GlobalAccelerator{
 				Spec: agaapi.GlobalAcceleratorSpec{
 					Tags: &map[string]string{
 						"Application": "my-app",
 					},
 				},
 			},
-			externalManagedTags: []string{},
-			defaultTags:         map[string]string{},
+			externalManagedTags:    []string{},
+			defaultTagsLowPriority: false,
+			defaultTags:            map[string]string{},
 			want: map[string]string{
 				"Application": "my-app",
 			},
@@ -152,12 +159,13 @@ func Test_tagHelperImpl_getAcceleratorTags(t *testing.T) {
 		},
 		{
 			name: "nil user tags",
-			ga: &agaapi.GlobalAccelerator{
+			ga: agaapi.GlobalAccelerator{
 				Spec: agaapi.GlobalAcceleratorSpec{
 					Tags: nil,
 				},
 			},
-			externalManagedTags: []string{},
+			externalManagedTags:    []string{},
+			defaultTagsLowPriority: false,
 			defaultTags: map[string]string{
 				"Environment": "test",
 			},
@@ -171,7 +179,7 @@ func Test_tagHelperImpl_getAcceleratorTags(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			externalManagedTagsSet := sets.New(tt.externalManagedTags...)
-			helper := newTagHelper(externalManagedTagsSet, tt.defaultTags)
+			helper := newTagHelper(externalManagedTagsSet, tt.defaultTags, tt.defaultTagsLowPriority)
 
 			got, err := helper.getAcceleratorTags(tt.ga)
 
@@ -187,151 +195,63 @@ func Test_tagHelperImpl_getAcceleratorTags(t *testing.T) {
 	}
 }
 
-func Test_tagHelperImpl_validateTagCollisionWithExternalManagedTags(t *testing.T) {
-	tests := []struct {
-		name                string
-		tags                map[string]string
-		externalManagedTags []string
-		wantErr             bool
-		expectedErrorMsg    string
-	}{
-		{
-			name: "no collision - empty external managed tags",
-			tags: map[string]string{
-				"Application": "my-app",
-				"Owner":       "team-a",
-			},
-			externalManagedTags: []string{},
-			wantErr:             false,
-		},
-		{
-			name: "no collision - different tag keys",
-			tags: map[string]string{
-				"Application": "my-app",
-				"Owner":       "team-a",
-			},
-			externalManagedTags: []string{"ExternalTag", "ManagedByTeam"},
-			wantErr:             false,
-		},
-		{
-			name: "collision - single external managed tag",
-			tags: map[string]string{
-				"Application": "my-app",
-				"ExternalTag": "external-value",
-			},
-			externalManagedTags: []string{"ExternalTag", "ManagedByTeam"},
-			wantErr:             true,
-			expectedErrorMsg:    "external managed tag key ExternalTag cannot be specified",
-		},
-		{
-			name: "collision - multiple external managed tags",
-			tags: map[string]string{
-				"Application":   "my-app",
-				"ExternalTag":   "external-value",
-				"ManagedByTeam": "platform-team",
-			},
-			externalManagedTags: []string{"ExternalTag", "ManagedByTeam"},
-			wantErr:             true,
-			// Error message will contain one of the colliding tags
-		},
-		{
-			name:                "no collision - empty tags",
-			tags:                map[string]string{},
-			externalManagedTags: []string{"ExternalTag", "ManagedByTeam"},
-			wantErr:             false,
-		},
-		{
-			name:                "no collision - nil tags",
-			tags:                nil,
-			externalManagedTags: []string{"ExternalTag", "ManagedByTeam"},
-			wantErr:             false,
-		},
-		{
-			name: "collision - case sensitive",
-			tags: map[string]string{
-				"externaltag": "external-value", // lowercase
-			},
-			externalManagedTags: []string{"ExternalTag"}, // uppercase
-			wantErr:             false,                   // Should not collide due to case sensitivity
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			externalManagedTagsSet := sets.New(tt.externalManagedTags...)
-			helper := &tagHelperImpl{
-				externalManagedTags: externalManagedTagsSet,
-				defaultTags:         map[string]string{},
-			}
-
-			err := helper.validateTagCollisionWithExternalManagedTags(tt.tags)
-
-			if tt.wantErr {
-				assert.Error(t, err)
-				if tt.expectedErrorMsg != "" {
-					assert.Contains(t, err.Error(), tt.expectedErrorMsg)
-				}
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
-}
-
 func Test_newTagHelper(t *testing.T) {
 	tests := []struct {
-		name                string
-		externalManagedTags []string
-		defaultTags         map[string]string
+		name                   string
+		externalManagedTags    []string
+		defaultTags            map[string]string
+		defaultTagsLowPriority bool
 	}{
 		{
-			name:                "create with empty external managed tags",
-			externalManagedTags: []string{},
+			name:                   "create with empty external managed tags",
+			externalManagedTags:    []string{},
+			defaultTagsLowPriority: false,
 			defaultTags: map[string]string{
 				"Environment": "test",
 			},
 		},
 		{
-			name:                "create with external managed tags",
-			externalManagedTags: []string{"ExternalTag", "ManagedByTeam"},
+			name:                   "create with external managed tags",
+			externalManagedTags:    []string{"ExternalTag", "ManagedByTeam"},
+			defaultTagsLowPriority: false,
 			defaultTags: map[string]string{
 				"Environment": "test",
 				"Team":        "platform",
 			},
 		},
 		{
-			name:                "create with nil external managed tags",
-			externalManagedTags: nil,
+			name:                   "create with nil external managed tags",
+			externalManagedTags:    nil,
+			defaultTagsLowPriority: false,
 			defaultTags: map[string]string{
 				"Environment": "test",
 			},
 		},
 		{
-			name:                "create with empty default tags",
-			externalManagedTags: []string{"ExternalTag"},
-			defaultTags:         map[string]string{},
+			name:                   "create with empty default tags",
+			externalManagedTags:    []string{"ExternalTag"},
+			defaultTagsLowPriority: false,
+			defaultTags:            map[string]string{},
 		},
 		{
-			name:                "create with nil default tags",
-			externalManagedTags: []string{"ExternalTag"},
-			defaultTags:         nil,
+			name:                   "create with nil default tags",
+			externalManagedTags:    []string{"ExternalTag"},
+			defaultTagsLowPriority: false,
+			defaultTags:            nil,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			externalManagedTagsSet := sets.New(tt.externalManagedTags...)
-			helper := newTagHelper(externalManagedTagsSet, tt.defaultTags)
+			helper := newTagHelper(externalManagedTagsSet, tt.defaultTags, tt.defaultTagsLowPriority)
 
 			assert.NotNil(t, helper)
 
 			// Verify the helper is of the correct type
 			helperImpl, ok := helper.(*tagHelperImpl)
 			assert.True(t, ok)
-
-			// Verify the fields are set correctly
-			assert.Equal(t, externalManagedTagsSet, helperImpl.externalManagedTags)
-			assert.Equal(t, tt.defaultTags, helperImpl.defaultTags)
+			assert.NotNil(t, helperImpl.sharedHelper)
 		})
 	}
 }

--- a/pkg/gateway/model/gateway_tag_helper.go
+++ b/pkg/gateway/model/gateway_tag_helper.go
@@ -1,54 +1,43 @@
 package model
 
 import (
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
-	"sigs.k8s.io/aws-load-balancer-controller/pkg/algorithm"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/shared_utils"
 )
 
 type tagHelper interface {
-	getGatewayTags(lbConf elbv2gw.LoadBalancerConfiguration) (map[string]string, error)
+	getLoadBalancerTags(lbConf elbv2gw.LoadBalancerConfiguration) (map[string]string, error)
+	getTargetGroupTags(tgProps *elbv2gw.TargetGroupProps) (map[string]string, error)
+	getListenerRuleTags(lrConf *elbv2gw.ListenerRuleConfiguration) (map[string]string, error)
 }
 
 type tagHelperImpl struct {
-	externalManagedTags               sets.Set[string]
-	defaultTags                       map[string]string
-	additionalTagsOverrideDefaultTags bool
+	sharedHelper shared_utils.TagHelper
 }
 
 func newTagHelper(externalManagedTags sets.Set[string], defaultTags map[string]string, additionalTagsOverrideDefaultTags bool) tagHelper {
+	config := shared_utils.TagHelperConfig{
+		ExternalManagedTags:               externalManagedTags,
+		DefaultTags:                       defaultTags,
+		AdditionalTagsOverrideDefaultTags: additionalTagsOverrideDefaultTags,
+	}
 	return &tagHelperImpl{
-		externalManagedTags:               externalManagedTags,
-		defaultTags:                       defaultTags,
-		additionalTagsOverrideDefaultTags: additionalTagsOverrideDefaultTags,
+		sharedHelper: shared_utils.NewTagHelper(config),
 	}
 }
 
-func (t *tagHelperImpl) getGatewayTags(lbConf elbv2gw.LoadBalancerConfiguration) (map[string]string, error) {
-	annotationTags := make(map[string]string)
-
-	if lbConf.Spec.Tags != nil {
-		for k, v := range *lbConf.Spec.Tags {
-			annotationTags[k] = v
-		}
-	}
-
-	if err := t.validateTagCollisionWithExternalManagedTags(annotationTags); err != nil {
-		return nil, err
-	}
-
-	if t.additionalTagsOverrideDefaultTags {
-		return algorithm.MergeStringMap(annotationTags, t.defaultTags), nil
-	}
-	return algorithm.MergeStringMap(t.defaultTags, annotationTags), nil
+func (t *tagHelperImpl) getLoadBalancerTags(lbConf elbv2gw.LoadBalancerConfiguration) (map[string]string, error) {
+	provider := NewLoadBalancerConfigurationTagProvider(lbConf)
+	return t.sharedHelper.ProcessTags(provider)
 }
 
-func (t *tagHelperImpl) validateTagCollisionWithExternalManagedTags(tags map[string]string) error {
-	for tagKey := range tags {
-		if t.externalManagedTags.Has(tagKey) {
-			return errors.Errorf("external managed tag key %v cannot be specified", tagKey)
-		}
-	}
-	return nil
+func (t *tagHelperImpl) getTargetGroupTags(tgProps *elbv2gw.TargetGroupProps) (map[string]string, error) {
+	provider := NewTargetGroupPropsTagProvider(tgProps)
+	return t.sharedHelper.ProcessTags(provider)
+}
+
+func (t *tagHelperImpl) getListenerRuleTags(lrConf *elbv2gw.ListenerRuleConfiguration) (map[string]string, error) {
+	provider := NewListenerRuleConfigurationTagProvider(lrConf)
+	return t.sharedHelper.ProcessTags(provider)
 }

--- a/pkg/gateway/model/gateway_tag_helper_test.go
+++ b/pkg/gateway/model/gateway_tag_helper_test.go
@@ -8,7 +8,7 @@ import (
 	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
 )
 
-func Test_tagHelperImpl_getGatewayTags(t *testing.T) {
+func Test_tagHelperImpl_getLoadBalancerTags(t *testing.T) {
 	tests := []struct {
 		name                   string
 		defaultTags            map[string]string
@@ -111,18 +111,293 @@ func Test_tagHelperImpl_getGatewayTags(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			h := &tagHelperImpl{
-				externalManagedTags:               sets.New("external-tag"),
-				defaultTags:                       tt.defaultTags,
-				additionalTagsOverrideDefaultTags: tt.defaultTagsLowPriority,
-			}
+			externalManagedTags := sets.New("external-tag")
+			h := newTagHelper(externalManagedTags, tt.defaultTags, tt.defaultTagsLowPriority)
 
-			lbConf := &elbv2gw.LoadBalancerConfiguration{}
+			lbConf := elbv2gw.LoadBalancerConfiguration{}
 			if len(tt.specTags) > 0 {
 				lbConf.Spec.Tags = &tt.specTags
 			}
 
-			got, err := h.getGatewayTags(*lbConf)
+			got, err := h.getLoadBalancerTags(lbConf)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func Test_tagHelperImpl_getTargetGroupTags(t *testing.T) {
+	tests := []struct {
+		name                   string
+		defaultTags            map[string]string
+		specTags               map[string]string
+		defaultTagsLowPriority bool
+		want                   map[string]string
+		wantErr                bool
+		nilProps               bool
+	}{
+		{
+			name: "when defaultTagsLowPriority is false, default tags override spec tags",
+			defaultTags: map[string]string{
+				"env":  "prod",
+				"team": "platform",
+			},
+			specTags: map[string]string{
+				"env": "dev",
+				"app": "web",
+			},
+			defaultTagsLowPriority: false,
+			want: map[string]string{
+				"env":  "prod",
+				"team": "platform",
+				"app":  "web",
+			},
+		},
+		{
+			name: "when defaultTagsLowPriority is true, spec tags override default tags",
+			defaultTags: map[string]string{
+				"env":  "prod",
+				"team": "platform",
+			},
+			specTags: map[string]string{
+				"env": "dev",
+				"app": "web",
+			},
+			defaultTagsLowPriority: true,
+			want: map[string]string{
+				"env":  "dev",
+				"team": "platform",
+				"app":  "web",
+			},
+		},
+		{
+			name: "when no overlapping tags, order doesn't matter",
+			defaultTags: map[string]string{
+				"team":        "platform",
+				"cost-center": "123",
+			},
+			specTags: map[string]string{
+				"app": "web",
+				"env": "dev",
+			},
+			defaultTagsLowPriority: false,
+			want: map[string]string{
+				"team":        "platform",
+				"cost-center": "123",
+				"app":         "web",
+				"env":         "dev",
+			},
+		},
+		{
+			name:        "when defaultTags is empty, all spec tags are used",
+			defaultTags: map[string]string{},
+			specTags: map[string]string{
+				"app": "web",
+				"env": "dev",
+			},
+			defaultTagsLowPriority: false,
+			want: map[string]string{
+				"app": "web",
+				"env": "dev",
+			},
+		},
+		{
+			name: "when specTags is empty, all default tags are used",
+			defaultTags: map[string]string{
+				"team":        "platform",
+				"cost-center": "123",
+			},
+			specTags:               map[string]string{},
+			defaultTagsLowPriority: false,
+			want: map[string]string{
+				"team":        "platform",
+				"cost-center": "123",
+			},
+		},
+		{
+			name: "when specTags contains external managed tag, returns error",
+			defaultTags: map[string]string{
+				"team": "platform",
+			},
+			specTags: map[string]string{
+				"external-tag": "value",
+			},
+			defaultTagsLowPriority: false,
+			want:                   nil,
+			wantErr:                true,
+		},
+		{
+			name: "when tgProps is nil, only default tags are used",
+			defaultTags: map[string]string{
+				"team":        "platform",
+				"cost-center": "123",
+			},
+			nilProps:               true,
+			defaultTagsLowPriority: false,
+			want: map[string]string{
+				"team":        "platform",
+				"cost-center": "123",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			externalManagedTags := sets.New("external-tag")
+			h := newTagHelper(externalManagedTags, tt.defaultTags, tt.defaultTagsLowPriority)
+
+			var tgProps *elbv2gw.TargetGroupProps
+			if !tt.nilProps {
+				tgProps = &elbv2gw.TargetGroupProps{}
+				if len(tt.specTags) > 0 {
+					tgProps.Tags = &tt.specTags
+				}
+			}
+
+			got, err := h.getTargetGroupTags(tgProps)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func Test_tagHelperImpl_getListenerRuleTags(t *testing.T) {
+	tests := []struct {
+		name                   string
+		defaultTags            map[string]string
+		specTags               map[string]string
+		defaultTagsLowPriority bool
+		want                   map[string]string
+		wantErr                bool
+		nilConf                bool
+	}{
+		{
+			name: "when defaultTagsLowPriority is false, default tags override spec tags",
+			defaultTags: map[string]string{
+				"env":  "prod",
+				"team": "platform",
+			},
+			specTags: map[string]string{
+				"env": "dev",
+				"app": "web",
+			},
+			defaultTagsLowPriority: false,
+			want: map[string]string{
+				"env":  "prod",
+				"team": "platform",
+				"app":  "web",
+			},
+		},
+		{
+			name: "when defaultTagsLowPriority is true, spec tags override default tags",
+			defaultTags: map[string]string{
+				"env":  "prod",
+				"team": "platform",
+			},
+			specTags: map[string]string{
+				"env": "dev",
+				"app": "web",
+			},
+			defaultTagsLowPriority: true,
+			want: map[string]string{
+				"env":  "dev",
+				"team": "platform",
+				"app":  "web",
+			},
+		},
+		{
+			name: "when no overlapping tags, order doesn't matter",
+			defaultTags: map[string]string{
+				"team":        "platform",
+				"cost-center": "123",
+			},
+			specTags: map[string]string{
+				"app": "web",
+				"env": "dev",
+			},
+			defaultTagsLowPriority: false,
+			want: map[string]string{
+				"team":        "platform",
+				"cost-center": "123",
+				"app":         "web",
+				"env":         "dev",
+			},
+		},
+		{
+			name:        "when defaultTags is empty, all spec tags are used",
+			defaultTags: map[string]string{},
+			specTags: map[string]string{
+				"app": "web",
+				"env": "dev",
+			},
+			defaultTagsLowPriority: false,
+			want: map[string]string{
+				"app": "web",
+				"env": "dev",
+			},
+		},
+		{
+			name: "when specTags is empty, all default tags are used",
+			defaultTags: map[string]string{
+				"team":        "platform",
+				"cost-center": "123",
+			},
+			specTags:               map[string]string{},
+			defaultTagsLowPriority: false,
+			want: map[string]string{
+				"team":        "platform",
+				"cost-center": "123",
+			},
+		},
+		{
+			name: "when specTags contains external managed tag, returns error",
+			defaultTags: map[string]string{
+				"team": "platform",
+			},
+			specTags: map[string]string{
+				"external-tag": "value",
+			},
+			defaultTagsLowPriority: false,
+			want:                   nil,
+			wantErr:                true,
+		},
+		{
+			name: "when lrConf is nil, only default tags are used",
+			defaultTags: map[string]string{
+				"team":        "platform",
+				"cost-center": "123",
+			},
+			nilConf:                true,
+			defaultTagsLowPriority: false,
+			want: map[string]string{
+				"team":        "platform",
+				"cost-center": "123",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			externalManagedTags := sets.New("external-tag")
+			h := newTagHelper(externalManagedTags, tt.defaultTags, tt.defaultTagsLowPriority)
+
+			var lrConf *elbv2gw.ListenerRuleConfiguration
+			if !tt.nilConf {
+				lrConf = &elbv2gw.ListenerRuleConfiguration{}
+				if len(tt.specTags) > 0 {
+					lrConf.Spec.Tags = &tt.specTags
+				}
+			}
+
+			got, err := h.getListenerRuleTags(lrConf)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/pkg/gateway/model/mock_gateway_tag_helper.go
+++ b/pkg/gateway/model/mock_gateway_tag_helper.go
@@ -7,7 +7,15 @@ type mockTagHelper struct {
 	err  error
 }
 
-func (m *mockTagHelper) getGatewayTags(lbConf elbv2gw.LoadBalancerConfiguration) (map[string]string, error) {
+func (m *mockTagHelper) getLoadBalancerTags(lbConf elbv2gw.LoadBalancerConfiguration) (map[string]string, error) {
+	return m.tags, m.err
+}
+
+func (m *mockTagHelper) getTargetGroupTags(tgProps *elbv2gw.TargetGroupProps) (map[string]string, error) {
+	return m.tags, m.err
+}
+
+func (m *mockTagHelper) getListenerRuleTags(lrConf *elbv2gw.ListenerRuleConfiguration) (map[string]string, error) {
 	return m.tags, m.err
 }
 

--- a/pkg/gateway/model/model_build_listener.go
+++ b/pkg/gateway/model/model_build_listener.go
@@ -105,7 +105,7 @@ func (l listenerBuilderImpl) buildListener(ctx context.Context, stack core.Stack
 }
 
 func (l listenerBuilderImpl) buildListenerSpec(ctx context.Context, lb *elbv2model.LoadBalancer, gw *gwv1.Gateway, port int32, lbCfg elbv2gw.LoadBalancerConfiguration, gwLsCfg *gwListenerConfig, lbLsCfg *elbv2gw.ListenerConfiguration) (*elbv2model.ListenerSpec, error) {
-	tags, err := l.buildListenerTags(gw, port, lbCfg, lbLsCfg)
+	tags, err := l.buildListenerTags(lbCfg)
 	if err != nil {
 		return &elbv2model.ListenerSpec{}, err
 	}
@@ -264,7 +264,7 @@ func (l listenerBuilderImpl) buildListenerRules(ctx context.Context, stack core.
 			actions = append(actions, *ruleRoutingAction)
 		}
 
-		tags, tagsErr := l.tagHelper.getGatewayTags(lbCfg)
+		tags, tagsErr := l.tagHelper.getListenerRuleTags(rule.GetListenerRuleConfig())
 		if tagsErr != nil {
 			return nil, tagsErr
 		}
@@ -292,9 +292,9 @@ func (l listenerBuilderImpl) buildListenerRules(ctx context.Context, stack core.
 	return secrets, nil
 }
 
-func (l listenerBuilderImpl) buildListenerTags(gw *gwv1.Gateway, port int32, lbCfg elbv2gw.LoadBalancerConfiguration, lbLsCfg *elbv2gw.ListenerConfiguration) (map[string]string, error) {
-	// TODO Add proper gateway tags for listener
-	return l.tagHelper.getGatewayTags(lbCfg)
+func (l listenerBuilderImpl) buildListenerTags(lbCfg elbv2gw.LoadBalancerConfiguration) (map[string]string, error) {
+	// We dont have tags at listener level cfg. Hence we add all the load balancer level tags to listeners.
+	return l.tagHelper.getLoadBalancerTags(lbCfg)
 }
 
 func buildListenerAttributes(lsCfg *elbv2gw.ListenerConfiguration) ([]elbv2model.ListenerAttribute, error) {

--- a/pkg/gateway/model/model_build_loadbalancer.go
+++ b/pkg/gateway/model/model_build_loadbalancer.go
@@ -38,7 +38,7 @@ func (lbModelBuilder *loadBalancerBuilderImpl) buildLoadBalancerSpec(scheme elbv
 		return elbv2model.LoadBalancerSpec{}, err
 	}
 
-	tags, err := lbModelBuilder.tagHelper.getGatewayTags(lbConf)
+	tags, err := lbModelBuilder.tagHelper.getLoadBalancerTags(lbConf)
 	if err != nil {
 		return elbv2model.LoadBalancerSpec{}, err
 	}

--- a/pkg/gateway/model/model_build_security_group.go
+++ b/pkg/gateway/model/model_build_security_group.go
@@ -150,7 +150,7 @@ func (builder *securityGroupBuilderImpl) getBackendSecurityGroup(ctx context.Con
 
 func (builder *securityGroupBuilderImpl) buildManagedSecurityGroup(stack core.Stack, lbConf elbv2gw.LoadBalancerConfiguration, gw *gwv1.Gateway, ipAddressType elbv2model.IPAddressType) (*ec2model.SecurityGroup, error) {
 	name := builder.buildManagedSecurityGroupName(gw)
-	tags, err := builder.tagHelper.getGatewayTags(lbConf)
+	tags, err := builder.tagHelper.getLoadBalancerTags(lbConf)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gateway/model/model_build_target_group.go
+++ b/pkg/gateway/model/model_build_target_group.go
@@ -234,7 +234,7 @@ func (builder *targetGroupBuilderImpl) buildTargetGroupSpec(gw *gwv1.Gateway, ro
 		return elbv2model.TargetGroupSpec{}, err
 	}
 
-	tags, err := builder.tagHelper.getGatewayTags(lbConfig)
+	tags, err := builder.tagHelper.getTargetGroupTags(targetGroupProps)
 	if err != nil {
 		return elbv2model.TargetGroupSpec{}, err
 	}

--- a/pkg/gateway/model/tag_adapters.go
+++ b/pkg/gateway/model/tag_adapters.go
@@ -1,0 +1,57 @@
+package model
+
+import (
+	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/shared_utils"
+)
+
+// LoadBalancerConfigurationTagProvider adapts LoadBalancerConfiguration to implement TagProvider
+type LoadBalancerConfigurationTagProvider struct {
+	lbConf elbv2gw.LoadBalancerConfiguration
+}
+
+// NewLoadBalancerConfigurationTagProvider creates a new LoadBalancerConfigurationTagProvider
+func NewLoadBalancerConfigurationTagProvider(lbConf elbv2gw.LoadBalancerConfiguration) shared_utils.TagProvider {
+	return &LoadBalancerConfigurationTagProvider{lbConf: lbConf}
+}
+
+// GetTags returns the tags from the LoadBalancerConfiguration spec
+func (l *LoadBalancerConfigurationTagProvider) GetTags() *map[string]string {
+	return l.lbConf.Spec.Tags
+}
+
+// TargetGroupPropsTagProvider adapts TargetGroupProps to implement TagProvider
+type TargetGroupPropsTagProvider struct {
+	tgProps *elbv2gw.TargetGroupProps
+}
+
+// NewTargetGroupPropsTagProvider creates a new TargetGroupPropsTagProvider
+func NewTargetGroupPropsTagProvider(tgProps *elbv2gw.TargetGroupProps) shared_utils.TagProvider {
+	return &TargetGroupPropsTagProvider{tgProps: tgProps}
+}
+
+// GetTags returns the tags from the TargetGroupProps
+func (t *TargetGroupPropsTagProvider) GetTags() *map[string]string {
+	if t.tgProps == nil {
+		return nil
+	}
+	return t.tgProps.Tags
+}
+
+// ListenerRuleConfigurationTagProvider adapts ListenerRuleConfiguration to implement TagProvider
+type ListenerRuleConfigurationTagProvider struct {
+	lrConf *elbv2gw.ListenerRuleConfiguration
+}
+
+// NewListenerRuleConfigurationTagProvider creates a new ListenerRuleConfigurationTagProvider
+func NewListenerRuleConfigurationTagProvider(lrConf *elbv2gw.ListenerRuleConfiguration) shared_utils.TagProvider {
+	return &ListenerRuleConfigurationTagProvider{lrConf: lrConf}
+}
+
+// GetTags returns the tags from the ListenerRuleConfiguration spec
+func (l *ListenerRuleConfigurationTagProvider) GetTags() *map[string]string {
+	if l.lrConf == nil {
+		return nil
+	}
+	return l.lrConf.Spec.Tags
+}

--- a/pkg/shared_utils/tag_helper.go
+++ b/pkg/shared_utils/tag_helper.go
@@ -1,0 +1,64 @@
+package shared_utils
+
+import (
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/algorithm"
+)
+
+// TagProvider defines an interface for objects that can provide tags
+type TagProvider interface {
+	GetTags() *map[string]string
+}
+
+// TagHelper provides common tag processing functionality
+type TagHelper interface {
+	ProcessTags(provider TagProvider) (map[string]string, error)
+}
+
+// TagHelperConfig holds configuration for tag processing
+type TagHelperConfig struct {
+	ExternalManagedTags               sets.Set[string]
+	DefaultTags                       map[string]string
+	AdditionalTagsOverrideDefaultTags bool
+}
+
+type tagHelperImpl struct {
+	config TagHelperConfig
+}
+
+// NewTagHelper creates a new tag helper with the given configuration
+func NewTagHelper(config TagHelperConfig) TagHelper {
+	return &tagHelperImpl{
+		config: config,
+	}
+}
+
+// ProcessTags processes tags from a TagProvider, validates them, and merges with default tags
+func (t *tagHelperImpl) ProcessTags(provider TagProvider) (map[string]string, error) {
+	providerTags := make(map[string]string)
+
+	if tags := provider.GetTags(); tags != nil {
+		for k, v := range *tags {
+			providerTags[k] = v
+		}
+	}
+
+	if err := t.validateTagCollisionWithExternalManagedTags(providerTags); err != nil {
+		return nil, err
+	}
+
+	if t.config.AdditionalTagsOverrideDefaultTags {
+		return algorithm.MergeStringMap(providerTags, t.config.DefaultTags), nil
+	}
+	return algorithm.MergeStringMap(t.config.DefaultTags, providerTags), nil
+}
+
+func (t *tagHelperImpl) validateTagCollisionWithExternalManagedTags(tags map[string]string) error {
+	for tagKey := range tags {
+		if t.config.ExternalManagedTags.Has(tagKey) {
+			return errors.Errorf("external managed tag key %v cannot be specified", tagKey)
+		}
+	}
+	return nil
+}

--- a/pkg/shared_utils/tag_helper_test.go
+++ b/pkg/shared_utils/tag_helper_test.go
@@ -1,0 +1,109 @@
+package shared_utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func TestTagHelperImpl_validateTagCollisionWithExternalManagedTags(t *testing.T) {
+	tests := []struct {
+		name                string
+		externalManagedTags sets.Set[string]
+		inputTags           map[string]string
+		expectedError       bool
+		expectedErrorMsg    string
+	}{
+		{
+			name:                "no external managed tags - no collision",
+			externalManagedTags: sets.New[string](),
+			inputTags:           map[string]string{"key1": "value1", "key2": "value2"},
+			expectedError:       false,
+		},
+		{
+			name:                "empty input tags - no collision",
+			externalManagedTags: sets.New[string]("managed-tag1", "managed-tag2"),
+			inputTags:           map[string]string{},
+			expectedError:       false,
+		},
+		{
+			name:                "nil input tags - no collision",
+			externalManagedTags: sets.New[string]("managed-tag1", "managed-tag2"),
+			inputTags:           nil,
+			expectedError:       false,
+		},
+		{
+			name:                "no collision with external managed tags",
+			externalManagedTags: sets.New[string]("managed-tag1", "managed-tag2"),
+			inputTags:           map[string]string{"user-tag1": "value1", "user-tag2": "value2"},
+			expectedError:       false,
+		},
+		{
+			name:                "single tag collision",
+			externalManagedTags: sets.New[string]("managed-tag1", "managed-tag2"),
+			inputTags:           map[string]string{"user-tag1": "value1", "managed-tag1": "value2"},
+			expectedError:       true,
+			expectedErrorMsg:    "external managed tag key managed-tag1 cannot be specified",
+		},
+		{
+			name:                "multiple tag collisions - returns error for first collision found",
+			externalManagedTags: sets.New[string]("managed-tag1", "managed-tag2"),
+			inputTags:           map[string]string{"managed-tag1": "value1", "managed-tag2": "value2"},
+			expectedError:       true,
+		},
+		{
+			name:                "case sensitive collision check",
+			externalManagedTags: sets.New[string]("Managed-Tag"),
+			inputTags:           map[string]string{"managed-tag": "value1"},
+			expectedError:       false,
+		},
+		{
+			name:                "exact case match collision",
+			externalManagedTags: sets.New[string]("Managed-Tag"),
+			inputTags:           map[string]string{"Managed-Tag": "value1"},
+			expectedError:       true,
+			expectedErrorMsg:    "external managed tag key Managed-Tag cannot be specified",
+		},
+		{
+			name:                "collision with AWS standard tags",
+			externalManagedTags: sets.New[string]("kubernetes.io/cluster/test", "kubernetes.io/service-name"),
+			inputTags:           map[string]string{"custom-tag": "value1", "kubernetes.io/cluster/test": "owned"},
+			expectedError:       true,
+			expectedErrorMsg:    "external managed tag key kubernetes.io/cluster/test cannot be specified",
+		},
+		{
+			name:                "no collision with similar but different tag names",
+			externalManagedTags: sets.New[string]("managed-tag"),
+			inputTags:           map[string]string{"managed-tag-suffix": "value1", "prefix-managed-tag": "value2"},
+			expectedError:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := TagHelperConfig{
+				ExternalManagedTags: tt.externalManagedTags,
+			}
+			helper := &tagHelperImpl{
+				config: config,
+			}
+
+			err := helper.validateTagCollisionWithExternalManagedTags(tt.inputTags)
+
+			if tt.expectedError {
+				assert.Error(t, err)
+				if tt.expectedErrorMsg != "" {
+					assert.Contains(t, err.Error(), tt.expectedErrorMsg)
+				}
+				// For multiple collisions, just verify it contains the expected error pattern
+				if len(tt.inputTags) > 1 && tt.expectedErrorMsg == "" {
+					assert.Contains(t, err.Error(), "external managed tag key")
+					assert.Contains(t, err.Error(), "cannot be specified")
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION


### Description

This PR introduces a unified tag processing system that can be shared between Gateway and AGA controllers, eliminating code duplication and providing a consistent approach to tag management across the codebase.

Key Changes:
1. New Generic Tag Helper System (pkg/shared_utils/tag_helper.go) 
  - Created `TagHelper` interface and implementation for processing tags with external managed tags validation
  - Supports configurable default tags and tag override behavior
  - Provides unified tag processing logic that both Gateway and AGA can utilize

2. Tag Adapter Pattern  
   - Introduced `TagProvider` interface to abstract different resource types
   - Created specific adapters for GlobalAccelerator, LoadBalancerConfiguration, TargetGroupProps, and ListenerRuleConfiguration


### Testing

Added the comprehensive unit tests. 

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [x] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:
