### PR TITLE
[feat gw-api]add dedupe in route mapper

### DIFF
--- a/pkg/gateway/routeutils/loader.go
+++ b/pkg/gateway/routeutils/loader.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -150,7 +149,7 @@ func (l *loaderImpl) LoadRoutesForGateway(ctx context.Context, gw gwv1.Gateway, 
 }
 
 // loadChildResources responsible for loading all resources that a route descriptor references.
-func (l *loaderImpl) loadChildResources(ctx context.Context, preloadedRoutes map[int][]preLoadRouteDescriptor, compatibleHostnamesByPort map[int32]map[types.NamespacedName][]gwv1.Hostname, gw gwv1.Gateway) (map[int32][]RouteDescriptor, []RouteData, error) {
+func (l *loaderImpl) loadChildResources(ctx context.Context, preloadedRoutes map[int][]preLoadRouteDescriptor, compatibleHostnamesByPort map[int32]map[string][]gwv1.Hostname, gw gwv1.Gateway) (map[int32][]RouteDescriptor, []RouteData, error) {
 	// Cache to reduce duplicate route lookups.
 	// Kind -> [NamespacedName:Previously Loaded Descriptor]
 	resourceCache := make(map[string]RouteDescriptor)
@@ -190,7 +189,7 @@ func (l *loaderImpl) loadChildResources(ctx context.Context, preloadedRoutes map
 	// Set compatible hostnames by port for all routes
 	for _, route := range resourceCache {
 		hostnamesByPort := make(map[int32][]gwv1.Hostname)
-		routeKey := route.GetRouteNamespacedName()
+		routeKey := fmt.Sprintf("%s-%s", route.GetRouteKind(), route.GetRouteNamespacedName())
 		for port, compatibleHostnames := range compatibleHostnamesByPort {
 			if hostnames, exists := compatibleHostnames[routeKey]; exists {
 				hostnamesByPort[port] = hostnames

--- a/pkg/gateway/routeutils/loader_test.go
+++ b/pkg/gateway/routeutils/loader_test.go
@@ -22,9 +22,9 @@ type mockMapper struct {
 	routeStatusUpdates []RouteData
 }
 
-func (m *mockMapper) mapGatewayAndRoutes(context context.Context, gw gwv1.Gateway, routes []preLoadRouteDescriptor) (map[int][]preLoadRouteDescriptor, map[int32]map[types.NamespacedName][]gwv1.Hostname, []RouteData, error) {
+func (m *mockMapper) mapGatewayAndRoutes(context context.Context, gw gwv1.Gateway, routes []preLoadRouteDescriptor) (map[int][]preLoadRouteDescriptor, map[int32]map[string][]gwv1.Hostname, []RouteData, error) {
 	assert.ElementsMatch(m.t, m.expectedRoutes, routes)
-	return m.mapToReturn, make(map[int32]map[types.NamespacedName][]gwv1.Hostname), m.routeStatusUpdates, nil
+	return m.mapToReturn, make(map[int32]map[string][]gwv1.Hostname), m.routeStatusUpdates, nil
 }
 
 var _ RouteDescriptor = &mockRoute{}

--- a/pkg/gateway/routeutils/route_listener_mapper_test.go
+++ b/pkg/gateway/routeutils/route_listener_mapper_test.go
@@ -3,12 +3,13 @@ package routeutils
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
-	"testing"
 )
 
 type mockListenerAttachmentHelper struct {
@@ -299,6 +300,99 @@ func Test_mapGatewayAndRoutes(t *testing.T) {
 			name:     "no output",
 			expected: make(map[int][]preLoadRouteDescriptor),
 		},
+		{
+			name: "route attaches to multiple listeners on same port - verify deduplication",
+			gw: gwv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gw1",
+					Namespace: "ns-gw",
+				},
+				Spec: gwv1.GatewaySpec{
+					Listeners: []gwv1.Listener{
+						{
+							Name: "listener1-port80",
+							Port: gwv1.PortNumber(80),
+						},
+						{
+							Name: "listener2-port80",
+							Port: gwv1.PortNumber(80),
+						},
+					},
+				},
+			},
+			routes: []preLoadRouteDescriptor{route1},
+			listenerAttachmentMap: map[string]bool{
+				"listener1-port80-80-route1-ns1": true,
+				"listener2-port80-80-route1-ns1": true,
+			},
+			routeListenerMap: map[string]bool{
+				"listener1-port80-80-route1-ns1": true,
+				"listener2-port80-80-route1-ns1": true,
+			},
+			routeGatewayMap: map[string]bool{
+				makeRouteGatewayMapKey(gateway, route1): true,
+			},
+			expected: map[int][]preLoadRouteDescriptor{
+				80: {route1}, // Only one route1, not duplicated
+			},
+		},
+		{
+			name: "different route kinds with same name attach to same listener",
+			gw: gwv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gw1",
+					Namespace: "ns-gw",
+				},
+				Spec: gwv1.GatewaySpec{
+					Listeners: []gwv1.Listener{
+						{
+							Name:     "https-listener",
+							Port:     gwv1.PortNumber(443),
+							Protocol: gwv1.HTTPSProtocolType,
+						},
+					},
+				},
+			},
+			routes: []preLoadRouteDescriptor{
+				convertHTTPRoute(gwv1.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-route",
+						Namespace: "default",
+					},
+				}),
+				convertGRPCRoute(gwv1.GRPCRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-route",
+						Namespace: "default",
+					},
+				}),
+			},
+			listenerAttachmentMap: map[string]bool{
+				"https-listener-443-my-route-default": true,
+			},
+			routeListenerMap: map[string]bool{
+				"https-listener-443-my-route-default": true,
+			},
+			routeGatewayMap: map[string]bool{
+				"gw1-ns-gw-my-route-default": true,
+			},
+			expected: map[int][]preLoadRouteDescriptor{
+				443: {
+					convertHTTPRoute(gwv1.HTTPRoute{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "my-route",
+							Namespace: "default",
+						},
+					}),
+					convertGRPCRoute(gwv1.GRPCRoute{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "my-route",
+							Namespace: "default",
+						},
+					}),
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -313,7 +407,7 @@ func Test_mapGatewayAndRoutes(t *testing.T) {
 				},
 				logger: logr.Discard(),
 			}
-			result, _, statusUpdates, err := mapper.mapGatewayAndRoutes(context.Background(), tc.gw, tc.routes)
+			result, compatibleHostnames, statusUpdates, err := mapper.mapGatewayAndRoutes(context.Background(), tc.gw, tc.routes)
 
 			if tc.expectErr {
 				assert.Error(t, err)
@@ -322,6 +416,7 @@ func Test_mapGatewayAndRoutes(t *testing.T) {
 
 			assert.NoError(t, err)
 			assert.Equal(t, len(tc.expected), len(result))
+			assert.NotNil(t, compatibleHostnames)
 
 			assert.Equal(t, 0, len(statusUpdates))
 


### PR DESCRIPTION
### Description
1. found a small bug while testing HTTPRouteListenerPortMatching. the previous logic does not dedupe on routes per port, so for the same listener, it will create multiple same rules. fixed it

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
```
    --- PASS: TestConformance/HTTPRouteListenerPortMatching (244.55s)
        --- PASS: TestConformance/HTTPRouteListenerPortMatching/0_request_to_'foo.com/'_should_go_to_infra-backend-v1 (0.09s)
        --- PASS: TestConformance/HTTPRouteListenerPortMatching/3_request_to_'foo.com:8090/'_should_go_to_infra-backend-v3 (0.09s)
        --- PASS: TestConformance/HTTPRouteListenerPortMatching/4_request_to_'bar.com:8090/'_should_receive_a_404 (0.09s)
        --- PASS: TestConformance/HTTPRouteListenerPortMatching/1_request_to_'foo.com:8080/'_should_go_to_infra-backend-v2 (0.09s)
        --- PASS: TestConformance/HTTPRouteListenerPortMatching/2_request_to_'bar.com:8080/'_should_go_to_infra-backend-v2 (0.09s)
```
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
