### PR TITLE
Run CI test in parallel 

### DIFF
--- a/scripts/ci_e2e_test.sh
+++ b/scripts/ci_e2e_test.sh
@@ -212,7 +212,7 @@ test_controller_image() {
   CERTIFICATE_ARNS=${CERTIFICATE_ARNS:-"${CERTIFICATE_ARN_PREFIX}/${CERT_ID1},${CERTIFICATE_ARN_PREFIX}/${CERT_ID2},${CERTIFICATE_ARN_PREFIX}/${CERT_ID3}"}
   echo "creating s3 bucket $S3_BUCKET"
   aws s3api create-bucket --bucket $S3_BUCKET --region $AWS_REGION --create-bucket-configuration LocationConstraint=$AWS_REGION || true
-  ginkgo -timeout 3h -v -r test/e2e -- \
+  ginkgo -timeout 3h -v -p -r test/e2e -- \
     --kubeconfig=${CLUSTER_KUBECONFIG} \
     --cluster-name=${CLUSTER_NAME} \
     --aws-region=${AWS_REGION} \

--- a/test/e2e/gateway/alb_resource_stack.go
+++ b/test/e2e/gateway/alb_resource_stack.go
@@ -66,6 +66,9 @@ func (s *albResourceStack) Deploy(ctx context.Context, f *framework.Framework) e
 }
 
 func (s *albResourceStack) Cleanup(ctx context.Context, f *framework.Framework) error {
+	if s == nil || s.commonStack == nil {
+		return nil
+	}
 	if err := s.commonStack.Cleanup(ctx, f); err != nil {
 		return err
 	}

--- a/test/e2e/gateway/alb_test_helper.go
+++ b/test/e2e/gateway/alb_test_helper.go
@@ -74,6 +74,9 @@ func (s *ALBTestStack) deploy(ctx context.Context, f *framework.Framework, gwLis
 }
 
 func (s *ALBTestStack) Cleanup(ctx context.Context, f *framework.Framework) error {
+	if s.albResourceStack == nil {
+		return nil
+	}
 	return s.albResourceStack.Cleanup(ctx, f)
 }
 

--- a/test/e2e/gateway/nlb_resource_stack.go
+++ b/test/e2e/gateway/nlb_resource_stack.go
@@ -60,6 +60,9 @@ func (s *nlbResourceStack) Deploy(ctx context.Context, f *framework.Framework) e
 }
 
 func (s *nlbResourceStack) Cleanup(ctx context.Context, f *framework.Framework) error {
+	if s == nil || s.commonStack == nil {
+		return nil
+	}
 	return s.commonStack.Cleanup(ctx, f)
 }
 

--- a/test/e2e/gateway/nlb_test_helper.go
+++ b/test/e2e/gateway/nlb_test_helper.go
@@ -317,6 +317,9 @@ func (s *NLBTestStack) CreateFENLBReferenceGrant(ctx context.Context, f *framewo
 }
 
 func (s *NLBTestStack) Cleanup(ctx context.Context, f *framework.Framework) error {
+	if s.nlbResourceStack == nil {
+		return nil
+	}
 	return s.nlbResourceStack.Cleanup(ctx, f)
 }
 

--- a/test/e2e/ingress/ingress_suite_test.go
+++ b/test/e2e/ingress/ingress_suite_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/gomega"
 	framework "sigs.k8s.io/aws-load-balancer-controller/test/framework"
 	"testing"
+	"time"
 )
 
 var tf *framework.Framework
@@ -14,10 +15,19 @@ func TestIngress(t *testing.T) {
 	RunSpecs(t, "Ingress Suite")
 }
 
-var _ = BeforeSuite(func() {
+var _ = SynchronizedBeforeSuite(func() []byte {
 	var err error
-
 	tf, err = framework.InitFramework()
+	Expect(err).NotTo(HaveOccurred())
 
+	if tf.Options.ControllerImage != "" {
+		err = tf.CTRLInstallationManager.UpgradeController(tf.Options.ControllerImage, true, true)
+		Expect(err).NotTo(HaveOccurred())
+		time.Sleep(60 * time.Second)
+	}
+	return nil
+}, func(data []byte) {
+	var err error
+	tf, err = framework.InitFramework()
 	Expect(err).NotTo(HaveOccurred())
 })

--- a/test/e2e/ingress/multi_path_backend_test.go
+++ b/test/e2e/ingress/multi_path_backend_test.go
@@ -21,14 +21,6 @@ var _ = Describe("test ingresses with multiple path and backends", func() {
 
 	BeforeEach(func() {
 		ctx = context.Background()
-
-		if tf.Options.ControllerImage != "" {
-			By(fmt.Sprintf("ensure cluster installed with controller: %s", tf.Options.ControllerImage), func() {
-				err := tf.CTRLInstallationManager.UpgradeController(tf.Options.ControllerImage, false, false)
-				Expect(err).NotTo(HaveOccurred())
-				time.Sleep(60 * time.Second)
-			})
-		}
 	})
 
 	AfterEach(func() {

--- a/test/e2e/ingress/target_control_port_test.go
+++ b/test/e2e/ingress/target_control_port_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/gavv/httpexpect/v2"
@@ -40,16 +39,6 @@ var _ = Describe("ALB target control agent injection and target control port tes
 
 	BeforeEach(func() {
 		ctx = context.Background()
-		if tf.Options.ControllerImage != "" {
-			By("upgrade controller with ALBTargetControlAgent enabled", func() {
-				tf.Logger.Info("Starting controller upgrade", "image", tf.Options.ControllerImage)
-				err := tf.CTRLInstallationManager.UpgradeController(tf.Options.ControllerImage, false, true)
-				Expect(err).NotTo(HaveOccurred())
-				tf.Logger.Info("Controller upgrade completed, waiting for rollout")
-				time.Sleep(60 * time.Second)
-				tf.Logger.Info("Controller should be ready now")
-			})
-		}
 		By("setup sandbox namespace", func() {
 			tf.Logger.Info("allocating namespace")
 			ns, err := tf.NSManager.AllocateNamespace(ctx, "alb-target-control-e2e")

--- a/test/e2e/ingress/vanilla_ingress_test.go
+++ b/test/e2e/ingress/vanilla_ingress_test.go
@@ -40,13 +40,6 @@ var _ = Describe("vanilla ingress tests", func() {
 
 	BeforeEach(func() {
 		ctx = context.Background()
-		if tf.Options.ControllerImage != "" {
-			By(fmt.Sprintf("ensure cluster installed with controller: %s", tf.Options.ControllerImage), func() {
-				err := tf.CTRLInstallationManager.UpgradeController(tf.Options.ControllerImage, false, false)
-				Expect(err).NotTo(HaveOccurred())
-				time.Sleep(60 * time.Second)
-			})
-		}
 
 		By("setup sandbox namespace", func() {
 			tf.Logger.Info("allocating namespace")
@@ -434,16 +427,6 @@ var _ = Describe("vanilla ingress tests", func() {
 	})
 
 	Context("with ALB IP targets, named target port and endPointSlices enabled", func() {
-		BeforeEach(func() {
-			ctx = context.Background()
-			if tf.Options.ControllerImage != "" {
-				By(fmt.Sprintf("upgrade controller with endPointSlices enabled."), func() {
-					err := tf.CTRLInstallationManager.UpgradeController(tf.Options.ControllerImage, true, false)
-					Expect(err).NotTo(HaveOccurred())
-					time.Sleep(60 * time.Second)
-				})
-			}
-		})
 		It("with 'alb.ingress.kubernetes.io/target-type' annotation explicitly specified, and endPointSlices enabled, one ALB shall be created and functional", func() {
 			appBuilder := manifest.NewFixedResponseServiceBuilder().WithTargetPortName("e2e-targetport")
 			ingBuilder := manifest.NewIngressBuilder()


### PR DESCRIPTION
### Description

- Enabled parallel test execution (-p flag added to ginkgo in scripts/ci_e2e_test.sh). With -p, it parallelizes individual test within each suite based available processes.  `Running in parallel across 15 processes` from the test 
- Ingress tests: Changed to SynchronizedBeforeSuite. Using SynchronizedBeforeSuite ensures controller upgrade happens once across all parallel processes, avoiding race conditions and redundant upgrades.
- Upgrades controller once before all parallel test processes start. Removes duplicate controller upgrade logic from individual test files. The reason we upgrade controller is to enable some by default false feature flag. we can just enable it once.
- Gateway tests: Added nil checks in cleanup methods. Prevents panics when cleanup is called on uninitialized stacks


### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
