### PR TITLE
fix(gateway): normalize status hostname to lowercase

### DIFF
--- a/controllers/gateway/gateway_controller.go
+++ b/controllers/gateway/gateway_controller.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/certs"
@@ -415,13 +416,14 @@ func (r *gatewayReconciler) updateGatewayStatusSuccess(ctx context.Context, lbSt
 	}
 
 	needPatch = r.gatewayConditionUpdater(gw, string(gwv1.GatewayConditionAccepted), metav1.ConditionTrue, string(gwv1.GatewayConditionAccepted), "") || needPatch
+	normalizedDNSName := strings.ToLower(lbStatus.DNSName)
 	if len(gw.Status.Addresses) != 1 ||
-		gw.Status.Addresses[0].Value != lbStatus.DNSName {
+		gw.Status.Addresses[0].Value != normalizedDNSName {
 		ipAddressType := gwv1.HostnameAddressType
 		gw.Status.Addresses = []gwv1.GatewayStatusAddress{
 			{
 				Type:  &ipAddressType,
-				Value: lbStatus.DNSName,
+				Value: normalizedDNSName,
 			},
 		}
 		needPatch = true

--- a/controllers/gateway/gateway_controller_test.go
+++ b/controllers/gateway/gateway_controller_test.go
@@ -6,13 +6,16 @@ import (
 	"testing"
 	"time"
 
+	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	ctrlerrors "sigs.k8s.io/aws-load-balancer-controller/pkg/error"
 	gateway_constants "sigs.k8s.io/aws-load-balancer-controller/pkg/gateway/constants"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/gateway/routeutils"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
+	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/testutils"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
@@ -139,4 +142,42 @@ func Test_handleReconcileError(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_updateGatewayStatusSuccess_normalizesDNSNameToLowercase(t *testing.T) {
+	k8sClient := testutils.GenerateTestClient()
+	gw := &gwv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gw",
+			Namespace: "test-ns",
+		},
+	}
+	err := k8sClient.Create(context.Background(), gw)
+	assert.NoError(t, err)
+
+	reconciler := &gatewayReconciler{
+		k8sClient:               k8sClient,
+		logger:                  logr.Discard(),
+		eventRecorder:           record.NewFakeRecorder(10),
+		gatewayConditionUpdater: prepareGatewayConditionUpdate,
+	}
+
+	lbStatus := &elbv2model.LoadBalancerStatus{
+		LoadBalancerARN: "arn:aws:elasticloadbalancing:region:account-id:loadbalancer/app/my-alb/123456789",
+		DNSName:         "MyCamelBalancer-1234567890.EU-WEST-1.ELB.AMAZONAWS.COM",
+		ProvisioningState: &elbv2types.LoadBalancerState{
+			Code: elbv2types.LoadBalancerStateEnumActive,
+		},
+	}
+
+	err = reconciler.updateGatewayStatusSuccess(context.Background(), lbStatus, gw, routeutils.LoaderResult{})
+	assert.NoError(t, err)
+
+	updatedGW := &gwv1.Gateway{}
+	err = k8sClient.Get(context.Background(), k8s.NamespacedName(gw), updatedGW)
+	assert.NoError(t, err)
+	assert.Len(t, updatedGW.Status.Addresses, 1)
+	assert.Equal(t, "mycamelbalancer-1234567890.eu-west-1.elb.amazonaws.com", updatedGW.Status.Addresses[0].Value)
+	assert.NotNil(t, updatedGW.Status.Addresses[0].Type)
+	assert.Equal(t, gwv1.HostnameAddressType, *updatedGW.Status.Addresses[0].Type)
 }


### PR DESCRIPTION
### Issue
- https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4585

### Description
This PR fixes a Gateway status update failure when the resolved load balancer DNS name contains uppercase characters.

#### Implementation decision

We normalize the DNS name to lowercase before writing it to `Gateway.status.addresses[].value` (instead of returning an error).

Rationale:
- DNS names are case-insensitive by specification.
- Lowercase is the recommended canonical form.
  - RFC 1035 — domain names are case-insensitive
  - RFC 4343 — clarification of DNS case-insensitivity
  - RFC 3986 — host is case-insensitive; lowercase normalization is recommended

#### Validation
- Added unit test: `Test_updateGatewayStatusSuccess_normalizesDNSNameToLowercase`
- Verified with:
```bash
go test ./controllers/gateway -run 'Test_updateGatewayStatusSuccess_normalizesDNSNameToLowercase|Test_handleReconcileError'
```

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2: