### PR TITLE
docs(prometheus): metric name should include aws_ prefix

### DIFF
--- a/docs/guide/metrics/prometheus/index.md
+++ b/docs/guide/metrics/prometheus/index.md
@@ -44,10 +44,10 @@ Following metrics are added:
 | aws_api_call_call_retries | Counter   | Number of times the SDK retried requests to AWS services for SDK API calls |
 | aws_api_requests_total | Counter   | Total number of HTTP requests that the SDK made |
 | aws_request_duration_seconds | Histogram | Latency of an individual HTTP request to the service endpoint |
-| api_call_permission_errors_total | Counter   | Number of failed AWS API calls due to auth or authorization failures |
-| api_call_service_limit_exceeded_errors_total | Counter   | Number of failed AWS API calls due to exceeding service limit |
-| api_call_throttled_errors_total | Counter   | Number of failed AWS API calls due to throttling error |
-| api_call_validation_errors_total | Counter   | Number of failed AWS API calls due to validation error |
+| aws_api_call_permission_errors_total | Counter   | Number of failed AWS API calls due to auth or authorization failures |
+| aws_api_call_service_limit_exceeded_errors_total | Counter   | Number of failed AWS API calls due to exceeding service limit |
+| aws_api_call_throttled_errors_total | Counter   | Number of failed AWS API calls due to throttling error |
+| aws_api_call_validation_errors_total | Counter   | Number of failed AWS API calls due to validation error |
 | aws_target_group_info | Gauge     | Information about target group |
 | awslbc_readiness_gate_ready_seconds | Histogram | Time to flip a readiness gate to true |
 | awslbc_reconcile_stage_duration | Histogram | Latency of different reconcile stages |


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

No existing issue - documentation bug fix

### Description

This PR fixes incorrect metric names in the Prometheus metrics documentation. The error metrics were documented without the `aws_` subsystem prefix, causing confusion when users tried to query these metrics.

**Changes:**
- Updated `docs/guide/metrics/prometheus/index.md` to correct four metric names:
  - `api_call_permission_errors_total` → `aws_api_call_permission_errors_total`
  - `api_call_service_limit_exceeded_errors_total` → `aws_api_call_service_limit_exceeded_errors_total`
  - `api_call_throttled_errors_total` → `aws_api_call_throttled_errors_total`
  - `api_call_validation_errors_total` → `aws_api_call_validation_errors_total`

**Why this matters:**
When users queried Prometheus using the documented metric names (without `aws_` prefix), they received no results. The actual metrics exported by the controller include the `aws_` subsystem prefix as defined in `pkg/metrics/aws/instruments.go`. This fix aligns the documentation with the actual implementation.

### Checklist
- [ ] Added tests that cover your change (if possible) - N/A for documentation fix
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested - verified metric names match actual Prometheus output
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2: