### PR TITLE
feat: Add support for preserving listeners with specific tags during reconciliation

### DIFF
--- a/pkg/deploy/elbv2/listener_synthesizer.go
+++ b/pkg/deploy/elbv2/listener_synthesizer.go
@@ -2,6 +2,8 @@ package elbv2
 
 import (
 	"context"
+	"os"
+
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -71,8 +73,17 @@ func (s *listenerSynthesizer) synthesizeListenersOnLB(ctx context.Context, lbARN
 	if err != nil {
 		return err
 	}
+	preventDeletionTagName := os.Getenv("PREVENT_DELETION_TAG_NAME")
 	matchedResAndSDKLSs, unmatchedResLSs, unmatchedSDKLSs := matchResAndSDKListeners(resLSs, sdkLSs)
 	for _, sdkLS := range unmatchedSDKLSs {
+		if preventDeletionTagName != "" {
+			if _, found := sdkLS.Tags[preventDeletionTagName]; found {
+				if sdkLS.Listener.ListenerArn != nil {
+					s.logger.Info("skip deleting listener", "arn", *sdkLS.Listener.ListenerArn)
+				}
+				continue
+			}
+		}
 		if err := s.lsManager.Delete(ctx, sdkLS); err != nil {
 			return err
 		}


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description

This change introduces an optional PREVENT_DELETION_TAG_NAME environment variable that allows operators to mark certain listeners on managed load balancers as externally managed, preventing the controller from deleting them during reconciliation.

Use case: This is useful when multiple systems need to manage listeners on the same NLB, such as when setting up AWS PrivateLink endpoints that require additional listeners beyond what the controller creates for Kubernetes Services.

When `PREVENT_DELETION_TAG_NAME` is set, the controller will skip deletion of any unmatched listeners that have the specified tag key, logging the skip action for visibility.

When `PREVENT_DELETION_TAG_NAME` is not set, behavior remains unchanged - all unmatched listeners are deleted as before.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [✅] Manually tested
- [✅] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
