### PR TITLE
refactor app protocol, add support for app protocols that kubernetes + elb supports

### DIFF
--- a/pkg/gateway/routeutils/backend.go
+++ b/pkg/gateway/routeutils/backend.go
@@ -48,6 +48,8 @@ type TargetGroupConfigurator interface {
 	GetTargetGroupPort(targetType elbv2model.TargetType) int32
 	// GetHealthCheckPort returns the port to send health check traffic
 	GetHealthCheckPort(targetType elbv2model.TargetType, isServiceExternalTrafficPolicyTypeLocal bool) (intstr.IntOrString, error)
+	// GetProtocolVersion returns the protocol version to use for this target group
+	GetProtocolVersion() *elbv2model.ProtocolVersion
 }
 
 // Backend an abstraction on the Gateway Backend, meant to hide the underlying backend type from consumers (unless they really want to see it :))

--- a/pkg/gateway/routeutils/backend_gateway.go
+++ b/pkg/gateway/routeutils/backend_gateway.go
@@ -27,6 +27,11 @@ type GatewayBackendConfig struct {
 	port             int32
 }
 
+func (g *GatewayBackendConfig) GetProtocolVersion() *elbv2model.ProtocolVersion {
+	// Gateway backends don't support a protocol version.
+	return nil
+}
+
 func NewGatewayBackendConfig(gateway *gwv1.Gateway, targetGroupProps *elbv2gw.TargetGroupProps, arn string, port int32) *GatewayBackendConfig {
 	return &GatewayBackendConfig{
 		gateway:          gateway,

--- a/pkg/gateway/routeutils/backend_gateway_test.go
+++ b/pkg/gateway/routeutils/backend_gateway_test.go
@@ -248,3 +248,8 @@ func TestValidateGatewayARN(t *testing.T) {
 		})
 	}
 }
+
+func TestGatewayBackendConfig_GetProtocolVersion(t *testing.T) {
+	config := &GatewayBackendConfig{}
+	assert.Nil(t, config.GetProtocolVersion())
+}

--- a/pkg/gateway/routeutils/backend_service_test.go
+++ b/pkg/gateway/routeutils/backend_service_test.go
@@ -264,3 +264,37 @@ func Test_buildTargetGroupTargetType(t *testing.T) {
 	res = svcBackendWithProps.GetTargetType(elbv2model.TargetTypeIP)
 	assert.Equal(t, elbv2model.TargetTypeInstance, res)
 }
+
+func Test_GetProtocolVersion(t *testing.T) {
+	testCases := []struct {
+		name     string
+		svcPort  *corev1.ServicePort
+		expected *elbv2model.ProtocolVersion
+	}{
+		{
+			name:    "null app protocol version",
+			svcPort: &corev1.ServicePort{},
+		},
+		{
+			name: "unknown app protocol version",
+			svcPort: &corev1.ServicePort{
+				AppProtocol: awssdk.String("foo"),
+			},
+		},
+		{
+			name: "supported protocol version",
+			svcPort: &corev1.ServicePort{
+				AppProtocol: awssdk.String("kubernetes.io/h2c"),
+			},
+			expected: &http2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			svcBackend := NewServiceBackendConfig(nil, nil, tc.svcPort)
+			res := svcBackend.GetProtocolVersion()
+			assert.Equal(t, res, tc.expected)
+		})
+	}
+}


### PR DESCRIPTION
### Issue

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4497

### Description

Per the issue, they were trying to use `kubernetes.io/h2c` to set the protocol version to HTTP2 on the constructed target group. Digging a bit, I had started working on supporting Service AppProtocol but left it half done (and the half that was done was incorrect :/)

This change adds support for the `kubernetes.io/h2c` AppProtocol (converting to HTTP2 on the TG). It also..

1. Adds guard rails so we don't attempt to set protocol version on listeners that don't support it. Credit to @starlightromero for noticing this edgecase.
2. Removed some incorrect AppProtocol validations, I was incorrectly using `http` and `grpc` as AppProtocol values.

In the future, I'd like to set up LBC specific protocol versions as per the AppProtocol spec: https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol but in the meantime, I'd like to get minimal support working while removing the obviously incorrect AppProtocol references in our code.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
