### PR TITLE
Update annotations.md with Classic Load Balancer warning

### DIFF
--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -13,6 +13,9 @@
     These annotations are specific to the kubernetes [service resources reconciled](#lb-type) by the AWS Load Balancer Controller. Although the list was initially derived from the k8s in-tree `kube-controller-manager`, this
     documentation is not an accurate reference for the services reconciled by the in-tree controller. 
 
+!!!warning
+    Creating a Classic Load Balancer isn't a best practice. If you want to create using AWS LB Controller/EKS Auto Mode > That's supported only from "kubectl edit service" client and not from any annotation. Thereby, create a Service with "type:ClusterIP/NodePort" and then edit it on "kubectl client" by changing it to "LoadBalancer" type which will create a Classic Load Balancer.
+
 !!!question "EKS Auto Mode users"
     If you are using EKS Auto Mode, please see the
     [EKS Auto Mode documentation](https://docs.aws.amazon.com/eks/latest/userguide/auto-configure-nlb.html#_considerations)


### PR DESCRIPTION
Added a warning about creating Classic Load Balancers and best practices (specially for Normal or EKS Auto Mode). As tested internally with a customer, and found this gap.

### Issue
There's no mentioning about "Classic Load Balancer" use-case as many customers do are interested to continue using it.
<!-- Please link the GitHub issues related to this PR, if available -->

### Description
When replicated, below are the steps:
- Created EKS Cluster/AutoMode Cluster
- Created sample App + Namespace & Service with "NodePort" Type [Didn't create any ELB]
- Edited the Service YAML manually using "kubectl edit svc <> -n <>" and changed the type to "LoadBalancer" and it created CLB on ELB Console

The same can't be done when a service is created via manifest using Type "LoadBalancer" as it will ask for "service.beta.kubernetes.io/aws-load-balancer-subnets" and it will make controller behave as NLB identification and no more CLB can be created, instead it will create NLB.

### Changes made
- Added a note/warning for CLB Creation

### Checklist
- [X] Added tests that cover your change (if possible)
- [X] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [X] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
