### PR TITLE
docs: fix service.beta.kubernetes.io/actions example

### DIFF
--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -225,27 +225,28 @@ on the load balancer.
 
     !!!example
         ```
-        service.beta.kubernetes.io/actions.TCP-80: {
-          "type": "forward",
-          "forwardConfig": {
-            "baseServiceWeight": 10,
-            "targetGroups": [
-              {
-                "serviceName": "service-1",
-                "servicePort": 81,
-                "weight": 20
-              },
-              {
-                "serviceName": "service-2",
-                "servicePort": 82,
-                "weight": 30
+        service.beta.kubernetes.io/actions.TCP-80: >
+          {
+            "type": "forward",
+            "forwardConfig": {
+              "baseServiceWeight": 10,
+              "targetGroups": [
+                {
+                  "serviceName": "service-1",
+                  "servicePort": 81,
+                  "weight": 20
+                },
+                {
+                  "serviceName": "service-2",
+                  "servicePort": 82,
+                  "weight": 30
+                }
+              ],
+              "targetGroupStickinessConfig": {
+                "enabled": true
               }
-            ],
-            "targetGroupStickinessConfig": {
-              "enabled": true
             }
           }
-        }
         ```
 
 ## Traffic Listening


### PR DESCRIPTION
The `service.beta.kubernetes.io/actions.*` annotation value must be a valid JSON string not a YAML map. Right now I get this controller error: `failed to parse json annotation...invalid character 'm' looking for beginning of value`.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes