### PR TITLE
Add HTTP client timeout to all AWS SDK clients

### DIFF
--- a/pkg/aws/aws_config.go
+++ b/pkg/aws/aws_config.go
@@ -2,6 +2,9 @@ package aws
 
 import (
 	"context"
+	"net/http"
+	"time"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsmiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
 	"github.com/aws/aws-sdk-go-v2/aws/ratelimit"
@@ -16,7 +19,14 @@ import (
 
 const (
 	userAgent = "elbv2.k8s.aws"
+	// defaultAWSSDKClientTimeout is the timeout for individual HTTP requests made by AWS SDK clients.
+	defaultAWSSDKClientTimeout = 10 * time.Second
 )
+
+// newDefaultHTTPClient returns an http.Client with the standard AWS SDK timeout.
+func newDefaultHTTPClient() *http.Client {
+	return &http.Client{Timeout: defaultAWSSDKClientTimeout}
+}
 
 func NewAWSConfigGenerator(cfg CloudConfig, ec2IMDSEndpointMode imds.EndpointModeState, metricsCollector *awsmetrics.Collector) AWSConfigGenerator {
 	return &awsConfigGeneratorImpl{
@@ -42,6 +52,7 @@ func (gen *awsConfigGeneratorImpl) GenerateAWSConfig(optFns ...func(*config.Load
 
 	defaultOpts := []func(*config.LoadOptions) error{
 		config.WithRegion(gen.cfg.Region),
+		config.WithHTTPClient(newDefaultHTTPClient()),
 		config.WithRetryer(func() aws.Retryer {
 			return retry.NewStandard(func(o *retry.StandardOptions) {
 				o.RateLimiter = ratelimit.None

--- a/pkg/aws/aws_config_test.go
+++ b/pkg/aws/aws_config_test.go
@@ -1,0 +1,25 @@
+package aws
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_GenerateAWSConfig_SetsHTTPClientTimeout(t *testing.T) {
+	gen := NewAWSConfigGenerator(CloudConfig{
+		Region:     "us-west-2",
+		MaxRetries: 3,
+	}, imds.EndpointModeStateIPv4, nil)
+
+	cfg, err := gen.GenerateAWSConfig()
+	require.NoError(t, err)
+	require.NotNil(t, cfg.HTTPClient)
+
+	httpClient, ok := cfg.HTTPClient.(*http.Client)
+	require.True(t, ok, "HTTPClient should be *http.Client")
+	assert.Equal(t, defaultAWSSDKClientTimeout, httpClient.Timeout)
+}

--- a/pkg/aws/cloud.go
+++ b/pkg/aws/cloud.go
@@ -53,10 +53,10 @@ func NewCloud(cfg CloudConfig, clusterName string, metricsCollector *aws_metrics
 		ec2IMDSEndpointMode = imds.EndpointModeStateIPv4
 	}
 	endpointsResolver := epresolver.NewResolver(cfg.AWSEndpoints)
-	ec2MetadataCfg, err := config.LoadDefaultConfig(context.TODO(),
-		config.WithRetryMaxAttempts(cfg.MaxRetries),
-		config.WithEC2IMDSEndpointMode(ec2IMDSEndpointMode),
-	)
+	ec2MetadataCfg, err := buildEC2MetadataConfig(cfg.MaxRetries, ec2IMDSEndpointMode)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build EC2 metadata config")
+	}
 	ec2Metadata := services.NewEC2Metadata(ec2MetadataCfg, endpointsResolver)
 
 	if len(cfg.Region) == 0 {
@@ -313,4 +313,12 @@ func (c *defaultCloud) Region() string {
 
 func (c *defaultCloud) VpcID() string {
 	return c.cfg.VpcID
+}
+
+func buildEC2MetadataConfig(maxRetries int, ec2IMDSEndpointMode imds.EndpointModeState) (aws.Config, error) {
+	return config.LoadDefaultConfig(context.TODO(),
+		config.WithHTTPClient(newDefaultHTTPClient()),
+		config.WithRetryMaxAttempts(maxRetries),
+		config.WithEC2IMDSEndpointMode(ec2IMDSEndpointMode),
+	)
 }

--- a/pkg/aws/cloud_test.go
+++ b/pkg/aws/cloud_test.go
@@ -3,13 +3,16 @@ package aws
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/services"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -135,4 +138,16 @@ func Test_getVpcID(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_buildEC2MetadataConfig_SetsHTTPClientTimeout(t *testing.T) {
+	t.Setenv("AWS_REGION", "us-west-2")
+	t.Setenv("AWS_DEFAULT_REGION", "us-west-2")
+	cfg, err := buildEC2MetadataConfig(3, imds.EndpointModeStateIPv4)
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg.HTTPClient)
+
+	httpClient, ok := cfg.HTTPClient.(*http.Client)
+	require.True(t, ok, "HTTPClient should be *http.Client")
+	assert.Equal(t, defaultAWSSDKClientTimeout, httpClient.Timeout)
 }


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description

<!--
Please explain the changes you made here.

Help your reviewers by guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->
AWS SDK v2 defaults to no HTTP request timeout, which means API calls can hang indefinitely if AWS is unresponsive. Set a 10-second timeout on all SDK clients by configuring an http.Client in GenerateAWSConfig and in the EC2 IMDS config.

This covers all 9 service clients (EC2, ELBV2, ACM, WAFv2, WAFRegional, Shield, RGT, STS, GlobalAccelerator), the EC2 IMDS client, and any dynamically-created assumed-role ELBV2 clients.

Extracted buildEC2MetadataConfig from NewCloud for testability. Added unit tests to verify both config paths set the timeout.

The in-cluster test confirmed the controller with the 10s HTTP client timeout starts up cleanly, successfully makes AWS API calls, acquires leader election, and runs all three controllers (ingress, service, targetGroupBinding) with zero errors or restarts.

### Checklist
- [X] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [X] Manually tested
- [X] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
