### PR TITLE
Add RegisterTargetsInterleaved for fair target allocation across target groups

### DIFF
--- a/pkg/targetgroupbinding/targets_manager_mock.go
+++ b/pkg/targetgroupbinding/targets_manager_mock.go
@@ -78,3 +78,17 @@ func (mr *MockTargetsManagerMockRecorder) RegisterTargets(arg0, arg1, arg2 inter
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterTargets", reflect.TypeOf((*MockTargetsManager)(nil).RegisterTargets), arg0, arg1, arg2)
 }
+
+// RegisterTargetsInterleaved mocks base method.
+func (m *MockTargetsManager) RegisterTargetsInterleaved(arg0 context.Context, arg1 []TargetGroupTargets) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RegisterTargetsInterleaved", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RegisterTargetsInterleaved indicates an expected call of RegisterTargetsInterleaved.
+func (mr *MockTargetsManagerMockRecorder) RegisterTargetsInterleaved(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterTargetsInterleaved", reflect.TypeOf((*MockTargetsManager)(nil).RegisterTargetsInterleaved), arg0, arg1)
+}


### PR DESCRIPTION
## Summary

This PR adds a new `RegisterTargetsInterleaved` method to `TargetsManager` that registers targets to multiple target groups in an interleaved manner, ensuring fair distribution when AWS quota limits are reached.

**Problem (Issue #4025):**
When replacing nodes in a cluster with an NLB serving multiple ports, the controller registers all targets to TG1 first, then TG2, etc. If the quota is exceeded midway, later target groups receive zero targets, causing service outages for those ports.

Example with 250 nodes, 4 ports, quota=500:
- **Current behavior:** TG1=250, TG2=250, TG3=0, TG4=0 (ports 3,4 have no traffic)
- **With interleaved:** TG1=125, TG2=125, TG3=125, TG4=125 (all ports work)

## Changes

- Added `TargetGroupTargets` struct to represent a TGB and its targets
- Added `RegisterTargetsInterleaved` method that:
  - Registers targets in chunks across all target groups before moving to the next chunk
  - Continues with other target groups even if one fails (fair distribution)
  - Falls back to standard registration for single target group
- Added comprehensive tests including:
  - 4-port NLB scenario (exact issue scenario)
  - Partial failure handling
  - Different target counts per TG

## Note

This PR adds the foundational API. The method is not yet called from the reconciler. Integration with `resource_manager.go` to actually use this method for multi-TGB scenarios would be the next step. I'd appreciate feedback on the preferred approach for that integration.

## Test plan

- [x] Unit tests for `RegisterTargetsInterleaved` pass
- [x] All existing tests pass

Related to: https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4025