### PR TITLE
correct regex value handling in gateway api

### DIFF
--- a/pkg/gateway/routeutils/route_rule_condition.go
+++ b/pkg/gateway/routeutils/route_rule_condition.go
@@ -77,9 +77,16 @@ func buildHttpPathCondition(path *gwv1.HTTPPathMatch) ([]elbv2model.RuleConditio
 		pathValues = append(pathValues, pathValue)
 	}
 
-	// for regex match, we do not need special processing, it will be taken as it is
+	// for regex match, use RegexValues so ALB applies regex matching instead of glob/value matching
 	if pathType == gwv1.PathMatchRegularExpression {
-		pathValues = append(pathValues, pathValue)
+		return []elbv2model.RuleCondition{
+			{
+				Field: elbv2model.RuleConditionFieldPathPattern,
+				PathPatternConfig: &elbv2model.PathPatternConditionConfig{
+					RegexValues: []string{pathValue},
+				},
+			},
+		}, nil
 	}
 
 	return []elbv2model.RuleCondition{

--- a/pkg/gateway/routeutils/route_rule_condition_test.go
+++ b/pkg/gateway/routeutils/route_rule_condition_test.go
@@ -213,7 +213,7 @@ func Test_buildHttpPathCondition(t *testing.T) {
 				{
 					Field: elbv2model.RuleConditionFieldPathPattern,
 					PathPatternConfig: &elbv2model.PathPatternConditionConfig{
-						Values: []string{regexPathValue},
+						RegexValues: []string{regexPathValue},
 					},
 				},
 			},

--- a/test/e2e/gateway/consts.go
+++ b/test/e2e/gateway/consts.go
@@ -318,4 +318,45 @@ const (
 	testOidcAuthorizationEndpoint = "https://test-oidc-provider.example.com/oauth2/authorize"
 	testOidcTokenEndpoint         = "https://test-oidc-provider.example.com/oauth2/token"
 	testOidcUserInfoEndpoint      = "https://test-oidc-provider.example.com/oauth2/userinfo"
+	// constants used in path matcher tests
+	testExactPath  = "/exact-match-path"
+	testPrefixPath = "/prefix-match"
+	testRegexPath  = "/regex/[a-z]+/items"
 )
+
+// httpRouteRulesWithPathMatchers defines HTTPRoute rules exercising Exact, Prefix, and RegularExpression path types.
+var httpRouteRulesWithPathMatchers = []gwv1.HTTPRouteRule{
+	{
+		Matches: []gwv1.HTTPRouteMatch{
+			{
+				Path: &gwv1.HTTPPathMatch{
+					Type:  &[]gwv1.PathMatchType{gwv1.PathMatchExact}[0],
+					Value: awssdk.String(testExactPath),
+				},
+			},
+		},
+		BackendRefs: DefaultHttpRouteRuleBackendRefs,
+	},
+	{
+		Matches: []gwv1.HTTPRouteMatch{
+			{
+				Path: &gwv1.HTTPPathMatch{
+					Type:  &[]gwv1.PathMatchType{gwv1.PathMatchPathPrefix}[0],
+					Value: awssdk.String(testPrefixPath),
+				},
+			},
+		},
+		BackendRefs: DefaultHttpRouteRuleBackendRefs,
+	},
+	{
+		Matches: []gwv1.HTTPRouteMatch{
+			{
+				Path: &gwv1.HTTPPathMatch{
+					Type:  &[]gwv1.PathMatchType{gwv1.PathMatchRegularExpression}[0],
+					Value: awssdk.String(testRegexPath),
+				},
+			},
+		},
+		BackendRefs: DefaultHttpRouteRuleBackendRefs,
+	},
+}

--- a/test/framework/verifier/aws_resource_verifier.go
+++ b/test/framework/verifier/aws_resource_verifier.go
@@ -490,6 +490,9 @@ func verifyListenerRuleConditions(actual, expected []elbv2types.RuleCondition) e
 					if !slices.Equal(actualCondition.PathPatternConfig.Values, expectedCondition.PathPatternConfig.Values) {
 						return errors.Errorf("expected listener rule condition path-pattern values %v, got %v", expectedCondition.PathPatternConfig.Values, actualCondition.PathPatternConfig.Values)
 					}
+					if !slices.Equal(actualCondition.PathPatternConfig.RegexValues, expectedCondition.PathPatternConfig.RegexValues) {
+						return errors.Errorf("expected listener rule condition path-pattern regex values %v, got %v", expectedCondition.PathPatternConfig.RegexValues, actualCondition.PathPatternConfig.RegexValues)
+					}
 				}
 			}
 			if !foundPath {


### PR DESCRIPTION
### Issue

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4573

### Description

We need to use the regex field when using a Regex match. The previous logic only used the `values` field, which led incorrect rule generation (or completely blocking reconciliation if a regex was used). Also added E2E tests to validate the rule generation.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [x] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
