### PR TITLE
fix: guard BaseEndpoint assignment for wafregional and shield clients

### DIFF
--- a/pkg/aws/provider/default_aws_clients_provider.go
+++ b/pkg/aws/provider/default_aws_clients_provider.go
@@ -61,11 +61,15 @@ func NewDefaultAWSClientsProvider(cfg aws.Config, endpointsResolver *endpoints.R
 	})
 	wafregionalClient := wafregional.NewFromConfig(cfg, func(o *wafregional.Options) {
 		o.Region = cfg.Region
-		o.BaseEndpoint = wafregionalCustomEndpoint
+		if wafregionalCustomEndpoint != nil {
+			o.BaseEndpoint = wafregionalCustomEndpoint
+		}
 	})
 	shieldClient := shield.NewFromConfig(cfg, func(o *shield.Options) {
 		o.Region = cfg.Region
-		o.BaseEndpoint = shieldCustomEndpoint
+		if shieldCustomEndpoint != nil {
+			o.BaseEndpoint = shieldCustomEndpoint
+		}
 	})
 	rgtClient := resourcegroupstaggingapi.NewFromConfig(cfg, func(o *resourcegroupstaggingapi.Options) {
 		if rgtCustomEndpoint != nil {


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description

All service clients in NewDefaultAWSClientsProvider guard the o.BaseEndpoint assignment with if customEndpoint != nil, except wafregional and shield. This is likely an oversight.

Without the guard, when --aws-api-endpoints is not set, nil is unconditionally assigned to o.BaseEndpoint, which overwrites the value inherited from cfg via NewFromConfig (e.g. AWS_ENDPOINT_URL).

This PR adds the same if != nil guard to these two clients, consistent with the other seven.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
