### PR TITLE
[feat gw-api]gateway level targetgroupconfiguration

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -192,6 +192,27 @@ webhooks:
       service:
         name: webhook-service
         namespace: system
+        path: /validate-gateway-k8s-aws-v1beta1-targetgroupconfiguration
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    name: vtargetgroupconfiguration.gateway.k8s.aws
+    rules:
+      - apiGroups:
+          - gateway.k8s.aws
+        apiVersions:
+          - v1beta1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - targetgroupconfigurations
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1beta1
+    clientConfig:
+      service:
+        name: webhook-service
+        namespace: system
         path: /validate-networking-v1-ingress
     failurePolicy: Fail
     matchPolicy: Equivalent

--- a/helm/aws-load-balancer-controller/templates/webhook.yaml
+++ b/helm/aws-load-balancer-controller/templates/webhook.yaml
@@ -326,6 +326,30 @@ webhooks:
     - ingresses
   sideEffects: None
 {{- end }}
+- clientConfig:
+    {{- if not $.Values.enableCertManager }}
+    caBundle: {{ $tls.caCert }}
+    {{- end }}
+    service:
+      name: {{ template "aws-load-balancer-controller.webhookService" . }}
+      namespace: {{ $.Release.Namespace }}
+      path: /validate-gateway-k8s-aws-v1beta1-targetgroupconfiguration
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: vtargetgroupconfiguration.gateway.k8s.aws
+  admissionReviewVersions:
+  - v1beta1
+  rules:
+  - apiGroups:
+    - gateway.k8s.aws
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - targetgroupconfigurations
+  sideEffects: None
 {{- if .Values.controllerConfig.featureGates.GlobalAcceleratorController }}
 - clientConfig:
     {{- if not $.Values.enableCertManager }}

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/aga"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/certs"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/shared_utils"
@@ -444,6 +445,7 @@ func main() {
 	elbv2webhook.NewTargetGroupBindingMutator(cloud.ELBV2(), ctrl.Log, lbcMetricsCollector).SetupWithManager(mgr)
 	elbv2webhook.NewTargetGroupBindingValidator(mgr.GetClient(), cloud.ELBV2(), cloud.VpcID(), ctrl.Log, lbcMetricsCollector).SetupWithManager(mgr)
 	networkingwebhook.NewIngressValidator(mgr.GetClient(), controllerCFG.IngressConfig, ctrl.Log, lbcMetricsCollector).SetupWithManager(mgr)
+	elbv2webhook.NewTargetGroupConfigurationValidator(mgr.GetClient(), ctrl.Log, lbcMetricsCollector).SetupWithManager(mgr)
 
 	// Setup GlobalAccelerator validator only if enabled
 	if aga.IsGlobalAcceleratorControllerEnabled(controllerCFG.FeatureGates, cloud.Region()) {

--- a/pkg/gateway/routeutils/descriptor.go
+++ b/pkg/gateway/routeutils/descriptor.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/types"
+	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
@@ -32,6 +33,9 @@ type routeMetadataDescriptor interface {
 	// setCompatibleHostnamesByPort is a package-private method to set compatible hostnames.
 	// This is called by the loader after route attachment validation.
 	setCompatibleHostnamesByPort(map[int32][]gwv1.Hostname)
+	// setGatewayDefaultTGConfig is a package-private method to set the Gateway-level TargetGroupConfiguration
+	// This is called by the loader once per reconcile cycle.
+	setGatewayDefaultTGConfig(*elbv2gw.TargetGroupConfiguration)
 }
 
 type routeLoadError struct {

--- a/pkg/gateway/routeutils/grpc.go
+++ b/pkg/gateway/routeutils/grpc.go
@@ -55,6 +55,11 @@ type grpcRouteDescription struct {
 	rules                     []RouteRule
 	ruleAccumulator           attachedRuleAccumulator[gwv1.GRPCRouteRule]
 	compatibleHostnamesByPort map[int32][]gwv1.Hostname
+	gatewayDefaultTGConfig    *elbv2gw.TargetGroupConfiguration
+}
+
+func (grpcRoute *grpcRouteDescription) setGatewayDefaultTGConfig(cfg *elbv2gw.TargetGroupConfiguration) {
+	grpcRoute.gatewayDefaultTGConfig = cfg
 }
 
 func (grpcRoute *grpcRouteDescription) loadAttachedRules(ctx context.Context, k8sClient client.Client) (RouteDescriptor, []routeLoadError) {
@@ -73,7 +78,7 @@ func (grpcRoute *grpcRouteDescription) loadAttachedRules(ctx context.Context, k8
 			})
 		}, func(grr *gwv1.GRPCRouteRule, backends []Backend, listenerRuleConfiguration *elbv2gw.ListenerRuleConfiguration) RouteRule {
 			return convertGRPCRouteRule(grr, backends, listenerRuleConfiguration)
-		})
+		}, grpcRoute.gatewayDefaultTGConfig)
 	grpcRoute.rules = convertedRules
 	return grpcRoute, allErrors
 }

--- a/pkg/gateway/routeutils/grpc_test.go
+++ b/pkg/gateway/routeutils/grpc_test.go
@@ -129,7 +129,7 @@ func Test_ListGRPCRoutes(t *testing.T) {
 
 func Test_GRPC_LoadAttachedRules(t *testing.T) {
 	weight := 0
-	mockBackendLoader := func(ctx context.Context, k8sClient client.Client, backendRef gwv1.BackendRef, routeIdentifier types.NamespacedName, routeKind RouteKind) (*Backend, error, error) {
+	mockBackendLoader := func(ctx context.Context, k8sClient client.Client, backendRef gwv1.BackendRef, routeIdentifier types.NamespacedName, routeKind RouteKind, gatewayDefaultTGConfig *elbv2gw.TargetGroupConfiguration) (*Backend, error, error) {
 		weight++
 		return &Backend{
 			Weight: weight,

--- a/pkg/gateway/routeutils/http_test.go
+++ b/pkg/gateway/routeutils/http_test.go
@@ -130,7 +130,7 @@ func Test_ListHTTPRoutes(t *testing.T) {
 
 func Test_HTTP_LoadAttachedRules(t *testing.T) {
 	weight := 0
-	mockLoader := func(ctx context.Context, k8sClient client.Client, backendRef gwv1.BackendRef, routeIdentifier types.NamespacedName, routeKind RouteKind) (*Backend, error, error) {
+	mockLoader := func(ctx context.Context, k8sClient client.Client, backendRef gwv1.BackendRef, routeIdentifier types.NamespacedName, routeKind RouteKind, gatewayDefaultTGConfig *elbv2gw.TargetGroupConfiguration) (*Backend, error, error) {
 		weight++
 		return &Backend{
 			Weight: weight,

--- a/pkg/gateway/routeutils/loader_test.go
+++ b/pkg/gateway/routeutils/loader_test.go
@@ -10,7 +10,9 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
 	gateway_constants "sigs.k8s.io/aws-load-balancer-controller/pkg/gateway/constants"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/testutils"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
@@ -51,6 +53,10 @@ func (m *mockRoute) GetCompatibleHostnamesByPort() map[int32][]gwv1.Hostname {
 
 func (m *mockRoute) setCompatibleHostnamesByPort(hostnamesByPort map[int32][]gwv1.Hostname) {
 	m.CompatibleHostnamesByPort = hostnamesByPort
+}
+
+func (m *mockRoute) setGatewayDefaultTGConfig(cfg *elbv2gw.TargetGroupConfiguration) {
+	// no-op for mock
 }
 
 func (m *mockRoute) loadAttachedRules(context context.Context, k8sClient client.Client) (RouteDescriptor, []routeLoadError) {
@@ -366,6 +372,7 @@ func Test_LoadRoutesForGateway(t *testing.T) {
 				allRouteLoaders: allRouteLoaders,
 				logger:          logr.Discard(),
 				routeSubmitter:  routeReconciler,
+				k8sClient:       testutils.GenerateTestClient(),
 			}
 
 			filter := &routeFilterImpl{acceptedKinds: tc.acceptedKinds}

--- a/pkg/gateway/routeutils/mock_route.go
+++ b/pkg/gateway/routeutils/mock_route.go
@@ -36,6 +36,7 @@ type MockRoute struct {
 	CreationTime              time.Time
 	Rules                     []RouteRule
 	CompatibleHostnamesByPort map[int32][]gwv1.Hostname
+	GatewayDefaultTGConfig    *elbv2gw.TargetGroupConfiguration
 }
 
 func (m *MockRoute) GetBackendRefs() []gwv1.BackendRef {
@@ -99,6 +100,10 @@ func (m *MockRoute) GetCompatibleHostnamesByPort() map[int32][]gwv1.Hostname {
 
 func (m *MockRoute) setCompatibleHostnamesByPort(hostnamesByPort map[int32][]gwv1.Hostname) {
 	m.CompatibleHostnamesByPort = hostnamesByPort
+}
+
+func (m *MockRoute) setGatewayDefaultTGConfig(config *elbv2gw.TargetGroupConfiguration) {
+	m.GatewayDefaultTGConfig = config
 }
 
 var _ RouteDescriptor = &MockRoute{}

--- a/pkg/gateway/routeutils/tcp.go
+++ b/pkg/gateway/routeutils/tcp.go
@@ -56,10 +56,15 @@ type tcpRouteDescription struct {
 	rules                     []RouteRule
 	ruleAccumulator           attachedRuleAccumulator[gwalpha2.TCPRouteRule]
 	compatibleHostnamesByPort map[int32][]gwv1.Hostname
+	gatewayDefaultTGConfig    *elbv2gw.TargetGroupConfiguration
 }
 
 func (tcpRoute *tcpRouteDescription) GetAttachedRules() []RouteRule {
 	return tcpRoute.rules
+}
+
+func (tcpRoute *tcpRouteDescription) setGatewayDefaultTGConfig(cfg *elbv2gw.TargetGroupConfiguration) {
+	tcpRoute.gatewayDefaultTGConfig = cfg
 }
 
 func (tcpRoute *tcpRouteDescription) loadAttachedRules(ctx context.Context, k8sClient client.Client) (RouteDescriptor, []routeLoadError) {
@@ -69,7 +74,7 @@ func (tcpRoute *tcpRouteDescription) loadAttachedRules(ctx context.Context, k8sC
 		return []gwv1.LocalObjectReference{}
 	}, func(trr *gwalpha2.TCPRouteRule, backends []Backend, listenerRuleConfiguration *elbv2gw.ListenerRuleConfiguration) RouteRule {
 		return convertTCPRouteRule(trr, backends)
-	})
+	}, tcpRoute.gatewayDefaultTGConfig)
 	tcpRoute.rules = convertedRules
 	return tcpRoute, allErrors
 }

--- a/pkg/gateway/routeutils/tcp_test.go
+++ b/pkg/gateway/routeutils/tcp_test.go
@@ -110,7 +110,7 @@ func Test_ListTCPRoutes(t *testing.T) {
 
 func Test_TCP_LoadAttachedRules(t *testing.T) {
 	weight := 0
-	mockLoader := func(ctx context.Context, k8sClient client.Client, backendRef gwv1.BackendRef, routeIdentifier types.NamespacedName, routeKind RouteKind) (*Backend, error, error) {
+	mockLoader := func(ctx context.Context, k8sClient client.Client, backendRef gwv1.BackendRef, routeIdentifier types.NamespacedName, routeKind RouteKind, gatewayDefaultTGConfig *elbv2gw.TargetGroupConfiguration) (*Backend, error, error) {
 		weight++
 		return &Backend{
 			Weight: weight,

--- a/pkg/gateway/routeutils/tls.go
+++ b/pkg/gateway/routeutils/tls.go
@@ -56,10 +56,15 @@ type tlsRouteDescription struct {
 	rules                     []RouteRule
 	ruleAccumulator           attachedRuleAccumulator[gwalpha2.TLSRouteRule]
 	compatibleHostnamesByPort map[int32][]gwv1.Hostname
+	gatewayDefaultTGConfig    *elbv2gw.TargetGroupConfiguration
 }
 
 func (tlsRoute *tlsRouteDescription) GetAttachedRules() []RouteRule {
 	return tlsRoute.rules
+}
+
+func (tlsRoute *tlsRouteDescription) setGatewayDefaultTGConfig(cfg *elbv2gw.TargetGroupConfiguration) {
+	tlsRoute.gatewayDefaultTGConfig = cfg
 }
 
 func (tlsRoute *tlsRouteDescription) loadAttachedRules(ctx context.Context, k8sClient client.Client) (RouteDescriptor, []routeLoadError) {
@@ -69,7 +74,7 @@ func (tlsRoute *tlsRouteDescription) loadAttachedRules(ctx context.Context, k8sC
 		return []gwv1.LocalObjectReference{}
 	}, func(trr *gwalpha2.TLSRouteRule, backends []Backend, listenerRuleConfiguration *elbv2gw.ListenerRuleConfiguration) RouteRule {
 		return convertTLSRouteRule(trr, backends)
-	})
+	}, tlsRoute.gatewayDefaultTGConfig)
 	tlsRoute.rules = convertedRules
 	return tlsRoute, allErrors
 }

--- a/pkg/gateway/routeutils/tls_test.go
+++ b/pkg/gateway/routeutils/tls_test.go
@@ -124,7 +124,7 @@ func Test_ListTLSRoutes(t *testing.T) {
 
 func Test_TLS_LoadAttachedRules(t *testing.T) {
 	weight := 0
-	mockLoader := func(ctx context.Context, k8sClient client.Client, backendRef gwv1.BackendRef, routeIdentifier types.NamespacedName, routeKind RouteKind) (*Backend, error, error) {
+	mockLoader := func(ctx context.Context, k8sClient client.Client, backendRef gwv1.BackendRef, routeIdentifier types.NamespacedName, routeKind RouteKind, gatewayDefaultTGConfig *elbv2gw.TargetGroupConfiguration) (*Backend, error, error) {
 		weight++
 		return &Backend{
 			Weight: weight,

--- a/pkg/gateway/routeutils/udp.go
+++ b/pkg/gateway/routeutils/udp.go
@@ -56,10 +56,15 @@ type udpRouteDescription struct {
 	rules                     []RouteRule
 	ruleAccumulator           attachedRuleAccumulator[gwalpha2.UDPRouteRule]
 	compatibleHostnamesByPort map[int32][]gwv1.Hostname
+	gatewayDefaultTGConfig    *elbv2gw.TargetGroupConfiguration
 }
 
 func (udpRoute *udpRouteDescription) GetAttachedRules() []RouteRule {
 	return udpRoute.rules
+}
+
+func (udpRoute *udpRouteDescription) setGatewayDefaultTGConfig(cfg *elbv2gw.TargetGroupConfiguration) {
+	udpRoute.gatewayDefaultTGConfig = cfg
 }
 
 func (udpRoute *udpRouteDescription) loadAttachedRules(ctx context.Context, k8sClient client.Client) (RouteDescriptor, []routeLoadError) {
@@ -69,7 +74,7 @@ func (udpRoute *udpRouteDescription) loadAttachedRules(ctx context.Context, k8sC
 		return []gwv1.LocalObjectReference{}
 	}, func(urr *gwalpha2.UDPRouteRule, backends []Backend, listenerRuleConfiguration *elbv2gw.ListenerRuleConfiguration) RouteRule {
 		return convertUDPRouteRule(urr, backends)
-	})
+	}, udpRoute.gatewayDefaultTGConfig)
 
 	udpRoute.rules = convertedRules
 	return udpRoute, allErrors

--- a/pkg/gateway/routeutils/udp_test.go
+++ b/pkg/gateway/routeutils/udp_test.go
@@ -110,7 +110,7 @@ func Test_ListUDPRoutes(t *testing.T) {
 
 func Test_UDP_LoadAttachedRules(t *testing.T) {
 	weight := 0
-	mockLoader := func(ctx context.Context, k8sClient client.Client, backendRef gwv1.BackendRef, routeIdentifier types.NamespacedName, routeKind RouteKind) (*Backend, error, error) {
+	mockLoader := func(ctx context.Context, k8sClient client.Client, backendRef gwv1.BackendRef, routeIdentifier types.NamespacedName, routeKind RouteKind, gatewayDefaultTGConfig *elbv2gw.TargetGroupConfiguration) (*Backend, error, error) {
 		weight++
 		return &Backend{
 			Weight: weight,

--- a/pkg/gateway/routeutils/utils_test.go
+++ b/pkg/gateway/routeutils/utils_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
 	mock_client "sigs.k8s.io/aws-load-balancer-controller/mocks/controller-runtime/client"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -90,6 +91,11 @@ func (m mockPreLoadRouteDescriptor) setCompatibleHostnamesByPort(hostnamesByPort
 	if hostnamesByPort[80] != nil {
 		m.compatibleHostnames = hostnamesByPort[80]
 	}
+}
+
+func (m mockPreLoadRouteDescriptor) setGatewayDefaultTGConfig(cfg *elbv2gw.TargetGroupConfiguration) {
+	//TODO implement me
+	panic("implement me")
 }
 
 func (m mockPreLoadRouteDescriptor) loadAttachedRules(context context.Context, k8sClient client.Client) (RouteDescriptor, []routeLoadError) {

--- a/test/e2e/gateway/alb_ip_target_test.go
+++ b/test/e2e/gateway/alb_ip_target_test.go
@@ -2100,4 +2100,168 @@ var _ = Describe("test k8s alb gateway using ip targets reconciled by the aws lo
 			})
 		})
 	})
+
+	Context("with ALB ip target configuration with Gateway-level default TGC inherited by two services", func() {
+		It("should provision load balancer with both services inheriting from gateway TGC", func() {
+			interf := elbv2gw.LoadBalancerSchemeInternetFacing
+			lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
+				Scheme: &interf,
+			}
+			ipTargetType := elbv2gw.TargetTypeIP
+			gwHCPath := "/gw-healthcheck"
+			gwHCProtocol := elbv2gw.TargetGroupHealthCheckProtocolHTTP
+			gwTgSpec := elbv2gw.TargetGroupConfigurationSpec{
+				DefaultConfiguration: elbv2gw.TargetGroupProps{
+					TargetType: &ipTargetType,
+					HealthCheckConfig: &elbv2gw.HealthCheckConfiguration{
+						HealthCheckPath:     &gwHCPath,
+						HealthCheckProtocol: &gwHCProtocol,
+					},
+				},
+			}
+
+			By("deploying stack", func() {
+				err := stack.DeployGatewayTGC(ctx, tf, lbcSpec, gwTgSpec, true)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("checking gateway status for lb dns name", func() {
+				dnsName = stack.GetLoadBalancerIngressHostName()
+				Expect(dnsName).ToNot(BeEmpty())
+			})
+
+			By("querying AWS loadbalancer from the dns name", func() {
+				var err error
+				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(lbARN).ToNot(BeEmpty())
+			})
+
+			By("verifying AWS loadbalancer resources with two ip target groups", func() {
+				expectedTargetGroups := []verifier.ExpectedTargetGroup{
+					{Protocol: "HTTP", Port: 80, NumTargets: int(*stack.albResourceStack.commonStack.dps[0].Spec.Replicas), TargetType: "ip"},
+					{Protocol: "HTTP", Port: 80, NumTargets: int(*stack.albResourceStack.commonStack.dps[1].Spec.Replicas), TargetType: "ip"},
+				}
+				err := verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
+					Type:         "application",
+					Scheme:       "internet-facing",
+					Listeners:    stack.albResourceStack.getListenersPortMap(),
+					TargetGroups: expectedTargetGroups,
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("verifying both target groups inherit gateway TGC health check path", func() {
+				targetGroups, err := tf.TGManager.GetTargetGroupsForLoadBalancer(ctx, lbARN)
+				Expect(err).NotTo(HaveOccurred())
+				for _, tg := range targetGroups {
+					Expect(awssdk.ToString(tg.HealthCheckPath)).To(Equal("/gw-healthcheck"))
+				}
+			})
+
+			By("waiting for target group targets to be healthy", func() {
+				err := verifier.WaitUntilAllTargetsAreHealthy(ctx, tf, lbARN, int(*stack.albResourceStack.commonStack.dps[0].Spec.Replicas)+int(*stack.albResourceStack.commonStack.dps[1].Spec.Replicas))
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("waiting until DNS name is available", func() {
+				err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("sending http request to the lb", func() {
+				url := fmt.Sprintf("http://%v/any-path", dnsName)
+				err := tf.HTTPVerifier.VerifyURL(url, http.ResponseCodeMatches(200))
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
+
+	Context("with ALB ip target configuration with service-level TGC overriding Gateway-level default TGC", func() {
+		It("should provision load balancer where service TGC takes priority over gateway TGC", func() {
+			interf := elbv2gw.LoadBalancerSchemeInternetFacing
+			lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
+				Scheme: &interf,
+			}
+			ipTargetType := elbv2gw.TargetTypeIP
+			gwHCPath := "/gw-healthcheck"
+			svcHCPath := "/svc-healthcheck"
+			hcProtocol := elbv2gw.TargetGroupHealthCheckProtocolHTTP
+			gwTgSpec := elbv2gw.TargetGroupConfigurationSpec{
+				DefaultConfiguration: elbv2gw.TargetGroupProps{
+					TargetType: &ipTargetType,
+					HealthCheckConfig: &elbv2gw.HealthCheckConfiguration{
+						HealthCheckPath:     &gwHCPath,
+						HealthCheckProtocol: &hcProtocol,
+					},
+				},
+			}
+			svcTgSpec := elbv2gw.TargetGroupConfigurationSpec{
+				DefaultConfiguration: elbv2gw.TargetGroupProps{
+					TargetType: &ipTargetType,
+					HealthCheckConfig: &elbv2gw.HealthCheckConfiguration{
+						HealthCheckPath:     &svcHCPath,
+						HealthCheckProtocol: &hcProtocol,
+					},
+				},
+			}
+
+			By("deploying stack", func() {
+				err := stack.DeployGatewayTGCOverride(ctx, tf, lbcSpec, gwTgSpec, svcTgSpec, true)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("checking gateway status for lb dns name", func() {
+				dnsName = stack.GetLoadBalancerIngressHostName()
+				Expect(dnsName).ToNot(BeEmpty())
+			})
+
+			By("querying AWS loadbalancer from the dns name", func() {
+				var err error
+				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(lbARN).ToNot(BeEmpty())
+			})
+
+			By("verifying AWS loadbalancer resources with two ip target groups", func() {
+				expectedTargetGroups := []verifier.ExpectedTargetGroup{
+					{Protocol: "HTTP", Port: 80, NumTargets: int(*stack.albResourceStack.commonStack.dps[0].Spec.Replicas), TargetType: "ip"},
+					{Protocol: "HTTP", Port: 80, NumTargets: int(*stack.albResourceStack.commonStack.dps[1].Spec.Replicas), TargetType: "ip"},
+				}
+				err := verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
+					Type:         "application",
+					Scheme:       "internet-facing",
+					Listeners:    stack.albResourceStack.getListenersPortMap(),
+					TargetGroups: expectedTargetGroups,
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("verifying svc1 inherits gateway TGC and svc2 uses service-level TGC health check path", func() {
+				targetGroups, err := tf.TGManager.GetTargetGroupsForLoadBalancer(ctx, lbARN)
+				Expect(err).NotTo(HaveOccurred())
+				hcPaths := []string{}
+				for _, tg := range targetGroups {
+					hcPaths = append(hcPaths, awssdk.ToString(tg.HealthCheckPath))
+				}
+				Expect(hcPaths).To(ContainElements("/gw-healthcheck", "/svc-healthcheck"))
+			})
+
+			By("waiting for target group targets to be healthy", func() {
+				err := verifier.WaitUntilAllTargetsAreHealthy(ctx, tf, lbARN, int(*stack.albResourceStack.commonStack.dps[0].Spec.Replicas)+int(*stack.albResourceStack.commonStack.dps[1].Spec.Replicas))
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("waiting until DNS name is available", func() {
+				err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("sending http request to the lb", func() {
+				url := fmt.Sprintf("http://%v/any-path", dnsName)
+				err := tf.HTTPVerifier.VerifyURL(url, http.ResponseCodeMatches(200))
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
 })

--- a/test/e2e/gateway/nlb_instance_target_test.go
+++ b/test/e2e/gateway/nlb_instance_target_test.go
@@ -3,10 +3,11 @@ package gateway
 import (
 	"context"
 	"fmt"
-	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 	"strconv"
 	"strings"
 	"time"
+
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	. "github.com/onsi/ginkgo/v2"
@@ -784,6 +785,178 @@ var _ = Describe("test nlb gateway using instance targets reconciled by the aws 
 
 			By("validating TCPRoute and Gateway status", func() {
 				validateTCPRouteListenerMismatch(tf, stack)
+			})
+		})
+	})
+
+	Context("with NLB instance target configuration with Gateway-level default TGC inherited by two services", func() {
+		It("should provision load balancer with both services inheriting from gateway TGC", func() {
+			interf := elbv2gw.LoadBalancerSchemeInternetFacing
+			lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
+				Scheme: &interf,
+			}
+			instanceTargetType := elbv2gw.TargetTypeInstance
+			gwHCPath := "/gw-healthcheck"
+			hcProtocol := elbv2gw.TargetGroupHealthCheckProtocolHTTP
+			gwTgSpec := elbv2gw.TargetGroupConfigurationSpec{
+				DefaultConfiguration: elbv2gw.TargetGroupProps{
+					TargetType: &instanceTargetType,
+					HealthCheckConfig: &elbv2gw.HealthCheckConfiguration{
+						HealthCheckPath:     &gwHCPath,
+						HealthCheckProtocol: &hcProtocol,
+					},
+				},
+			}
+
+			By("deploying stack", func() {
+				err := stack.DeployGatewayTGC(ctx, tf, lbcSpec, gwTgSpec, false, getNamespaceLabels(false))
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("checking gateway status for lb dns name", func() {
+				dnsName = stack.GetLoadBalancerIngressHostName()
+				Expect(dnsName).ToNot(BeEmpty())
+			})
+
+			By("querying AWS loadbalancer from the dns name", func() {
+				var err error
+				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(lbARN).ToNot(BeEmpty())
+			})
+
+			By("verifying AWS loadbalancer resources with two instance target groups", func() {
+				nodeList, err := stack.GetWorkerNodes(ctx, tf)
+				Expect(err).ToNot(HaveOccurred())
+				expectedTargetGroups := []verifier.ExpectedTargetGroup{
+					{Protocol: "TCP", Port: stack.nlbResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort, NumTargets: len(nodeList), TargetType: "instance"},
+					{Protocol: "TCP", Port: stack.nlbResourceStack.commonStack.svcs[1].Spec.Ports[0].NodePort, NumTargets: len(nodeList), TargetType: "instance"},
+				}
+				err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
+					Type:         "network",
+					Scheme:       "internet-facing",
+					Listeners:    stack.nlbResourceStack.getListenersPortMap(),
+					TargetGroups: expectedTargetGroups,
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("verifying both target groups inherit gateway TGC health check path", func() {
+				targetGroups, err := tf.TGManager.GetTargetGroupsForLoadBalancer(ctx, lbARN)
+				Expect(err).NotTo(HaveOccurred())
+				for _, tg := range targetGroups {
+					Expect(awssdk.ToString(tg.HealthCheckPath)).To(Equal("/gw-healthcheck"))
+				}
+			})
+
+			By("waiting for target group targets to be healthy", func() {
+				nodeList, err := stack.GetWorkerNodes(ctx, tf)
+				Expect(err).ToNot(HaveOccurred())
+				err = verifier.WaitUntilAllTargetsAreHealthy(ctx, tf, lbARN, len(nodeList)*2)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("waiting until DNS name is available", func() {
+				err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("sending http request to the lb", func() {
+				url := fmt.Sprintf("http://%v/any-path", dnsName)
+				err := tf.HTTPVerifier.VerifyURL(url, http.ResponseCodeMatches(200))
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
+
+	Context("with NLB instance target configuration with service-level TGC overriding Gateway-level default TGC", func() {
+		It("should provision load balancer where service TGC takes priority over gateway TGC", func() {
+			interf := elbv2gw.LoadBalancerSchemeInternetFacing
+			lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
+				Scheme: &interf,
+			}
+			instanceTargetType := elbv2gw.TargetTypeInstance
+			gwHCPath := "/gw-healthcheck"
+			svcHCPath := "/svc-healthcheck"
+			hcProtocol := elbv2gw.TargetGroupHealthCheckProtocolHTTP
+			gwTgSpec := elbv2gw.TargetGroupConfigurationSpec{
+				DefaultConfiguration: elbv2gw.TargetGroupProps{
+					TargetType: &instanceTargetType,
+					HealthCheckConfig: &elbv2gw.HealthCheckConfiguration{
+						HealthCheckPath:     &gwHCPath,
+						HealthCheckProtocol: &hcProtocol,
+					},
+				},
+			}
+			svcTgSpec := elbv2gw.TargetGroupConfigurationSpec{
+				DefaultConfiguration: elbv2gw.TargetGroupProps{
+					TargetType: &instanceTargetType,
+					HealthCheckConfig: &elbv2gw.HealthCheckConfiguration{
+						HealthCheckPath:     &svcHCPath,
+						HealthCheckProtocol: &hcProtocol,
+					},
+				},
+			}
+
+			By("deploying stack", func() {
+				err := stack.DeployGatewayTGCOverride(ctx, tf, lbcSpec, gwTgSpec, svcTgSpec, false, getNamespaceLabels(false))
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("checking gateway status for lb dns name", func() {
+				dnsName = stack.GetLoadBalancerIngressHostName()
+				Expect(dnsName).ToNot(BeEmpty())
+			})
+
+			By("querying AWS loadbalancer from the dns name", func() {
+				var err error
+				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(lbARN).ToNot(BeEmpty())
+			})
+
+			By("verifying AWS loadbalancer resources with two instance target groups", func() {
+				nodeList, err := stack.GetWorkerNodes(ctx, tf)
+				Expect(err).ToNot(HaveOccurred())
+				expectedTargetGroups := []verifier.ExpectedTargetGroup{
+					{Protocol: "TCP", Port: stack.nlbResourceStack.commonStack.svcs[0].Spec.Ports[0].NodePort, NumTargets: len(nodeList), TargetType: "instance"},
+					{Protocol: "TCP", Port: stack.nlbResourceStack.commonStack.svcs[1].Spec.Ports[0].NodePort, NumTargets: len(nodeList), TargetType: "instance"},
+				}
+				err = verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
+					Type:         "network",
+					Scheme:       "internet-facing",
+					Listeners:    stack.nlbResourceStack.getListenersPortMap(),
+					TargetGroups: expectedTargetGroups,
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("verifying svc1 inherits gateway TGC and svc2 uses service-level TGC health check path", func() {
+				targetGroups, err := tf.TGManager.GetTargetGroupsForLoadBalancer(ctx, lbARN)
+				Expect(err).NotTo(HaveOccurred())
+				hcPaths := []string{}
+				for _, tg := range targetGroups {
+					hcPaths = append(hcPaths, awssdk.ToString(tg.HealthCheckPath))
+				}
+				Expect(hcPaths).To(ContainElements("/gw-healthcheck", "/svc-healthcheck"))
+			})
+
+			By("waiting for target group targets to be healthy", func() {
+				nodeList, err := stack.GetWorkerNodes(ctx, tf)
+				Expect(err).ToNot(HaveOccurred())
+				err = verifier.WaitUntilAllTargetsAreHealthy(ctx, tf, lbARN, len(nodeList)*2)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("waiting until DNS name is available", func() {
+				err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("sending http request to the lb", func() {
+				url := fmt.Sprintf("http://%v/any-path", dnsName)
+				err := tf.HTTPVerifier.VerifyURL(url, http.ResponseCodeMatches(200))
+				Expect(err).NotTo(HaveOccurred())
 			})
 		})
 	})

--- a/webhooks/elbv2/targetgroupconfig_validator.go
+++ b/webhooks/elbv2/targetgroupconfig_validator.go
@@ -1,0 +1,90 @@
+package elbv2
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime"
+	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
+	lbcmetrics "sigs.k8s.io/aws-load-balancer-controller/pkg/metrics/lbc"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/webhook"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+const (
+	apiPathValidateGatewayTargetGroupConfiguration = "/validate-gateway-k8s-aws-v1beta1-targetgroupconfiguration"
+	gatewayKind                                    = "Gateway"
+)
+
+// NewTargetGroupConfigurationValidator returns a validator for the TargetGroupConfiguration CRD.
+func NewTargetGroupConfigurationValidator(k8sClient client.Client, logger logr.Logger, metricsCollector lbcmetrics.MetricCollector) *targetGroupConfigurationValidator {
+	return &targetGroupConfigurationValidator{
+		k8sClient:        k8sClient,
+		logger:           logger,
+		metricsCollector: metricsCollector,
+	}
+}
+
+var _ webhook.Validator = &targetGroupConfigurationValidator{}
+
+type targetGroupConfigurationValidator struct {
+	k8sClient        client.Client
+	logger           logr.Logger
+	metricsCollector lbcmetrics.MetricCollector
+}
+
+func (v *targetGroupConfigurationValidator) Prototype(_ admission.Request) (runtime.Object, error) {
+	return &elbv2gw.TargetGroupConfiguration{}, nil
+}
+
+func (v *targetGroupConfigurationValidator) ValidateCreate(ctx context.Context, obj runtime.Object) error {
+	tgc := obj.(*elbv2gw.TargetGroupConfiguration)
+	return v.checkGatewayTGCUniqueness(ctx, tgc)
+}
+
+func (v *targetGroupConfigurationValidator) ValidateUpdate(ctx context.Context, obj runtime.Object, _ runtime.Object) error {
+	tgc := obj.(*elbv2gw.TargetGroupConfiguration)
+	return v.checkGatewayTGCUniqueness(ctx, tgc)
+}
+
+func (v *targetGroupConfigurationValidator) ValidateDelete(_ context.Context, _ runtime.Object) error {
+	return nil
+}
+
+// checkGatewayTGCUniqueness ensures at most one TargetGroupConfiguration with
+// targetReference.kind=Gateway exists per Gateway in the same namespace.
+func (v *targetGroupConfigurationValidator) checkGatewayTGCUniqueness(ctx context.Context, tgc *elbv2gw.TargetGroupConfiguration) error {
+	if tgc.Spec.TargetReference.Kind == nil || *tgc.Spec.TargetReference.Kind != gatewayKind {
+		return nil
+	}
+
+	tgcList := &elbv2gw.TargetGroupConfigurationList{}
+	if err := v.k8sClient.List(ctx, tgcList, client.InNamespace(tgc.Namespace)); err != nil {
+		return fmt.Errorf("Unable to list TargetGroupConfigurations: %w", err)
+	}
+
+	for _, existing := range tgcList.Items {
+		if existing.Name == tgc.Name {
+			continue
+		}
+		if existing.Spec.TargetReference.Kind != nil &&
+			*existing.Spec.TargetReference.Kind == gatewayKind &&
+			existing.Spec.TargetReference.Name == tgc.Spec.TargetReference.Name {
+			if v.metricsCollector != nil {
+				v.metricsCollector.ObserveWebhookValidationError(apiPathValidateGatewayTargetGroupConfiguration, "checkGatewayTGCUniqueness")
+			}
+			return fmt.Errorf("TargetGroupConfiguration referencing Gateway %q already exists in namespace %q (%s), only one is allowed per Gateway",
+				tgc.Spec.TargetReference.Name, tgc.Namespace, existing.Name)
+		}
+	}
+	return nil
+}
+
+// +kubebuilder:webhook:path=/validate-gateway-k8s-aws-v1beta1-targetgroupconfiguration,mutating=false,failurePolicy=fail,groups=gateway.k8s.aws,resources=targetgroupconfigurations,verbs=create;update,versions=v1beta1,name=vtargetgroupconfiguration.gateway.k8s.aws,sideEffects=None,matchPolicy=Equivalent,webhookVersions=v1,admissionReviewVersions=v1beta1
+
+func (v *targetGroupConfigurationValidator) SetupWithManager(mgr ctrl.Manager) {
+	mgr.GetWebhookServer().Register(apiPathValidateGatewayTargetGroupConfiguration, webhook.ValidatingWebhookForValidator(v, mgr.GetScheme()))
+}

--- a/webhooks/elbv2/targetgroupconfig_validator_test.go
+++ b/webhooks/elbv2/targetgroupconfig_validator_test.go
@@ -1,0 +1,204 @@
+package elbv2
+
+import (
+	"context"
+	"testing"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/testutils"
+)
+
+func TestCheckGatewayTGCUniqueness(t *testing.T) {
+	testCases := []struct {
+		name        string
+		existing    []elbv2gw.TargetGroupConfiguration
+		newTGC      *elbv2gw.TargetGroupConfiguration
+		expectError bool
+	}{
+		{
+			name: "service TGC — no uniqueness check",
+			newTGC: &elbv2gw.TargetGroupConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: "svc-tgc", Namespace: "ns"},
+				Spec: elbv2gw.TargetGroupConfigurationSpec{
+					TargetReference: elbv2gw.Reference{
+						Kind: awssdk.String("Service"),
+						Name: "my-svc",
+					},
+				},
+			},
+		},
+		{
+			name: "service TGC — multiple for same service in same namespace — no conflict",
+			existing: []elbv2gw.TargetGroupConfiguration{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "svc-tgc-1", Namespace: "ns"},
+					Spec: elbv2gw.TargetGroupConfigurationSpec{
+						TargetReference: elbv2gw.Reference{
+							Kind: awssdk.String("Service"),
+							Name: "my-svc",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "svc-tgc-2", Namespace: "ns"},
+					Spec: elbv2gw.TargetGroupConfigurationSpec{
+						TargetReference: elbv2gw.Reference{
+							Kind: awssdk.String("Service"),
+							Name: "my-svc",
+						},
+					},
+				},
+			},
+			newTGC: &elbv2gw.TargetGroupConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: "svc-tgc-3", Namespace: "ns"},
+				Spec: elbv2gw.TargetGroupConfigurationSpec{
+					TargetReference: elbv2gw.Reference{
+						Kind: awssdk.String("Service"),
+						Name: "my-svc",
+					},
+				},
+			},
+		},
+		{
+			name: "gateway TGC — no conflict",
+			newTGC: &elbv2gw.TargetGroupConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: "gw-tgc", Namespace: "ns"},
+				Spec: elbv2gw.TargetGroupConfigurationSpec{
+					TargetReference: elbv2gw.Reference{
+						Kind: awssdk.String(gatewayKind),
+						Name: "my-gw",
+					},
+				},
+			},
+		},
+		{
+			name: "gateway TGC — conflict with existing",
+			existing: []elbv2gw.TargetGroupConfiguration{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "existing-tgc", Namespace: "ns"},
+					Spec: elbv2gw.TargetGroupConfigurationSpec{
+						TargetReference: elbv2gw.Reference{
+							Kind: awssdk.String(gatewayKind),
+							Name: "my-gw",
+						},
+					},
+				},
+			},
+			newTGC: &elbv2gw.TargetGroupConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: "new-tgc", Namespace: "ns"},
+				Spec: elbv2gw.TargetGroupConfigurationSpec{
+					TargetReference: elbv2gw.Reference{
+						Kind: awssdk.String(gatewayKind),
+						Name: "my-gw",
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "gateway TGC — same name (update case) — no conflict",
+			existing: []elbv2gw.TargetGroupConfiguration{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "gw-tgc", Namespace: "ns"},
+					Spec: elbv2gw.TargetGroupConfigurationSpec{
+						TargetReference: elbv2gw.Reference{
+							Kind: awssdk.String(gatewayKind),
+							Name: "my-gw",
+						},
+					},
+				},
+			},
+			newTGC: &elbv2gw.TargetGroupConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: "gw-tgc", Namespace: "ns"},
+				Spec: elbv2gw.TargetGroupConfigurationSpec{
+					TargetReference: elbv2gw.Reference{
+						Kind: awssdk.String(gatewayKind),
+						Name: "my-gw",
+					},
+				},
+			},
+		},
+		{
+			name: "gateway TGC — different gateway name — no conflict",
+			existing: []elbv2gw.TargetGroupConfiguration{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "existing-tgc", Namespace: "ns"},
+					Spec: elbv2gw.TargetGroupConfigurationSpec{
+						TargetReference: elbv2gw.Reference{
+							Kind: awssdk.String(gatewayKind),
+							Name: "other-gw",
+						},
+					},
+				},
+			},
+			newTGC: &elbv2gw.TargetGroupConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: "new-tgc", Namespace: "ns"},
+				Spec: elbv2gw.TargetGroupConfigurationSpec{
+					TargetReference: elbv2gw.Reference{
+						Kind: awssdk.String(gatewayKind),
+						Name: "my-gw",
+					},
+				},
+			},
+		},
+		{
+			name: "gateway TGC — different namespace — no conflict",
+			existing: []elbv2gw.TargetGroupConfiguration{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "existing-tgc", Namespace: "other-ns"},
+					Spec: elbv2gw.TargetGroupConfigurationSpec{
+						TargetReference: elbv2gw.Reference{
+							Kind: awssdk.String(gatewayKind),
+							Name: "my-gw",
+						},
+					},
+				},
+			},
+			newTGC: &elbv2gw.TargetGroupConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: "new-tgc", Namespace: "ns"},
+				Spec: elbv2gw.TargetGroupConfigurationSpec{
+					TargetReference: elbv2gw.Reference{
+						Kind: awssdk.String(gatewayKind),
+						Name: "my-gw",
+					},
+				},
+			},
+		},
+		{
+			name: "nil kind — no uniqueness check",
+			newTGC: &elbv2gw.TargetGroupConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: "tgc", Namespace: "ns"},
+				Spec: elbv2gw.TargetGroupConfigurationSpec{
+					TargetReference: elbv2gw.Reference{
+						Name: "my-svc",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			k8sClient := testutils.GenerateTestClient()
+
+			for i := range tc.existing {
+				err := k8sClient.Create(context.Background(), &tc.existing[i])
+				assert.NoError(t, err)
+			}
+
+			v := &targetGroupConfigurationValidator{
+				k8sClient: k8sClient,
+			}
+
+			err := v.checkGatewayTGCUniqueness(context.Background(), tc.newTGC)
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Issue
https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4589

### Description
Added support for gateway level tgc definition. Priority order: 
- Service-level TGC exists → use its defaultConfiguration + its routeConfigurations (gateway TGC ignored entirely)
- No service-level TGC, gateway-level TGC exists → use gateway TGC's defaultConfiguration + its routeConfigurations
- Neither exists → controller defaults

Changes summary
- add webhook to verify only one gateway level TGC allowed in same namespace, error will occur when apply 
```
Error from server (Forbidden): error when creating "gateway-level-tgc.yaml": admission webhook "vtargetgroupconfiguration.gateway.k8s.aws" denied the request: TargetGroupConfiguration referencing Gateway "my-gateway" already exists in namespace "gw-tgc-test" (gateway-defaults), only one is allowed per Gateway
```
- add `setGatewayDefaultTGConfig` so it will only need to be loaded once per reconcile. i thought about passes gatewayNamespacedName down the chain, and serviceLoader does a k8s List call every time it needs the fallback. With N service backends and none having their own TGC, that's N identical List calls per reconcile. so ended up not choosing this method 
- modify documentation 
- added test case to e2e test

### Checklist
- [x] Added tests that cover your change (if possible)
```
ginkgo -v -r test/e2e/gateway -- --kubeconfig=$KUBECONFIG --cluster-name=awslbc-xx --aws-region=us-west-2 --aws-vpc-id=vpc-xxx --enable-gateway-tests -ginkgo.focus="Gateway-level default TGC"

Ran 8 of 49 Specs in 2272.136 seconds
SUCCESS! -- 8 Passed | 0 Failed | 0 Pending | 41 Skipped
PASS

Ginkgo ran 1 suite in 38m25.478929708s
Test Suite Passed
```
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
```
##############################################
# 1. Namespace
##############################################
apiVersion: v1
kind: Namespace
metadata:
  name: gw-tgc-test
---
##############################################
# 2. GatewayClass (ALB)
##############################################
apiVersion: gateway.networking.k8s.io/v1
kind: GatewayClass
metadata:
  name: gw-tgc-test-class
spec:
  controllerName: gateway.k8s.aws/alb
---
##############################################
# 3. Gateway
##############################################
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: my-gateway
  namespace: gw-tgc-test
spec:
  gatewayClassName: gw-tgc-test-class
  listeners:
    - name: http
      port: 80
      protocol: HTTP
---
##############################################
# 4. LoadBalancerConfiguration
##############################################
apiVersion: gateway.k8s.aws/v1beta1
kind: LoadBalancerConfiguration
metadata:
  name: my-gateway
  namespace: gw-tgc-test
spec:
  scheme: internet-facing
---
##############################################
# 5. Gateway-level TargetGroupConfiguration
#    (targets the Gateway, not a Service)
##############################################
apiVersion: gateway.k8s.aws/v1beta1
kind: TargetGroupConfiguration
metadata:
  name: gateway-defaults
  namespace: gw-tgc-test
spec:
  targetReference:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: my-gateway
  defaultConfiguration:
    targetType: ip
    healthCheckConfig:
      healthCheckProtocol: HTTP
      healthCheckPath: /gw-healthcheck
      healthCheckInterval: 15
      healthyThresholdCount: 2
      unhealthyThresholdCount: 3
---
apiVersion: gateway.k8s.aws/v1beta1
kind: TargetGroupConfiguration
metadata:
  name: gateway-defaults-should-fail
  namespace: gw-tgc-test
spec:
  targetReference:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: my-gateway
  defaultConfiguration:
    targetType: ip
    healthCheckConfig:
      healthCheckProtocol: HTTP
      healthCheckPath: /gw-healthcheck
      healthCheckInterval: 10
      healthyThresholdCount: 10
      unhealthyThresholdCount: 10
---
##############################################
# 6. Deployment — svc1 (no service-level TGC,
#    should inherit from gateway TGC)
##############################################
apiVersion: apps/v1
kind: Deployment
metadata:
  name: svc1
  namespace: gw-tgc-test
spec:
  replicas: 2
  selector:
    matchLabels:
      app: svc1
  template:
    metadata:
      labels:
        app: svc1
    spec:
      containers:
        - name: app
          image: public.ecr.aws/nginx/nginx:latest
          ports:
            - containerPort: 80
---
apiVersion: v1
kind: Service
metadata:
  name: svc1
  namespace: gw-tgc-test
spec:
  selector:
    app: svc1
  ports:
    - port: 80
      targetPort: 80
---
##############################################
# 7. Deployment — svc2 (has its own service-level
#    TGC that overrides the gateway TGC)
##############################################
apiVersion: apps/v1
kind: Deployment
metadata:
  name: svc2
  namespace: gw-tgc-test
spec:
  replicas: 2
  selector:
    matchLabels:
      app: svc2
  template:
    metadata:
      labels:
        app: svc2
    spec:
      containers:
        - name: app
          image: public.ecr.aws/nginx/nginx:latest
          ports:
            - containerPort: 80
---
apiVersion: v1
kind: Service
metadata:
  name: svc2
  namespace: gw-tgc-test
spec:
  selector:
    app: svc2
  ports:
    - port: 80
      targetPort: 80
---
##############################################
# 8. Service-level TGC for svc2 only
#    (overrides gateway TGC for this service)
##############################################
apiVersion: gateway.k8s.aws/v1beta1
kind: TargetGroupConfiguration
metadata:
  name: svc2-tgc
  namespace: gw-tgc-test
spec:
  targetReference:
    kind: Service
    name: svc2
  defaultConfiguration:
    targetType: ip
    healthCheckConfig:
      healthCheckProtocol: HTTP
      healthCheckPath: /svc-healthcheck
      healthCheckInterval: 10
      healthyThresholdCount: 3
      unhealthyThresholdCount: 2
---
##############################################
# 9. HTTPRoute — routes traffic to both services
##############################################
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: test-route
  namespace: gw-tgc-test
spec:
  parentRefs:
    - name: my-gateway
      sectionName: http
  rules:
    - backendRefs:
        - name: svc1
          port: 80
        - name: svc2
          port: 80

```
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
