### PR TITLE
Fix apiVersion declarations

### DIFF
--- a/docs/guide/gateway/gateway.md
+++ b/docs/guide/gateway/gateway.md
@@ -84,7 +84,7 @@ The L4 and L7 gateways handle misconfigured services differently.
 
 ```
 # my-tcproute.yaml
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: TCPRoute
 metadata:
   name: my-tcp-app-route

--- a/docs/guide/gateway/gateway_chaining.md
+++ b/docs/guide/gateway/gateway_chaining.md
@@ -29,7 +29,7 @@ setup the NLB Gateway always uses private IP addresses to communicate with the A
 
 ```yaml
 # alb-gatewayclass.yaml
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
   name: aws-alb-gateway-class
@@ -37,7 +37,7 @@ spec:
   controllerName: gateway.k8s.aws/alb
 ---
 # my-alb-gateway.yaml
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: my-alb-gateway
@@ -104,7 +104,7 @@ to connect. The NLB will route traffic to the internal ALB using private IP addr
 
 ```yaml
 # nlb-gatewayclass.yaml
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
   name: aws-nlb-gateway-class
@@ -112,7 +112,7 @@ spec:
   controllerName: gateway.k8s.aws/nlb
 ---
 # my-nlb-gateway.yaml
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: my-tcp-gateway

--- a/docs/guide/gateway/l4gateway.md
+++ b/docs/guide/gateway/l4gateway.md
@@ -39,7 +39,7 @@ Consider a scenario where an application requires direct TCP traffic routing:
 
 ```yaml
 # nlb-gatewayclass.yaml
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
   name: aws-nlb-gateway-class
@@ -47,7 +47,7 @@ spec:
   controllerName: gateway.k8s.aws/nlb
 ---
 # my-nlb-gateway.yaml
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: my-tcp-gateway

--- a/docs/guide/gateway/l7gateway.md
+++ b/docs/guide/gateway/l7gateway.md
@@ -39,7 +39,7 @@ Consider a scenario where an application exposes an HTTP and HTTPS endpoint.
 
 ```yaml
 # alb-gatewayclass.yaml
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
   name: aws-alb-gateway-class
@@ -47,7 +47,7 @@ spec:
   controllerName: gateway.k8s.aws/alb
 ---
 # my-alb-gateway.yaml
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: my-alb-gateway
@@ -263,7 +263,7 @@ spec:
           value: example.com
 ---
 # my-alb-gateway.yaml
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: my-alb-gateway


### PR DESCRIPTION
Fixes: #4506

### Issue

Fix incorrect apiVersion declarations that introduced by #4466.

### Description

With GatewayAPI v1.2.x CRD applied,
* The actual supported apiVersion for GatewayClass should only accept `v1` or `v1beta1` but no other.
* The actual supported apiVersion for TCPRoute should only accept `v1alpha2` but no other.

Verified with the following script

```bash
─────┬─────────────────────────────────────────────────────────────────────────────────────────────────
     │ File: verify-api-support.sh
─────┼─────────────────────────────────────────────────────────────────────────────────────────────────
   1 │ #!/usr/bin/env bash
   2 │
   3 │ RESOURCES=(
   4 │   "GatewayClass"
   5 │   "Gateway"
   6 │   "TCPRoute"
   7 │ )
   8 │
   9 │ APIVERSIONS=(
  10 │   "gateway.networking.k8s.io/v1beta1"
  11 │   "gateway.networking.k8s.io/v1"
  12 │   "gateway.networking.k8s.io/v1alpha3"
  13 │   "gateway.networking.k8s.io/v1alpha2"
  14 │ )
  15 │
  16 │ for resource in ${RESOURCES[@]}; do
  17 │   echo "Testing for \"${resource}\""
  18 │   for apiVersion in ${APIVERSIONS[@]}; do
  19 │     kubectl explain ${resource} --api-version "${apiVersion}" 2>/dev/null 1>/dev/null && \
  20 │       echo "* ${apiVersion}: supported ✅" || \
  21 │       echo "* ${apiVersion}: not supported"
  22 │   done
  23 │   echo "---"
  24 │ done
─────┴────────────────────────────────────────────────────────────────────────────────────────────────
```

Test results

```bash
Testing for "GatewayClass"
* gateway.networking.k8s.io/v1beta1: supported ✅
* gateway.networking.k8s.io/v1: supported ✅
* gateway.networking.k8s.io/v1alpha3: not supported
* gateway.networking.k8s.io/v1alpha2: not supported
---
Testing for "Gateway"
* gateway.networking.k8s.io/v1beta1: supported ✅
* gateway.networking.k8s.io/v1: supported ✅
* gateway.networking.k8s.io/v1alpha3: not supported
* gateway.networking.k8s.io/v1alpha2: not supported
---
Testing for "TCPRoute"
* gateway.networking.k8s.io/v1beta1: not supported
* gateway.networking.k8s.io/v1: not supported
* gateway.networking.k8s.io/v1alpha3: not supported
* gateway.networking.k8s.io/v1alpha2: supported ✅
---
```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [X] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [X] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
