### PR TITLE
Update vanilla ingress e2e test for alb.ingress.kubernetes.io/load-balancer-name annotation to use lowercase hostname following RFC 1123

### DIFF
--- a/test/e2e/ingress/vanilla_ingress_test.go
+++ b/test/e2e/ingress/vanilla_ingress_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"sigs.k8s.io/aws-load-balancer-controller/pkg/shared_utils"
 	"strings"
 	"time"
+
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/shared_utils"
 
 	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
 	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
@@ -350,7 +351,7 @@ var _ = Describe("vanilla ingress tests", func() {
 					},
 				},
 			}
-			safeClusterName := strings.ReplaceAll(tf.Options.ClusterName, ".", "-")
+			safeClusterName := strings.ReplaceAll(strings.ToLower(tf.Options.ClusterName), ".", "-")
 			lbName := fmt.Sprintf("%.16s-%.15s", safeClusterName, sandboxNS.Name)
 			annotation := map[string]string{
 				"kubernetes.io/ingress.class":                  "alb",


### PR DESCRIPTION
### Description

The test `"with 'alb.ingress.kubernetes.io/load-balancer-name' annotation explicitly specified, one ALB shall be created and functional"` is failing during the `ExpectOneLBProvisionedForIngress` check [here](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/test/e2e/ingress/vanilla_ingress_test.go#L1073).

Looking through the controller logs, I see this:

`
{"name":"ing","namespace":"aws-lb-e2e-a8f3bb"},"namespace":"aws-lb-e2e-a8f3bb","name":"ing","reconcileID":"c60d0832-f7b9-45cb-b545-b5592caf87f9","error":"failed to update ingress status: aws-lb-e2e-a8f3bb/ing: Ingress.networking.k8s.io \"ing\" is invalid: status.loadBalancer.ingress[0].hostname: Invalid value: \"ELBK8sLoadBalanc-aws-lb-e2e-a8f3-1709960282.us-east-1.elb.amazonaws.com\": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')"}
`

The test is failing because the cluster name (`ELBK8sLoadBalanc...`) contains uppercase letters. This PR ensures that the `hostname` is always lowercase. It also sorts the imports for that file.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
