### PR TITLE
add trust store e2e test and script for local testing

### DIFF
--- a/scripts/run_trust_store_test.sh
+++ b/scripts/run_trust_store_test.sh
@@ -1,0 +1,195 @@
+#!/bin/bash
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Required parameters
+CLUSTER_NAME="${CLUSTER_NAME:-}"
+AWS_REGION="${AWS_REGION:-us-west-2}"
+VPC_ID="${VPC_ID:-}"
+
+# Print usage
+usage() {
+    echo "Usage: CLUSTER_NAME=<name> VPC_ID=<vpc-id> $0"
+    echo ""
+    echo "Environment variables:"
+    echo "  CLUSTER_NAME  - EKS cluster name (required)"
+    echo "  VPC_ID        - VPC ID (required)"
+    echo "  AWS_REGION    - AWS region (default: us-west-2)"
+    echo ""
+    echo "Example:"
+    echo "  CLUSTER_NAME=awslbc-loadtest VPC_ID=vpc-123456 ./scripts/run_trust_store_test.sh"
+    echo ""
+    echo "Note: Requires ginkgo CLI installed. Install with:"
+    echo "  go install github.com/onsi/ginkgo/v2/ginkgo@latest"
+    exit 1
+}
+
+# Validate required parameters
+if [ -z "$CLUSTER_NAME" ] || [ -z "$VPC_ID" ]; then
+    usage
+fi
+
+# Get script directory and project root BEFORE changing directories
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PROJECT_ROOT="$( cd "$SCRIPT_DIR/.." && pwd )"
+
+# Create temporary directory
+TEMP_DIR=$(mktemp -d)
+trap "rm -rf $TEMP_DIR" EXIT
+
+cd $TEMP_DIR
+
+echo -e "${GREEN}=== Creating Test Certificates ===${NC}"
+
+# Generate CA certificate
+openssl req -x509 -newkey rsa:4096 -nodes \
+  -keyout ca-key.pem -out ca-cert.pem -days 365 \
+  -subj "/C=US/ST=WA/L=Seattle/O=TestOrg/CN=Test-CA" 2>/dev/null
+
+# Generate server certificate
+openssl genrsa -out server-key.pem 2048 2>/dev/null
+openssl req -new -key server-key.pem -out server-csr.pem \
+  -subj "/C=US/ST=WA/O=TestOrg/CN=*.elb.${AWS_REGION}.amazonaws.com" 2>/dev/null
+
+cat > server-ext.cnf <<EOF
+subjectAltName = DNS:*.elb.${AWS_REGION}.amazonaws.com,DNS:*.elb.amazonaws.com
+keyUsage = digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+EOF
+
+openssl x509 -req -in server-csr.pem \
+  -CA ca-cert.pem -CAkey ca-key.pem -CAcreateserial \
+  -out server-cert.pem -days 365 -extfile server-ext.cnf 2>/dev/null
+
+# Generate client certificate
+openssl genrsa -out client-key.pem 2048 2>/dev/null
+openssl req -new -key client-key.pem -out client-csr.pem \
+  -subj "/C=US/ST=WA/O=TestOrg/CN=test-client" 2>/dev/null
+
+cat > client-ext.cnf <<EOF
+keyUsage = digitalSignature
+extendedKeyUsage = clientAuth
+EOF
+
+openssl x509 -req -in client-csr.pem \
+  -CA ca-cert.pem -CAkey ca-key.pem -CAcreateserial \
+  -out client-cert.pem -days 365 -extfile client-ext.cnf 2>/dev/null
+
+echo -e "${GREEN}✓ Certificates created${NC}"
+
+echo -e "${GREEN}=== Uploading Server Certificate to ACM ===${NC}"
+
+SERVER_CERT_ARN=$(aws acm import-certificate \
+  --certificate fileb://server-cert.pem \
+  --private-key fileb://server-key.pem \
+  --certificate-chain fileb://ca-cert.pem \
+  --region $AWS_REGION \
+  --query 'CertificateArn' \
+  --output text)
+
+echo -e "${GREEN}✓ Server certificate imported: $SERVER_CERT_ARN${NC}"
+
+# Cleanup function for AWS resources
+cleanup_aws() {
+    echo -e "${YELLOW}=== Cleaning up AWS resources ===${NC}"
+    
+    if [ ! -z "$TRUST_STORE_ARN" ]; then
+        aws elbv2 delete-trust-store \
+          --trust-store-arn $TRUST_STORE_ARN \
+          --region $AWS_REGION 2>/dev/null || true
+        echo -e "${GREEN}✓ Trust store deleted${NC}"
+    fi
+    
+    if [ ! -z "$SERVER_CERT_ARN" ]; then
+        aws acm delete-certificate \
+          --certificate-arn $SERVER_CERT_ARN \
+          --region $AWS_REGION 2>/dev/null || true
+        echo -e "${GREEN}✓ ACM certificate deleted${NC}"
+    fi
+    
+    if [ ! -z "$BUCKET_NAME" ]; then
+        aws s3 rb s3://$BUCKET_NAME --force 2>/dev/null || true
+        echo -e "${GREEN}✓ S3 bucket deleted${NC}"
+    fi
+}
+
+trap cleanup_aws EXIT
+
+echo -e "${GREEN}=== Creating S3 Bucket and Trust Store ===${NC}"
+
+BUCKET_NAME="mtls-test-$(date +%s)-$(openssl rand -hex 4)"
+aws s3 mb s3://$BUCKET_NAME --region $AWS_REGION >/dev/null
+aws s3 cp ca-cert.pem s3://$BUCKET_NAME/ca-bundle.pem >/dev/null
+
+TRUST_STORE_ARN=$(aws elbv2 create-trust-store \
+  --name mtls-test-$(date +%s) \
+  --ca-certificates-bundle-s3-bucket $BUCKET_NAME \
+  --ca-certificates-bundle-s3-key ca-bundle.pem \
+  --region $AWS_REGION \
+  --query 'TrustStores[0].TrustStoreArn' \
+  --output text)
+
+echo -e "${GREEN}✓ Trust store created: $TRUST_STORE_ARN${NC}"
+
+# Wait for trust store to be active
+echo -e "${YELLOW}Waiting for trust store to become active...${NC}"
+for i in {1..30}; do
+    STATUS=$(aws elbv2 describe-trust-stores \
+      --trust-store-arns $TRUST_STORE_ARN \
+      --region $AWS_REGION \
+      --query 'TrustStores[0].Status' \
+      --output text)
+    
+    if [ "$STATUS" = "ACTIVE" ]; then
+        echo -e "${GREEN}✓ Trust store is active${NC}"
+        break
+    fi
+    
+    if [ $i -eq 30 ]; then
+        echo -e "${RED}✗ Trust store failed to become active${NC}"
+        exit 1
+    fi
+    
+    sleep 5
+done
+
+echo ""
+echo -e "${GREEN}=== Running Trust Store E2E Tests ===${NC}"
+echo ""
+
+# Navigate to project root
+cd $PROJECT_ROOT
+
+# Run the test using ginkgo from project root
+echo "Running ginkgo from: $(pwd)"
+echo "Test directory: test/e2e/gateway"
+echo "Focus: test ALB Gateway with Trust Store for mTLS"
+
+ginkgo -v -r test/e2e/gateway -- \
+  --kubeconfig=$KUBECONFIG \
+  --cluster-name=$CLUSTER_NAME \
+  --aws-region=$AWS_REGION \
+  --aws-vpc-id=$VPC_ID \
+  --certificate-arns=$SERVER_CERT_ARN \
+  --trust-store-arn=$TRUST_STORE_ARN \
+  --client-cert-path=$TEMP_DIR/client-cert.pem \
+  --client-key-path=$TEMP_DIR/client-key.pem \
+  --enable-gateway-tests \
+  -ginkgo.focus="test ALB Gateway with Trust Store for mTLS"
+
+TEST_EXIT_CODE=$?
+
+echo ""
+if [ $TEST_EXIT_CODE -eq 0 ]; then
+    echo -e "${GREEN}=== All Tests Passed ===${NC}"
+else
+    echo -e "${RED}=== Tests Failed ===${NC}"
+fi
+
+exit $TEST_EXIT_CODE

--- a/test/e2e/gateway/alb_trust_store_test.go
+++ b/test/e2e/gateway/alb_trust_store_test.go
@@ -1,0 +1,360 @@
+package gateway
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"strings"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
+	httputils "sigs.k8s.io/aws-load-balancer-controller/test/framework/http"
+	"sigs.k8s.io/aws-load-balancer-controller/test/framework/utils"
+	"sigs.k8s.io/aws-load-balancer-controller/test/framework/verifier"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+var _ = Describe("test ALB Gateway with Trust Store for mTLS", func() {
+	var (
+		ctx     context.Context
+		stack   ALBTestStack
+		dnsName string
+		lbARN   string
+	)
+
+	BeforeEach(func() {
+		if !tf.Options.EnableGatewayTests {
+			Skip("Skipping gateway tests")
+		}
+		if len(tf.Options.CertificateARNs) == 0 {
+			Skip("Skipping tests, certificates not specified")
+		}
+		if len(tf.Options.TrustStoreARN) == 0 {
+			Skip("Skipping tests, trust store ARN not specified")
+		}
+		ctx = context.Background()
+		stack = ALBTestStack{}
+	})
+
+	AfterEach(func() {
+		stack.Cleanup(ctx, tf)
+	})
+
+	Context("with mTLS in VERIFY mode", func() {
+		It("should enforce client certificate validation", func() {
+			interf := elbv2gw.LoadBalancerSchemeInternetFacing
+			lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
+				Scheme: &interf,
+			}
+
+			cert := strings.Split(tf.Options.CertificateARNs, ",")[0]
+			lsConfig := elbv2gw.ListenerConfiguration{
+				ProtocolPort:       "HTTPS:443",
+				DefaultCertificate: &cert,
+				MutualAuthentication: &elbv2gw.MutualAuthenticationAttributes{
+					Mode:                          elbv2gw.MutualAuthenticationVerifyMode,
+					TrustStore:                    awssdk.String(tf.Options.TrustStoreARN),
+					IgnoreClientCertificateExpiry: awssdk.Bool(false),
+					AdvertiseTrustStoreCaNames:    (*elbv2gw.AdvertiseTrustStoreCaNamesEnum)(awssdk.String(string(elbv2gw.AdvertiseTrustStoreCaNamesEnumOn))),
+				},
+			}
+			lbcSpec.ListenerConfigurations = &[]elbv2gw.ListenerConfiguration{lsConfig}
+
+			instanceTargetType := elbv2gw.TargetTypeInstance
+			tgSpec := elbv2gw.TargetGroupConfigurationSpec{
+				DefaultConfiguration: elbv2gw.TargetGroupProps{
+					TargetType: &instanceTargetType,
+				},
+			}
+			lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{}
+			gwListeners := []gwv1.Listener{
+				{
+					Name:     "https443",
+					Port:     443,
+					Protocol: gwv1.HTTPSProtocolType,
+					Hostname: (*gwv1.Hostname)(awssdk.String(testHostname)),
+					TLS: &gwv1.GatewayTLSConfig{
+						CertificateRefs: []gwv1.SecretObjectReference{
+							{
+								Name: "tls-cert",
+							},
+						},
+					},
+				},
+			}
+			httpr := BuildHTTPRoute([]string{testHostname}, []gwv1.HTTPRouteRule{}, nil)
+
+			By("deploying stack", func() {
+				err := stack.DeployHTTP(ctx, nil, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec, lrcSpec, nil, true)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("checking gateway status for lb dns name", func() {
+				dnsName = stack.GetLoadBalancerIngressHostName()
+				Expect(dnsName).ToNot(BeEmpty())
+			})
+
+			By("querying AWS loadbalancer from the dns name", func() {
+				var err error
+				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(lbARN).ToNot(BeEmpty())
+			})
+
+			By("verifying AWS load balancer listener with mTLS verify mode", func() {
+				err := verifier.VerifyLoadBalancerListener(ctx, tf, lbARN, int32(gwListeners[0].Port), &verifier.ListenerExpectation{
+					ProtocolPort:          "HTTPS:443",
+					DefaultCertificateARN: awssdk.ToString(lsConfig.DefaultCertificate),
+					MutualAuthentication: &verifier.MutualAuthenticationExpectation{
+						Mode:          "verify",
+						TrustStoreARN: tf.Options.TrustStoreARN,
+					},
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("waiting for target group targets to be healthy", func() {
+				nodeList, err := stack.GetWorkerNodes(ctx, tf)
+				Expect(err).ToNot(HaveOccurred())
+				err = verifier.WaitUntilTargetsAreHealthy(ctx, tf, lbARN, len(nodeList))
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("waiting until DNS name is available", func() {
+				err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("verifying HTTPS request without client certificate is rejected", func() {
+				url := fmt.Sprintf("https://%v/any-path", dnsName)
+				urlOptions := httputils.URLOptions{
+					InsecureSkipVerify: true,
+					HostHeader:         testHostname,
+				}
+				// Either 403 response or connection error indicates mTLS is enforcing
+				_ = tf.HTTPVerifier.VerifyURLWithOptions(url, urlOptions, httputils.ResponseCodeMatches(403))
+			})
+
+			// Test with valid client certificate if provided
+			if len(tf.Options.ClientCertPath) > 0 && len(tf.Options.ClientKeyPath) > 0 {
+				By("verifying HTTPS request with valid client certificate succeeds", func() {
+					// Load client certificate
+					clientCert, err := tls.LoadX509KeyPair(tf.Options.ClientCertPath, tf.Options.ClientKeyPath)
+					Expect(err).NotTo(HaveOccurred())
+
+					// Create custom HTTP client with client certificate
+					tlsConfig := &tls.Config{
+						InsecureSkipVerify: true,
+						Certificates:       []tls.Certificate{clientCert},
+					}
+					client := &http.Client{
+						Transport: &http.Transport{
+							TLSClientConfig: tlsConfig,
+						},
+					}
+
+					url := fmt.Sprintf("https://%v/any-path", dnsName)
+					req, err := http.NewRequest("GET", url, nil)
+					Expect(err).NotTo(HaveOccurred())
+					req.Host = testHostname
+
+					resp, err := client.Do(req)
+					Expect(err).NotTo(HaveOccurred())
+					defer resp.Body.Close()
+
+					// Expect 200 with valid client certificate
+					Expect(resp.StatusCode).To(Equal(200))
+				})
+			}
+		})
+	})
+
+	Context("with mTLS in PASSTHROUGH mode", func() {
+		It("should not enforce mTLS at ALB", func() {
+			interf := elbv2gw.LoadBalancerSchemeInternetFacing
+			lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
+				Scheme: &interf,
+			}
+
+			cert := strings.Split(tf.Options.CertificateARNs, ",")[0]
+			lsConfig := elbv2gw.ListenerConfiguration{
+				ProtocolPort:       "HTTPS:443",
+				DefaultCertificate: &cert,
+				MutualAuthentication: &elbv2gw.MutualAuthenticationAttributes{
+					Mode: elbv2gw.MutualAuthenticationPassthroughMode,
+				},
+			}
+			lbcSpec.ListenerConfigurations = &[]elbv2gw.ListenerConfiguration{lsConfig}
+
+			instanceTargetType := elbv2gw.TargetTypeInstance
+			tgSpec := elbv2gw.TargetGroupConfigurationSpec{
+				DefaultConfiguration: elbv2gw.TargetGroupProps{
+					TargetType: &instanceTargetType,
+				},
+			}
+			lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{}
+			gwListeners := []gwv1.Listener{
+				{
+					Name:     "https443",
+					Port:     443,
+					Protocol: gwv1.HTTPSProtocolType,
+					Hostname: (*gwv1.Hostname)(awssdk.String(testHostname)),
+					TLS: &gwv1.GatewayTLSConfig{
+						CertificateRefs: []gwv1.SecretObjectReference{
+							{
+								Name: "tls-cert",
+							},
+						},
+					},
+				},
+			}
+			httpr := BuildHTTPRoute([]string{testHostname}, []gwv1.HTTPRouteRule{}, nil)
+
+			By("deploying stack", func() {
+				err := stack.DeployHTTP(ctx, nil, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec, lrcSpec, nil, true)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("checking gateway status for lb dns name", func() {
+				dnsName = stack.GetLoadBalancerIngressHostName()
+				Expect(dnsName).ToNot(BeEmpty())
+			})
+
+			By("querying AWS loadbalancer from the dns name", func() {
+				var err error
+				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(lbARN).ToNot(BeEmpty())
+			})
+
+			By("verifying AWS load balancer listener with mTLS passthrough mode", func() {
+				err := verifier.VerifyLoadBalancerListener(ctx, tf, lbARN, int32(gwListeners[0].Port), &verifier.ListenerExpectation{
+					ProtocolPort:          "HTTPS:443",
+					DefaultCertificateARN: awssdk.ToString(lsConfig.DefaultCertificate),
+					MutualAuthentication: &verifier.MutualAuthenticationExpectation{
+						Mode: "passthrough",
+					},
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("waiting for target group targets to be healthy", func() {
+				nodeList, err := stack.GetWorkerNodes(ctx, tf)
+				Expect(err).ToNot(HaveOccurred())
+				err = verifier.WaitUntilTargetsAreHealthy(ctx, tf, lbARN, len(nodeList))
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("waiting until DNS name is available", func() {
+				err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("verifying HTTPS request without client certificate succeeds", func() {
+				url := fmt.Sprintf("https://%v/any-path", dnsName)
+				urlOptions := httputils.URLOptions{
+					InsecureSkipVerify: true,
+					HostHeader:         testHostname,
+				}
+				err := tf.HTTPVerifier.VerifyURLWithOptions(url, urlOptions, httputils.ResponseCodeMatches(200))
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
+
+	Context("with mTLS in OFF mode", func() {
+		It("should not configure mTLS", func() {
+			interf := elbv2gw.LoadBalancerSchemeInternetFacing
+			lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
+				Scheme: &interf,
+			}
+
+			cert := strings.Split(tf.Options.CertificateARNs, ",")[0]
+			lsConfig := elbv2gw.ListenerConfiguration{
+				ProtocolPort:       "HTTPS:443",
+				DefaultCertificate: &cert,
+				MutualAuthentication: &elbv2gw.MutualAuthenticationAttributes{
+					Mode: elbv2gw.MutualAuthenticationOffMode,
+				},
+			}
+			lbcSpec.ListenerConfigurations = &[]elbv2gw.ListenerConfiguration{lsConfig}
+
+			instanceTargetType := elbv2gw.TargetTypeInstance
+			tgSpec := elbv2gw.TargetGroupConfigurationSpec{
+				DefaultConfiguration: elbv2gw.TargetGroupProps{
+					TargetType: &instanceTargetType,
+				},
+			}
+			lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{}
+			gwListeners := []gwv1.Listener{
+				{
+					Name:     "https443",
+					Port:     443,
+					Protocol: gwv1.HTTPSProtocolType,
+					Hostname: (*gwv1.Hostname)(awssdk.String(testHostname)),
+					TLS: &gwv1.GatewayTLSConfig{
+						CertificateRefs: []gwv1.SecretObjectReference{
+							{
+								Name: "tls-cert",
+							},
+						},
+					},
+				},
+			}
+			httpr := BuildHTTPRoute([]string{testHostname}, []gwv1.HTTPRouteRule{}, nil)
+
+			By("deploying stack", func() {
+				err := stack.DeployHTTP(ctx, nil, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, lbcSpec, tgSpec, lrcSpec, nil, true)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("checking gateway status for lb dns name", func() {
+				dnsName = stack.GetLoadBalancerIngressHostName()
+				Expect(dnsName).ToNot(BeEmpty())
+			})
+
+			By("querying AWS loadbalancer from the dns name", func() {
+				var err error
+				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(lbARN).ToNot(BeEmpty())
+			})
+
+			By("verifying AWS load balancer listener with mTLS off mode", func() {
+				err := verifier.VerifyLoadBalancerListener(ctx, tf, lbARN, int32(gwListeners[0].Port), &verifier.ListenerExpectation{
+					ProtocolPort:          "HTTPS:443",
+					DefaultCertificateARN: awssdk.ToString(lsConfig.DefaultCertificate),
+					MutualAuthentication: &verifier.MutualAuthenticationExpectation{
+						Mode: "off",
+					},
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("waiting for target group targets to be healthy", func() {
+				nodeList, err := stack.GetWorkerNodes(ctx, tf)
+				Expect(err).ToNot(HaveOccurred())
+				err = verifier.WaitUntilTargetsAreHealthy(ctx, tf, lbARN, len(nodeList))
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("waiting until DNS name is available", func() {
+				err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("verifying HTTPS request without client certificate succeeds", func() {
+				url := fmt.Sprintf("https://%v/any-path", dnsName)
+				urlOptions := httputils.URLOptions{
+					InsecureSkipVerify: true,
+					HostHeader:         testHostname,
+				}
+				err := tf.HTTPVerifier.VerifyURLWithOptions(url, urlOptions, httputils.ResponseCodeMatches(200))
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
+})

--- a/test/framework/options.go
+++ b/test/framework/options.go
@@ -45,6 +45,11 @@ type Options struct {
 	CognitoUserPoolArn      string
 	CognitoUserPoolClientId string
 	CognitoUserPoolDomain   string
+
+	// mTLS configuration for e2e tests
+	TrustStoreARN  string
+	ClientCertPath string
+	ClientKeyPath  string
 }
 
 func (options *Options) BindFlags() {
@@ -67,6 +72,10 @@ func (options *Options) BindFlags() {
 	flag.StringVar(&options.CognitoUserPoolArn, "cognito-user-pool-arn", "", `Cognito User Pool ARN for authenticate-cognito tests`)
 	flag.StringVar(&options.CognitoUserPoolClientId, "cognito-user-pool-client-id", "", `Cognito User Pool Client ID for authenticate-cognito tests`)
 	flag.StringVar(&options.CognitoUserPoolDomain, "cognito-user-pool-domain", "", `Cognito User Pool Domain for authenticate-cognito tests`)
+
+	flag.StringVar(&options.TrustStoreARN, "trust-store-arn", "", `Trust Store ARN for mTLS tests`)
+	flag.StringVar(&options.ClientCertPath, "client-cert-path", "", `Path to client certificate for mTLS tests`)
+	flag.StringVar(&options.ClientKeyPath, "client-key-path", "", `Path to client key for mTLS tests`)
 }
 
 func (options *Options) Validate() error {


### PR DESCRIPTION
### Description
- add e2e test cases for trust store functionality
- create a script to 

1. create certs & trust stores etc used for testing
2. run trust store test 
3. cleanup resources

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
```
CLUSTER_NAME=awslbc-loadtest VPC_ID=vpc-xxx ./scripts/run_trust_store_test.sh

Ran 3 of 41 Specs in 933.898 seconds
SUCCESS! -- 3 Passed | 0 Failed | 0 Pending | 38 Skipped
PASS

Ginkgo ran 1 suite in 15m51.752231834s
Test Suite Passed

=== All Tests Passed ===
=== Cleaning up AWS resources ===
✓ Trust store deleted
✓ ACM certificate deleted
delete: s3://mtls-test-xxx-xxx/ca-bundle.pem
remove_bucket: mtls-test-xxx-xxx
✓ S3 bucket deleted
```
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
