### PR TITLE
update to use controller-gen v0.19.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,8 +129,7 @@ docker-push-w-buildx:
 				--push \
         		--platform ${IMG_PLATFORM}
 
-# find or download controller-gen
-# download controller-gen if necessary
+# download controller-gen v0.19.0
 controller-gen:
 	@{ \
 	set -e ;\


### PR DESCRIPTION
### Description
- seeing inconsistency in make crds if already have controller-gen v0.14.0 installed. modify makefile so it will use controller-gen v0.19.0 no matter what's installed.
- 
### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
