### PR TITLE
Update docs for service.beta.kubernetes.io/aws-load-balancer-type annotation

### DIFF
--- a/docs/deploy/installation.md
+++ b/docs/deploy/installation.md
@@ -11,7 +11,9 @@ The LBC is supported by AWS. Some clusters may be using the legacy "in-tree" fun
 !!!warning "When using AWS Load Balancer Controller v2.5+"
     The AWS LBC provides a mutating webhook for service resources to set the `spec.loadBalancerClass` field for service of type LoadBalancer on create.
     This makes the AWS LBC the **default controller for service** of type LoadBalancer. You can disable this feature and revert to set Cloud Controller Manager (in-tree controller) as the default by setting the helm chart value **enableServiceMutatorWebhook to false** with `--set enableServiceMutatorWebhook=false` .
-    You will no longer be able to provision new Classic Load Balancer (CLB) from your kubernetes service unless you disable this feature. Existing CLB will continue to work fine.
+    You will no longer be able to provision new Classic Load Balancer (CLB) from your kubernetes service unless you disable this feature. Existing CLB will continue to work fine. 
+
+    If you are updating the `type` of an existing Service to `LoadBalancer`, the webhook **will not** run. If you want the LBC to be the controller for your Service, you must specify it explicitly. [See instructions](../guide/service/nlb.md).
 
 ## Supported Kubernetes versions
 * AWS Load Balancer Controller v2.0.0~v2.1.3 requires Kubernetes 1.15-1.21

--- a/docs/guide/service/annotations.md
+++ b/docs/guide/service/annotations.md
@@ -91,9 +91,12 @@ Traffic Routing can be controlled with following annotations:
     !!!note ""
         - [Deprecated] For type `nlb-ip`, the controller will provision an NLB with targets registered by IP address. This value is supported for backwards compatibility.
         - For type `external`, the NLB target type depends on the [nlb-target-type](#nlb-target-type) annotation.
+        - `nlb` is **not** a valid value for this annotation.
 
-    !!!warning "limitations"
-        - This annotation should not be modified after service creation.
+    !!!warning "Limitations"
+        - Do not add this annotation to an existing Service.
+        - Do not modify this annotation on an existing Service.
+        - Adding or modifying this annotation on an existing Service can lead to leaked resources or security issues such as unintentionally exposing your NLB to the Internet.
 
     !!!example
         ```

--- a/docs/guide/service/nlb.md
+++ b/docs/guide/service/nlb.md
@@ -93,10 +93,10 @@ In order for the LBC to manage the reconciliation of Kubernetes Service resource
 
     When you specify the [`service.beta.kubernetes.io/aws-load-balancer-type` annotation](./annotations.md#lb-type) to be `external` on a Kubernetes Service resource of type `LoadBalancer`, the in-tree controller ignores the Service resource. In addition, if you specify the [`service.beta.kubernetes.io/aws-load-balancer-nlb-target-type` annotation](./annotations.md#nlb-target-type) on the Service resource, the LBC takes charge of reconciliation by provisioning an NLB.
 
-    !!! warning
-        - It's not recommended to modify or add the `service.beta.kubernetes.io/aws-load-balancer-type` annotation on an existing Service resource. If a change is desired, delete the existing Service resource and create a new one instead of modifying an existing Service.
-
-        - If you modify this annotation on an existing Service resource, you might end up with leaked LBC resources.
+    !!! warning "Limitations"
+        - Do not modify or add the `service.beta.kubernetes.io/aws-load-balancer-type` annotation on an existing Service resource. 
+        - Modifying or adding this annotation on an existing Service can lead to leaked resources or security issues such as unintentionally exposing your NLB to the Internet.
+        - If a change is desired, delete the existing Service resource and create a new one instead of modifying an existing Service.
 
     !!! note "backwards compatibility for `nlb-ip` type"
         For backwards compatibility, both the in-tree and LBC controller supports `nlb-ip` as a value for the `service.beta.kubernetes.io/aws-load-balancer-type` annotation. The controllers treats it as if you specified both of the following annotations:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,7 +94,8 @@ markdown_extensions:
   - pymdownx.tasklist:
       custom_checkbox: true
   - pymdownx.superfences
-  - pymdownx.tabbed
+  - pymdownx.tabbed:
+      alternate_style: true
   - pymdownx.emoji:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg


### PR DESCRIPTION
### Description
- Add warnings about `service.beta.kubernetes.io/aws-load-balancer-type` annotation
- Clarify that webhook for setting LBC as default for service resources does not work on updates of existing Service

Docs preview:

<img width="1291" height="692" alt="annotation" src="https://github.com/user-attachments/assets/946f8e63-c264-4105-a9a2-b631105f7428" />
<img width="1209" height="699" alt="nlb-config" src="https://github.com/user-attachments/assets/a6ee19f2-3599-42f8-97a3-a3fc5235e698" />
<img width="1281" height="742" alt="lbc-installation" src="https://github.com/user-attachments/assets/b8c04aea-a331-4a7f-8ab0-90137fce53f7" />

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2: