### PR TITLE
Fix ingress and service controllers to normalize dns name

### DIFF
--- a/controllers/ingress/group_controller.go
+++ b/controllers/ingress/group_controller.go
@@ -3,6 +3,8 @@ package ingress
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	awsmetrics "sigs.k8s.io/aws-load-balancer-controller/pkg/metrics/aws"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/shared_utils"
 
@@ -166,14 +168,17 @@ func (r *groupReconciler) reconcile(ctx context.Context, req reconcile.Request) 
 			if statusErr != nil {
 				return
 			}
+			normalizedLbDNSName := strings.ToLower(lbDNS)
 			var frontendNlbDNS string
+			var normalizedFrontendNlbDNS string
 			if frontendNlb != nil {
 				frontendNlbDNS, statusErr = frontendNlb.DNSName().Resolve(ctx)
 				if statusErr != nil {
 					return
 				}
+				normalizedFrontendNlbDNS = strings.ToLower(frontendNlbDNS)
 			}
-			statusErr = r.updateIngressGroupStatus(ctx, ingGroup, lbDNS, frontendNlbDNS, listenerPorts)
+			statusErr = r.updateIngressGroupStatus(ctx, ingGroup, normalizedLbDNSName, normalizedFrontendNlbDNS, listenerPorts)
 			if statusErr != nil {
 				r.recordIngressGroupEvent(ctx, ingGroup, corev1.EventTypeWarning, k8s.IngressEventReasonFailedUpdateStatus,
 					fmt.Sprintf("Failed update status due to %v", statusErr))

--- a/controllers/service/service_controller.go
+++ b/controllers/service/service_controller.go
@@ -3,6 +3,8 @@ package service
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	awsmetrics "sigs.k8s.io/aws-load-balancer-controller/pkg/metrics/aws"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/shared_constants"
 
@@ -198,6 +200,8 @@ func (r *serviceReconciler) reconcileLoadBalancerResources(ctx context.Context, 
 		return ctrlerrors.NewErrorWithMetrics(controllerName, "dns_resolve_error", err, r.metricsCollector)
 	}
 
+	normalizedLbDNS := strings.ToLower(lbDNS)
+
 	if !backendSGRequired {
 		if err := r.backendSGProvider.Release(ctx, networking.ResourceTypeService, []types.NamespacedName{k8s.NamespacedName(svc)}); err != nil {
 			return ctrlerrors.NewErrorWithMetrics(controllerName, "release_auto_generated_backend_sg_error", err, r.metricsCollector)
@@ -205,7 +209,7 @@ func (r *serviceReconciler) reconcileLoadBalancerResources(ctx context.Context, 
 	}
 
 	updateStatusFn := func() {
-		err = r.updateServiceStatus(ctx, lbDNS, svc)
+		err = r.updateServiceStatus(ctx, normalizedLbDNS, svc)
 	}
 	r.metricsCollector.ObserveControllerReconcileLatency(controllerName, "update_status", updateStatusFn)
 	if err != nil {


### PR DESCRIPTION
### Description

When my cluster name has uppercase characters (ex. `ELBK8sLoadBalanc...`), the test `"with 'alb.ingress.kubernetes.io/load-balancer-name' annotation explicitly specified, one ALB shall be created and functional"` fails during the `ExpectOneLBProvisionedForIngress` check [here](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/test/e2e/ingress/vanilla_ingress_test.go#L1073).

Looking through the controller logs, I see this:

`
{"name":"ing","namespace":"aws-lb-e2e-a8f3bb"},"namespace":"aws-lb-e2e-a8f3bb","name":"ing","reconcileID":"c60d0832-f7b9-45cb-b545-b5592caf87f9","error":"failed to update ingress status: aws-lb-e2e-a8f3bb/ing: Ingress.networking.k8s.io \"ing\" is invalid: status.loadBalancer.ingress[0].hostname: Invalid value: \"ELBK8sLoadBalanc-aws-lb-e2e-a8f3-1709960282.us-east-1.elb.amazonaws.com\": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')"}
`

This PR normalizes the DNS name for ingress and service controllers, similar to what [gateway controller](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/a9f7decd63be3bcaffe58dfb44bbbce19997f9bd/controllers/gateway/gateway_controller.go#L439) does

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
