### PR TITLE
Fix NLB target group association limit issue for weighted configs

### DIFF
--- a/pkg/service/model_build_listener.go
+++ b/pkg/service/model_build_listener.go
@@ -159,7 +159,9 @@ func (t *defaultModelBuildTask) buildListenerSpec(ctx context.Context, port core
 		// Build the default action
 		defaultActions = t.buildListenerDefaultActionsViaAnnotation(actionCfg, targetGroups)
 	} else {
-		targetGroup, err := t.buildTargetGroup(ctx, t.service, baseSvcAnnotations, port, tgProtocol, scheme)
+		// For standard (non-weighted) NLB configurations, we pass nil as the base service parameter
+		// as target group name uniqueness is already guaranteed by the service's own properties.
+		targetGroup, err := t.buildTargetGroup(ctx, nil, t.service, baseSvcAnnotations, port, tgProtocol, scheme)
 		if err != nil {
 			return elbv2model.ListenerSpec{}, err
 		}

--- a/test/e2e/globalaccelerator/service_endpoint_test.go
+++ b/test/e2e/globalaccelerator/service_endpoint_test.go
@@ -48,7 +48,7 @@ var _ = Describe("GlobalAccelerator with Service endpoint", func() {
 			annotations := createServiceAnnotations("nlb-ip", "internet-facing", tf.Options.IPFamily)
 			svc := createLoadBalancerService(svcName, labels, annotations)
 
-			svcStack = service.NewResourceStack(deployment, svc, nil, baseName, map[string]string{})
+			svcStack = service.NewResourceStack(deployment, svc, nil, nil, baseName, map[string]string{})
 			err := svcStack.Deploy(ctx, tf)
 			Expect(err).NotTo(HaveOccurred())
 			namespace = svcStack.GetNamespace()
@@ -181,7 +181,7 @@ var _ = Describe("GlobalAccelerator with Service endpoint", func() {
 			annotations["service.beta.kubernetes.io/aws-load-balancer-nlb-target-type"] = "instance"
 			svc := createLoadBalancerService(instanceSvcName, labels, annotations)
 
-			instanceSvcStack = service.NewResourceStack(deployment, svc, nil, instanceBaseName, map[string]string{})
+			instanceSvcStack = service.NewResourceStack(deployment, svc, nil, nil, instanceBaseName, map[string]string{})
 			err := instanceSvcStack.Deploy(ctx, tf)
 			Expect(err).NotTo(HaveOccurred())
 			instanceNs = instanceSvcStack.GetNamespace()
@@ -414,7 +414,7 @@ var _ = Describe("GlobalAccelerator with Service endpoint", func() {
 			annotations["service.beta.kubernetes.io/aws-load-balancer-nlb-target-type"] = "instance"
 			svc := createLoadBalancerServiceWithPorts(instanceSvcName, labels, annotations, 80, 443)
 
-			instanceSvcStack = service.NewResourceStack(deployment, svc, nil, instanceBaseName, map[string]string{})
+			instanceSvcStack = service.NewResourceStack(deployment, svc, nil, nil, instanceBaseName, map[string]string{})
 			err := instanceSvcStack.Deploy(ctx, tf)
 			Expect(err).NotTo(HaveOccurred())
 			instanceNs = instanceSvcStack.GetNamespace()

--- a/test/e2e/service/nlb_ip_target.go
+++ b/test/e2e/service/nlb_ip_target.go
@@ -17,8 +17,8 @@ type NLBIPTestStack struct {
 	resourceStack *ResourceStack
 }
 
-func (s *NLBIPTestStack) Deploy(ctx context.Context, f *framework.Framework, svc *corev1.Service, dp *appsv1.Deployment, svcs []*corev1.Service, namespaceLabels map[string]string) error {
-	s.resourceStack = NewResourceStack(dp, svc, svcs, "service-ip-e2e", namespaceLabels)
+func (s *NLBIPTestStack) Deploy(ctx context.Context, f *framework.Framework, svc *corev1.Service, dp *appsv1.Deployment, lbTypeSvcs []*corev1.Service, nonLbTypeSvcs []*corev1.Service, namespaceLabels map[string]string) error {
+	s.resourceStack = NewResourceStack(dp, svc, lbTypeSvcs, nonLbTypeSvcs, "service-ip-e2e", namespaceLabels)
 	return s.resourceStack.Deploy(ctx, f)
 }
 

--- a/test/e2e/service/nlb_quic_test.go
+++ b/test/e2e/service/nlb_quic_test.go
@@ -107,7 +107,7 @@ var _ = Describe("NLB QUIC support", func() {
 
 		It("Should create NLB with QUIC protocol and targets with server IDs", func() {
 			By("deploying stack", func() {
-				err := stack.Deploy(ctx, tf, svc, deployment, nil, map[string]string{
+				err := stack.Deploy(ctx, tf, svc, deployment, nil, nil, map[string]string{
 					"elbv2.k8s.aws/quic-server-id-inject": "enabled",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -199,7 +199,7 @@ var _ = Describe("NLB QUIC support", func() {
 
 		It("Should create NLB with TCP_QUIC protocol and targets with server IDs", func() {
 			By("deploying stack", func() {
-				err := stack.Deploy(ctx, tf, svc, deployment, nil, map[string]string{
+				err := stack.Deploy(ctx, tf, svc, deployment, nil, nil, map[string]string{
 					"elbv2.k8s.aws/quic-server-id-inject": "enabled",
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -281,7 +281,7 @@ var _ = Describe("NLB QUIC support", func() {
 
 		It("Should create NLB with TCP protocol and targets without server IDs", func() {
 			By("deploying stack", func() {
-				err := stack.Deploy(ctx, tf, svc, deployment, nil, map[string]string{
+				err := stack.Deploy(ctx, tf, svc, deployment, nil, nil, map[string]string{
 					"elbv2.k8s.aws/quic-server-id-inject": "enabled",
 				})
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
### Issue

[<!-- Please link the GitHub issues related to this PR, if available -->](https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4528)

### Description

## Problem

When using weighted target groups with multiple NLB services that reference the same backend services, the controller attempts to use the same target groups for multiple load balancers. This violates AWS's limitation that NLB target groups can only be associated with one load balancer, resulting in errors like:

```javascript
TargetGroupAssociationLimit: The following target groups cannot be associated with more than one load balancer
```

## Solution

Modified the target group name generation by including the base service's UID in the hash calculation. This ensures each NLB service creates its own unique target groups when using weighted target configurations, even when they reference the same backend services.

## Testing

Added E2E tests that create two different NLB services referencing the same backend services in weighted target group configurations, verifying that each NLB gets its own set of uniquely named target groups.

## Potential Impact

_This change will cause a one-time disruption for existing NLBs with weighted target groups, as new target groups will be created when this change is applied. This behavior should be documented in release notes as a necessary improvement to fix the underlying issue._ - Initial thinking. Not true anymore

The good news is that the NLB(weighted/non-weighted) which is already created before the new version don't change. These older tgs dont get deleted and remain attached to the load balancer. The reason behind this is we don't change the stack tags for these target groups. So when we run synthesizer we fetch the target groups through stack tags and we get the same target groups we created before. So no downtime on those.
The NLBs which were stuck before now gets new target groups and get unstuck and traffic now flows for these. (edited) 


### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [x] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:
