### PR TITLE
fix(ingress): honor IngressClassParams deletion protection in inactive member deletion guard

### DIFF
--- a/pkg/ingress/model_build_load_balancer_attributes_test.go
+++ b/pkg/ingress/model_build_load_balancer_attributes_test.go
@@ -22,6 +22,39 @@ func Test_defaultModelBuildTask_buildIngressGroupLoadBalancerAttributes(t *testi
 		wantErr error
 	}{
 		{
+			name: "deletion protection from IngressClassParams is applied without ingress annotation",
+			args: args{
+				ingList: []ClassifiedIngress{
+					{
+						Ing: &networking.Ingress{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "awesome-ns",
+								Name:      "awesome-ing",
+							},
+						},
+						IngClassConfig: ClassConfiguration{
+							IngClassParams: &elbv2api.IngressClassParams{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: "awesome-class",
+								},
+								Spec: elbv2api.IngressClassParamsSpec{
+									LoadBalancerAttributes: []elbv2api.Attribute{
+										{
+											Key:   "deletion_protection.enabled",
+											Value: "true",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: map[string]string{
+				"deletion_protection.enabled": "true",
+			},
+		},
+		{
 			name: "attributes from multiple Ingress that do not conflict",
 			args: args{
 				ingList: []ClassifiedIngress{


### PR DESCRIPTION
### Issue
- https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4325

### Description
This PR fixes the deletion protection decision logic during Ingress deletion.

Currently, deletion guard checks for `InactiveMembers` only look at the Ingress annotation
`alb.ingress.kubernetes.io/load-balancer-attributes`.
On the other hand, load balancer attribute resolution also considers
`IngressClassParams.spec.loadBalancerAttributes`.
Because of this gap, even when `deletion_protection.enabled=true` is set in `IngressClassParams`,
it is not reflected in deletion guard decisions, causing inconsistent behavior.

This change aligns deletion guard decisions with the attribute resolution logic,
so `IngressClassParams` is also considered.

Precedence:
- Precedence is `IngressClassParams > annotation`
- Rationale is the existing code comment:
https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/760e4e9714b40d2fc22da63bb4160b5a92cde9ca/pkg/ingress/model_build_load_balancer_attributes.go#L49
- Reviewer feedback on this precedence is welcome

### Test scenarios (before / after)

- annotation unset, class unset
  - before: not blocked
  - after: not blocked (no change)
- annotation=true, class unset
  - before: blocked
  - after: blocked (no change)
- annotation unset, class=true
  - before: not blocked
  - **after: blocked (fixed)**
- annotation=false, class=true (conflict)
  - before: not blocked (annotation-based)
  - **after: blocked (class wins)**
- annotation=true, class=false (conflict)
  - before: blocked (annotation-based)
  - **after: not blocked (class wins)**


> [!WARNING]
> This change may block deletions that previously succeeded.
> It affects environments where `IngressClassParams.spec.loadBalancerAttributes`
> sets `deletion_protection.enabled=true`.
> 
> Recommended checks:
> - Whether `deletion_protection.enabled` is set in `IngressClassParams.spec.loadBalancerAttributes`
> - Whether that setting conflicts with Ingress annotation values
> - Whether deletion behavior matches your operational expectation
> (especially class=true / annotation=false cases)

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2: