### PR TITLE
Add missing RBAC permissions for GlobalAccelerator CRD

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -50,6 +50,23 @@ rules:
   - update
   - watch
 - apiGroups:
+  - aga.k8s.aws
+  resources:
+  - globalaccelerators
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - aga.k8s.aws
+  resources:
+  - globalaccelerators/finalizers
+  - globalaccelerators/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
   - discovery.k8s.io
   resources:
   - endpointslices

--- a/controllers/aga/globalaccelerator_controller.go
+++ b/controllers/aga/globalaccelerator_controller.go
@@ -186,9 +186,10 @@ type globalAcceleratorReconciler struct {
 	maxExponentialBackoffDelay time.Duration
 }
 
-// +kubebuilder:rbac:groups=aga.k8s.aws,resources=globalaccelerators,verbs=get;list;watch;patch
-// +kubebuilder:rbac:groups=aga.k8s.aws,resources=globalaccelerators/status,verbs=update;patch
-// +kubebuilder:rbac:groups=aga.k8s.aws,resources=globalaccelerators/finalizers,verbs=update;patch
+//+kubebuilder:rbac:groups=aga.k8s.aws,resources=globalaccelerators,verbs=get;list;watch;patch
+//+kubebuilder:rbac:groups=aga.k8s.aws,resources=globalaccelerators/status,verbs=update;patch
+//+kubebuilder:rbac:groups=aga.k8s.aws,resources=globalaccelerators/finalizers,verbs=update;patch
+
 func (r *globalAcceleratorReconciler) Reconcile(ctx context.Context, req reconcile.Request) (ctrl.Result, error) {
 	r.reconcileTracker(req.NamespacedName)
 	r.logger.V(1).Info("Reconcile request", "name", req.Name)


### PR DESCRIPTION
### Issue

Add missing RBAC permissions for GlobalAccelerator CRD. The auto generated was not working due to the wrong template of the makers.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
