### PR TITLE
fix(routeutils): add nil check for AuthenticationRequestExtraParams

### DIFF
--- a/pkg/gateway/routeutils/route_rule_action.go
+++ b/pkg/gateway/routeutils/route_rule_action.go
@@ -100,19 +100,22 @@ func buildJwtValidationAction(jwtValidationConfig *elbv2gw.JwtValidationActionCo
 }
 
 func buildAuthenticateCognitoAction(authCognitoActionConfig *elbv2gw.AuthenticateCognitoActionConfig) (*elbv2model.Action, *types.NamespacedName, error) {
-	return &elbv2model.Action{
+	action := &elbv2model.Action{
 		Type: elbv2model.ActionTypeAuthenticateCognito,
 		AuthenticateCognitoConfig: &elbv2model.AuthenticateCognitoActionConfig{
-			UserPoolARN:                      authCognitoActionConfig.UserPoolArn,
-			UserPoolClientID:                 authCognitoActionConfig.UserPoolClientID,
-			UserPoolDomain:                   authCognitoActionConfig.UserPoolDomain,
-			AuthenticationRequestExtraParams: *authCognitoActionConfig.AuthenticationRequestExtraParams,
-			OnUnauthenticatedRequest:         elbv2model.AuthenticateCognitoActionConditionalBehavior(*authCognitoActionConfig.OnUnauthenticatedRequest),
-			Scope:                            authCognitoActionConfig.Scope,
-			SessionCookieName:                authCognitoActionConfig.SessionCookieName,
-			SessionTimeout:                   authCognitoActionConfig.SessionTimeout,
+			UserPoolARN:              authCognitoActionConfig.UserPoolArn,
+			UserPoolClientID:         authCognitoActionConfig.UserPoolClientID,
+			UserPoolDomain:           authCognitoActionConfig.UserPoolDomain,
+			OnUnauthenticatedRequest: elbv2model.AuthenticateCognitoActionConditionalBehavior(*authCognitoActionConfig.OnUnauthenticatedRequest),
+			Scope:                    authCognitoActionConfig.Scope,
+			SessionCookieName:        authCognitoActionConfig.SessionCookieName,
+			SessionTimeout:           authCognitoActionConfig.SessionTimeout,
 		},
-	}, nil, nil
+	}
+	if authCognitoActionConfig.AuthenticationRequestExtraParams != nil {
+		action.AuthenticateCognitoConfig.AuthenticationRequestExtraParams = *authCognitoActionConfig.AuthenticationRequestExtraParams
+	}
+	return action, nil, nil
 }
 
 func buildAuthenticateOIDCAction(ctx context.Context, authenticateOIDCActionConfig *elbv2gw.AuthenticateOidcActionConfig, route RouteDescriptor, k8sClient client.Client, secretsManager k8s.SecretsManager) (*elbv2model.Action, *types.NamespacedName, error) {
@@ -141,22 +144,26 @@ func buildAuthenticateOIDCAction(ctx context.Context, authenticateOIDCActionConf
 
 	clientID := strings.TrimRightFunc(string(rawClientID), unicode.IsSpace)
 	clientSecret := strings.TrimRightFunc(string(rawClientSecret), unicode.IsControl)
-	return &elbv2model.Action{
+
+	action := &elbv2model.Action{
 		Type: elbv2model.ActionTypeAuthenticateOIDC,
 		AuthenticateOIDCConfig: &elbv2model.AuthenticateOIDCActionConfig{
-			Issuer:                           authenticateOIDCActionConfig.Issuer,
-			AuthorizationEndpoint:            authenticateOIDCActionConfig.AuthorizationEndpoint,
-			TokenEndpoint:                    authenticateOIDCActionConfig.TokenEndpoint,
-			UserInfoEndpoint:                 authenticateOIDCActionConfig.UserInfoEndpoint,
-			ClientID:                         clientID,
-			ClientSecret:                     clientSecret,
-			AuthenticationRequestExtraParams: *authenticateOIDCActionConfig.AuthenticationRequestExtraParams,
-			OnUnauthenticatedRequest:         elbv2model.AuthenticateOIDCActionConditionalBehavior(*authenticateOIDCActionConfig.OnUnauthenticatedRequest),
-			Scope:                            authenticateOIDCActionConfig.Scope,
-			SessionCookieName:                authenticateOIDCActionConfig.SessionCookieName,
-			SessionTimeout:                   authenticateOIDCActionConfig.SessionTimeout,
+			Issuer:                   authenticateOIDCActionConfig.Issuer,
+			AuthorizationEndpoint:    authenticateOIDCActionConfig.AuthorizationEndpoint,
+			TokenEndpoint:            authenticateOIDCActionConfig.TokenEndpoint,
+			UserInfoEndpoint:         authenticateOIDCActionConfig.UserInfoEndpoint,
+			ClientID:                 clientID,
+			ClientSecret:             clientSecret,
+			OnUnauthenticatedRequest: elbv2model.AuthenticateOIDCActionConditionalBehavior(*authenticateOIDCActionConfig.OnUnauthenticatedRequest),
+			Scope:                    authenticateOIDCActionConfig.Scope,
+			SessionCookieName:        authenticateOIDCActionConfig.SessionCookieName,
+			SessionTimeout:           authenticateOIDCActionConfig.SessionTimeout,
 		},
-	}, &secretKey, nil
+	}
+	if authenticateOIDCActionConfig.AuthenticationRequestExtraParams != nil {
+		action.AuthenticateOIDCConfig.AuthenticationRequestExtraParams = *authenticateOIDCActionConfig.AuthenticationRequestExtraParams
+	}
+	return action, &secretKey, nil
 }
 
 func buildForwardRoutingAction(routingAction *elbv2gw.Action, targetGroupTuples []elbv2model.TargetGroupTuple) (*elbv2model.Action, error) {

--- a/pkg/gateway/routeutils/route_rule_action_test.go
+++ b/pkg/gateway/routeutils/route_rule_action_test.go
@@ -337,6 +337,32 @@ func Test_buildAuthenticateCognitoAction(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "authenticate cognito with nil AuthenticationRequestExtraParams",
+			config: &elbv2gw.AuthenticateCognitoActionConfig{
+				UserPoolArn:                      userPoolArn,
+				UserPoolClientID:                 userPoolClientID,
+				UserPoolDomain:                   userPoolDomain,
+				AuthenticationRequestExtraParams: nil,
+				OnUnauthenticatedRequest:         &authenticateBehavior,
+				Scope:                            &scope,
+				SessionCookieName:                &sessionCookieName,
+				SessionTimeout:                   &sessionTimeout,
+			},
+			want: &elbv2model.Action{
+				Type: elbv2model.ActionTypeAuthenticateCognito,
+				AuthenticateCognitoConfig: &elbv2model.AuthenticateCognitoActionConfig{
+					UserPoolARN:              userPoolArn,
+					UserPoolClientID:         userPoolClientID,
+					UserPoolDomain:           userPoolDomain,
+					OnUnauthenticatedRequest: elbv2model.AuthenticateCognitoActionConditionalBehavior(authenticateBehavior),
+					Scope:                    &scope,
+					SessionCookieName:        &sessionCookieName,
+					SessionTimeout:           &sessionTimeout,
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "authenticate cognito with required fields only",
 			config: &elbv2gw.AuthenticateCognitoActionConfig{
 				UserPoolArn:                      userPoolArn,
@@ -494,6 +520,48 @@ func Test_buildAuthenticateOIDCAction(t *testing.T) {
 					Scope:                            &scope,
 					SessionCookieName:                &sessionCookieName,
 					SessionTimeout:                   &sessionTimeout,
+				},
+			},
+			wantSecretRef: &types.NamespacedName{
+				Namespace: secretNamespace,
+				Name:      secretName,
+			},
+			wantErr: false,
+		},
+		{
+			name: "authenticate OIDC with nil AuthenticationRequestExtraParams",
+			config: &elbv2gw.AuthenticateOidcActionConfig{
+				Issuer:                issuer,
+				AuthorizationEndpoint: authzEndpoint,
+				TokenEndpoint:         tokenEndpoint,
+				UserInfoEndpoint:      userInfoEndpoint,
+				Secret: &elbv2gw.Secret{
+					Name: secretName,
+				},
+				AuthenticationRequestExtraParams: nil,
+				OnUnauthenticatedRequest:         &authenticateBehavior,
+				Scope:                            &scope,
+				SessionCookieName:                &sessionCookieName,
+				SessionTimeout:                   &sessionTimeout,
+			},
+			secretData: map[string][]byte{
+				"clientID":     []byte(clientID),
+				"clientSecret": []byte(clientSecret),
+			},
+			secretExists: true,
+			want: &elbv2model.Action{
+				Type: elbv2model.ActionTypeAuthenticateOIDC,
+				AuthenticateOIDCConfig: &elbv2model.AuthenticateOIDCActionConfig{
+					Issuer:                   issuer,
+					AuthorizationEndpoint:    authzEndpoint,
+					TokenEndpoint:            tokenEndpoint,
+					UserInfoEndpoint:         userInfoEndpoint,
+					ClientID:                 clientID,
+					ClientSecret:             clientSecret,
+					OnUnauthenticatedRequest: elbv2model.AuthenticateOIDCActionConditionalBehavior(authenticateBehavior),
+					Scope:                    &scope,
+					SessionCookieName:        &sessionCookieName,
+					SessionTimeout:           &sessionTimeout,
 				},
 			},
 			wantSecretRef: &types.NamespacedName{


### PR DESCRIPTION
### Description

Fix nil pointer dereference crash in buildAuthenticateCognitoAction() and buildAuthenticateOIDCAction() that occurs when AuthenticationRequestExtraParams is omitted from the YAML configuration.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
