### PR TITLE
[Gateway API] Validate ListenerSet listeners

### DIFF
--- a/controllers/gateway/gateway_controller.go
+++ b/controllers/gateway/gateway_controller.go
@@ -231,12 +231,16 @@ func (r *gatewayReconciler) reconcileHelper(ctx context.Context, req reconcile.R
 
 	loaderResults, err := r.gatewayLoader.LoadRoutesForGateway(ctx, *gw, r.routeFilter, r.controllerName, resolvedDefaultTGC)
 
-	if err != nil || loaderResults.ValidationResults.HasErrors {
+	validationHasErrors := false
+	if loaderResults != nil {
+		validationHasErrors = loaderResults.ValidationResults.HasErrors()
+	}
+	if err != nil || validationHasErrors {
 		var loaderErr routeutils.LoaderError
-		if errors.As(err, &loaderErr) || loaderResults.ValidationResults.HasErrors {
+		if errors.As(err, &loaderErr) || validationHasErrors {
 			var gatewayReason gwv1.GatewayConditionReason
 			var gatewayMessage string
-			if loaderErr == nil && loaderResults.ValidationResults.HasErrors {
+			if loaderErr == nil && validationHasErrors {
 				gatewayReason = gwv1.GatewayReasonAccepted
 				gatewayMessage = gateway_constants.GatewayAcceptedFalseMessage
 			} else {

--- a/controllers/gateway/listener_status_utils.go
+++ b/controllers/gateway/listener_status_utils.go
@@ -11,8 +11,9 @@ import (
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
-func buildListenerStatus(gateway gwv1.Gateway, listeners []gwv1.Listener, attachedRoutesMap map[gwv1.SectionName]int32, validateListenerResults routeutils.ListenerValidationResults, isProgrammed bool) []gwv1.ListenerStatus {
+func buildListenerStatus(gateway gwv1.Gateway, listeners []gwv1.Listener, attachedRoutesMap map[gwv1.SectionName]int32, validatedListeners routeutils.ValidatedGatewayListeners, isProgrammed bool) []gwv1.ListenerStatus {
 	var listenerStatuses []gwv1.ListenerStatus
+	validateListenerResults := validatedListeners.GatewayListenerValidation
 
 	for _, listener := range listeners {
 		listenerValidationResult := validateListenerResults.Results[listener.Name]

--- a/controllers/gateway/listener_status_utils_test.go
+++ b/controllers/gateway/listener_status_utils_test.go
@@ -16,7 +16,7 @@ func Test_buildListenerStatus(t *testing.T) {
 		name                    string
 		gateway                 gwv1.Gateway
 		attachedRoutesMap       map[gwv1.SectionName]int32
-		validateListenerResults routeutils.ListenerValidationResults
+		validateListenerResults routeutils.ValidatedGatewayListeners
 		supportedKinds          []gwv1.RouteGroupKind
 		isProgrammed            bool
 		expectedListenerCount   int
@@ -37,11 +37,13 @@ func Test_buildListenerStatus(t *testing.T) {
 				},
 			},
 			attachedRoutesMap: map[gwv1.SectionName]int32{"listener1": 1},
-			validateListenerResults: routeutils.ListenerValidationResults{
-				Results: map[gwv1.SectionName]routeutils.ListenerValidationResult{
-					"listener1": {Reason: gwv1.ListenerReasonAccepted, Message: "accepted", SupportedKinds: []gwv1.RouteGroupKind{{
-						Kind: "HTTPRoute",
-					}}},
+			validateListenerResults: routeutils.ValidatedGatewayListeners{
+				GatewayListenerValidation: routeutils.ListenerValidationResults{
+					Results: map[gwv1.SectionName]routeutils.ListenerValidationResult{
+						"listener1": {Reason: gwv1.ListenerReasonAccepted, Message: "accepted", SupportedKinds: []gwv1.RouteGroupKind{{
+							Kind: "HTTPRoute",
+						}}},
+					},
 				},
 			},
 			supportedKinds: []gwv1.RouteGroupKind{{
@@ -59,7 +61,7 @@ func Test_buildListenerStatus(t *testing.T) {
 				},
 			},
 			attachedRoutesMap:       map[gwv1.SectionName]int32{},
-			validateListenerResults: routeutils.ListenerValidationResults{},
+			validateListenerResults: routeutils.ValidatedGatewayListeners{},
 			isProgrammed:            true,
 			expectedListenerCount:   0,
 		},

--- a/pkg/gateway/routeutils/listener_set.go
+++ b/pkg/gateway/routeutils/listener_set.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
@@ -21,7 +23,7 @@ const (
 )
 
 type listenerSetLoader interface {
-	retrieveListenersFromListenerSets(ctx context.Context, gateway gwv1.Gateway) ([]gwv1.Listener, []*gwv1.ListenerSet, error)
+	retrieveListenersFromListenerSets(ctx context.Context, gateway gwv1.Gateway) (listenerSetLoadResult, []*gwv1.ListenerSet, error)
 }
 
 type listenerSetLoaderImpl struct {
@@ -34,30 +36,40 @@ func newListenerSetLoader(k8sClient client.Client, logger logr.Logger) listenerS
 	return &listenerSetLoaderImpl{
 		k8sClient:         k8sClient,
 		namespaceSelector: newNamespaceSelector(k8sClient),
-		logger:            logger.WithName("listener-set-loader"),
+		logger:            logger,
 	}
 }
 
-func (l *listenerSetLoaderImpl) retrieveListenersFromListenerSets(ctx context.Context, gateway gwv1.Gateway) ([]gwv1.Listener, []*gwv1.ListenerSet, error) {
+type listenerSetLoadResult struct {
+	listenersPerListenerSet map[types.NamespacedName][]listenerSetListenerSource
+	acceptedListenerSets    []*gwv1.ListenerSet
+}
+
+func (l *listenerSetLoaderImpl) retrieveListenersFromListenerSets(ctx context.Context, gateway gwv1.Gateway) (listenerSetLoadResult, []*gwv1.ListenerSet, error) {
 	listenerSets := &gwv1.ListenerSetList{}
 	err := l.k8sClient.List(ctx, listenerSets)
 	if err != nil {
-		return nil, nil, err
+		return listenerSetLoadResult{}, nil, err
 	}
 
 	rejectedListenerSets := make([]*gwv1.ListenerSet, 0)
 
-	var result []gwv1.Listener
+	listenersPerListenerSet := make(map[types.NamespacedName][]listenerSetListenerSource)
+	acceptedListenerSets := make([]*gwv1.ListenerSet, 0)
 	for i, item := range listenerSets.Items {
 		handshake, err := l.listenerSetGatewayHandshake(ctx, item, gateway)
 		if err != nil {
-			return nil, nil, err
+			return listenerSetLoadResult{}, nil, err
 		}
 		switch handshake {
 		case acceptedHandshakeState:
+			var convertedListeners []listenerSetListenerSource
 			for _, listener := range item.Spec.Listeners {
-				result = append(result, l.convertListenerSetListenerToGatewayListener(listener))
+				convertedListeners = append(convertedListeners, l.convertListenerSetListenerToGatewayListener(item, listener))
 			}
+			itemPtr := &listenerSets.Items[i]
+			listenersPerListenerSet[k8s.NamespacedName(itemPtr)] = convertedListeners
+			acceptedListenerSets = append(acceptedListenerSets, itemPtr)
 			break
 		case gatewayRejectedHandshakeState:
 			rejectedListenerSets = append(rejectedListenerSets, &listenerSets.Items[i])
@@ -69,7 +81,10 @@ func (l *listenerSetLoaderImpl) retrieveListenersFromListenerSets(ctx context.Co
 
 	}
 
-	return result, rejectedListenerSets, nil
+	return listenerSetLoadResult{
+		listenersPerListenerSet: listenersPerListenerSet,
+		acceptedListenerSets:    acceptedListenerSets,
+	}, rejectedListenerSets, nil
 }
 
 func (l *listenerSetLoaderImpl) listenerSetGatewayHandshake(ctx context.Context, listenerSet gwv1.ListenerSet, gw gwv1.Gateway) (handshakeState, error) {
@@ -110,14 +125,18 @@ func (l *listenerSetLoaderImpl) convertListenerSetParentRef(ref gwv1.ParentGatew
 	}
 }
 
-func (l *listenerSetLoaderImpl) convertListenerSetListenerToGatewayListener(entry gwv1.ListenerEntry) gwv1.Listener {
-	return gwv1.Listener{
+func (l *listenerSetLoaderImpl) convertListenerSetListenerToGatewayListener(listenerSet gwv1.ListenerSet, entry gwv1.ListenerEntry) listenerSetListenerSource {
+	v := gwv1.Listener{
 		Name:          entry.Name,
 		Hostname:      entry.Hostname,
 		Port:          entry.Port,
 		Protocol:      entry.Protocol,
 		TLS:           entry.TLS,
 		AllowedRoutes: entry.AllowedRoutes,
+	}
+	return listenerSetListenerSource{
+		parentRef: listenerSet,
+		listener:  v,
 	}
 }
 

--- a/pkg/gateway/routeutils/listener_set_test.go
+++ b/pkg/gateway/routeutils/listener_set_test.go
@@ -60,6 +60,10 @@ func Test_convertListenerSetListenerToGatewayListener(t *testing.T) {
 	hostname := gwv1.Hostname("example.com")
 	tlsMode := gwv1.TLSModeTerminate
 
+	ls := gwv1.ListenerSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-ls", Namespace: "ns1"},
+	}
+
 	entry := gwv1.ListenerEntry{
 		Name:     "my-listener",
 		Hostname: &hostname,
@@ -75,14 +79,15 @@ func Test_convertListenerSetListenerToGatewayListener(t *testing.T) {
 		},
 	}
 
-	result := loader.convertListenerSetListenerToGatewayListener(entry)
+	result := loader.convertListenerSetListenerToGatewayListener(ls, entry)
 
-	assert.Equal(t, gwv1.SectionName("my-listener"), result.Name)
-	assert.Equal(t, &hostname, result.Hostname)
-	assert.Equal(t, gwv1.PortNumber(8080), result.Port)
-	assert.Equal(t, gwv1.HTTPSProtocolType, result.Protocol)
-	assert.Equal(t, &tlsMode, result.TLS.Mode)
-	assert.NotNil(t, result.AllowedRoutes)
+	assert.Equal(t, ls, result.parentRef)
+	assert.Equal(t, gwv1.SectionName("my-listener"), result.listener.Name)
+	assert.Equal(t, &hostname, result.listener.Hostname)
+	assert.Equal(t, gwv1.PortNumber(8080), result.listener.Port)
+	assert.Equal(t, gwv1.HTTPSProtocolType, result.listener.Protocol)
+	assert.Equal(t, &tlsMode, result.listener.TLS.Mode)
+	assert.NotNil(t, result.listener.AllowedRoutes)
 }
 
 func Test_listenerSetGatewayHandshake(t *testing.T) {
@@ -104,9 +109,7 @@ func Test_listenerSetGatewayHandshake(t *testing.T) {
 			listenerSet: gwv1.ListenerSet{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "ns1"},
 				Spec: gwv1.ListenerSetSpec{
-					ParentRef: gwv1.ParentGatewayReference{
-						Name: "other-gw",
-					},
+					ParentRef: gwv1.ParentGatewayReference{Name: "other-gw"},
 				},
 			},
 			gw: gwv1.Gateway{
@@ -119,9 +122,7 @@ func Test_listenerSetGatewayHandshake(t *testing.T) {
 			listenerSet: gwv1.ListenerSet{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "ns1"},
 				Spec: gwv1.ListenerSetSpec{
-					ParentRef: gwv1.ParentGatewayReference{
-						Name: "my-gw",
-					},
+					ParentRef: gwv1.ParentGatewayReference{Name: "my-gw"},
 				},
 			},
 			gw: gwv1.Gateway{
@@ -134,18 +135,14 @@ func Test_listenerSetGatewayHandshake(t *testing.T) {
 			listenerSet: gwv1.ListenerSet{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "ns1"},
 				Spec: gwv1.ListenerSetSpec{
-					ParentRef: gwv1.ParentGatewayReference{
-						Name: "my-gw",
-					},
+					ParentRef: gwv1.ParentGatewayReference{Name: "my-gw"},
 				},
 			},
 			gw: gwv1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{Name: "my-gw", Namespace: "ns1"},
 				Spec: gwv1.GatewaySpec{
 					AllowedListeners: &gwv1.AllowedListeners{
-						Namespaces: &gwv1.ListenerNamespaces{
-							From: &nsSame,
-						},
+						Namespaces: &gwv1.ListenerNamespaces{From: &nsSame},
 					},
 				},
 			},
@@ -166,9 +163,7 @@ func Test_listenerSetGatewayHandshake(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "my-gw", Namespace: "ns1"},
 				Spec: gwv1.GatewaySpec{
 					AllowedListeners: &gwv1.AllowedListeners{
-						Namespaces: &gwv1.ListenerNamespaces{
-							From: &nsSame,
-						},
+						Namespaces: &gwv1.ListenerNamespaces{From: &nsSame},
 					},
 				},
 			},
@@ -189,9 +184,7 @@ func Test_listenerSetGatewayHandshake(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "my-gw", Namespace: "ns1"},
 				Spec: gwv1.GatewaySpec{
 					AllowedListeners: &gwv1.AllowedListeners{
-						Namespaces: &gwv1.ListenerNamespaces{
-							From: &nsAll,
-						},
+						Namespaces: &gwv1.ListenerNamespaces{From: &nsAll},
 					},
 				},
 			},
@@ -258,7 +251,6 @@ func Test_listenerSetGatewayHandshake(t *testing.T) {
 				},
 				logger: logr.Discard(),
 			}
-
 			result, err := loader.listenerSetGatewayHandshake(context.Background(), tc.listenerSet, tc.gw)
 			if tc.expectErr {
 				assert.Error(t, err)
@@ -279,7 +271,7 @@ func Test_retrieveListenersFromListenerSets(t *testing.T) {
 		listenerSets          []*gwv1.ListenerSet
 		gw                    gwv1.Gateway
 		expectedListenerCount int
-		expectedListenerNames []gwv1.SectionName
+		expectedMapKeys       int
 		expectedRejectedCount int
 		expectedRejectedNames []string
 		expectErr             bool
@@ -290,13 +282,12 @@ func Test_retrieveListenersFromListenerSets(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "my-gw", Namespace: "ns1"},
 				Spec: gwv1.GatewaySpec{
 					AllowedListeners: &gwv1.AllowedListeners{
-						Namespaces: &gwv1.ListenerNamespaces{
-							From: &nsAll,
-						},
+						Namespaces: &gwv1.ListenerNamespaces{From: &nsAll},
 					},
 				},
 			},
 			expectedListenerCount: 0,
+			expectedMapKeys:       0,
 			expectedRejectedCount: 0,
 		},
 		{
@@ -305,20 +296,10 @@ func Test_retrieveListenersFromListenerSets(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "ls1", Namespace: "ns1"},
 					Spec: gwv1.ListenerSetSpec{
-						ParentRef: gwv1.ParentGatewayReference{
-							Name: "my-gw",
-						},
+						ParentRef: gwv1.ParentGatewayReference{Name: "my-gw"},
 						Listeners: []gwv1.ListenerEntry{
-							{
-								Name:     "listener-a",
-								Port:     8080,
-								Protocol: gwv1.HTTPProtocolType,
-							},
-							{
-								Name:     "listener-b",
-								Port:     8443,
-								Protocol: gwv1.HTTPSProtocolType,
-							},
+							{Name: "listener-a", Port: 8080, Protocol: gwv1.HTTPProtocolType},
+							{Name: "listener-b", Port: 8443, Protocol: gwv1.HTTPSProtocolType},
 						},
 					},
 				},
@@ -327,14 +308,12 @@ func Test_retrieveListenersFromListenerSets(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "my-gw", Namespace: "ns1"},
 				Spec: gwv1.GatewaySpec{
 					AllowedListeners: &gwv1.AllowedListeners{
-						Namespaces: &gwv1.ListenerNamespaces{
-							From: &nsAll,
-						},
+						Namespaces: &gwv1.ListenerNamespaces{From: &nsAll},
 					},
 				},
 			},
 			expectedListenerCount: 2,
-			expectedListenerNames: []gwv1.SectionName{"listener-a", "listener-b"},
+			expectedMapKeys:       1,
 			expectedRejectedCount: 0,
 		},
 		{
@@ -343,15 +322,9 @@ func Test_retrieveListenersFromListenerSets(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "ls1", Namespace: "ns1"},
 					Spec: gwv1.ListenerSetSpec{
-						ParentRef: gwv1.ParentGatewayReference{
-							Name: "other-gw",
-						},
+						ParentRef: gwv1.ParentGatewayReference{Name: "other-gw"},
 						Listeners: []gwv1.ListenerEntry{
-							{
-								Name:     "listener-a",
-								Port:     8080,
-								Protocol: gwv1.HTTPProtocolType,
-							},
+							{Name: "listener-a", Port: 8080, Protocol: gwv1.HTTPProtocolType},
 						},
 					},
 				},
@@ -360,13 +333,12 @@ func Test_retrieveListenersFromListenerSets(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "my-gw", Namespace: "ns1"},
 				Spec: gwv1.GatewaySpec{
 					AllowedListeners: &gwv1.AllowedListeners{
-						Namespaces: &gwv1.ListenerNamespaces{
-							From: &nsAll,
-						},
+						Namespaces: &gwv1.ListenerNamespaces{From: &nsAll},
 					},
 				},
 			},
 			expectedListenerCount: 0,
+			expectedMapKeys:       0,
 			expectedRejectedCount: 0,
 		},
 		{
@@ -380,11 +352,7 @@ func Test_retrieveListenersFromListenerSets(t *testing.T) {
 							Namespace: (*gwv1.Namespace)(awssdk.String("ns1")),
 						},
 						Listeners: []gwv1.ListenerEntry{
-							{
-								Name:     "rejected-listener",
-								Port:     80,
-								Protocol: gwv1.HTTPProtocolType,
-							},
+							{Name: "rejected-listener", Port: 80, Protocol: gwv1.HTTPProtocolType},
 						},
 					},
 				},
@@ -393,13 +361,12 @@ func Test_retrieveListenersFromListenerSets(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "my-gw", Namespace: "ns1"},
 				Spec: gwv1.GatewaySpec{
 					AllowedListeners: &gwv1.AllowedListeners{
-						Namespaces: &gwv1.ListenerNamespaces{
-							From: &nsSame,
-						},
+						Namespaces: &gwv1.ListenerNamespaces{From: &nsSame},
 					},
 				},
 			},
 			expectedListenerCount: 0,
+			expectedMapKeys:       0,
 			expectedRejectedCount: 1,
 			expectedRejectedNames: []string{"ls-rejected"},
 		},
@@ -409,15 +376,9 @@ func Test_retrieveListenersFromListenerSets(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "ls-accepted", Namespace: "ns1"},
 					Spec: gwv1.ListenerSetSpec{
-						ParentRef: gwv1.ParentGatewayReference{
-							Name: "my-gw",
-						},
+						ParentRef: gwv1.ParentGatewayReference{Name: "my-gw"},
 						Listeners: []gwv1.ListenerEntry{
-							{
-								Name:     "accepted-listener",
-								Port:     80,
-								Protocol: gwv1.HTTPProtocolType,
-							},
+							{Name: "accepted-listener", Port: 80, Protocol: gwv1.HTTPProtocolType},
 						},
 					},
 				},
@@ -429,26 +390,16 @@ func Test_retrieveListenersFromListenerSets(t *testing.T) {
 							Namespace: (*gwv1.Namespace)(awssdk.String("ns1")),
 						},
 						Listeners: []gwv1.ListenerEntry{
-							{
-								Name:     "rejected-listener",
-								Port:     80,
-								Protocol: gwv1.HTTPProtocolType,
-							},
+							{Name: "rejected-listener", Port: 80, Protocol: gwv1.HTTPProtocolType},
 						},
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "ls-irrelevant", Namespace: "ns1"},
 					Spec: gwv1.ListenerSetSpec{
-						ParentRef: gwv1.ParentGatewayReference{
-							Name: "other-gw",
-						},
+						ParentRef: gwv1.ParentGatewayReference{Name: "other-gw"},
 						Listeners: []gwv1.ListenerEntry{
-							{
-								Name:     "irrelevant-listener",
-								Port:     80,
-								Protocol: gwv1.HTTPProtocolType,
-							},
+							{Name: "irrelevant-listener", Port: 80, Protocol: gwv1.HTTPProtocolType},
 						},
 					},
 				},
@@ -457,14 +408,12 @@ func Test_retrieveListenersFromListenerSets(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "my-gw", Namespace: "ns1"},
 				Spec: gwv1.GatewaySpec{
 					AllowedListeners: &gwv1.AllowedListeners{
-						Namespaces: &gwv1.ListenerNamespaces{
-							From: &nsSame,
-						},
+						Namespaces: &gwv1.ListenerNamespaces{From: &nsSame},
 					},
 				},
 			},
 			expectedListenerCount: 1,
-			expectedListenerNames: []gwv1.SectionName{"accepted-listener"},
+			expectedMapKeys:       1,
 			expectedRejectedCount: 1,
 			expectedRejectedNames: []string{"ls-rejected"},
 		},
@@ -484,22 +433,23 @@ func Test_retrieveListenersFromListenerSets(t *testing.T) {
 				logger:            logr.Discard(),
 			}
 
-			listeners, rejectedSets, err := loader.retrieveListenersFromListenerSets(context.Background(), tc.gw)
+			loadResult, rejectedSets, err := loader.retrieveListenersFromListenerSets(context.Background(), tc.gw)
 			if tc.expectErr {
 				assert.Error(t, err)
 				return
 			}
 			assert.NoError(t, err)
-			assert.Len(t, listeners, tc.expectedListenerCount)
+			assert.Len(t, loadResult.listenersPerListenerSet, tc.expectedMapKeys)
 			assert.Len(t, rejectedSets, tc.expectedRejectedCount)
 
-			if tc.expectedListenerNames != nil {
-				var names []gwv1.SectionName
-				for _, l := range listeners {
-					names = append(names, l.Name)
-				}
-				assert.Equal(t, tc.expectedListenerNames, names)
+			totalListeners := 0
+			for _, sources := range loadResult.listenersPerListenerSet {
+				totalListeners += len(sources)
 			}
+			assert.Equal(t, tc.expectedListenerCount, totalListeners)
+
+			// acceptedListenerSets count should match the number of map keys
+			assert.Len(t, loadResult.acceptedListenerSets, tc.expectedMapKeys)
 
 			if tc.expectedRejectedNames != nil {
 				var rejectedNames []string

--- a/pkg/gateway/routeutils/listener_utils.go
+++ b/pkg/gateway/routeutils/listener_utils.go
@@ -2,11 +2,41 @@ package routeutils
 
 import (
 	"fmt"
+	"sort"
 
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	gateway_constants "sigs.k8s.io/aws-load-balancer-controller/pkg/gateway/constants"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
+
+type listenerSetListenerSource struct {
+	parentRef gwv1.ListenerSet
+	listener  gwv1.Listener
+}
+
+type allListeners struct {
+	GatewayListeners     []gwv1.Listener
+	ListenerSetListeners listenerSetLoadResult
+}
+
+type ValidatedGatewayListeners struct {
+	GatewayListenerValidation     ListenerValidationResults
+	ListenerSetListenerValidation map[types.NamespacedName]ListenerValidationResults
+}
+
+func (v ValidatedGatewayListeners) HasErrors() bool {
+	if v.GatewayListenerValidation.HasErrors {
+		return true
+	}
+	for _, lsValidation := range v.ListenerSetListenerValidation {
+		if lsValidation.HasErrors {
+			return true
+		}
+	}
+	return false
+}
 
 type ListenerValidationResult struct {
 	ListenerName   gwv1.SectionName
@@ -26,19 +56,44 @@ type ListenerValidationResults struct {
 // It checks for supported route kinds, valid port ranges (1-65535), controller-compatible protocols
 // (ALB: HTTP/HTTPS/GRPC, NLB: TCP/UDP/TLS), protocol conflicts on same ports (except TCP+UDP),
 // hostname conflicts - same port trying to use same hostname
-func validateListeners(listeners []gwv1.Listener, controllerName string) ListenerValidationResults {
+func validateListeners(configuredListeners allListeners, controllerName string) ValidatedGatewayListeners {
+	portHostnameMap := make(map[string]bool)
+	portProtocolMap := make(map[gwv1.PortNumber]gwv1.ProtocolType)
+
+	// Track portHostnameMap and portProtocolMap throughout the validation cycle. This allows us to give priority
+	// to listeners. For example, we need to allow listeners defined in the Gateway directly to be given configuration
+	// priority over listeners defined in a listener set. By validating listeners from the Gateway first, we allow those
+	// listeners to pass validation, any listener set listeners that will conflict will fail validation but not
+	// block the listener attachment process.
+
+	gatewayValidationResults := validateListenerList(configuredListeners.GatewayListeners, portHostnameMap, portProtocolMap, controllerName)
+
+	listenerSetPriorityOrder := arrangeListenerSetsForValidation(configuredListeners.ListenerSetListeners)
+
+	// The sorting is important, as we are building the combined listener representation in
+	// portProtocolMap and portHostnameMap.
+	// We give precedence to listeners seen previously,
+	// meaning that we will accept the initial listener, and then fail the subsequent listener that conflicts.
+
+	listenerSetValidationResults := map[types.NamespacedName]ListenerValidationResults{}
+
+	for _, ls := range listenerSetPriorityOrder {
+		listenerSetListeners := configuredListeners.ListenerSetListeners.listenersPerListenerSet[k8s.NamespacedName(ls)]
+		listenerSetValidationResults[k8s.NamespacedName(ls)] = validateListenerList(extractListenerFromListenerSource(listenerSetListeners), portHostnameMap, portProtocolMap, controllerName)
+	}
+
+	return ValidatedGatewayListeners{
+		GatewayListenerValidation:     gatewayValidationResults,
+		ListenerSetListenerValidation: listenerSetValidationResults,
+	}
+}
+
+func validateListenerList(listenerList []gwv1.Listener, portHostnameMap map[string]bool, portProtocolMap map[gwv1.PortNumber]gwv1.ProtocolType, controllerName string) ListenerValidationResults {
 	results := ListenerValidationResults{
 		Results: make(map[gwv1.SectionName]ListenerValidationResult),
 	}
 
-	if len(listeners) == 0 {
-		return results
-	}
-
-	portHostnameMap := make(map[string]bool)
-	portProtocolMap := make(map[gwv1.PortNumber]gwv1.ProtocolType)
-
-	for _, listener := range listeners {
+	for _, listener := range listenerList {
 		// check supported kinds
 		supportedKinds, isKindSupported := getSupportedKinds(controllerName, listener)
 		result := ListenerValidationResult{
@@ -102,10 +157,8 @@ func validateListeners(listeners []gwv1.Listener, controllerName string) Listene
 				}
 			}
 		}
-
 		results.Results[listener.Name] = result
 	}
-
 	return results
 }
 
@@ -147,4 +200,47 @@ func getSupportedKinds(controllerName string, listener gwv1.Listener) ([]gwv1.Ro
 	}
 
 	return supportedKinds, isKindSupported
+}
+
+func arrangeListenerSetsForValidation(lsResult listenerSetLoadResult) []*gwv1.ListenerSet {
+	/*
+		Listeners in a Gateway and their attached ListenerSets are concatenated as a list when programming the underlying infrastructure
+
+		Listeners should be merged using the following precedence:
+
+		    "parent" Gateway
+		    ListenerSet ordered by creation time (oldest first)
+		    ListenerSet ordered alphabetically by “{namespace}/{name}”.
+		https://gateway-api.sigs.k8s.io/geps/gep-1713/#listener-precedence
+	*/
+
+	orderedListenerSets := make([]*gwv1.ListenerSet, 0)
+	for i := range lsResult.acceptedListenerSets {
+		orderedListenerSets = append(orderedListenerSets, lsResult.acceptedListenerSets[i])
+	}
+
+	// First sort by namespaced name (conveniently the namespaced name generates the string representation in the form
+	// “{namespace}/{name}”.
+	sort.Slice(orderedListenerSets, func(i, j int) bool {
+		insn := k8s.NamespacedName(orderedListenerSets[i])
+		jnsn := k8s.NamespacedName(orderedListenerSets[j])
+		return insn.String() < jnsn.String()
+	})
+
+	// Next, we we sort by the creation time using a stable sort. This means that the list is ordered
+	// where oldest listenersets come first and the stable sort breaks the tie for any resources with the same created
+	// time.
+	sort.SliceStable(orderedListenerSets, func(i, j int) bool {
+		return orderedListenerSets[i].CreationTimestamp.Unix() < orderedListenerSets[j].CreationTimestamp.Unix()
+	})
+
+	return orderedListenerSets
+}
+
+func extractListenerFromListenerSource(listenerSources []listenerSetListenerSource) []gwv1.Listener {
+	result := make([]gwv1.Listener, 0)
+	for _, src := range listenerSources {
+		result = append(result, src.listener)
+	}
+	return result
 }

--- a/pkg/gateway/routeutils/listener_utils_test.go
+++ b/pkg/gateway/routeutils/listener_utils_test.go
@@ -1,45 +1,51 @@
 package routeutils
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	gateway_constants "sigs.k8s.io/aws-load-balancer-controller/pkg/gateway/constants"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
+type mockListenerSetLoader struct {
+	result   listenerSetLoadResult
+	rejected []*gwv1.ListenerSet
+	error    error
+}
+
+func (l *mockListenerSetLoader) retrieveListenersFromListenerSets(ctx context.Context, gateway gwv1.Gateway) (listenerSetLoadResult, []*gwv1.ListenerSet, error) {
+	return l.result, l.rejected, l.error
+}
+
 func TestValidateListeners(t *testing.T) {
 	tests := []struct {
 		name            string
-		gateway         gwv1.Gateway
+		listeners       []gwv1.Listener
 		controllerName  string
 		expectedErrors  bool
 		expectedCount   int
 		expectedReasons []gwv1.ListenerConditionReason
 	}{
 		{
-			name: "empty listeners",
-			gateway: gwv1.Gateway{
-				Spec: gwv1.GatewaySpec{
-					Listeners: []gwv1.Listener{},
-				},
-			},
+			name:           "empty listeners",
+			listeners:      []gwv1.Listener{},
 			controllerName: gateway_constants.ALBGatewayController,
 			expectedErrors: false,
 			expectedCount:  0,
 		},
 		{
 			name: "valid HTTP listener",
-			gateway: gwv1.Gateway{
-				Spec: gwv1.GatewaySpec{
-					Listeners: []gwv1.Listener{
-						{
-							Name:          "http",
-							Port:          80,
-							Protocol:      gwv1.HTTPProtocolType,
-							AllowedRoutes: &gwv1.AllowedRoutes{},
-						},
-					},
+			listeners: []gwv1.Listener{
+				{
+					Name:          "http",
+					Port:          80,
+					Protocol:      gwv1.HTTPProtocolType,
+					AllowedRoutes: &gwv1.AllowedRoutes{},
 				},
 			},
 			controllerName:  gateway_constants.ALBGatewayController,
@@ -49,16 +55,12 @@ func TestValidateListeners(t *testing.T) {
 		},
 		{
 			name: "invalid port - too low",
-			gateway: gwv1.Gateway{
-				Spec: gwv1.GatewaySpec{
-					Listeners: []gwv1.Listener{
-						{
-							Name:          "invalid-low",
-							Port:          0,
-							Protocol:      gwv1.HTTPProtocolType,
-							AllowedRoutes: &gwv1.AllowedRoutes{},
-						},
-					},
+			listeners: []gwv1.Listener{
+				{
+					Name:          "invalid-low",
+					Port:          0,
+					Protocol:      gwv1.HTTPProtocolType,
+					AllowedRoutes: &gwv1.AllowedRoutes{},
 				},
 			},
 			controllerName:  gateway_constants.ALBGatewayController,
@@ -68,16 +70,12 @@ func TestValidateListeners(t *testing.T) {
 		},
 		{
 			name: "invalid port - too high",
-			gateway: gwv1.Gateway{
-				Spec: gwv1.GatewaySpec{
-					Listeners: []gwv1.Listener{
-						{
-							Name:          "invalid-high",
-							Port:          65536,
-							Protocol:      gwv1.HTTPProtocolType,
-							AllowedRoutes: &gwv1.AllowedRoutes{},
-						},
-					},
+			listeners: []gwv1.Listener{
+				{
+					Name:          "invalid-high",
+					Port:          65536,
+					Protocol:      gwv1.HTTPProtocolType,
+					AllowedRoutes: &gwv1.AllowedRoutes{},
 				},
 			},
 			controllerName:  gateway_constants.ALBGatewayController,
@@ -87,16 +85,12 @@ func TestValidateListeners(t *testing.T) {
 		},
 		{
 			name: "ALB unsupported TCP protocol",
-			gateway: gwv1.Gateway{
-				Spec: gwv1.GatewaySpec{
-					Listeners: []gwv1.Listener{
-						{
-							Name:          "tcp",
-							Port:          80,
-							Protocol:      gwv1.TCPProtocolType,
-							AllowedRoutes: &gwv1.AllowedRoutes{},
-						},
-					},
+			listeners: []gwv1.Listener{
+				{
+					Name:          "tcp",
+					Port:          80,
+					Protocol:      gwv1.TCPProtocolType,
+					AllowedRoutes: &gwv1.AllowedRoutes{},
 				},
 			},
 			controllerName:  gateway_constants.ALBGatewayController,
@@ -106,16 +100,12 @@ func TestValidateListeners(t *testing.T) {
 		},
 		{
 			name: "ALB unsupported UDP protocol",
-			gateway: gwv1.Gateway{
-				Spec: gwv1.GatewaySpec{
-					Listeners: []gwv1.Listener{
-						{
-							Name:          "udp",
-							Port:          80,
-							Protocol:      gwv1.UDPProtocolType,
-							AllowedRoutes: &gwv1.AllowedRoutes{},
-						},
-					},
+			listeners: []gwv1.Listener{
+				{
+					Name:          "udp",
+					Port:          80,
+					Protocol:      gwv1.UDPProtocolType,
+					AllowedRoutes: &gwv1.AllowedRoutes{},
 				},
 			},
 			controllerName:  gateway_constants.ALBGatewayController,
@@ -125,16 +115,12 @@ func TestValidateListeners(t *testing.T) {
 		},
 		{
 			name: "ALB unsupported TLS protocol",
-			gateway: gwv1.Gateway{
-				Spec: gwv1.GatewaySpec{
-					Listeners: []gwv1.Listener{
-						{
-							Name:          "tls",
-							Port:          80,
-							Protocol:      gwv1.TLSProtocolType,
-							AllowedRoutes: &gwv1.AllowedRoutes{},
-						},
-					},
+			listeners: []gwv1.Listener{
+				{
+					Name:          "tls",
+					Port:          80,
+					Protocol:      gwv1.TLSProtocolType,
+					AllowedRoutes: &gwv1.AllowedRoutes{},
 				},
 			},
 			controllerName:  gateway_constants.ALBGatewayController,
@@ -144,16 +130,12 @@ func TestValidateListeners(t *testing.T) {
 		},
 		{
 			name: "NLB unsupported HTTP protocol",
-			gateway: gwv1.Gateway{
-				Spec: gwv1.GatewaySpec{
-					Listeners: []gwv1.Listener{
-						{
-							Name:          "http",
-							Port:          80,
-							Protocol:      gwv1.HTTPProtocolType,
-							AllowedRoutes: &gwv1.AllowedRoutes{},
-						},
-					},
+			listeners: []gwv1.Listener{
+				{
+					Name:          "http",
+					Port:          80,
+					Protocol:      gwv1.HTTPProtocolType,
+					AllowedRoutes: &gwv1.AllowedRoutes{},
 				},
 			},
 			controllerName:  gateway_constants.NLBGatewayController,
@@ -163,16 +145,12 @@ func TestValidateListeners(t *testing.T) {
 		},
 		{
 			name: "NLB unsupported HTTPS protocol",
-			gateway: gwv1.Gateway{
-				Spec: gwv1.GatewaySpec{
-					Listeners: []gwv1.Listener{
-						{
-							Name:          "https",
-							Port:          443,
-							Protocol:      gwv1.HTTPSProtocolType,
-							AllowedRoutes: &gwv1.AllowedRoutes{},
-						},
-					},
+			listeners: []gwv1.Listener{
+				{
+					Name:          "https",
+					Port:          443,
+					Protocol:      gwv1.HTTPSProtocolType,
+					AllowedRoutes: &gwv1.AllowedRoutes{},
 				},
 			},
 			controllerName:  gateway_constants.NLBGatewayController,
@@ -182,22 +160,18 @@ func TestValidateListeners(t *testing.T) {
 		},
 		{
 			name: "protocol conflict - HTTP vs HTTPS",
-			gateway: gwv1.Gateway{
-				Spec: gwv1.GatewaySpec{
-					Listeners: []gwv1.Listener{
-						{
-							Name:          "http",
-							Port:          80,
-							Protocol:      gwv1.HTTPProtocolType,
-							AllowedRoutes: &gwv1.AllowedRoutes{},
-						},
-						{
-							Name:          "https",
-							Port:          80,
-							Protocol:      gwv1.HTTPSProtocolType,
-							AllowedRoutes: &gwv1.AllowedRoutes{},
-						},
-					},
+			listeners: []gwv1.Listener{
+				{
+					Name:          "http",
+					Port:          80,
+					Protocol:      gwv1.HTTPProtocolType,
+					AllowedRoutes: &gwv1.AllowedRoutes{},
+				},
+				{
+					Name:          "https",
+					Port:          80,
+					Protocol:      gwv1.HTTPSProtocolType,
+					AllowedRoutes: &gwv1.AllowedRoutes{},
 				},
 			},
 			controllerName:  gateway_constants.ALBGatewayController,
@@ -207,22 +181,18 @@ func TestValidateListeners(t *testing.T) {
 		},
 		{
 			name: "TCP+UDP allowed on same port",
-			gateway: gwv1.Gateway{
-				Spec: gwv1.GatewaySpec{
-					Listeners: []gwv1.Listener{
-						{
-							Name:          "tcp",
-							Port:          80,
-							Protocol:      gwv1.TCPProtocolType,
-							AllowedRoutes: &gwv1.AllowedRoutes{},
-						},
-						{
-							Name:          "udp",
-							Port:          80,
-							Protocol:      gwv1.UDPProtocolType,
-							AllowedRoutes: &gwv1.AllowedRoutes{},
-						},
-					},
+			listeners: []gwv1.Listener{
+				{
+					Name:          "tcp",
+					Port:          80,
+					Protocol:      gwv1.TCPProtocolType,
+					AllowedRoutes: &gwv1.AllowedRoutes{},
+				},
+				{
+					Name:          "udp",
+					Port:          80,
+					Protocol:      gwv1.UDPProtocolType,
+					AllowedRoutes: &gwv1.AllowedRoutes{},
 				},
 			},
 			controllerName:  gateway_constants.NLBGatewayController,
@@ -232,24 +202,20 @@ func TestValidateListeners(t *testing.T) {
 		},
 		{
 			name: "hostname conflict",
-			gateway: gwv1.Gateway{
-				Spec: gwv1.GatewaySpec{
-					Listeners: []gwv1.Listener{
-						{
-							Name:          "http1",
-							Port:          80,
-							Protocol:      gwv1.HTTPProtocolType,
-							Hostname:      (*gwv1.Hostname)(&[]string{"example.com"}[0]),
-							AllowedRoutes: &gwv1.AllowedRoutes{},
-						},
-						{
-							Name:          "http2",
-							Port:          80,
-							Protocol:      gwv1.HTTPProtocolType,
-							Hostname:      (*gwv1.Hostname)(&[]string{"example.com"}[0]),
-							AllowedRoutes: &gwv1.AllowedRoutes{},
-						},
-					},
+			listeners: []gwv1.Listener{
+				{
+					Name:          "http1",
+					Port:          80,
+					Protocol:      gwv1.HTTPProtocolType,
+					Hostname:      (*gwv1.Hostname)(&[]string{"example.com"}[0]),
+					AllowedRoutes: &gwv1.AllowedRoutes{},
+				},
+				{
+					Name:          "http2",
+					Port:          80,
+					Protocol:      gwv1.HTTPProtocolType,
+					Hostname:      (*gwv1.Hostname)(&[]string{"example.com"}[0]),
+					AllowedRoutes: &gwv1.AllowedRoutes{},
 				},
 			},
 			controllerName:  gateway_constants.ALBGatewayController,
@@ -259,24 +225,20 @@ func TestValidateListeners(t *testing.T) {
 		},
 		{
 			name: "different hostnames on same port - valid",
-			gateway: gwv1.Gateway{
-				Spec: gwv1.GatewaySpec{
-					Listeners: []gwv1.Listener{
-						{
-							Name:          "http1",
-							Port:          80,
-							Protocol:      gwv1.HTTPProtocolType,
-							Hostname:      (*gwv1.Hostname)(&[]string{"example.com"}[0]),
-							AllowedRoutes: &gwv1.AllowedRoutes{},
-						},
-						{
-							Name:          "http2",
-							Port:          80,
-							Protocol:      gwv1.HTTPProtocolType,
-							Hostname:      (*gwv1.Hostname)(&[]string{"test.com"}[0]),
-							AllowedRoutes: &gwv1.AllowedRoutes{},
-						},
-					},
+			listeners: []gwv1.Listener{
+				{
+					Name:          "http1",
+					Port:          80,
+					Protocol:      gwv1.HTTPProtocolType,
+					Hostname:      (*gwv1.Hostname)(&[]string{"example.com"}[0]),
+					AllowedRoutes: &gwv1.AllowedRoutes{},
+				},
+				{
+					Name:          "http2",
+					Port:          80,
+					Protocol:      gwv1.HTTPProtocolType,
+					Hostname:      (*gwv1.Hostname)(&[]string{"test.com"}[0]),
+					AllowedRoutes: &gwv1.AllowedRoutes{},
 				},
 			},
 			controllerName:  gateway_constants.ALBGatewayController,
@@ -286,18 +248,14 @@ func TestValidateListeners(t *testing.T) {
 		},
 		{
 			name: "invalid route kinds",
-			gateway: gwv1.Gateway{
-				Spec: gwv1.GatewaySpec{
-					Listeners: []gwv1.Listener{
-						{
-							Name:     "invalid-kinds",
-							Port:     80,
-							Protocol: gwv1.HTTPProtocolType,
-							AllowedRoutes: &gwv1.AllowedRoutes{
-								Kinds: []gwv1.RouteGroupKind{
-									{Kind: gwv1.Kind(TCPRouteKind)},
-								},
-							},
+			listeners: []gwv1.Listener{
+				{
+					Name:     "invalid-kinds",
+					Port:     80,
+					Protocol: gwv1.HTTPProtocolType,
+					AllowedRoutes: &gwv1.AllowedRoutes{
+						Kinds: []gwv1.RouteGroupKind{
+							{Kind: gwv1.Kind(TCPRouteKind)},
 						},
 					},
 				},
@@ -311,14 +269,14 @@ func TestValidateListeners(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := validateListeners(tt.gateway.Spec.Listeners, tt.controllerName)
+			result := validateListeners(allListeners{GatewayListeners: tt.listeners}, tt.controllerName)
 
-			assert.Equal(t, tt.expectedErrors, result.HasErrors)
-			assert.Equal(t, tt.expectedCount, len(result.Results))
+			assert.Equal(t, tt.expectedErrors, result.GatewayListenerValidation.HasErrors)
+			assert.Equal(t, tt.expectedCount, len(result.GatewayListenerValidation.Results))
 
 			if len(tt.expectedReasons) > 0 {
-				reasons := make([]gwv1.ListenerConditionReason, 0, len(result.Results))
-				for _, res := range result.Results {
+				reasons := make([]gwv1.ListenerConditionReason, 0, len(result.GatewayListenerValidation.Results))
+				for _, res := range result.GatewayListenerValidation.Results {
 					reasons = append(reasons, res.Reason)
 				}
 				assert.ElementsMatch(t, tt.expectedReasons, reasons)
@@ -401,6 +359,233 @@ func TestGetSupportedKinds(t *testing.T) {
 
 			assert.Equal(t, tt.expectedSupported, supported)
 			assert.Equal(t, tt.expectedCount, len(kinds))
+		})
+	}
+}
+
+func TestValidateListeners_ListenerSets(t *testing.T) {
+	lsNN := func(ns, name string) types.NamespacedName {
+		return types.NamespacedName{Namespace: ns, Name: name}
+	}
+
+	makeLS := func(ns, name string, creationTime time.Time) gwv1.ListenerSet {
+		return gwv1.ListenerSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              name,
+				Namespace:         ns,
+				CreationTimestamp: metav1.NewTime(creationTime),
+			},
+		}
+	}
+
+	makeLSSources := func(ls gwv1.ListenerSet, listeners ...gwv1.Listener) []listenerSetListenerSource {
+		sources := make([]listenerSetListenerSource, 0, len(listeners))
+		for _, l := range listeners {
+			sources = append(sources, listenerSetListenerSource{parentRef: ls, listener: l})
+		}
+		return sources
+	}
+
+	tests := []struct {
+		name                     string
+		gatewayListeners         []gwv1.Listener
+		listenerSetLoadResult    listenerSetLoadResult
+		controllerName           string
+		expectedGatewayHasErrors bool
+		expectedHasErrors        bool
+		expectedLSValidationKeys []types.NamespacedName
+		expectedLSReasons        map[types.NamespacedName]map[gwv1.SectionName]gwv1.ListenerConditionReason
+		expectedGatewayReasons   map[gwv1.SectionName]gwv1.ListenerConditionReason
+	}{
+		{
+			name:             "valid listener set listener - no conflicts",
+			gatewayListeners: []gwv1.Listener{},
+			listenerSetLoadResult: func() listenerSetLoadResult {
+				ls := makeLS("ns1", "ls1", time.Now())
+				return listenerSetLoadResult{
+					listenersPerListenerSet: map[types.NamespacedName][]listenerSetListenerSource{
+						lsNN("ns1", "ls1"): makeLSSources(ls,
+							gwv1.Listener{Name: "http", Port: 80, Protocol: gwv1.HTTPProtocolType, AllowedRoutes: &gwv1.AllowedRoutes{}},
+						),
+					},
+					acceptedListenerSets: []*gwv1.ListenerSet{&ls},
+				}
+			}(),
+			controllerName:           gateway_constants.ALBGatewayController,
+			expectedGatewayHasErrors: false,
+			expectedHasErrors:        false,
+			expectedLSValidationKeys: []types.NamespacedName{lsNN("ns1", "ls1")},
+			expectedLSReasons: map[types.NamespacedName]map[gwv1.SectionName]gwv1.ListenerConditionReason{
+				lsNN("ns1", "ls1"): {"http": gwv1.ListenerReasonAccepted},
+			},
+		},
+		{
+			name: "listener set conflicts with gateway listener - LS gets protocol conflict",
+			gatewayListeners: []gwv1.Listener{
+				{Name: "gw-http", Port: 80, Protocol: gwv1.HTTPProtocolType, AllowedRoutes: &gwv1.AllowedRoutes{}},
+			},
+			listenerSetLoadResult: func() listenerSetLoadResult {
+				ls := makeLS("ns1", "ls1", time.Now())
+				return listenerSetLoadResult{
+					listenersPerListenerSet: map[types.NamespacedName][]listenerSetListenerSource{
+						lsNN("ns1", "ls1"): makeLSSources(ls,
+							gwv1.Listener{Name: "ls-https", Port: 80, Protocol: gwv1.HTTPSProtocolType, AllowedRoutes: &gwv1.AllowedRoutes{}},
+						),
+					},
+					acceptedListenerSets: []*gwv1.ListenerSet{&ls},
+				}
+			}(),
+			controllerName:           gateway_constants.ALBGatewayController,
+			expectedGatewayHasErrors: false,
+			expectedHasErrors:        true,
+			expectedGatewayReasons:   map[gwv1.SectionName]gwv1.ListenerConditionReason{"gw-http": gwv1.ListenerReasonAccepted},
+			expectedLSValidationKeys: []types.NamespacedName{lsNN("ns1", "ls1")},
+			expectedLSReasons: map[types.NamespacedName]map[gwv1.SectionName]gwv1.ListenerConditionReason{
+				lsNN("ns1", "ls1"): {"ls-https": gwv1.ListenerReasonProtocolConflict},
+			},
+		},
+		{
+			name: "listener set hostname conflict with gateway listener",
+			gatewayListeners: []gwv1.Listener{
+				{Name: "gw-http", Port: 80, Protocol: gwv1.HTTPProtocolType, Hostname: (*gwv1.Hostname)(&[]string{"example.com"}[0]), AllowedRoutes: &gwv1.AllowedRoutes{}},
+			},
+			listenerSetLoadResult: func() listenerSetLoadResult {
+				ls := makeLS("ns1", "ls1", time.Now())
+				return listenerSetLoadResult{
+					listenersPerListenerSet: map[types.NamespacedName][]listenerSetListenerSource{
+						lsNN("ns1", "ls1"): makeLSSources(ls,
+							gwv1.Listener{Name: "ls-http", Port: 80, Protocol: gwv1.HTTPProtocolType, Hostname: (*gwv1.Hostname)(&[]string{"example.com"}[0]), AllowedRoutes: &gwv1.AllowedRoutes{}},
+						),
+					},
+					acceptedListenerSets: []*gwv1.ListenerSet{&ls},
+				}
+			}(),
+			controllerName:           gateway_constants.ALBGatewayController,
+			expectedGatewayHasErrors: false,
+			expectedHasErrors:        true,
+			expectedGatewayReasons:   map[gwv1.SectionName]gwv1.ListenerConditionReason{"gw-http": gwv1.ListenerReasonAccepted},
+			expectedLSReasons: map[types.NamespacedName]map[gwv1.SectionName]gwv1.ListenerConditionReason{
+				lsNN("ns1", "ls1"): {"ls-http": gwv1.ListenerReasonHostnameConflict},
+			},
+		},
+		{
+			name:             "listener set with invalid protocol for ALB",
+			gatewayListeners: []gwv1.Listener{},
+			listenerSetLoadResult: func() listenerSetLoadResult {
+				ls := makeLS("ns1", "ls1", time.Now())
+				return listenerSetLoadResult{
+					listenersPerListenerSet: map[types.NamespacedName][]listenerSetListenerSource{
+						lsNN("ns1", "ls1"): makeLSSources(ls,
+							gwv1.Listener{Name: "tcp", Port: 80, Protocol: gwv1.TCPProtocolType, AllowedRoutes: &gwv1.AllowedRoutes{}},
+						),
+					},
+					acceptedListenerSets: []*gwv1.ListenerSet{&ls},
+				}
+			}(),
+			controllerName:           gateway_constants.ALBGatewayController,
+			expectedGatewayHasErrors: false,
+			expectedHasErrors:        true,
+			expectedLSReasons: map[types.NamespacedName]map[gwv1.SectionName]gwv1.ListenerConditionReason{
+				lsNN("ns1", "ls1"): {"tcp": gwv1.ListenerReasonUnsupportedProtocol},
+			},
+		},
+		{
+			name:             "multiple listener sets - older LS takes priority over newer LS on conflict",
+			gatewayListeners: []gwv1.Listener{},
+			listenerSetLoadResult: func() listenerSetLoadResult {
+				ls1 := makeLS("ns1", "ls-older", time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+				ls2 := makeLS("ns1", "ls-newer", time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC))
+				return listenerSetLoadResult{
+					listenersPerListenerSet: map[types.NamespacedName][]listenerSetListenerSource{
+						lsNN("ns1", "ls-older"): makeLSSources(ls1,
+							gwv1.Listener{Name: "http", Port: 80, Protocol: gwv1.HTTPProtocolType, AllowedRoutes: &gwv1.AllowedRoutes{}},
+						),
+						lsNN("ns1", "ls-newer"): makeLSSources(ls2,
+							gwv1.Listener{Name: "https", Port: 80, Protocol: gwv1.HTTPSProtocolType, AllowedRoutes: &gwv1.AllowedRoutes{}},
+						),
+					},
+					acceptedListenerSets: []*gwv1.ListenerSet{&ls1, &ls2},
+				}
+			}(),
+			controllerName:           gateway_constants.ALBGatewayController,
+			expectedGatewayHasErrors: false,
+			expectedHasErrors:        true,
+			expectedLSReasons: map[types.NamespacedName]map[gwv1.SectionName]gwv1.ListenerConditionReason{
+				lsNN("ns1", "ls-older"): {"http": gwv1.ListenerReasonAccepted},
+				lsNN("ns1", "ls-newer"): {"https": gwv1.ListenerReasonProtocolConflict},
+			},
+		},
+		{
+			name:             "empty listener set load result",
+			gatewayListeners: []gwv1.Listener{},
+			listenerSetLoadResult: listenerSetLoadResult{
+				listenersPerListenerSet: map[types.NamespacedName][]listenerSetListenerSource{},
+				acceptedListenerSets:    []*gwv1.ListenerSet{},
+			},
+			controllerName:           gateway_constants.ALBGatewayController,
+			expectedGatewayHasErrors: false,
+			expectedHasErrors:        false,
+		},
+		{
+			name: "gateway and listener set both valid on different ports",
+			gatewayListeners: []gwv1.Listener{
+				{Name: "gw-http", Port: 80, Protocol: gwv1.HTTPProtocolType, AllowedRoutes: &gwv1.AllowedRoutes{}},
+			},
+			listenerSetLoadResult: func() listenerSetLoadResult {
+				ls := makeLS("ns1", "ls1", time.Now())
+				return listenerSetLoadResult{
+					listenersPerListenerSet: map[types.NamespacedName][]listenerSetListenerSource{
+						lsNN("ns1", "ls1"): makeLSSources(ls,
+							gwv1.Listener{Name: "ls-https", Port: 443, Protocol: gwv1.HTTPSProtocolType, AllowedRoutes: &gwv1.AllowedRoutes{}},
+						),
+					},
+					acceptedListenerSets: []*gwv1.ListenerSet{&ls},
+				}
+			}(),
+			controllerName:           gateway_constants.ALBGatewayController,
+			expectedGatewayHasErrors: false,
+			expectedHasErrors:        false,
+			expectedGatewayReasons:   map[gwv1.SectionName]gwv1.ListenerConditionReason{"gw-http": gwv1.ListenerReasonAccepted},
+			expectedLSReasons: map[types.NamespacedName]map[gwv1.SectionName]gwv1.ListenerConditionReason{
+				lsNN("ns1", "ls1"): {"ls-https": gwv1.ListenerReasonAccepted},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := allListeners{
+				GatewayListeners:     tt.gatewayListeners,
+				ListenerSetListeners: tt.listenerSetLoadResult,
+			}
+			result := validateListeners(input, tt.controllerName)
+
+			assert.Equal(t, tt.expectedGatewayHasErrors, result.GatewayListenerValidation.HasErrors)
+			assert.Equal(t, tt.expectedHasErrors, result.HasErrors())
+
+			if tt.expectedGatewayReasons != nil {
+				for name, expectedReason := range tt.expectedGatewayReasons {
+					actual, ok := result.GatewayListenerValidation.Results[name]
+					assert.True(t, ok, "expected gateway listener result for %s", name)
+					assert.Equal(t, expectedReason, actual.Reason)
+				}
+			}
+
+			if tt.expectedLSValidationKeys != nil {
+				assert.Len(t, result.ListenerSetListenerValidation, len(tt.expectedLSValidationKeys))
+			}
+
+			if tt.expectedLSReasons != nil {
+				for lsKey, listenerReasons := range tt.expectedLSReasons {
+					lsResult, ok := result.ListenerSetListenerValidation[lsKey]
+					assert.True(t, ok, "expected listener set validation for %s", lsKey)
+					for listenerName, expectedReason := range listenerReasons {
+						actual, ok := lsResult.Results[listenerName]
+						assert.True(t, ok, "expected listener result for %s in %s", listenerName, lsKey)
+						assert.Equal(t, expectedReason, actual.Reason)
+					}
+				}
+			}
 		})
 	}
 }

--- a/pkg/gateway/routeutils/loader.go
+++ b/pkg/gateway/routeutils/loader.go
@@ -57,13 +57,14 @@ type LoaderResult struct {
 	Routes            map[int32][]RouteDescriptor
 	Listeners         []gwv1.Listener
 	AttachedRoutesMap map[gwv1.SectionName]int32
-	ValidationResults ListenerValidationResults
+	ValidationResults ValidatedGatewayListeners
 }
 
 var _ Loader = &loaderImpl{}
 
 type loaderImpl struct {
 	mapper          listenerToRouteMapper
+	lsLoader        listenerSetLoader
 	routeSubmitter  RouteReconcilerSubmitter
 	k8sClient       client.Client
 	logger          logr.Logger
@@ -73,6 +74,7 @@ type loaderImpl struct {
 func NewLoader(k8sClient client.Client, routeSubmitter RouteReconcilerSubmitter, logger logr.Logger) Loader {
 	return &loaderImpl{
 		mapper:          newListenerToRouteMapper(k8sClient, logger.WithName("route-mapper")),
+		lsLoader:        newListenerSetLoader(k8sClient, logger.WithName("listener-set-loader")),
 		routeSubmitter:  routeSubmitter,
 		k8sClient:       k8sClient,
 		allRouteLoaders: allRoutes,
@@ -102,6 +104,16 @@ func (l *loaderImpl) LoadRoutesForGateway(ctx context.Context, gw gwv1.Gateway, 
 		}
 	}()
 
+	listenerSetListeners, rejectedListenerSets, err := l.lsLoader.retrieveListenersFromListenerSets(ctx, gw)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(rejectedListenerSets) > 0 {
+		// Submit these rejected listener sets to a status updater //
+	}
+
 	for route, loader := range l.allRouteLoaders {
 		applicable := filter.IsApplicable(route)
 		l.logger.V(1).Info("Processing route", "route", route, "is applicable", applicable)
@@ -114,13 +126,15 @@ func (l *loaderImpl) LoadRoutesForGateway(ctx context.Context, gw gwv1.Gateway, 
 		}
 	}
 
-	// validate listeners configuration and get listener status
-	listeners := gw.Spec.Listeners
-	listenerValidationResults := validateListeners(listeners, controllerName)
+	gatewayListeners := allListeners{
+		GatewayListeners:     gw.Spec.Listeners,
+		ListenerSetListeners: listenerSetListeners,
+	}
+	listenerValidationResults := validateListeners(gatewayListeners, controllerName)
 
 	// 2. Remove routes that aren't granted attachment by the listener.
 	// Map any routes that are granted attachment to the listener port that allows the attachment.
-	mappedRoutes, compatibleHostnamesByPort, statusUpdates, matchedParentRefs, attachedRouteMap, err := l.mapper.mapGatewayAndRoutes(ctx, gw, listeners, loadedRoutes)
+	mappedRoutes, compatibleHostnamesByPort, statusUpdates, matchedParentRefs, attachedRouteMap, err := l.mapper.mapGatewayAndRoutes(ctx, gw, gw.Spec.Listeners, loadedRoutes)
 
 	routeStatusUpdates = append(routeStatusUpdates, statusUpdates...)
 
@@ -149,7 +163,7 @@ func (l *loaderImpl) LoadRoutesForGateway(ctx context.Context, gw gwv1.Gateway, 
 
 	return &LoaderResult{
 		Routes:            loadedRoute,
-		Listeners:         listeners,
+		Listeners:         gw.Spec.Listeners,
 		AttachedRoutesMap: attachedRouteMap,
 		ValidationResults: listenerValidationResults,
 	}, nil

--- a/pkg/gateway/routeutils/loader_test.go
+++ b/pkg/gateway/routeutils/loader_test.go
@@ -367,6 +367,9 @@ func Test_LoadRoutesForGateway(t *testing.T) {
 				allRouteLoaders: allRouteLoaders,
 				logger:          logr.Discard(),
 				routeSubmitter:  routeReconciler,
+				lsLoader: &mockListenerSetLoader{
+					result: listenerSetLoadResult{},
+				},
 			}
 
 			filter := &routeFilterImpl{acceptedKinds: tc.acceptedKinds}


### PR DESCRIPTION
### Description

Validate Listeners originating from the ListenerSets are valid. This follows the precendence ordering found [here](https://gateway-api.sigs.k8s.io/geps/gep-1713/#listener-precedence). What this PR does NOT do, 1/ adds the listener entries from a listenerset into the gateway, 2/ handles listener status updates.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
