### PR TITLE
resolve parent ref gateway whenever listener is used

### DIFF
--- a/pkg/gateway/gatewayutils/gateway_utils.go
+++ b/pkg/gateway/gatewayutils/gateway_utils.go
@@ -74,16 +74,38 @@ func GetImpactedGatewaysFromParentRefs(ctx context.Context, k8sClient client.Cli
 	}
 	impactedGateways := make([]types.NamespacedName, 0, len(parentRefs))
 	unknownGateways := make([]types.NamespacedName, 0, len(parentRefs))
+	failedListenerSetResolutions := make([]types.NamespacedName, 0)
 	var err error
 	for _, parent := range parentRefs {
-		gwNamespace := resourceNamespace
+		namespaceToUse := resourceNamespace
 		if parent.Namespace != nil {
-			gwNamespace = string(*parent.Namespace)
+			namespaceToUse = string(*parent.Namespace)
 		}
 
-		gwName := types.NamespacedName{
-			Namespace: gwNamespace,
+		parentResourceNsn := types.NamespacedName{
+			Namespace: namespaceToUse,
 			Name:      string(parent.Name),
+		}
+
+		var gwName types.NamespacedName
+		if parent.Kind != nil && *parent.Kind == "ListenerSet" {
+			ls := &gwv1.ListenerSet{}
+			if err := k8sClient.Get(ctx, parentResourceNsn, ls); err != nil {
+				failedListenerSetResolutions = append(failedListenerSetResolutions, parentResourceNsn)
+				continue
+			}
+
+			gwNamespace := ls.Namespace
+			if ls.Spec.ParentRef.Namespace != nil {
+				gwNamespace = string(*ls.Spec.ParentRef.Namespace)
+			}
+
+			gwName = types.NamespacedName{
+				Namespace: gwNamespace,
+				Name:      string(ls.Spec.ParentRef.Name),
+			}
+		} else {
+			gwName = parentResourceNsn
 		}
 
 		gw := &gwv1.Gateway{}
@@ -97,8 +119,12 @@ func GetImpactedGatewaysFromParentRefs(ctx context.Context, k8sClient client.Cli
 			impactedGateways = append(impactedGateways, gwName)
 		}
 	}
-	if len(unknownGateways) > 0 {
+	if len(unknownGateways) > 0 && len(failedListenerSetResolutions) > 0 {
+		err = fmt.Errorf("failed to list gateways, %s, failed to resolve listenersets %s", unknownGateways, failedListenerSetResolutions)
+	} else if len(unknownGateways) > 0 {
 		err = fmt.Errorf("failed to list gateways, %s", unknownGateways)
+	} else if len(failedListenerSetResolutions) > 0 {
+		err = fmt.Errorf("failed to resolve listenersets %s", failedListenerSetResolutions)
 	}
 	return impactedGateways, err
 }
@@ -178,7 +204,7 @@ func GetGatewaysManagedByGatewayClass(ctx context.Context, k8sClient client.Clie
 // removeDuplicateParentRefs make sure parentRefs in list is unique
 func removeDuplicateParentRefs(parentRefs []gwv1.ParentReference, resourceNamespace string) []gwv1.ParentReference {
 	result := make([]gwv1.ParentReference, 0, len(parentRefs))
-	exist := sets.Set[types.NamespacedName]{}
+	exist := map[string]sets.Set[types.NamespacedName]{}
 	for _, parentRef := range parentRefs {
 		var namespaceToUse string
 		if parentRef.Namespace != nil {
@@ -190,8 +216,17 @@ func removeDuplicateParentRefs(parentRefs []gwv1.ParentReference, resourceNamesp
 			Namespace: namespaceToUse,
 			Name:      string(parentRef.Name),
 		}
-		if !exist.Has(namespacedName) {
-			exist.Insert(namespacedName)
+		kind := "Gateway"
+		if parentRef.Kind != nil {
+			kind = string(*parentRef.Kind)
+		}
+
+		if _, kindOk := exist[kind]; !kindOk {
+			exist[kind] = sets.Set[types.NamespacedName]{}
+		}
+
+		if !exist[kind].Has(namespacedName) {
+			exist[kind].Insert(namespacedName)
 			result = append(result, parentRef)
 		}
 	}

--- a/pkg/gateway/gatewayutils/gateway_utils_test.go
+++ b/pkg/gateway/gatewayutils/gateway_utils_test.go
@@ -219,12 +219,14 @@ func Test_GetGatewayClassesManagedByLBController(t *testing.T) {
 }
 
 func Test_GetImpactedGatewaysFromParentRefs(t *testing.T) {
+	listenerSetKind := gwv1.Kind("ListenerSet")
 	type args struct {
 		parentRefs                        []gwv1.ParentReference
 		originalParentRefsFromRouteStatus []gwv1.RouteParentStatus
 		resourceNS                        string
 		gateways                          []*gwv1.Gateway
 		gatewayClasses                    []*gwv1.GatewayClass
+		listenerSets                      []*gwv1.ListenerSet
 		gwController                      string
 	}
 	tests := []struct {
@@ -577,6 +579,277 @@ func Test_GetImpactedGatewaysFromParentRefs(t *testing.T) {
 			},
 			wantErr: nil,
 		},
+		{
+			name: "listenerset parent ref resolves to managed gateway",
+			args: args{
+				parentRefs: []gwv1.ParentReference{
+					{
+						Name:      "test-ls",
+						Kind:      &listenerSetKind,
+						Namespace: (*gwv1.Namespace)(ptr.To("test-ns")),
+					},
+				},
+				resourceNS: "test-ns",
+				listenerSets: []*gwv1.ListenerSet{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-ls",
+							Namespace: "test-ns",
+						},
+						Spec: gwv1.ListenerSetSpec{
+							ParentRef: gwv1.ParentGatewayReference{
+								Name: "test-gw",
+							},
+						},
+					},
+				},
+				gateways: []*gwv1.Gateway{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-gw",
+							Namespace: "test-ns",
+						},
+						Spec: gwv1.GatewaySpec{
+							GatewayClassName: "nlb-class",
+						},
+					},
+				},
+				gatewayClasses: []*gwv1.GatewayClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "nlb-class",
+						},
+						Spec: gwv1.GatewayClassSpec{
+							ControllerName: constants.NLBGatewayController,
+						},
+					},
+				},
+				gwController: constants.NLBGatewayController,
+			},
+			want: []types.NamespacedName{
+				{
+					Namespace: "test-ns",
+					Name:      "test-gw",
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "listenerset parent ref with cross-namespace gateway",
+			args: args{
+				parentRefs: []gwv1.ParentReference{
+					{
+						Name:      "test-ls",
+						Kind:      &listenerSetKind,
+						Namespace: (*gwv1.Namespace)(ptr.To("ls-ns")),
+					},
+				},
+				resourceNS: "route-ns",
+				listenerSets: []*gwv1.ListenerSet{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-ls",
+							Namespace: "ls-ns",
+						},
+						Spec: gwv1.ListenerSetSpec{
+							ParentRef: gwv1.ParentGatewayReference{
+								Name:      "test-gw",
+								Namespace: (*gwv1.Namespace)(ptr.To("gw-ns")),
+							},
+						},
+					},
+				},
+				gateways: []*gwv1.Gateway{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-gw",
+							Namespace: "gw-ns",
+						},
+						Spec: gwv1.GatewaySpec{
+							GatewayClassName: "alb-class",
+						},
+					},
+				},
+				gatewayClasses: []*gwv1.GatewayClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "alb-class",
+						},
+						Spec: gwv1.GatewayClassSpec{
+							ControllerName: constants.ALBGatewayController,
+						},
+					},
+				},
+				gwController: constants.ALBGatewayController,
+			},
+			want: []types.NamespacedName{
+				{
+					Namespace: "gw-ns",
+					Name:      "test-gw",
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "listenerset parent ref not found",
+			args: args{
+				parentRefs: []gwv1.ParentReference{
+					{
+						Name:      "missing-ls",
+						Kind:      &listenerSetKind,
+						Namespace: (*gwv1.Namespace)(ptr.To("test-ns")),
+					},
+				},
+				resourceNS:   "test-ns",
+				gwController: constants.NLBGatewayController,
+			},
+			want:    []types.NamespacedName{},
+			wantErr: fmt.Errorf("failed to resolve listenersets [%s]", types.NamespacedName{Namespace: "test-ns", Name: "missing-ls"}),
+		},
+		{
+			name: "mix of gateway and listenerset parent refs",
+			args: args{
+				parentRefs: []gwv1.ParentReference{
+					{
+						Name:      "test-gw-direct",
+						Namespace: (*gwv1.Namespace)(ptr.To("test-ns")),
+					},
+					{
+						Name:      "test-ls",
+						Kind:      &listenerSetKind,
+						Namespace: (*gwv1.Namespace)(ptr.To("test-ns")),
+					},
+				},
+				resourceNS: "test-ns",
+				listenerSets: []*gwv1.ListenerSet{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-ls",
+							Namespace: "test-ns",
+						},
+						Spec: gwv1.ListenerSetSpec{
+							ParentRef: gwv1.ParentGatewayReference{
+								Name: "test-gw-from-ls",
+							},
+						},
+					},
+				},
+				gateways: []*gwv1.Gateway{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-gw-direct",
+							Namespace: "test-ns",
+						},
+						Spec: gwv1.GatewaySpec{
+							GatewayClassName: "nlb-class",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-gw-from-ls",
+							Namespace: "test-ns",
+						},
+						Spec: gwv1.GatewaySpec{
+							GatewayClassName: "nlb-class",
+						},
+					},
+				},
+				gatewayClasses: []*gwv1.GatewayClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "nlb-class",
+						},
+						Spec: gwv1.GatewayClassSpec{
+							ControllerName: constants.NLBGatewayController,
+						},
+					},
+				},
+				gwController: constants.NLBGatewayController,
+			},
+			want: []types.NamespacedName{
+				{
+					Namespace: "test-ns",
+					Name:      "test-gw-direct",
+				},
+				{
+					Namespace: "test-ns",
+					Name:      "test-gw-from-ls",
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "unknown gateway and failed listenerset resolution",
+			args: args{
+				parentRefs: []gwv1.ParentReference{
+					{
+						Name:      "unknown-gw",
+						Namespace: (*gwv1.Namespace)(ptr.To("test-ns")),
+					},
+					{
+						Name:      "missing-ls",
+						Kind:      &listenerSetKind,
+						Namespace: (*gwv1.Namespace)(ptr.To("test-ns")),
+					},
+				},
+				resourceNS:   "test-ns",
+				gwController: constants.NLBGatewayController,
+			},
+			want: []types.NamespacedName{},
+			wantErr: fmt.Errorf("failed to list gateways, [%s], failed to resolve listenersets [%s]",
+				types.NamespacedName{Namespace: "test-ns", Name: "unknown-gw"},
+				types.NamespacedName{Namespace: "test-ns", Name: "missing-ls"}),
+		},
+		{
+			name: "listenerset resolves to unmanaged gateway",
+			args: args{
+				parentRefs: []gwv1.ParentReference{
+					{
+						Name:      "test-ls",
+						Kind:      &listenerSetKind,
+						Namespace: (*gwv1.Namespace)(ptr.To("test-ns")),
+					},
+				},
+				resourceNS: "test-ns",
+				listenerSets: []*gwv1.ListenerSet{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-ls",
+							Namespace: "test-ns",
+						},
+						Spec: gwv1.ListenerSetSpec{
+							ParentRef: gwv1.ParentGatewayReference{
+								Name: "unmanaged-gw",
+							},
+						},
+					},
+				},
+				gateways: []*gwv1.Gateway{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "unmanaged-gw",
+							Namespace: "test-ns",
+						},
+						Spec: gwv1.GatewaySpec{
+							GatewayClassName: "unmanaged-class",
+						},
+					},
+				},
+				gatewayClasses: []*gwv1.GatewayClass{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "unmanaged-class",
+						},
+						Spec: gwv1.GatewayClassSpec{
+							ControllerName: "some.other.controller",
+						},
+					},
+				},
+				gwController: constants.NLBGatewayController,
+			},
+			want:    []types.NamespacedName{},
+			wantErr: nil,
+		},
 	}
 
 	for _, tt := range tests {
@@ -588,6 +861,9 @@ func Test_GetImpactedGatewaysFromParentRefs(t *testing.T) {
 			}
 			for _, gwClass := range tt.args.gatewayClasses {
 				k8sClient.Create(context.Background(), gwClass)
+			}
+			for _, ls := range tt.args.listenerSets {
+				k8sClient.Create(context.Background(), ls)
 			}
 
 			got, err := GetImpactedGatewaysFromParentRefs(context.Background(), k8sClient, tt.args.parentRefs, tt.args.originalParentRefsFromRouteStatus, tt.args.resourceNS, tt.args.gwController)


### PR DESCRIPTION
### Description

Route eventhandlers always assumed that the parent ref was a gateway. This PR adds resolution of ListenerSets to the connected gateway.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
