### PR TITLE
Auto discovery default certificate and certificate list

### DIFF
--- a/pkg/deploy/elbv2/listener_manager.go
+++ b/pkg/deploy/elbv2/listener_manager.go
@@ -422,6 +422,8 @@ func buildSDKModifyListenerInput(lsSpec elbv2model.ListenerSpec, desiredDefaultA
 
 // buildSDKCertificates builds the certificate list for listener.
 // returns the default certificates and extra certificates.
+// All certs are included in the extra list to ensure the default cert remains
+// attached as an additional cert for auto-discovery (e.g., ECDSA/RSA selection).
 func buildSDKCertificates(modelCerts []elbv2model.Certificate) ([]elbv2types.Certificate, []elbv2types.Certificate) {
 	if len(modelCerts) == 0 {
 		return nil, nil

--- a/pkg/deploy/elbv2/listener_manager.go
+++ b/pkg/deploy/elbv2/listener_manager.go
@@ -430,7 +430,7 @@ func buildSDKCertificates(modelCerts []elbv2model.Certificate) ([]elbv2types.Cer
 	var defaultSDKCerts []elbv2types.Certificate
 	var extraSDKCerts []elbv2types.Certificate
 	defaultSDKCerts = append(defaultSDKCerts, buildSDKCertificate(modelCerts[0]))
-	for _, cert := range modelCerts[1:] {
+	for _, cert := range modelCerts {
 		extraSDKCerts = append(extraSDKCerts, buildSDKCertificate(cert))
 	}
 	return defaultSDKCerts, extraSDKCerts

--- a/test/framework/verifier/aws_resource_verifier.go
+++ b/test/framework/verifier/aws_resource_verifier.go
@@ -190,24 +190,21 @@ func VerifyLoadBalancerListenerCertificates(ctx context.Context, f *framework.Fr
 	listenerCerts, err := f.LBManager.GetLoadBalancerListenerCertificates(ctx, awssdk.ToString(listeners[0].ListenerArn))
 	Expect(err).ToNot(HaveOccurred())
 
-	var observedCertArns []string
+	observedCertSet := sets.New[string]()
 	var defaultCert string
 	for _, cert := range listenerCerts {
 		if awssdk.ToBool(cert.IsDefault) {
 			defaultCert = awssdk.ToString(cert.CertificateArn)
 		}
-		observedCertArns = append(observedCertArns, awssdk.ToString(cert.CertificateArn))
+		observedCertSet.Insert(awssdk.ToString(cert.CertificateArn))
 	}
 	if defaultCert != expectedCertARNS[0] {
 		return errors.New("default cert does not match")
 	}
-	//Expect(defaultCert).To(Equal(expectedCertARNS[0]))
-	if len(expectedCertARNS) != len(observedCertArns) {
-		return errors.New("cert len mismatch")
+	expectedCertSet := sets.New[string](expectedCertARNS...)
+	if !observedCertSet.Equal(expectedCertSet) {
+		return errors.New("cert mismatch")
 	}
-	sort.Strings(observedCertArns)
-	sort.Strings(expectedCertARNS)
-	Expect(expectedCertARNS).To(Equal(observedCertArns))
 	return nil
 }
 


### PR DESCRIPTION
### Issue
https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4090

<!-- Please link the GitHub issues related to this PR, if available -->

### Description
AWS ELB API ignores the default certificate when certificate list is provided in TLS negotiation.
The auto discovered default certificate is needed for TLS negotiation. Adding the default certificate discovered to the extre certificate list
<!--
Please explain the changes you made here.

Help your reviewers by guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

brief logic change:
 * add default certificate to extraCert list as AWS ELBs ignores default certificate in certain SNI TLS negotiation scenario
 * [TODO discussion: accept user specified default certificate](https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4090) - skipping as `certificate-arn` implements similar functionality, and that logic shortcircuits auto-discovery execution

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [x] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2: