### PR TITLE
Fix: skip empty ExternalId in AssumeRole for cross-account TGB

### DIFF
--- a/pkg/aws/cloud.go
+++ b/pkg/aws/cloud.go
@@ -246,11 +246,14 @@ func (c *defaultCloud) GetAssumedRoleELBV2(ctx context.Context, assumeRoleArn st
 		return nil, err
 	}
 
-	response, err := stsClient.AssumeRole(ctx, &sts.AssumeRoleInput{
+	assumeRoleInput := &sts.AssumeRoleInput{
 		RoleArn:         aws.String(assumeRoleArn),
 		RoleSessionName: aws.String(generateAssumeRoleSessionName(c.clusterName)),
-		ExternalId:      aws.String(externalId),
-	})
+	}
+	if externalId != "" {
+		assumeRoleInput.ExternalId = aws.String(externalId)
+	}
+	response, err := stsClient.AssumeRole(ctx, assumeRoleInput)
 	if err != nil {
 		c.logger.Error(err, "Unable to assume target role", "roleArn", assumeRoleArn)
 		return nil, err


### PR DESCRIPTION
When assumeRoleExternalId is omitted from the TargetGroupBinding spec, the controller passes an empty string to sts:AssumeRole instead of omitting the ExternalId parameter. STS rejects this with a ValidationError since ExternalId must be at least 2 characters.

This change only sets ExternalId when a non-empty value is provided.

Fixes cross-account TargetGroupBinding creation when assumeRoleExternalId is not specified.

Prior to this fix, I encountered the following validation error:
```
Error from server (Forbidden): error when creating "tgb.yaml": admission webhook "mtargetgroupbinding.elbv2.k8s.aws" denied the request: couldn't determine TargetType: operation error STS: AssumeRole, https response error StatusCode: 400, RequestID: 34ed19b8-9e22-4c49-9b2f-41cce727f1c0, api error ValidationError: 1 validation error detected: Value '' at 'externalId' failed to satisfy constraint: Member must have length greater than or equal to 2
```

### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description

<!--
Please explain the changes you made here.

Help your reviewers by guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
