### PR TITLE
[gateway api] remove route count check for deleting gateway

### DIFF
--- a/controllers/gateway/utils.go
+++ b/controllers/gateway/utils.go
@@ -190,3 +190,8 @@ func getServicesFromRoutes(listenerRouteMap map[int32][]routeutils.RouteDescript
 	}
 	return res.UnsortedList()
 }
+
+// isGatewayDeleting returns true if the gateway has a deletion timestamp set
+func isGatewayDeleting(gw *gwv1.Gateway) bool {
+	return gw.DeletionTimestamp != nil && !gw.DeletionTimestamp.IsZero()
+}

--- a/pkg/gateway/model/base_model_builder_test.go
+++ b/pkg/gateway/model/base_model_builder_test.go
@@ -1,0 +1,268 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
+	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/shared_constants"
+)
+
+func Test_baseModelBuilder_isDeleteProtected(t *testing.T) {
+	tests := []struct {
+		name   string
+		lbConf elbv2gw.LoadBalancerConfiguration
+		want   bool
+	}{
+		{
+			name: "deletion protection enabled",
+			lbConf: elbv2gw.LoadBalancerConfiguration{
+				Spec: elbv2gw.LoadBalancerConfigurationSpec{
+					LoadBalancerAttributes: []elbv2gw.LoadBalancerAttribute{
+						{
+							Key:   shared_constants.LBAttributeDeletionProtection,
+							Value: "true",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "deletion protection disabled",
+			lbConf: elbv2gw.LoadBalancerConfiguration{
+				Spec: elbv2gw.LoadBalancerConfigurationSpec{
+					LoadBalancerAttributes: []elbv2gw.LoadBalancerAttribute{
+						{
+							Key:   shared_constants.LBAttributeDeletionProtection,
+							Value: "false",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "deletion protection not specified",
+			lbConf: elbv2gw.LoadBalancerConfiguration{
+				Spec: elbv2gw.LoadBalancerConfigurationSpec{
+					LoadBalancerAttributes: []elbv2gw.LoadBalancerAttribute{},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "deletion protection with invalid value",
+			lbConf: elbv2gw.LoadBalancerConfiguration{
+				Spec: elbv2gw.LoadBalancerConfigurationSpec{
+					LoadBalancerAttributes: []elbv2gw.LoadBalancerAttribute{
+						{
+							Key:   shared_constants.LBAttributeDeletionProtection,
+							Value: "invalid",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "deletion protection among other attributes",
+			lbConf: elbv2gw.LoadBalancerConfiguration{
+				Spec: elbv2gw.LoadBalancerConfigurationSpec{
+					LoadBalancerAttributes: []elbv2gw.LoadBalancerAttribute{
+						{
+							Key:   "idle_timeout.timeout_seconds",
+							Value: "60",
+						},
+						{
+							Key:   shared_constants.LBAttributeDeletionProtection,
+							Value: "true",
+						},
+						{
+							Key:   "access_logs.s3.enabled",
+							Value: "false",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name:   "empty config",
+			lbConf: elbv2gw.LoadBalancerConfiguration{},
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := &baseModelBuilder{
+				logger: logr.Discard(),
+			}
+			got := builder.isDeleteProtected(tt.lbConf)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_baseModelBuilder_buildLoadBalancerScheme(t *testing.T) {
+	internetFacing := elbv2gw.LoadBalancerScheme(elbv2model.LoadBalancerSchemeInternetFacing)
+	internal := elbv2gw.LoadBalancerScheme(elbv2model.LoadBalancerSchemeInternal)
+	unknown := elbv2gw.LoadBalancerScheme("unknown")
+
+	tests := []struct {
+		name          string
+		lbConf        elbv2gw.LoadBalancerConfiguration
+		defaultScheme elbv2model.LoadBalancerScheme
+		want          elbv2model.LoadBalancerScheme
+		wantErr       bool
+	}{
+		{
+			name: "internet-facing scheme",
+			lbConf: elbv2gw.LoadBalancerConfiguration{
+				Spec: elbv2gw.LoadBalancerConfigurationSpec{
+					Scheme: &internetFacing,
+				},
+			},
+			defaultScheme: elbv2model.LoadBalancerSchemeInternal,
+			want:          elbv2model.LoadBalancerSchemeInternetFacing,
+			wantErr:       false,
+		},
+		{
+			name: "internal scheme",
+			lbConf: elbv2gw.LoadBalancerConfiguration{
+				Spec: elbv2gw.LoadBalancerConfigurationSpec{
+					Scheme: &internal,
+				},
+			},
+			defaultScheme: elbv2model.LoadBalancerSchemeInternetFacing,
+			want:          elbv2model.LoadBalancerSchemeInternal,
+			wantErr:       false,
+		},
+		{
+			name: "nil scheme uses default",
+			lbConf: elbv2gw.LoadBalancerConfiguration{
+				Spec: elbv2gw.LoadBalancerConfigurationSpec{
+					Scheme: nil,
+				},
+			},
+			defaultScheme: elbv2model.LoadBalancerSchemeInternal,
+			want:          elbv2model.LoadBalancerSchemeInternal,
+			wantErr:       false,
+		},
+		{
+			name: "unknown scheme returns error",
+			lbConf: elbv2gw.LoadBalancerConfiguration{
+				Spec: elbv2gw.LoadBalancerConfigurationSpec{
+					Scheme: &unknown,
+				},
+			},
+			defaultScheme: elbv2model.LoadBalancerSchemeInternal,
+			want:          "",
+			wantErr:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := &baseModelBuilder{
+				defaultLoadBalancerScheme: tt.defaultScheme,
+			}
+			got, err := builder.buildLoadBalancerScheme(tt.lbConf)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_baseModelBuilder_buildLoadBalancerIPAddressType(t *testing.T) {
+	ipv4 := elbv2gw.LoadBalancerIpAddressType(elbv2model.IPAddressTypeIPV4)
+	dualStack := elbv2gw.LoadBalancerIpAddressType(elbv2model.IPAddressTypeDualStack)
+	dualStackWithoutPublicIPv4 := elbv2gw.LoadBalancerIpAddressType(elbv2model.IPAddressTypeDualStackWithoutPublicIPV4)
+	unknown := elbv2gw.LoadBalancerIpAddressType("unknown")
+
+	tests := []struct {
+		name        string
+		lbConf      elbv2gw.LoadBalancerConfiguration
+		defaultType elbv2model.IPAddressType
+		want        elbv2model.IPAddressType
+		wantErr     bool
+	}{
+		{
+			name: "ipv4 address type",
+			lbConf: elbv2gw.LoadBalancerConfiguration{
+				Spec: elbv2gw.LoadBalancerConfigurationSpec{
+					IpAddressType: &ipv4,
+				},
+			},
+			defaultType: elbv2model.IPAddressTypeDualStack,
+			want:        elbv2model.IPAddressTypeIPV4,
+			wantErr:     false,
+		},
+		{
+			name: "dualstack address type",
+			lbConf: elbv2gw.LoadBalancerConfiguration{
+				Spec: elbv2gw.LoadBalancerConfigurationSpec{
+					IpAddressType: &dualStack,
+				},
+			},
+			defaultType: elbv2model.IPAddressTypeIPV4,
+			want:        elbv2model.IPAddressTypeDualStack,
+			wantErr:     false,
+		},
+		{
+			name: "dualstack without public ipv4 address type",
+			lbConf: elbv2gw.LoadBalancerConfiguration{
+				Spec: elbv2gw.LoadBalancerConfigurationSpec{
+					IpAddressType: &dualStackWithoutPublicIPv4,
+				},
+			},
+			defaultType: elbv2model.IPAddressTypeIPV4,
+			want:        elbv2model.IPAddressTypeDualStackWithoutPublicIPV4,
+			wantErr:     false,
+		},
+		{
+			name: "nil address type uses default",
+			lbConf: elbv2gw.LoadBalancerConfiguration{
+				Spec: elbv2gw.LoadBalancerConfigurationSpec{
+					IpAddressType: nil,
+				},
+			},
+			defaultType: elbv2model.IPAddressTypeIPV4,
+			want:        elbv2model.IPAddressTypeIPV4,
+			wantErr:     false,
+		},
+		{
+			name: "unknown address type returns error",
+			lbConf: elbv2gw.LoadBalancerConfiguration{
+				Spec: elbv2gw.LoadBalancerConfigurationSpec{
+					IpAddressType: &unknown,
+				},
+			},
+			defaultType: elbv2model.IPAddressTypeIPV4,
+			want:        "",
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := &baseModelBuilder{
+				defaultIPType: tt.defaultType,
+			}
+			got, err := builder.buildLoadBalancerIPAddressType(tt.lbConf)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/gateway/model/model_build_listener.go
+++ b/pkg/gateway/model/model_build_listener.go
@@ -173,11 +173,11 @@ func (l listenerBuilderImpl) buildL4ListenerSpec(ctx context.Context, stack core
 	listenerSpec.ALPNPolicy = alpnPolicy
 
 	tgTuples, err := l.buildL4TargetGroupTuples(stack, routes, gw, port, listenerSpec.Protocol, lb.Spec.IPAddressType)
-	
+
 	if err != nil {
 		return &elbv2model.ListenerSpec{}, err
 	}
-	
+
 	if len(tgTuples) == 0 {
 		l.logger.Info("Skipping listener creation due to no backend references", "listener", fmt.Sprintf("%v:%v", listenerSpec.Protocol, port), "gateway", k8s.NamespacedName(gw))
 		return nil, nil


### PR DESCRIPTION
### Description

Originally, when the controller was written, I had made an assumption that the Gateway API mandates blocking Gateway deletions that have routes attached. When implementing Gateway clean up in eksctl, this made things tough. After further investigation, and playing around with Envoy Gateway, I don't think this check is necessary.

Situations tested:

- Deleted Gateway with Routes attached [works]
- Delete Gateway without Routes attached [works]
- Deleted Gateway and Recreate Gateway with same name [works].

I chose to emulate Envoy Gateway behavior, which is to leave routes with dangling Gateway attachments untouched. This simplified the implementation as we would have to worry about such edgecases in terms of ReferenceGrants. 

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [x] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:
