### PR TITLE
add port defaulting for scheme

### DIFF
--- a/pkg/gateway/routeutils/route_rule_action.go
+++ b/pkg/gateway/routeutils/route_rule_action.go
@@ -268,10 +268,23 @@ func buildHttpRedirectAction(filter *gwv1.HTTPRequestRedirectFilter, redirectCon
 	var protocol *string
 	if filter.Scheme != nil {
 		upperScheme := strings.ToUpper(*filter.Scheme)
-		if upperScheme != "HTTP" && upperScheme != "HTTPS" {
+
+		var defaultPort string
+		switch upperScheme {
+		case "HTTP":
+			defaultPort = "80"
+			break
+		case "HTTPS":
+			defaultPort = "443"
+			break
+		default:
 			return nil, errors.Errorf("unsupported redirect scheme: %v", upperScheme)
 		}
 		protocol = &upperScheme
+
+		if port == nil {
+			port = &defaultPort
+		}
 	}
 
 	var path *string


### PR DESCRIPTION
### Issue

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4567

### Description

We missed the API definition that mentions we should use the scheme to default the port, when it's not specified:
```
Port is the port to be used in the value of the Location
header in the response.
If no port is specified, the redirect port MUST be derived using the
following rules:
If redirect scheme is not-empty, the redirect port MUST be the well-known
port associated with the redirect scheme. Specifically "http" to port 80
and "https" to port 443. If the redirect scheme does not have a
well-known port, the listener port of the Gateway SHOULD be used.
If redirect scheme is empty, the redirect port MUST be the Gateway
Listener port.
Implementations SHOULD NOT add the port number in the 'Location'
header in the following cases:
A Location header that will use HTTP (whether that is determined via
the Listener protocol or the Scheme field) and use port 80.
A Location header that will use HTTPS (whether that is determined via
the Listener protocol or the Scheme field) and use port 443.
```

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
