### PR TITLE
Use regex matching for regex paths, instead of value (glob)

### DIFF
--- a/pkg/gateway/routeutils/route_rule_condition.go
+++ b/pkg/gateway/routeutils/route_rule_condition.go
@@ -79,7 +79,14 @@ func buildHttpPathCondition(path *gwv1.HTTPPathMatch) ([]elbv2model.RuleConditio
 
 	// for regex match, we do not need special processing, it will be taken as it is
 	if pathType == gwv1.PathMatchRegularExpression {
-		pathValues = append(pathValues, pathValue)
+		return []elbv2model.RuleCondition{
+			{
+				Field: elbv2model.RuleConditionFieldPathPattern,
+				PathPatternConfig: &elbv2model.PathPatternConditionConfig{
+					RegexValues: append(pathValues, pathValue),
+				},
+			},
+		}, nil
 	}
 
 	return []elbv2model.RuleCondition{

--- a/pkg/gateway/routeutils/route_rule_condition_test.go
+++ b/pkg/gateway/routeutils/route_rule_condition_test.go
@@ -213,7 +213,7 @@ func Test_buildHttpPathCondition(t *testing.T) {
 				{
 					Field: elbv2model.RuleConditionFieldPathPattern,
 					PathPatternConfig: &elbv2model.PathPatternConditionConfig{
-						Values: []string{regexPathValue},
+						RegexValues: []string{regexPathValue},
 					},
 				},
 			},


### PR DESCRIPTION
### Issue

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4573

### Description

Modified path based routing for ALB to correctly use `RegexValues` in the ELB API when set to use `RegularExpression` path matching.

NOTE: I am uncertain if the behavior of previously successful usages of RegularExepression rules will be the same after this change (i.e glob vs regex behavior) and don't have a way to easily build, deploy and test the controller. 

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
