### PR TITLE
feat: Support for deploying LB to multiple regions using `region` property on `LoadBalancerConfiguration`

### DIFF
--- a/apis/gateway/v1beta1/loadbalancerconfig_types.go
+++ b/apis/gateway/v1beta1/loadbalancerconfig_types.go
@@ -198,6 +198,20 @@ type LoadBalancerConfigurationSpec struct {
 	// +optional
 	MergingMode *LoadBalancerConfigMergeMode `json:"mergingMode,omitempty"`
 
+	// region is the AWS region where the load balancer will be deployed. When unset, the controller's default region is used.
+	// When set to a different region, vpcId, vpcSelector, or loadBalancerSubnets with identifiers must be set so the VPC can be resolved.
+	// +optional
+	Region *string `json:"region,omitempty"`
+
+	// vpcId is the VPC ID in the target region. Used when region is set (and especially when it differs from the controller default).
+	// +optional
+	VpcID *string `json:"vpcId,omitempty"`
+
+	// vpcSelector selects the VPC in the target region by tags. Each key is a tag name; the value list is the allowed tag values.
+	// A VPC matches if it has each tag key with one of the corresponding values. Exactly one VPC must match in the target region.
+	// +optional
+	VpcSelector *map[string][]string `json:"vpcSelector,omitempty"`
+
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=32
 	// loadBalancerName defines the name of the LB to provision. If unspecified, it will be automatically generated.

--- a/apis/gateway/v1beta1/zz_generated.deepcopy.go
+++ b/apis/gateway/v1beta1/zz_generated.deepcopy.go
@@ -655,6 +655,36 @@ func (in *LoadBalancerConfigurationSpec) DeepCopyInto(out *LoadBalancerConfigura
 		*out = new(LoadBalancerConfigMergeMode)
 		**out = **in
 	}
+	if in.Region != nil {
+		in, out := &in.Region, &out.Region
+		*out = new(string)
+		**out = **in
+	}
+	if in.VpcID != nil {
+		in, out := &in.VpcID, &out.VpcID
+		*out = new(string)
+		**out = **in
+	}
+	if in.VpcSelector != nil {
+		in, out := &in.VpcSelector, &out.VpcSelector
+		*out = new(map[string][]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make(map[string][]string, len(*in))
+			for key, val := range *in {
+				var outVal []string
+				if val == nil {
+					(*out)[key] = nil
+				} else {
+					inVal := (*in)[key]
+					in, out := &inVal, &outVal
+					*out = make([]string, len(*in))
+					copy(*out, *in)
+				}
+				(*out)[key] = outVal
+			}
+		}
+	}
 	if in.LoadBalancerName != nil {
 		in, out := &in.LoadBalancerName, &out.LoadBalancerName
 		*out = new(string)

--- a/config/crd/gateway/gateway-crds.yaml
+++ b/config/crd/gateway/gateway-crds.yaml
@@ -733,6 +733,11 @@ spec:
                 required:
                 - capacityUnits
                 type: object
+              region:
+                description: |-
+                  region is the AWS region where the load balancer will be deployed. When unset, the controller's default region is used.
+                  When set to a different region, vpcId, vpcSelector, or loadBalancerSubnets with identifiers must be set so the VPC can be resolved.
+                type: string
               scheme:
                 description: scheme defines the type of LB to provision. If unspecified,
                   it will be automatically inferred.
@@ -771,6 +776,19 @@ spec:
                 additionalProperties:
                   type: string
                 description: Tags the AWS Tags on all related resources to the gateway.
+                type: object
+              vpcId:
+                description: vpcId is the VPC ID in the target region. Used when region
+                  is set (and especially when it differs from the controller default).
+                type: string
+              vpcSelector:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: |-
+                  vpcSelector selects the VPC in the target region by tags. Each key is a tag name; the value list is the allowed tag values.
+                  A VPC matches if it has each tag key with one of the corresponding values. Exactly one VPC must match in the target region.
                 type: object
               wafV2:
                 description: WAFv2 define the AWS WAFv2 settings for a Gateway [Application

--- a/config/crd/gateway/gateway.k8s.aws_loadbalancerconfigurations.yaml
+++ b/config/crd/gateway/gateway.k8s.aws_loadbalancerconfigurations.yaml
@@ -278,6 +278,11 @@ spec:
                 required:
                 - capacityUnits
                 type: object
+              region:
+                description: |-
+                  region is the AWS region where the load balancer will be deployed. When unset, the controller's default region is used.
+                  When set to a different region, vpcId, vpcSelector, or loadBalancerSubnets with identifiers must be set so the VPC can be resolved.
+                type: string
               scheme:
                 description: scheme defines the type of LB to provision. If unspecified,
                   it will be automatically inferred.
@@ -316,6 +321,19 @@ spec:
                 additionalProperties:
                   type: string
                 description: Tags the AWS Tags on all related resources to the gateway.
+                type: object
+              vpcId:
+                description: vpcId is the VPC ID in the target region. Used when region
+                  is set (and especially when it differs from the controller default).
+                type: string
+              vpcSelector:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: |-
+                  vpcSelector selects the VPC in the target region by tags. Each key is a tag name; the value list is the allowed tag values.
+                  A VPC matches if it has each tag key with one of the corresponding values. Exactly one VPC must match in the target region.
                 type: object
               wafV2:
                 description: WAFv2 define the AWS WAFv2 settings for a Gateway [Application

--- a/docs/guide/gateway/loadbalancerconfig.md
+++ b/docs/guide/gateway/loadbalancerconfig.md
@@ -65,6 +65,26 @@ Defines the LoadBalancer Scheme.
 
 **Default** internal
 
+#### Region
+
+`region`
+
+The AWS region where the load balancer will be deployed. When unset, the controller's default region (from `--aws-region` or environment) is used. When set to a different region, you must specify the VPC in that region using one of: `vpcId`, `vpcSelector`, or `loadBalancerSubnets` with subnet identifiers so the controller can resolve the VPC.
+
+**Default** Controller's default region
+
+#### VpcID
+
+`vpcId`
+
+The VPC ID in the target region. Used when `region` is set, especially when it differs from the controller default. Required (or use `vpcSelector` / `loadBalancerSubnets` with identifiers) when deploying to a non-default region.
+
+#### VpcSelector
+
+`vpcSelector`
+
+Selects the VPC in the target region by tags. Same shape as `loadBalancerSubnetsSelector`: each key is a tag name, the value list is the allowed tag values. A VPC matches if it has each tag key with one of the corresponding values. Exactly one VPC must match in the target region. Use when `region` is set and you prefer tag-based selection over a fixed `vpcId`.
+
 #### IpAddressType
 
 `ipAddressType`

--- a/docs/guide/gateway/spec.md
+++ b/docs/guide/gateway/spec.md
@@ -460,6 +460,9 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `mergingMode` _[LoadBalancerConfigMergeMode](#loadbalancerconfigmergemode)_ | mergingMode defines the merge behavior when both the Gateway and GatewayClass have a defined LoadBalancerConfiguration.<br />This field is only honored for the configuration attached to the GatewayClass. |  | Enum: [prefer-gateway prefer-gateway-class] <br /> |
+| `region` _string_ | region is the AWS region where the load balancer will be deployed. When unset, the controller's default region is used. When set to a different region, set vpcId, vpcSelector, or loadBalancerSubnets with identifiers so the VPC can be resolved. |  |  |
+| `vpcId` _string_ | vpcId is the VPC ID in the target region. Used when region is set (especially when it differs from the controller default). |  |  |
+| `vpcSelector` _map[string][]string_ | vpcSelector selects the VPC in the target region by tags. Each key is a tag name; the value list is the allowed tag values. Exactly one VPC must match in the target region. |  |  |
 | `loadBalancerName` _string_ | loadBalancerName defines the name of the LB to provision. If unspecified, it will be automatically generated. |  | MaxLength: 32 <br />MinLength: 1 <br /> |
 | `scheme` _[LoadBalancerScheme](#loadbalancerscheme)_ | scheme defines the type of LB to provision. If unspecified, it will be automatically inferred. |  | Enum: [internal internet-facing] <br /> |
 | `ipAddressType` _[LoadBalancerIpAddressType](#loadbalanceripaddresstype)_ | loadBalancerIPType defines what kind of load balancer to provision (ipv4, dual stack) |  | Enum: [ipv4 dualstack dualstack-without-public-ipv4] <br /> |
@@ -472,7 +475,6 @@ _Appears in:_
 | `securityGroups` _string_ | securityGroups an optional list of security group ids or names to apply to the LB |  |  |
 | `securityGroupPrefixes` _string_ | securityGroupPrefixes an optional list of prefixes that are allowed to access the LB. |  |  |
 | `sourceRanges` _string_ | sourceRanges an optional list of CIDRs that are allowed to access the LB. |  |  |
-| `vpcId` _string_ | vpcId is the ID of the VPC for the load balancer. |  |  |
 | `loadBalancerAttributes` _[LoadBalancerAttribute](#loadbalancerattribute) array_ | LoadBalancerAttributes defines the attribute of LB |  |  |
 | `tags` _map[string]string_ | Tags the AWS Tags on all related resources to the gateway. |  |  |
 | `enableICMP` _boolean_ | EnableICMP [Network LoadBalancer]<br />enables the creation of security group rules to the managed security group<br />to allow explicit ICMP traffic for Path MTU discovery for IPv4 and dual-stack VPCs |  |  |

--- a/helm/aws-load-balancer-controller/crds/gateway-crds.yaml
+++ b/helm/aws-load-balancer-controller/crds/gateway-crds.yaml
@@ -733,6 +733,11 @@ spec:
                 required:
                 - capacityUnits
                 type: object
+              region:
+                description: |-
+                  region is the AWS region where the load balancer will be deployed. When unset, the controller's default region is used.
+                  When set to a different region, vpcId, vpcSelector, or loadBalancerSubnets with identifiers must be set so the VPC can be resolved.
+                type: string
               scheme:
                 description: scheme defines the type of LB to provision. If unspecified,
                   it will be automatically inferred.
@@ -771,6 +776,19 @@ spec:
                 additionalProperties:
                   type: string
                 description: Tags the AWS Tags on all related resources to the gateway.
+                type: object
+              vpcId:
+                description: vpcId is the VPC ID in the target region. Used when region
+                  is set (and especially when it differs from the controller default).
+                type: string
+              vpcSelector:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: |-
+                  vpcSelector selects the VPC in the target region by tags. Each key is a tag name; the value list is the allowed tag values.
+                  A VPC matches if it has each tag key with one of the corresponding values. Exactly one VPC must match in the target region.
                 type: object
               wafV2:
                 description: WAFv2 define the AWS WAFv2 settings for a Gateway [Application

--- a/pkg/aws/region.go
+++ b/pkg/aws/region.go
@@ -1,0 +1,83 @@
+package aws
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	epresolver "sigs.k8s.io/aws-load-balancer-controller/pkg/aws/endpoints"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/provider"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/services"
+	aws_metrics "sigs.k8s.io/aws-load-balancer-controller/pkg/metrics/aws"
+)
+
+// NewCloudForRegion creates a Cloud for the given region and vpcID without using EC2 metadata.
+// The base cfg is copied; only Region and VpcID are set. Use this when deploying to a non-default region.
+func NewCloudForRegion(cfg CloudConfig, region, vpcID string, clusterName string, metricsCollector *aws_metrics.Collector, logger logr.Logger, lbStabilizationTime time.Duration) (services.Cloud, error) {
+	cfgForRegion := cfg
+	cfgForRegion.Region = region
+	cfgForRegion.VpcID = vpcID
+	return NewCloud(cfgForRegion, clusterName, metricsCollector, logger, nil, lbStabilizationTime)
+}
+
+// NewEC2ClientForRegion returns an EC2 client configured for the given region.
+// Used for VPC resolution (e.g. DescribeVpcs, DescribeSubnets) in that region before creating a full Cloud.
+func NewEC2ClientForRegion(cfg CloudConfig, region string, metricsCollector *aws_metrics.Collector, logger logr.Logger) (services.EC2, error) {
+	awsClientsProvider, err := newClientsProviderForRegion(cfg, region, metricsCollector)
+	if err != nil {
+		return nil, err
+	}
+	return services.NewEC2(awsClientsProvider), nil
+}
+
+// NewELBV2ForRegion returns an ELBV2 client configured for the given region.
+// Used by webhooks and model builders that need to describe/validate resources in a non-default region.
+// This does not require a VPC ID or full Cloud — only the region is needed for API calls like DescribeTargetGroups.
+func NewELBV2ForRegion(cfg CloudConfig, region string, metricsCollector *aws_metrics.Collector, logger logr.Logger, lbStabilizationTime time.Duration) (services.ELBV2, error) {
+	awsClientsProvider, err := newClientsProviderForRegion(cfg, region, metricsCollector)
+	if err != nil {
+		return nil, err
+	}
+	cloud := &regionStubCloud{region: region}
+	elbv2 := services.NewELBV2(awsClientsProvider, cloud, lbStabilizationTime)
+	cloud.elbv2 = elbv2
+	return elbv2, nil
+}
+
+func newClientsProviderForRegion(cfg CloudConfig, region string, metricsCollector *aws_metrics.Collector) (provider.AWSClientsProvider, error) {
+	cfgForRegion := cfg
+	cfgForRegion.Region = region
+	endpointsResolver := epresolver.NewResolver(cfgForRegion.AWSEndpoints)
+	configGenerator := NewAWSConfigGenerator(cfgForRegion, imds.EndpointModeStateIPv4, metricsCollector)
+	awsConfig, err := configGenerator.GenerateAWSConfig()
+	if err != nil {
+		return nil, err
+	}
+	return provider.NewDefaultAWSClientsProvider(awsConfig, endpointsResolver)
+}
+
+// regionStubCloud is a minimal Cloud implementation used only by NewELBV2ForRegion.
+// Only Region() and ELBV2() are meaningful; other methods are unused by the ELBV2 client
+// for basic operations like DescribeTargetGroups.
+type regionStubCloud struct {
+	region string
+	elbv2  services.ELBV2
+}
+
+func (c *regionStubCloud) Region() string                                { return c.region }
+func (c *regionStubCloud) VpcID() string                                 { return "" }
+func (c *regionStubCloud) ELBV2() services.ELBV2                         { return c.elbv2 }
+func (c *regionStubCloud) EC2() services.EC2                             { return nil }
+func (c *regionStubCloud) ACM() services.ACM                             { return nil }
+func (c *regionStubCloud) WAFv2() services.WAFv2                         { return nil }
+func (c *regionStubCloud) WAFRegional() services.WAFRegional             { return nil }
+func (c *regionStubCloud) Shield() services.Shield                       { return nil }
+func (c *regionStubCloud) RGT() services.RGT                             { return nil }
+func (c *regionStubCloud) GlobalAccelerator() services.GlobalAccelerator { return nil }
+func (c *regionStubCloud) GetAssumedRoleELBV2(_ context.Context, _ string, _ string) (services.ELBV2, error) {
+	return nil, errors.New("AssumeRole is not supported for cross-region stub cloud; use a full Cloud instead")
+}
+
+var _ services.Cloud = &regionStubCloud{}

--- a/pkg/gateway/cloud_provider.go
+++ b/pkg/gateway/cloud_provider.go
@@ -1,0 +1,281 @@
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	ec2sdk "github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
+	awspkg "sigs.k8s.io/aws-load-balancer-controller/pkg/aws"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/services"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/certs"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/config"
+	elbv2deploy "sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/elbv2"
+	awsmetrics "sigs.k8s.io/aws-load-balancer-controller/pkg/metrics/aws"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/networking"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/shared_utils"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ReconcileContext holds the Cloud and region-specific resolvers for a gateway reconcile.
+// For the default region it wraps the default cloud and resolvers with optional fields nil.
+// For non-default regions all fields are populated with region-scoped implementations.
+type ReconcileContext struct {
+	Cloud               services.Cloud
+	SubnetsResolver     networking.SubnetsResolver
+	VPCInfoProvider     networking.VPCInfoProvider
+	Elbv2TaggingManager elbv2deploy.TaggingManager
+	BackendSGProvider   networking.BackendSGProvider
+	SecurityGroupResolver networking.SecurityGroupResolver
+	CertDiscovery         certs.CertDiscovery
+	TargetGroupARNMapper  shared_utils.TargetGroupARNMapper
+	crossRegion           bool
+}
+
+// GetCloud returns the Cloud for this context.
+func (r *ReconcileContext) GetCloud() services.Cloud { return r.Cloud }
+
+// GetSubnetsResolver returns the SubnetsResolver for this context.
+func (r *ReconcileContext) GetSubnetsResolver() networking.SubnetsResolver { return r.SubnetsResolver }
+
+// GetVPCInfoProvider returns the VPCInfoProvider for this context.
+func (r *ReconcileContext) GetVPCInfoProvider() networking.VPCInfoProvider { return r.VPCInfoProvider }
+
+// GetElbv2TaggingManager returns the ELBV2 tagging manager for this context, or nil to use the default.
+func (r *ReconcileContext) GetElbv2TaggingManager() elbv2deploy.TaggingManager {
+	return r.Elbv2TaggingManager
+}
+
+// GetBackendSGProvider returns the BackendSGProvider for this context, or nil to use the default (default region).
+func (r *ReconcileContext) GetBackendSGProvider() networking.BackendSGProvider {
+	return r.BackendSGProvider
+}
+
+// GetSecurityGroupResolver returns the SecurityGroupResolver for this context, or nil to use the default.
+func (r *ReconcileContext) GetSecurityGroupResolver() networking.SecurityGroupResolver {
+	return r.SecurityGroupResolver
+}
+
+// GetCertDiscovery returns the CertDiscovery for this context, or nil to use the default (default region's ACM).
+func (r *ReconcileContext) GetCertDiscovery() certs.CertDiscovery { return r.CertDiscovery }
+
+// GetTargetGroupARNMapper returns the TargetGroupARNMapper for this context, or nil to use the default.
+func (r *ReconcileContext) GetTargetGroupARNMapper() shared_utils.TargetGroupARNMapper {
+	return r.TargetGroupARNMapper
+}
+
+// IsCrossRegion returns true when the gateway targets a region different from the controller's default.
+func (r *ReconcileContext) IsCrossRegion() bool { return r.crossRegion }
+
+// CloudProvider returns a ReconcileContext for a given region and optional LoadBalancerConfiguration spec.
+// For the default region it returns the default context; for other regions it resolves VPC and creates (or caches) a Cloud and resolvers.
+type CloudProvider interface {
+	GetReconcileContext(ctx context.Context, region string, spec *elbv2gw.LoadBalancerConfigurationSpec) (*ReconcileContext, error)
+}
+
+// NewDefaultCloudProvider returns a CloudProvider that uses the default cloud for the default region
+// and creates Clouds for other regions with VPC resolution from spec (vpcId, vpcSelector, or first subnet).
+// k8sClient is used to create region-scoped BackendSGProvider for non-default regions.
+func NewDefaultCloudProvider(
+	defaultCloud services.Cloud,
+	defaultSubnetsResolver networking.SubnetsResolver,
+	defaultVPCInfoProvider networking.VPCInfoProvider,
+	baseConfig awspkg.CloudConfig,
+	controllerConfig config.ControllerConfig,
+	k8sClient client.Client,
+	metricsCollector *awsmetrics.Collector,
+	logger logr.Logger,
+) CloudProvider {
+	return &defaultCloudProvider{
+		defaultCloud:           defaultCloud,
+		defaultSubnetsResolver: defaultSubnetsResolver,
+		defaultVPCInfoProvider: defaultVPCInfoProvider,
+		baseConfig:             baseConfig,
+		controllerConfig:       controllerConfig,
+		k8sClient:              k8sClient,
+		metricsCollector:       metricsCollector,
+		logger:                 logger,
+		cache:                  make(map[string]*ReconcileContext),
+	}
+}
+
+var _ CloudProvider = &defaultCloudProvider{}
+
+type defaultCloudProvider struct {
+	defaultCloud           services.Cloud
+	defaultSubnetsResolver networking.SubnetsResolver
+	defaultVPCInfoProvider networking.VPCInfoProvider
+	baseConfig             awspkg.CloudConfig
+	controllerConfig       config.ControllerConfig
+	k8sClient              client.Client
+	metricsCollector       *awsmetrics.Collector
+	logger                 logr.Logger
+	mu                     sync.RWMutex
+	cache                  map[string]*ReconcileContext
+}
+
+func (p *defaultCloudProvider) GetReconcileContext(ctx context.Context, region string, spec *elbv2gw.LoadBalancerConfigurationSpec) (*ReconcileContext, error) {
+	defaultRegion := p.defaultCloud.Region()
+	if region == "" || region == defaultRegion {
+		return &ReconcileContext{
+			Cloud:           p.defaultCloud,
+			SubnetsResolver: p.defaultSubnetsResolver,
+			VPCInfoProvider: p.defaultVPCInfoProvider,
+		}, nil
+	}
+
+	// Resolve VPC for the target region
+	vpcID, err := p.resolveVPCForRegion(ctx, region, spec)
+	if err != nil {
+		return nil, err
+	}
+
+	cacheKey := region + ":" + vpcID
+	p.mu.RLock()
+	if ctx, ok := p.cache[cacheKey]; ok {
+		p.mu.RUnlock()
+		return ctx, nil
+	}
+	p.mu.RUnlock()
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if ctx, ok := p.cache[cacheKey]; ok {
+		return ctx, nil
+	}
+
+	cloud, err := awspkg.NewCloudForRegion(p.baseConfig, region, vpcID, p.controllerConfig.ClusterName, p.metricsCollector, p.logger, awspkg.DefaultLbStabilizationTime)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create cloud for region %q vpc %q", region, vpcID)
+	}
+
+	azInfoProvider := networking.NewDefaultAZInfoProvider(cloud.EC2(), p.logger.WithName("az-info-provider"))
+	vpcInfoProvider := networking.NewDefaultVPCInfoProvider(cloud.EC2(), p.logger.WithName("vpc-info-provider"))
+	subnetsResolver := networking.NewDefaultSubnetsResolver(
+		azInfoProvider,
+		cloud.EC2(),
+		cloud.VpcID(),
+		p.controllerConfig.ClusterName,
+		p.controllerConfig.FeatureGates.Enabled(config.SubnetsClusterTagCheck),
+		p.controllerConfig.FeatureGates.Enabled(config.ALBSingleSubnet),
+		p.controllerConfig.FeatureGates.Enabled(config.SubnetDiscoveryByReachability),
+		p.logger.WithName("subnets-resolver"),
+	)
+
+	elbv2TaggingManager := elbv2deploy.NewDefaultTaggingManager(cloud.ELBV2(), cloud.VpcID(), p.controllerConfig.FeatureGates, cloud.RGT(), p.logger.WithName("elbv2-tagging"))
+	enableGatewayCheck := p.controllerConfig.FeatureGates.Enabled(config.NLBGatewayAPI) || p.controllerConfig.FeatureGates.Enabled(config.ALBGatewayAPI)
+	backendSGProvider := networking.NewBackendSGProvider(
+		p.controllerConfig.ClusterName,
+		p.controllerConfig.BackendSecurityGroup,
+		cloud.VpcID(),
+		cloud.EC2(),
+		p.k8sClient,
+		p.controllerConfig.DefaultTags,
+		enableGatewayCheck,
+		p.logger.WithName("backend-sg-provider").WithName(region),
+	)
+	sgResolver := networking.NewDefaultSecurityGroupResolver(cloud.EC2(), cloud.VpcID())
+	certDiscovery := certs.NewACMCertDiscovery(cloud.ACM(), p.controllerConfig.IngressConfig.AllowedCertificateAuthorityARNs, p.logger.WithName("cert-discovery").WithName(region))
+	tgARNMapper := shared_utils.NewTargetGroupNameToArnMapper(cloud.ELBV2())
+	reconcileCtx := &ReconcileContext{
+		Cloud:                 cloud,
+		SubnetsResolver:       subnetsResolver,
+		VPCInfoProvider:       vpcInfoProvider,
+		Elbv2TaggingManager:   elbv2TaggingManager,
+		BackendSGProvider:     backendSGProvider,
+		SecurityGroupResolver: sgResolver,
+		CertDiscovery:         certDiscovery,
+		TargetGroupARNMapper:  tgARNMapper,
+		crossRegion:           true,
+	}
+	p.cache[cacheKey] = reconcileCtx
+	return reconcileCtx, nil
+}
+
+// resolveVPCForRegion resolves the VPC ID for the target region from spec (vpcId, vpcSelector, or first subnet).
+func (p *defaultCloudProvider) resolveVPCForRegion(ctx context.Context, region string, spec *elbv2gw.LoadBalancerConfigurationSpec) (string, error) {
+	if spec == nil {
+		return "", errors.New("when region differs from controller default, set vpcId, vpcSelector, or loadBalancerSubnets with identifiers in LoadBalancerConfiguration")
+	}
+
+	if spec.VpcID != nil && *spec.VpcID != "" {
+		return *spec.VpcID, nil
+	}
+
+	ec2Client, err := awspkg.NewEC2ClientForRegion(p.baseConfig, region, p.metricsCollector, p.logger)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to create EC2 client for region %q", region)
+	}
+
+	if spec.VpcSelector != nil && len(*spec.VpcSelector) > 0 {
+		vpcID, err := p.resolveVPCFromSelector(ctx, ec2Client, *spec.VpcSelector)
+		if err != nil {
+			return "", err
+		}
+		return vpcID, nil
+	}
+
+	if spec.LoadBalancerSubnets != nil && len(*spec.LoadBalancerSubnets) > 0 {
+		first := (*spec.LoadBalancerSubnets)[0]
+		if first.Identifier != "" {
+			vpcID, err := p.resolveVPCFromFirstSubnet(ctx, ec2Client, first.Identifier)
+			if err != nil {
+				return "", err
+			}
+			return vpcID, nil
+		}
+	}
+
+	return "", errors.New("when region differs from controller default, set vpcId, vpcSelector, or loadBalancerSubnets with identifiers in LoadBalancerConfiguration")
+}
+
+func (p *defaultCloudProvider) resolveVPCFromSelector(ctx context.Context, ec2Client services.EC2, selector map[string][]string) (string, error) {
+	filters := make([]ec2types.Filter, 0, len(selector))
+	for tagKey, values := range selector {
+		if len(values) == 0 {
+			continue
+		}
+		filters = append(filters, ec2types.Filter{
+			Name:   awssdk.String("tag:" + tagKey),
+			Values: values,
+		})
+	}
+	if len(filters) == 0 {
+		return "", errors.New("vpcSelector must have at least one tag key with values")
+	}
+
+	vpcs, err := ec2Client.DescribeVPCsAsList(ctx, &ec2sdk.DescribeVpcsInput{
+		Filters: filters,
+	})
+	if err != nil {
+		return "", errors.Wrap(err, "failed to describe VPCs by tag selector")
+	}
+	if len(vpcs) == 0 {
+		return "", errors.New("no VPC found matching vpcSelector in target region")
+	}
+	if len(vpcs) > 1 {
+		return "", fmt.Errorf("multiple VPCs (%d) found matching vpcSelector in target region; exactly one is required", len(vpcs))
+	}
+	return awssdk.ToString(vpcs[0].VpcId), nil
+}
+
+func (p *defaultCloudProvider) resolveVPCFromFirstSubnet(ctx context.Context, ec2Client services.EC2, subnetIDOrName string) (string, error) {
+	subnets, err := ec2Client.DescribeSubnetsAsList(ctx, &ec2sdk.DescribeSubnetsInput{
+		SubnetIds: []string{subnetIDOrName},
+	})
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to describe subnet %q in target region", subnetIDOrName)
+	}
+	if len(subnets) == 0 {
+		return "", fmt.Errorf("subnet %q not found in target region", subnetIDOrName)
+	}
+	if subnets[0].VpcId == nil {
+		return "", fmt.Errorf("subnet %q has no VpcId", subnetIDOrName)
+	}
+	return *subnets[0].VpcId, nil
+}

--- a/pkg/gateway/cloud_provider_test.go
+++ b/pkg/gateway/cloud_provider_test.go
@@ -1,0 +1,406 @@
+package gateway
+
+import (
+	"context"
+	"testing"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	ec2sdk "github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/go-logr/logr"
+	"github.com/golang/mock/gomock"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/services"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/certs"
+	elbv2deploy "sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/elbv2"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/networking"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/shared_utils"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// fakeCloud implements services.Cloud for testing without needing the full aws package.
+type fakeCloud struct {
+	region string
+	vpcID  string
+}
+
+func (c *fakeCloud) Region() string                   { return c.region }
+func (c *fakeCloud) VpcID() string                    { return c.vpcID }
+func (c *fakeCloud) ELBV2() services.ELBV2            { return nil }
+func (c *fakeCloud) EC2() services.EC2                { return nil }
+func (c *fakeCloud) ACM() services.ACM                { return nil }
+func (c *fakeCloud) WAFv2() services.WAFv2            { return nil }
+func (c *fakeCloud) WAFRegional() services.WAFRegional { return nil }
+func (c *fakeCloud) Shield() services.Shield          { return nil }
+func (c *fakeCloud) RGT() services.RGT                { return nil }
+func (c *fakeCloud) GlobalAccelerator() services.GlobalAccelerator { return nil }
+func (c *fakeCloud) GetAssumedRoleELBV2(_ context.Context, _ string, _ string) (services.ELBV2, error) {
+	return nil, errors.New("not supported")
+}
+
+var _ services.Cloud = &fakeCloud{}
+
+// --- ReconcileContext getter tests ---
+
+func TestReconcileContext_Getters(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cloud := &fakeCloud{region: "us-east-1", vpcID: "vpc-111"}
+	subnetsResolver := networking.NewMockSubnetsResolver(ctrl)
+	vpcInfoProvider := networking.NewMockVPCInfoProvider(ctrl)
+
+	rc := &ReconcileContext{
+		Cloud:           cloud,
+		SubnetsResolver: subnetsResolver,
+		VPCInfoProvider: vpcInfoProvider,
+	}
+
+	assert.Equal(t, cloud, rc.GetCloud())
+	assert.Equal(t, subnetsResolver, rc.GetSubnetsResolver())
+	assert.Equal(t, vpcInfoProvider, rc.GetVPCInfoProvider())
+	assert.Nil(t, rc.GetElbv2TaggingManager())
+	assert.Nil(t, rc.GetBackendSGProvider())
+	assert.Nil(t, rc.GetSecurityGroupResolver())
+	assert.Nil(t, rc.GetCertDiscovery())
+	assert.Nil(t, rc.GetTargetGroupARNMapper())
+	assert.False(t, rc.IsCrossRegion())
+}
+
+func TestReconcileContext_NonDefaultRegionGetters(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cloud := &fakeCloud{region: "ap-northeast-1", vpcID: "vpc-222"}
+	subnetsResolver := networking.NewMockSubnetsResolver(ctrl)
+	vpcInfoProvider := networking.NewMockVPCInfoProvider(ctrl)
+
+	type fakeTaggingManager struct{ elbv2deploy.TaggingManager }
+	type fakeBackendSGProvider struct{ networking.BackendSGProvider }
+	type fakeSGResolver struct{ networking.SecurityGroupResolver }
+	type fakeCertDiscovery struct{ certs.CertDiscovery }
+	type fakeTGMapper struct{ shared_utils.TargetGroupARNMapper }
+
+	taggingMgr := &fakeTaggingManager{}
+	backendSG := &fakeBackendSGProvider{}
+	sgResolver := &fakeSGResolver{}
+	certDisc := &fakeCertDiscovery{}
+	tgMapper := &fakeTGMapper{}
+
+	rc := &ReconcileContext{
+		Cloud:                 cloud,
+		SubnetsResolver:       subnetsResolver,
+		VPCInfoProvider:       vpcInfoProvider,
+		Elbv2TaggingManager:   taggingMgr,
+		BackendSGProvider:     backendSG,
+		SecurityGroupResolver: sgResolver,
+		CertDiscovery:         certDisc,
+		TargetGroupARNMapper:  tgMapper,
+	}
+
+	assert.Equal(t, cloud, rc.GetCloud())
+	assert.Equal(t, subnetsResolver, rc.GetSubnetsResolver())
+	assert.Equal(t, vpcInfoProvider, rc.GetVPCInfoProvider())
+	assert.Equal(t, taggingMgr, rc.GetElbv2TaggingManager())
+	assert.Equal(t, backendSG, rc.GetBackendSGProvider())
+	assert.Equal(t, sgResolver, rc.GetSecurityGroupResolver())
+	assert.Equal(t, certDisc, rc.GetCertDiscovery())
+	assert.Equal(t, tgMapper, rc.GetTargetGroupARNMapper())
+	assert.False(t, rc.IsCrossRegion())
+}
+
+func TestReconcileContext_IsCrossRegion(t *testing.T) {
+	defaultRC := &ReconcileContext{
+		Cloud: &fakeCloud{region: "us-east-1"},
+	}
+	assert.False(t, defaultRC.IsCrossRegion())
+
+	crossRegionRC := &ReconcileContext{
+		Cloud:       &fakeCloud{region: "ap-northeast-1"},
+		crossRegion: true,
+	}
+	assert.True(t, crossRegionRC.IsCrossRegion())
+}
+
+// --- GetReconcileContext default region tests ---
+
+func TestGetReconcileContext_DefaultRegion(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cloud := &fakeCloud{region: "us-east-1", vpcID: "vpc-default"}
+	subnetsResolver := networking.NewMockSubnetsResolver(ctrl)
+	vpcInfoProvider := networking.NewMockVPCInfoProvider(ctrl)
+
+	provider := &defaultCloudProvider{
+		defaultCloud:           cloud,
+		defaultSubnetsResolver: subnetsResolver,
+		defaultVPCInfoProvider: vpcInfoProvider,
+		logger:                 logr.New(&log.NullLogSink{}),
+		cache:                  make(map[string]*ReconcileContext),
+	}
+
+	rc, err := provider.GetReconcileContext(context.Background(), "us-east-1", nil)
+	assert.NoError(t, err)
+	assert.Equal(t, cloud, rc.Cloud)
+	assert.Equal(t, subnetsResolver, rc.SubnetsResolver)
+	assert.Equal(t, vpcInfoProvider, rc.VPCInfoProvider)
+	assert.Nil(t, rc.Elbv2TaggingManager)
+	assert.Nil(t, rc.BackendSGProvider)
+	assert.Nil(t, rc.SecurityGroupResolver)
+	assert.Nil(t, rc.CertDiscovery)
+	assert.Nil(t, rc.TargetGroupARNMapper)
+	assert.False(t, rc.IsCrossRegion())
+}
+
+func TestGetReconcileContext_EmptyRegion(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cloud := &fakeCloud{region: "us-east-1", vpcID: "vpc-default"}
+	subnetsResolver := networking.NewMockSubnetsResolver(ctrl)
+	vpcInfoProvider := networking.NewMockVPCInfoProvider(ctrl)
+
+	provider := &defaultCloudProvider{
+		defaultCloud:           cloud,
+		defaultSubnetsResolver: subnetsResolver,
+		defaultVPCInfoProvider: vpcInfoProvider,
+		logger:                 logr.New(&log.NullLogSink{}),
+		cache:                  make(map[string]*ReconcileContext),
+	}
+
+	rc, err := provider.GetReconcileContext(context.Background(), "", nil)
+	assert.NoError(t, err)
+	assert.Equal(t, cloud, rc.Cloud)
+	assert.False(t, rc.IsCrossRegion())
+}
+
+// --- resolveVPCForRegion tests ---
+
+func TestResolveVPCForRegion_NilSpec(t *testing.T) {
+	provider := &defaultCloudProvider{
+		logger: logr.New(&log.NullLogSink{}),
+	}
+
+	_, err := provider.resolveVPCForRegion(context.Background(), "ap-northeast-1", nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "set vpcId, vpcSelector, or loadBalancerSubnets")
+}
+
+func TestResolveVPCForRegion_ExplicitVpcID(t *testing.T) {
+	provider := &defaultCloudProvider{
+		logger: logr.New(&log.NullLogSink{}),
+	}
+
+	spec := &elbv2gw.LoadBalancerConfigurationSpec{
+		VpcID: awssdk.String("vpc-explicit"),
+	}
+	vpcID, err := provider.resolveVPCForRegion(context.Background(), "ap-northeast-1", spec)
+	assert.NoError(t, err)
+	assert.Equal(t, "vpc-explicit", vpcID)
+}
+
+func TestResolveVPCForRegion_EmptyVpcID_NoSelectorNoSubnets(t *testing.T) {
+	provider := &defaultCloudProvider{
+		logger: logr.New(&log.NullLogSink{}),
+	}
+
+	spec := &elbv2gw.LoadBalancerConfigurationSpec{
+		VpcID: awssdk.String(""),
+	}
+	_, err := provider.resolveVPCForRegion(context.Background(), "ap-northeast-1", spec)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "set vpcId, vpcSelector, or loadBalancerSubnets")
+}
+
+func TestResolveVPCForRegion_EmptySpec(t *testing.T) {
+	provider := &defaultCloudProvider{
+		logger: logr.New(&log.NullLogSink{}),
+	}
+
+	spec := &elbv2gw.LoadBalancerConfigurationSpec{}
+	_, err := provider.resolveVPCForRegion(context.Background(), "eu-west-1", spec)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "set vpcId, vpcSelector, or loadBalancerSubnets")
+}
+
+// --- resolveVPCFromSelector tests ---
+
+func TestResolveVPCFromSelector_SingleMatch(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ec2Client := services.NewMockEC2(ctrl)
+	ec2Client.EXPECT().DescribeVPCsAsList(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, input *ec2sdk.DescribeVpcsInput) ([]ec2types.Vpc, error) {
+			assert.Len(t, input.Filters, 1)
+			assert.Equal(t, "tag:env", *input.Filters[0].Name)
+			assert.Equal(t, []string{"production"}, input.Filters[0].Values)
+			return []ec2types.Vpc{
+				{VpcId: awssdk.String("vpc-matched")},
+			}, nil
+		},
+	)
+
+	provider := &defaultCloudProvider{logger: logr.New(&log.NullLogSink{})}
+	vpcID, err := provider.resolveVPCFromSelector(context.Background(), ec2Client, map[string][]string{
+		"env": {"production"},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "vpc-matched", vpcID)
+}
+
+func TestResolveVPCFromSelector_NoMatch(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ec2Client := services.NewMockEC2(ctrl)
+	ec2Client.EXPECT().DescribeVPCsAsList(gomock.Any(), gomock.Any()).Return([]ec2types.Vpc{}, nil)
+
+	provider := &defaultCloudProvider{logger: logr.New(&log.NullLogSink{})}
+	_, err := provider.resolveVPCFromSelector(context.Background(), ec2Client, map[string][]string{
+		"env": {"staging"},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no VPC found matching vpcSelector")
+}
+
+func TestResolveVPCFromSelector_MultipleMatches(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ec2Client := services.NewMockEC2(ctrl)
+	ec2Client.EXPECT().DescribeVPCsAsList(gomock.Any(), gomock.Any()).Return([]ec2types.Vpc{
+		{VpcId: awssdk.String("vpc-1")},
+		{VpcId: awssdk.String("vpc-2")},
+	}, nil)
+
+	provider := &defaultCloudProvider{logger: logr.New(&log.NullLogSink{})}
+	_, err := provider.resolveVPCFromSelector(context.Background(), ec2Client, map[string][]string{
+		"env": {"production"},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "multiple VPCs (2) found")
+}
+
+func TestResolveVPCFromSelector_EmptySelector(t *testing.T) {
+	provider := &defaultCloudProvider{logger: logr.New(&log.NullLogSink{})}
+	_, err := provider.resolveVPCFromSelector(context.Background(), nil, map[string][]string{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one tag key with values")
+}
+
+func TestResolveVPCFromSelector_SelectorWithEmptyValues(t *testing.T) {
+	provider := &defaultCloudProvider{logger: logr.New(&log.NullLogSink{})}
+	_, err := provider.resolveVPCFromSelector(context.Background(), nil, map[string][]string{
+		"env": {},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one tag key with values")
+}
+
+func TestResolveVPCFromSelector_APIError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ec2Client := services.NewMockEC2(ctrl)
+	ec2Client.EXPECT().DescribeVPCsAsList(gomock.Any(), gomock.Any()).Return(nil, errors.New("throttled"))
+
+	provider := &defaultCloudProvider{logger: logr.New(&log.NullLogSink{})}
+	_, err := provider.resolveVPCFromSelector(context.Background(), ec2Client, map[string][]string{
+		"env": {"prod"},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "throttled")
+}
+
+func TestResolveVPCFromSelector_MultipleFilters(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ec2Client := services.NewMockEC2(ctrl)
+	ec2Client.EXPECT().DescribeVPCsAsList(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, input *ec2sdk.DescribeVpcsInput) ([]ec2types.Vpc, error) {
+			assert.Len(t, input.Filters, 2)
+			return []ec2types.Vpc{
+				{VpcId: awssdk.String("vpc-multi-tag")},
+			}, nil
+		},
+	)
+
+	provider := &defaultCloudProvider{logger: logr.New(&log.NullLogSink{})}
+	vpcID, err := provider.resolveVPCFromSelector(context.Background(), ec2Client, map[string][]string{
+		"env":     {"production"},
+		"cluster": {"main"},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "vpc-multi-tag", vpcID)
+}
+
+// --- resolveVPCFromFirstSubnet tests ---
+
+func TestResolveVPCFromFirstSubnet_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ec2Client := services.NewMockEC2(ctrl)
+	ec2Client.EXPECT().DescribeSubnetsAsList(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, input *ec2sdk.DescribeSubnetsInput) ([]ec2types.Subnet, error) {
+			assert.Equal(t, []string{"subnet-abc123"}, input.SubnetIds)
+			return []ec2types.Subnet{
+				{
+					SubnetId: awssdk.String("subnet-abc123"),
+					VpcId:    awssdk.String("vpc-from-subnet"),
+				},
+			}, nil
+		},
+	)
+
+	provider := &defaultCloudProvider{logger: logr.New(&log.NullLogSink{})}
+	vpcID, err := provider.resolveVPCFromFirstSubnet(context.Background(), ec2Client, "subnet-abc123")
+	assert.NoError(t, err)
+	assert.Equal(t, "vpc-from-subnet", vpcID)
+}
+
+func TestResolveVPCFromFirstSubnet_NotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ec2Client := services.NewMockEC2(ctrl)
+	ec2Client.EXPECT().DescribeSubnetsAsList(gomock.Any(), gomock.Any()).Return([]ec2types.Subnet{}, nil)
+
+	provider := &defaultCloudProvider{logger: logr.New(&log.NullLogSink{})}
+	_, err := provider.resolveVPCFromFirstSubnet(context.Background(), ec2Client, "subnet-missing")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found in target region")
+}
+
+func TestResolveVPCFromFirstSubnet_NilVpcID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ec2Client := services.NewMockEC2(ctrl)
+	ec2Client.EXPECT().DescribeSubnetsAsList(gomock.Any(), gomock.Any()).Return([]ec2types.Subnet{
+		{SubnetId: awssdk.String("subnet-no-vpc"), VpcId: nil},
+	}, nil)
+
+	provider := &defaultCloudProvider{logger: logr.New(&log.NullLogSink{})}
+	_, err := provider.resolveVPCFromFirstSubnet(context.Background(), ec2Client, "subnet-no-vpc")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "has no VpcId")
+}
+
+func TestResolveVPCFromFirstSubnet_APIError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ec2Client := services.NewMockEC2(ctrl)
+	ec2Client.EXPECT().DescribeSubnetsAsList(gomock.Any(), gomock.Any()).Return(nil, errors.New("access denied"))
+
+	provider := &defaultCloudProvider{logger: logr.New(&log.NullLogSink{})}
+	_, err := provider.resolveVPCFromFirstSubnet(context.Background(), ec2Client, "subnet-denied")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "access denied")
+}

--- a/pkg/gateway/lb_config_merger.go
+++ b/pkg/gateway/lb_config_merger.go
@@ -136,6 +136,24 @@ func (merger *loadBalancerConfigMergerImpl) performTakeOneMerges(merged *elbv2gw
 		merged.LoadBalancerSubnetsSelector = lowPriority.Spec.LoadBalancerSubnetsSelector
 	}
 
+	if highPriority.Spec.Region != nil {
+		merged.Region = highPriority.Spec.Region
+	} else {
+		merged.Region = lowPriority.Spec.Region
+	}
+
+	if highPriority.Spec.VpcID != nil {
+		merged.VpcID = highPriority.Spec.VpcID
+	} else {
+		merged.VpcID = lowPriority.Spec.VpcID
+	}
+
+	if highPriority.Spec.VpcSelector != nil {
+		merged.VpcSelector = highPriority.Spec.VpcSelector
+	} else {
+		merged.VpcSelector = lowPriority.Spec.VpcSelector
+	}
+
 	if highPriority.Spec.SecurityGroups != nil {
 		merged.SecurityGroups = highPriority.Spec.SecurityGroups
 	} else {

--- a/pkg/gateway/lb_config_merger_test.go
+++ b/pkg/gateway/lb_config_merger_test.go
@@ -510,6 +510,61 @@ func Test_Merge(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "region and vpc merge - prefer gateway class",
+			gwClassLbConfig: elbv2gw.LoadBalancerConfiguration{
+				Spec: elbv2gw.LoadBalancerConfigurationSpec{
+					MergingMode: &mergeModeGWC,
+					Region:      awssdk.String("us-east-1"),
+					VpcID:       awssdk.String("vpc-111"),
+					VpcSelector: &map[string][]string{"Environment": {"prod"}},
+					Tags:        &map[string]string{},
+				},
+			},
+			gwLbConfig: elbv2gw.LoadBalancerConfiguration{
+				Spec: elbv2gw.LoadBalancerConfigurationSpec{
+					Region:      awssdk.String("eu-west-1"),
+					VpcID:       awssdk.String("vpc-222"),
+					VpcSelector: &map[string][]string{"Purpose": {"shared"}},
+					Tags:        &map[string]string{},
+				},
+			},
+			expected: elbv2gw.LoadBalancerConfiguration{
+				Spec: elbv2gw.LoadBalancerConfigurationSpec{
+					Region:                 awssdk.String("us-east-1"),
+					VpcID:                  awssdk.String("vpc-111"),
+					VpcSelector:            &map[string][]string{"Environment": {"prod"}},
+					LoadBalancerAttributes: []elbv2gw.LoadBalancerAttribute{},
+					Tags:                   &map[string]string{},
+				},
+			},
+		},
+		{
+			name: "region and vpc merge - prefer gateway",
+			gwClassLbConfig: elbv2gw.LoadBalancerConfiguration{
+				Spec: elbv2gw.LoadBalancerConfigurationSpec{
+					MergingMode: &mergeModeGW,
+					Region:      awssdk.String("us-east-1"),
+					VpcID:       awssdk.String("vpc-111"),
+					Tags:        &map[string]string{},
+				},
+			},
+			gwLbConfig: elbv2gw.LoadBalancerConfiguration{
+				Spec: elbv2gw.LoadBalancerConfigurationSpec{
+					Region: awssdk.String("eu-west-1"),
+					VpcID:  awssdk.String("vpc-222"),
+					Tags:   &map[string]string{},
+				},
+			},
+			expected: elbv2gw.LoadBalancerConfiguration{
+				Spec: elbv2gw.LoadBalancerConfigurationSpec{
+					Region:                 awssdk.String("eu-west-1"),
+					VpcID:                  awssdk.String("vpc-222"),
+					LoadBalancerAttributes: []elbv2gw.LoadBalancerAttribute{},
+					Tags:                   &map[string]string{},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/gateway/model/model_build_target_group_binding_network_test.go
+++ b/pkg/gateway/model/model_build_target_group_binding_network_test.go
@@ -421,6 +421,22 @@ func Test_buildTargetGroupBindingNetworking_standardBuilder(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "nil backend SG token (cross-region) returns nil networking",
+			sgOutput: securityGroupOutput{
+				securityGroupTokens:           []core.StringToken{core.LiteralStringToken("sg-remote-region")},
+				backendSecurityGroupToken:     nil,
+				backendSecurityGroupAllocated: false,
+			},
+			tgSpec: elbv2model.TargetGroupSpec{
+				Protocol: elbv2model.ProtocolHTTP,
+				HealthCheckConfig: &elbv2model.TargetGroupHealthCheckConfig{
+					Port: &intstr80,
+				},
+			},
+			targetPort: intstr80,
+			expected:   nil,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/targetgroupbinding/targets_manager_resolve_test.go
+++ b/pkg/targetgroupbinding/targets_manager_resolve_test.go
@@ -1,0 +1,116 @@
+package targetgroupbinding
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/services"
+)
+
+func Test_cachedTargetsManager_resolveELBV2(t *testing.T) {
+	tests := []struct {
+		name           string
+		defaultRegion  string
+		tgARN          string
+		hasProvider    bool
+		providerRegion string
+		providerErr    error
+		wantDefault    bool
+		wantErr        string
+	}{
+		{
+			name:          "same region ARN returns default client",
+			defaultRegion: "us-east-1",
+			tgARN:         "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/tg/abc",
+			hasProvider:   true,
+			wantDefault:   true,
+		},
+		{
+			name:           "different region ARN returns provider client",
+			defaultRegion:  "us-east-1",
+			tgARN:          "arn:aws:elasticloadbalancing:ap-northeast-1:025054649006:targetgroup/tg/abc",
+			hasProvider:    true,
+			providerRegion: "ap-northeast-1",
+			wantDefault:    false,
+		},
+		{
+			name:          "empty ARN returns default client",
+			defaultRegion: "us-east-1",
+			tgARN:         "",
+			hasProvider:   true,
+			wantDefault:   true,
+		},
+		{
+			name:          "nil provider returns default client for cross-region ARN",
+			defaultRegion: "us-east-1",
+			tgARN:         "arn:aws:elasticloadbalancing:ap-northeast-1:025054649006:targetgroup/tg/abc",
+			hasProvider:   false,
+			wantDefault:   true,
+		},
+		{
+			name:           "provider error is propagated",
+			defaultRegion:  "us-east-1",
+			tgARN:          "arn:aws:elasticloadbalancing:eu-west-1:111111111111:targetgroup/tg/abc",
+			hasProvider:    true,
+			providerRegion: "eu-west-1",
+			providerErr:    errors.New("region not supported"),
+			wantErr:        "region not supported",
+		},
+		{
+			name:          "malformed ARN returns default client",
+			defaultRegion: "us-east-1",
+			tgARN:         "not-an-arn",
+			hasProvider:   true,
+			wantDefault:   true,
+		},
+		{
+			name:          "ARN with empty region field returns default client",
+			defaultRegion: "us-east-1",
+			tgARN:         "arn:aws:elasticloadbalancing::123456789012:targetgroup/tg/abc",
+			hasProvider:   true,
+			wantDefault:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			defaultClient := services.NewMockELBV2(ctrl)
+			providerClient := services.NewMockELBV2(ctrl)
+
+			var provider ELBV2ClientProvider
+			if tt.hasProvider {
+				provider = func(region string) (services.ELBV2, error) {
+					if tt.providerRegion != "" {
+						assert.Equal(t, tt.providerRegion, region)
+					}
+					if tt.providerErr != nil {
+						return nil, tt.providerErr
+					}
+					return providerClient, nil
+				}
+			}
+
+			m := &cachedTargetsManager{
+				elbv2Client:   defaultClient,
+				defaultRegion: tt.defaultRegion,
+				elbv2Provider: provider,
+			}
+
+			got, err := m.resolveELBV2(tt.tgARN)
+			if tt.wantErr != "" {
+				assert.EqualError(t, err, tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+				if tt.wantDefault {
+					assert.Equal(t, defaultClient, got)
+				} else {
+					assert.Equal(t, providerClient, got)
+				}
+			}
+		})
+	}
+}

--- a/webhooks/elbv2/targetgroup_helper.go
+++ b/webhooks/elbv2/targetgroup_helper.go
@@ -2,12 +2,42 @@ package elbv2
 
 import (
 	"context"
+	"strings"
+
 	elbv2sdk "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
 	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 	"github.com/pkg/errors"
 	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/services"
 )
+
+// ELBV2ClientProvider returns an ELBV2 client configured for the given region.
+// Used by webhooks to describe target groups in a non-default region.
+type ELBV2ClientProvider func(region string) (services.ELBV2, error)
+
+// regionFromTGARN extracts the AWS region from a target group ARN.
+// ARN format: arn:aws:elasticloadbalancing:<region>:<account>:targetgroup/...
+// Returns empty string if the ARN cannot be parsed.
+func regionFromTGARN(arn string) string {
+	parts := strings.SplitN(arn, ":", 6)
+	if len(parts) >= 5 {
+		return parts[3]
+	}
+	return ""
+}
+
+// resolveELBV2ForTGB returns the ELBV2 client that should be used for the given TGB.
+// If the TGB's target group ARN refers to a different region, a regional client is obtained from the provider.
+func resolveELBV2ForTGB(defaultClient services.ELBV2, defaultRegion string, provider ELBV2ClientProvider, tgARN string) (services.ELBV2, error) {
+	if tgARN == "" || provider == nil {
+		return defaultClient, nil
+	}
+	arnRegion := regionFromTGARN(tgARN)
+	if arnRegion == "" || arnRegion == defaultRegion {
+		return defaultClient, nil
+	}
+	return provider(arnRegion)
+}
 
 // getTargetGroupFromAWS returns the AWS target group corresponding to the arn
 func getTargetGroupFromAWS(ctx context.Context, elbv2Client services.ELBV2, tgb *elbv2api.TargetGroupBinding) (*elbv2types.TargetGroup, error) {

--- a/webhooks/elbv2/targetgroup_helper_test.go
+++ b/webhooks/elbv2/targetgroup_helper_test.go
@@ -1,0 +1,162 @@
+package elbv2
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/services"
+)
+
+func Test_regionFromTGARN(t *testing.T) {
+	tests := []struct {
+		name string
+		arn  string
+		want string
+	}{
+		{
+			name: "standard TG ARN",
+			arn:  "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/my-tg/abc123",
+			want: "us-east-1",
+		},
+		{
+			name: "tokyo region TG ARN",
+			arn:  "arn:aws:elasticloadbalancing:ap-northeast-1:025054649006:targetgroup/k8s-kubesyst-traefikt-1cdbaaab9f/964ac6392723fe3a",
+			want: "ap-northeast-1",
+		},
+		{
+			name: "eu-west-1 region",
+			arn:  "arn:aws:elasticloadbalancing:eu-west-1:111111111111:targetgroup/tg-name/deadbeef",
+			want: "eu-west-1",
+		},
+		{
+			name: "empty ARN",
+			arn:  "",
+			want: "",
+		},
+		{
+			name: "malformed ARN with fewer colons",
+			arn:  "arn:aws:elasticloadbalancing",
+			want: "",
+		},
+		{
+			name: "ARN with exactly 4 parts",
+			arn:  "arn:aws:elasticloadbalancing:us-west-2",
+			want: "",
+		},
+		{
+			name: "ARN with 5 parts (minimum for region extraction)",
+			arn:  "arn:aws:elasticloadbalancing:us-west-2:123456789012",
+			want: "us-west-2",
+		},
+		{
+			name: "china partition ARN",
+			arn:  "arn:aws-cn:elasticloadbalancing:cn-north-1:123456789012:targetgroup/tg/abc",
+			want: "cn-north-1",
+		},
+		{
+			name: "govcloud ARN",
+			arn:  "arn:aws-us-gov:elasticloadbalancing:us-gov-west-1:123456789012:targetgroup/tg/abc",
+			want: "us-gov-west-1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := regionFromTGARN(tt.arn)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_resolveELBV2ForTGB(t *testing.T) {
+	tests := []struct {
+		name            string
+		defaultRegion   string
+		tgARN           string
+		providerRegion  string
+		providerReturns bool
+		providerErr     error
+		wantDefault     bool
+		wantErr         string
+	}{
+		{
+			name:          "empty ARN returns default client",
+			defaultRegion: "us-east-1",
+			tgARN:         "",
+			wantDefault:   true,
+		},
+		{
+			name:          "same region returns default client",
+			defaultRegion: "us-east-1",
+			tgARN:         "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/tg/abc",
+			wantDefault:   true,
+		},
+		{
+			name:            "different region returns provider client",
+			defaultRegion:   "us-east-1",
+			tgARN:           "arn:aws:elasticloadbalancing:ap-northeast-1:123456789012:targetgroup/tg/abc",
+			providerRegion:  "ap-northeast-1",
+			providerReturns: true,
+			wantDefault:     false,
+		},
+		{
+			name:           "provider error is propagated",
+			defaultRegion:  "us-east-1",
+			tgARN:          "arn:aws:elasticloadbalancing:eu-west-1:123456789012:targetgroup/tg/abc",
+			providerRegion: "eu-west-1",
+			providerErr:    errors.New("failed to create client"),
+			wantErr:        "failed to create client",
+		},
+		{
+			name:          "nil provider returns default client even for different region",
+			defaultRegion: "us-east-1",
+			tgARN:         "arn:aws:elasticloadbalancing:ap-northeast-1:123456789012:targetgroup/tg/abc",
+			wantDefault:   true,
+		},
+		{
+			name:          "malformed ARN returns default client",
+			defaultRegion: "us-east-1",
+			tgARN:         "not-an-arn",
+			wantDefault:   true,
+		},
+		{
+			name:          "ARN with empty region returns default client",
+			defaultRegion: "us-east-1",
+			tgARN:         "arn:aws:elasticloadbalancing::123456789012:targetgroup/tg/abc",
+			wantDefault:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			defaultClient := services.NewMockELBV2(ctrl)
+			providerClient := services.NewMockELBV2(ctrl)
+
+			var provider ELBV2ClientProvider
+			if tt.providerRegion != "" {
+				provider = func(region string) (services.ELBV2, error) {
+					assert.Equal(t, tt.providerRegion, region)
+					if tt.providerErr != nil {
+						return nil, tt.providerErr
+					}
+					return providerClient, nil
+				}
+			}
+
+			got, err := resolveELBV2ForTGB(defaultClient, tt.defaultRegion, provider, tt.tgARN)
+			if tt.wantErr != "" {
+				assert.EqualError(t, err, tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+				if tt.wantDefault {
+					assert.Equal(t, defaultClient, got)
+				} else {
+					assert.Equal(t, providerClient, got)
+				}
+			}
+		})
+	}
+}

--- a/webhooks/elbv2/targetgroupbinding_validator_test.go
+++ b/webhooks/elbv2/targetgroupbinding_validator_test.go
@@ -766,7 +766,7 @@ func Test_targetGroupBindingValidator_checkRequiredFields(t *testing.T) {
 				logger:           logr.New(&log.NullLogSink{}),
 				metricsCollector: mockMetricsCollector,
 			}
-			err := v.checkRequiredFields(context.Background(), tt.args.tgb)
+			err := v.checkRequiredFields(context.Background(), tt.args.tgb, nil)
 			if tt.wantErr != nil {
 				assert.EqualError(t, err, tt.wantErr.Error())
 			} else {


### PR DESCRIPTION
### Description

**Motivation:** Support deploying edge ALBs in AWS regions closer to end users, enabling TLS termination at the edge to reduce latency. For example, a cluster running in `us-east-1` can now deploy an ALB in `ap-northeast-1` via the Gateway API, terminating TLS in Tokyo rather than routing encrypted traffic back to the US.

#### What this PR does

Adds multi-region support to the AWS Load Balancer Controller's Gateway API implementation. A new optional `region` field on `LoadBalancerConfiguration` allows users to specify an AWS region for the ALB/NLB, and the controller handles all cross-region resource management automatically.

**Key changes:**

1. **`LoadBalancerConfiguration` API** (`apis/gateway/v1beta1/loadbalancerconfig_types.go`)
   - Added `Region` and `VpcID` fields to `LoadBalancerConfigurationSpec`, allowing users to target a specific AWS region and VPC for the load balancer.

2. **`ReconcileContext` / Cloud Provider** (`pkg/gateway/cloud_provider.go`)
   - New `ReconcileContext` encapsulates region-specific AWS clients (ELBV2, EC2, ACM) and resolvers (subnets, VPC info, security groups, cert discovery, tagging manager, TG ARN mapper).
   - `ReconcileContext` is always passed to `Build()` — for the default region it wraps the existing clients/resolvers; for non-default regions all fields are region-scoped.
   - `IsCrossRegion() bool` on the context lets downstream code branch on cross-region without comparing VPC IDs or regions directly.
   - `GetReconcileContext` auto-discovers the VPC in the target region (via `vpcId`, `vpcSelector`, or first subnet) and caches the result.

3. **Gateway Controller** (`controllers/gateway/gateway_controller.go`)
   - Always obtains a `ReconcileContext` from `CloudProvider` and passes it through to the model builder and stack deployer.
   - Uses `reconcileContext.IsCrossRegion()` to select the region-scoped stack deployer and backend SG provider.

4. **Model Builder** (`pkg/gateway/model/base_model_builder.go`)
   - `Build()` takes a required `ReconcileContextInterface` parameter (no variadic/optional). All effective clients and resolvers come from the RC unconditionally.
   - `ReconcileContextInterface` exposes `IsCrossRegion()` — used to disable backend SG allocation and clear the backend SG token on `TargetGroupBinding` resources for cross-region gateways (cross-region SG references are not supported by AWS).

5. **Region-aware AWS clients** (`pkg/aws/region.go`)
   - `NewCloudForRegion`, `NewEC2ClientForRegion`, `NewELBV2ForRegion` — factory functions for creating region-scoped AWS service clients without EC2 metadata.
   - `regionStubCloud` — minimal `Cloud` implementation for ELBV2-only operations (webhooks, ARN validation).

6. **TGB Webhooks** (`webhooks/elbv2/targetgroup_helper.go`, `targetgroupbinding_mutator.go`, `targetgroupbinding_validator.go`)
   - `ELBV2ClientProvider` type and `resolveELBV2ForTGB` helper extract the region from a target group ARN and return the correct regional ELBV2 client.
   - Mutator and validator use the regional client for `DescribeTargetGroups` calls, preventing `ValidationError` when validating cross-region TG ARNs.

7. **TGB Reconciler** (`pkg/targetgroupbinding/targets_manager.go`, `resource_manager.go`)
   - `cachedTargetsManager.resolveELBV2()` dynamically selects the correct ELBV2 client based on target group ARN region for `RegisterTargets`, `DeregisterTargets`, and `DescribeTargetHealth`.
   - `generateOverrideAzFn` now handles cross-region VPCs (not just cross-account) — when the TGB's VPC differs from the controller's VPC and `DescribeVpcs` returns `InvalidVpcID.NotFound`, target AZs are overridden to "all".

8. **Security Group Synthesizer** (`pkg/deploy/ec2/security_group_synthesizer.go`)
   - Handles cross-region SG cleanup gracefully.

9. **Documentation** (`docs/guide/gateway/loadbalancerconfig.md`, `docs/guide/gateway/spec.md`)
   - Documents the new `region` and `vpcID` fields with usage examples.

10. **Tests**
    - `webhooks/elbv2/targetgroup_helper_test.go` — `regionFromTGARN` and `resolveELBV2ForTGB` (18 cases)
    - `pkg/targetgroupbinding/targets_manager_resolve_test.go` — `cachedTargetsManager.resolveELBV2` (7 cases)
    - `pkg/aws/region_test.go` — `regionStubCloud` interface compliance and getters (12 cases)
    - `pkg/gateway/cloud_provider_test.go` — `ReconcileContext` getters, `IsCrossRegion()`, `GetReconcileContext` default path, `resolveVPCForRegion`, `resolveVPCFromSelector`, `resolveVPCFromFirstSubnet` (21 cases)
    - Updated `pkg/targetgroupbinding/resource_manager_test.go` — cross-region VPC override AZ test case
    - Updated `pkg/gateway/model/model_build_target_group_binding_network_test.go` — nil backend SG token (cross-region) case

#### Example usage

```yaml
apiVersion: gateway.k8s.aws/v1beta1
kind: LoadBalancerConfiguration
metadata:
  name: edge-tokyo
spec:
  region: ap-northeast-1
  scheme: internet-facing
  # vpcID is auto-discovered from the target region
```

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist
- [x] Backfilled missing tests for code in same general area
- [x] Refactored something and made the world a better place
