### PR TITLE
Change default client-side rate-limiter to correctly match ELBv2 api limits

### DIFF
--- a/docs/deploy/configurations.md
+++ b/docs/deploy/configurations.md
@@ -159,7 +159,7 @@ Once disabled, the controller shall not take any actions on the waf addons of th
 Controller uses the following default throttle config:
 
 ```
-WAF Regional:^AssociateWebACL|DisassociateWebACL=0.5:1,WAF Regional:^GetWebACLForResource|ListResourcesForWebACL=1:1,WAFV2:^AssociateWebACL|DisassociateWebACL=0.5:1,WAFV2:^GetWebACLForResource|ListResourcesForWebACL=1:1,Elastic Load Balancing v2:^RegisterTargets|^DeregisterTargets=4:20,Elastic Load Balancing v2:^Describe.*=10:40,Elastic Load Balancing v2:^Modify.*=3:20
+WAF Regional:^AssociateWebACL|DisassociateWebACL=0.5:1,WAF Regional:^GetWebACLForResource|ListResourcesForWebACL=1:1,WAFV2:^AssociateWebACL|DisassociateWebACL=0.5:1,WAFV2:^GetWebACLForResource|ListResourcesForWebACL=1:1,Elastic Load Balancing v2:^RegisterTargets|^DeregisterTargets=4:20,Elastic Load Balancing v2:^Describe.*=50:200,Elastic Load Balancing v2:^Modify.*=3:20
 ```
 Client side throttling enables gradual scaling of the api calls. Additional throttle config can be specified via the `--aws-api-throttle` flag. You can get the ServiceID from the API definition in AWS SDK. For e.g, ELBv2 it is [Elastic Load Balancing v2](https://github.com/aws/aws-sdk-go/blob/main/models/apis/elasticloadbalancingv2/2015-12-01/api-2.json#L9).
 

--- a/pkg/aws/throttle/defaults.go
+++ b/pkg/aws/throttle/defaults.go
@@ -45,8 +45,8 @@ func NewDefaultServiceOperationsThrottleConfig() *ServiceOperationsThrottleConfi
 				},
 				{
 					operationPtn: regexp.MustCompile("^Describe.*"),
-					r:            rate.Limit(10),
-					burst:        40,
+					r:            rate.Limit(50),
+					burst:        200,
 				},
 				{
 					operationPtn: regexp.MustCompile("^Modify.*"),


### PR DESCRIPTION
### Description

The current default client-side throttling rules for ALBs cause calls to `RegisterTargets|DeregisterTargets` to consume buckets from 2 different Limiters. This was found by reading the code after looking into AWS API request rate metrics when using a very high controller concurrency configuration.

The default ELB throttling rules have a second rule for ELBv2 matching everything (`.*`). However, calls to RegisterTargets do not stop evaluating after matching the first rule, and end up matching that `.*` rule as well. Consuming tokens from both: https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/75eb48adadbb836ecd4d4fd5e6401dc7dd704e8c/pkg/aws/throttle/throttler.go#L76-L80


This PR fixes this by using more restrictive Regexps and also adds a new rule specifically for `Modify.*` calls, which have a different rate limit rule according to ELB docs: https://docs.aws.amazon.com/elasticloadbalancing/latest/userguide/elb-api-throttling.html#bucket-capacity-and-refill-rate



### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
