### PR TITLE
Fix FindLoadBalancerByDNSName to be case-insensitive

### DIFF
--- a/test/framework/resources/aws/load_balancer.go
+++ b/test/framework/resources/aws/load_balancer.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"context"
+	"strings"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	elbv2sdk "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
@@ -48,7 +49,8 @@ func (m *defaultLoadBalancerManager) FindLoadBalancerByDNSName(ctx context.Conte
 		return "", err
 	}
 	for _, lb := range lbs {
-		if awssdk.ToString(lb.DNSName) == dnsName {
+		// DNS names are case-insensitive
+		if strings.EqualFold(*lb.DNSName, dnsName) {
 			return awssdk.ToString(lb.LoadBalancerArn), nil
 		}
 	}


### PR DESCRIPTION
### Description

Currently, `FindLoadBalancerByDNSName` fails if the load balancer name has capital letters since the ingress `dnsName` will always be lowercase. DNS names are case-insensitive so we should update this function to perform a case-insensitive check.

This PR replaces `==` check with `strings.EqualFold`.

>// EqualFold reports whether s and t, interpreted as UTF-8 strings,
// are equal under simple Unicode case-folding, which is a more general
// form of case-insensitivity.
https://pkg.go.dev/strings#EqualFold

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
