### PR TITLE
Filter RequeueNeeded errors to skip event triggers on TGB controller

### DIFF
--- a/controllers/elbv2/targetgroupbinding_controller.go
+++ b/controllers/elbv2/targetgroupbinding_controller.go
@@ -141,7 +141,9 @@ func (r *targetGroupBindingReconciler) reconcileTargetGroupBinding(ctx context.C
 	}
 	r.metricsCollector.ObserveControllerReconcileLatency(controllerName, "reconcile_targetgroupbinding", tgbResourceFn)
 	if err != nil {
-		r.eventRecorder.Event(tgb, corev1.EventTypeWarning, k8s.TargetGroupBindingEventReasonFailedReconcile, fmt.Sprintf("Failed reconcile due to %v", err))
+		if !runtime.IsRequeueError(err) {
+			r.eventRecorder.Event(tgb, corev1.EventTypeWarning, k8s.TargetGroupBindingEventReasonFailedReconcile, fmt.Sprintf("Failed reconcile due to %v", err))
+		}
 		return ctrlerrors.NewErrorWithMetrics(controllerName, "reconcile_targetgroupbinding_error", err, r.metricsCollector)
 	}
 

--- a/pkg/runtime/reconcile.go
+++ b/pkg/runtime/reconcile.go
@@ -29,6 +29,19 @@ func HandleReconcileError(inputErr error, log logr.Logger) (ctrl.Result, error) 
 	return ctrl.Result{}, inputErr
 }
 
+// IsRequeueError returns true when err indicates a requeue (expected retry).
+func IsRequeueError(err error) bool {
+	var requeueNeededAfter *ctrlerrors.RequeueNeededAfter
+	if errors.As(err, &requeueNeededAfter) {
+		return true
+	}
+	var requeueNeeded *ctrlerrors.RequeueNeeded
+	if errors.As(err, &requeueNeeded) {
+		return true
+	}
+	return false
+}
+
 func handleNestedError(err error) error {
 	if err == nil {
 		return nil


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description
This PR is a follow up to address https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4571#issuecomment-3887323179

FailedReconcile event has been added to the targetgroupbinding controller to surface failures. However, there are some intended errors for requeing logic. This change filters those errors (RequeueNeeded and RequeueNeededAfter) and skips FailedReconcile event emission for them.

<!--
Please explain the changes you made here.

Help your reviewers by guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
