### PR TITLE
Add check for duplicate endpoints

### DIFF
--- a/apis/aga/v1beta1/globalaccelerator_types.go
+++ b/apis/aga/v1beta1/globalaccelerator_types.go
@@ -279,7 +279,7 @@ type IPSet struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
-// +kubebuilder:printcolumn:name="NAME",type="string",JSONPath=".spec.name",description="The Global Accelerator name"
+// +kubebuilder:printcolumn:name="ACCELERATOR-NAME",type="string",JSONPath=".spec.name",description="The Global Accelerator name"
 // +kubebuilder:printcolumn:name="DNS-NAME",type="string",JSONPath=".status.dnsName",description="The Global Accelerator DNS name"
 // +kubebuilder:printcolumn:name="TYPE",type="string",JSONPath=".spec.type",description="The Global Accelerator type"
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.status",description="The Global Accelerator status"

--- a/config/crd/aga/aga-crds.yaml
+++ b/config/crd/aga/aga-crds.yaml
@@ -17,7 +17,7 @@ spec:
   - additionalPrinterColumns:
     - description: The Global Accelerator name
       jsonPath: .spec.name
-      name: NAME
+      name: ACCELERATOR-NAME
       type: string
     - description: The Global Accelerator DNS name
       jsonPath: .status.dnsName

--- a/config/crd/aga/aga.k8s.aws_globalaccelerators.yaml
+++ b/config/crd/aga/aga.k8s.aws_globalaccelerators.yaml
@@ -17,7 +17,7 @@ spec:
   - additionalPrinterColumns:
     - description: The Global Accelerator name
       jsonPath: .spec.name
-      name: NAME
+      name: ACCELERATOR-NAME
       type: string
     - description: The Global Accelerator DNS name
       jsonPath: .status.dnsName

--- a/helm/aws-load-balancer-controller/crds/aga-crds.yaml
+++ b/helm/aws-load-balancer-controller/crds/aga-crds.yaml
@@ -17,7 +17,7 @@ spec:
   - additionalPrinterColumns:
     - description: The Global Accelerator name
       jsonPath: .spec.name
-      name: NAME
+      name: ACCELERATOR-NAME
       type: string
     - description: The Global Accelerator DNS name
       jsonPath: .status.dnsName

--- a/helm/aws-load-balancer-controller/templates/webhook.yaml
+++ b/helm/aws-load-balancer-controller/templates/webhook.yaml
@@ -326,6 +326,36 @@ webhooks:
     - ingresses
   sideEffects: None
 {{- end }}
+{{- if .Values.controllerConfig.featureGates.GlobalAcceleratorController }}
+- clientConfig:
+    {{- if not $.Values.enableCertManager }}
+    caBundle: {{ $tls.caCert }}
+    {{- end }}
+    service:
+      name: {{ template "aws-load-balancer-controller.webhookService" . }}
+      namespace: {{ $.Release.Namespace }}
+      path: /validate-aga-k8s-aws-v1beta1-globalaccelerator
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: vglobalaccelerator.aga.k8s.aws
+  admissionReviewVersions:
+  - v1beta1
+  namespaceSelector: {}
+  objectSelector: {}
+  rules:
+  - apiGroups:
+    - aga.k8s.aws
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - globalaccelerators
+  sideEffects: None
+  timeoutSeconds: 10
+{{- end }}
 ---
 {{- if not $.Values.enableCertManager }}
 apiVersion: v1

--- a/pkg/deploy/aga/accelerator_manager.go
+++ b/pkg/deploy/aga/accelerator_manager.go
@@ -118,7 +118,7 @@ func (m *defaultAcceleratorManager) Update(ctx context.Context, resAccelerator *
 
 	var updatedAccelerator *agatypes.Accelerator
 	if !m.isSDKAcceleratorSettingsDrifted(resAccelerator, sdkAccelerator) {
-		m.logger.Info("No drift detected in accelerator settings, skipping update",
+		m.logger.V(1).Info("No drift detected in accelerator settings, skipping update",
 			"stackID", resAccelerator.Stack().StackID(),
 			"resourceID", resAccelerator.ID(),
 			"acceleratorARN", *sdkAccelerator.Accelerator.AcceleratorArn)

--- a/pkg/deploy/aga/endpoint_group_manager.go
+++ b/pkg/deploy/aga/endpoint_group_manager.go
@@ -146,7 +146,7 @@ func (m *defaultEndpointGroupManager) buildSDKUpdateEndpointGroupInput(_ context
 func (m *defaultEndpointGroupManager) Update(ctx context.Context, resEndpointGroup *agamodel.EndpointGroup, sdkEndpointGroup *agatypes.EndpointGroup) (agamodel.EndpointGroupStatus, error) {
 	// Check if the endpoint group actually needs an update
 	if !m.isSDKEndpointGroupSettingsDrifted(resEndpointGroup, sdkEndpointGroup) {
-		m.logger.Info("No drift detected in endpoint group settings, skipping update",
+		m.logger.V(1).Info("No drift detected in endpoint group settings, skipping update",
 			"stackID", resEndpointGroup.Stack().StackID(),
 			"resourceID", resEndpointGroup.ID(),
 			"endpointGroupARN", *sdkEndpointGroup.EndpointGroupArn)

--- a/pkg/deploy/aga/listener_manager.go
+++ b/pkg/deploy/aga/listener_manager.go
@@ -131,7 +131,7 @@ func (m *defaultListenerManager) buildSDKUpdateListenerInput(ctx context.Context
 func (m *defaultListenerManager) Update(ctx context.Context, resListener *agamodel.Listener, sdkListener *ListenerResource) (agamodel.ListenerStatus, error) {
 	// Check if the listener actually needs an update
 	if !m.isSDKListenerSettingsDrifted(resListener, sdkListener) {
-		m.logger.Info("No drift detected in listener settings, skipping update",
+		m.logger.V(1).Info("No drift detected in listener settings, skipping update",
 			"stackID", resListener.Stack().StackID(),
 			"resourceID", resListener.ID(),
 			"listenerARN", *sdkListener.Listener.ListenerArn)

--- a/test/e2e/globalaccelerator/gateway_endpoint_test.go
+++ b/test/e2e/globalaccelerator/gateway_endpoint_test.go
@@ -23,7 +23,7 @@ var _ = Describe("GlobalAccelerator with Gateway endpoint", func() {
 
 	BeforeEach(func() {
 		if !tf.Options.EnableAGATests || !tf.Options.EnableGatewayTests {
-			Skip("Skipping Global Accelerator Gateway tests (requires --enable-aga-tests and --enable-gateway-tests)")
+			Skip("Skipping Global Accelerator Gateway endpoint tests (requires --enable-aga-tests and --enable-gateway-tests)")
 		}
 		ctx = context.Background()
 	})

--- a/test/e2e/globalaccelerator/multi_endpoint_test.go
+++ b/test/e2e/globalaccelerator/multi_endpoint_test.go
@@ -31,7 +31,7 @@ var _ = Describe("GlobalAccelerator with multiple endpoint types", func() {
 
 	BeforeEach(func() {
 		if !tf.Options.EnableAGATests {
-			Skip("Skipping Global Accelerator Gateway tests (requires --enable-aga-tests)")
+			Skip("Skipping Global Accelerator tests (requires --enable-aga-tests)")
 		}
 		ctx = context.Background()
 		ns, err := tf.NSManager.AllocateNamespace(ctx, "aga-multi-e2e")

--- a/test/e2e/globalaccelerator/service_endpoint_test.go
+++ b/test/e2e/globalaccelerator/service_endpoint_test.go
@@ -24,7 +24,7 @@ var _ = Describe("GlobalAccelerator with Service endpoint", func() {
 
 	BeforeEach(func() {
 		if !tf.Options.EnableAGATests {
-			Skip("Skipping Global Accelerator Gateway tests (requires --enable-aga-tests)")
+			Skip("Skipping Global Accelerator tests (requires --enable-aga-tests)")
 		}
 		ctx = context.Background()
 	})


### PR DESCRIPTION
### Description

1. Added checkForDuplicateEndpoints() function to detect duplicate endpoints
- Added getEndpointKey() helper to generate unique keys for endpoints (type/namespace/name)
- Validates on both Create and Update operations
- Handles different endpoint types (Service, Ingress, Gateway, EndpointID)

2. Added 4 test cases covering:
- Valid: unique endpoints
- Invalid: duplicate endpoints (same name/namespace)
- Valid: same name in different namespaces
- Valid: same name with different endpoint types

3. Added GlobalAccelerator webhook to the helm template (it was in config but missed in helm) ! It's conditionally rendered when the feature gate is enabled

4. E2E Test Improvements
- Fixed GatewayClass creation to handle AlreadyExists errors - This is for preparing in parallel test 
- Added proper namespace cleanup in ingress tests
- Fixed listener verification to be order-independent - This fix sometimes multiple listener tests failed due to API return order
- Updated skip messages

5. Logging Improvements
- Changed "no drift" log messages from Info to V(1) (debug level) in accelerator/listener/endpoint managers

6. Minor Fixes
- Changed kubectl column name from "NAME" to "ACCELERATOR-NAME" for clarity. This avoids the confusion of having two "NAME" columns. 


### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
