### PR TITLE
remove special isolated region check for listener attributes

### DIFF
--- a/.github/workflows/deprecated-api-detect.yaml
+++ b/.github/workflows/deprecated-api-detect.yaml
@@ -9,7 +9,7 @@ jobs:
     name: Detect deprecated apiGroups
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - run: |
           version=$(curl -sL https://api.github.com/repos/FairwindsOps/pluto/releases/latest | jq -r ".tag_name")
           number=${version:1}

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -24,11 +24,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           show-progress: false
       - name: "Dependency Review"
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48
         with:
           base-ref: ${{ inputs.base_ref || github.event.pull_request.base.sha || 'main' }}
           head-ref: ${{ inputs.head_ref || github.event.pull_request.head.sha || github.ref }}
@@ -36,13 +36,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           show-progress: false
       - name: Setup Go Version
         run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
       - id: govulncheck
-        uses: golang/govulncheck-action@v1
+        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee
         with:
           go-version-input: ${{ env.GO_VERSION }}
           go-version-file: go.mod

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
       - run: /usr/bin/git config --global user.email actions@github.com

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,12 +10,12 @@ jobs:
     - name: Setup Go Version
       run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
       with:
         go-version: ${{ env.GO_VERSION }}
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
     - name: Run unit tests
       run: |
@@ -23,14 +23,14 @@ jobs:
         make test
 
     - name: Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2
       with:
         file: ./cover.out # optional
 
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: make quick-ci
         run: |

--- a/pkg/deploy/elbv2/listener_manager.go
+++ b/pkg/deploy/elbv2/listener_manager.go
@@ -2,7 +2,6 @@ package elbv2
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
@@ -29,14 +28,7 @@ var alpnNone = []string{
 	string(elbv2model.ALPNPolicyNone),
 }
 
-var PROTOCOLS_SUPPORTING_LISTENER_ATTRIBUTES = map[elbv2model.Protocol]bool{
-	elbv2model.ProtocolHTTP:    true,
-	elbv2model.ProtocolHTTPS:   true,
-	elbv2model.ProtocolTCP:     true,
-	elbv2model.ProtocolUDP:     false,
-	elbv2model.ProtocolTLS:     false,
-	elbv2model.ProtocolTCP_UDP: true,
-}
+var blockedProtocolsForAttributes = sets.New[elbv2model.Protocol](elbv2model.ProtocolTLS)
 
 // ListenerManager is responsible for create/update/delete Listener resources.
 type ListenerManager interface {
@@ -112,8 +104,7 @@ func (m *defaultListenerManager) Create(ctx context.Context, resLS *elbv2model.L
 	}); err != nil {
 		return elbv2model.ListenerStatus{}, errors.Wrap(err, "failed to update extra certificates on listener")
 	}
-	listenerARN := awssdk.ToString(sdkLS.Listener.ListenerArn)
-	if !isIsolatedRegion(getRegionFromARN(listenerARN)) && areListenerAttributesSupported(resLS.Spec.Protocol) {
+	if areListenerAttributesSupported(resLS.Spec.Protocol) {
 		if err := m.attributesReconciler.Reconcile(ctx, resLS, sdkLS); err != nil {
 			return elbv2model.ListenerStatus{}, err
 		}
@@ -133,8 +124,7 @@ func (m *defaultListenerManager) Update(ctx context.Context, resLS *elbv2model.L
 	if err := m.updateSDKListenerWithExtraCertificates(ctx, resLS, sdkLS, false); err != nil {
 		return elbv2model.ListenerStatus{}, err
 	}
-	listenerARN := awssdk.ToString(sdkLS.Listener.ListenerArn)
-	if !isIsolatedRegion(getRegionFromARN(listenerARN)) && areListenerAttributesSupported(resLS.Spec.Protocol) {
+	if areListenerAttributesSupported(resLS.Spec.Protocol) {
 		if err := m.attributesReconciler.Reconcile(ctx, resLS, sdkLS); err != nil {
 			return elbv2model.ListenerStatus{}, err
 		}
@@ -477,18 +467,7 @@ func buildResListenerStatus(sdkLS ListenerWithTags) elbv2model.ListenerStatus {
 }
 
 func areListenerAttributesSupported(protocol elbv2model.Protocol) bool {
-	supported, exists := PROTOCOLS_SUPPORTING_LISTENER_ATTRIBUTES[protocol]
-	return exists && supported
-}
-
-func getRegionFromARN(arn string) string {
-	if strings.HasPrefix(arn, "arn:") {
-		arnElements := strings.Split(arn, ":")
-		if len(arnElements) > 3 {
-			return arnElements[3]
-		}
-	}
-	return ""
+	return !blockedProtocolsForAttributes.Has(protocol)
 }
 
 // isRemoveMTLS -- should we inject the 'off' button for mutual auth?
@@ -521,10 +500,6 @@ func isRemoveALPN(sdkLS ListenerWithTags, lsSpec elbv2model.ListenerSpec) bool {
 
 	// Getting here indicates that the desired state is nil AND the SDK has ALPN data which needs to be removed.
 	return true
-}
-
-func isIsolatedRegion(region string) bool {
-	return strings.Contains(strings.ToLower(region), "-iso-")
 }
 
 func translateAdvertiseCAToEnum(s *string) elbv2types.AdvertiseTrustStoreCaNamesEnum {

--- a/pkg/deploy/elbv2/listener_manager_test.go
+++ b/pkg/deploy/elbv2/listener_manager_test.go
@@ -1,12 +1,13 @@
 package elbv2
 
 import (
+	"testing"
+
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	elbv2sdk "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
 	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 	"github.com/stretchr/testify/assert"
 	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
-	"testing"
 )
 
 func Test_isSDKListenerSettingsDrifted(t *testing.T) {
@@ -1150,6 +1151,61 @@ func Test_isRemoveALPN(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			res := isRemoveALPN(tc.sdkLS, tc.listenerSpec)
 			assert.Equal(t, tc.expected, res)
+		})
+	}
+}
+
+func Test_areListenerAttributesSupported(t *testing.T) {
+	testCases := []struct {
+		name     string
+		protocol elbv2model.Protocol
+		result   bool
+	}{
+		{
+			name:     "protocol HTTP",
+			protocol: elbv2model.ProtocolHTTP,
+			result:   true,
+		},
+		{
+			name:     "protocol HTTPS",
+			protocol: elbv2model.ProtocolHTTPS,
+			result:   true,
+		},
+		{
+			name:     "protocol TCP",
+			protocol: elbv2model.ProtocolTCP,
+			result:   true,
+		},
+		{
+			name:     "protocol UDP",
+			protocol: elbv2model.ProtocolUDP,
+			result:   true,
+		},
+		{
+			name:     "protocol TCP_UDP",
+			protocol: elbv2model.ProtocolTCP_UDP,
+			result:   true,
+		},
+		{
+			name:     "protocol QUIC",
+			protocol: elbv2model.ProtocolQUIC,
+			result:   true,
+		},
+		{
+			name:     "protocol TCP_QUIC",
+			protocol: elbv2model.ProtocolTCP_QUIC,
+			result:   true,
+		},
+		{
+			name:     "protocol TLS",
+			protocol: elbv2model.ProtocolTLS,
+			result:   false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := areListenerAttributesSupported(tc.protocol)
+			assert.Equal(t, tc.result, res)
 		})
 	}
 }

--- a/test/e2e/service/nlb_instance_target_test.go
+++ b/test/e2e/service/nlb_instance_target_test.go
@@ -185,23 +185,20 @@ var _ = Describe("test k8s service using instance target reconciled by the aws l
 				})
 				Expect(err).NotTo(HaveOccurred())
 			})
-			// remove this once listener attributes are available in isolated region
-			if !strings.Contains(tf.Options.AWSRegion, "-iso-") {
-				By("modifying listener attributes", func() {
-					err := stack.UpdateServiceAnnotations(ctx, tf, map[string]string{
-						"service.beta.kubernetes.io/aws-load-balancer-listener-attributes.TCP-80": "tcp.idle_timeout.seconds=400",
-					})
-					Expect(err).NotTo(HaveOccurred())
-
-					lsARN := verifier.GetLoadBalancerListenerARN(ctx, tf, lbARN, "80")
-
-					Eventually(func() bool {
-						return verifier.VerifyListenerAttributes(ctx, tf, lsARN, map[string]string{
-							"tcp.idle_timeout.seconds": "400",
-						}) == nil
-					}, utils.PollTimeoutShort, utils.PollIntervalMedium).Should(BeTrue())
+			By("modifying listener attributes", func() {
+				err := stack.UpdateServiceAnnotations(ctx, tf, map[string]string{
+					"service.beta.kubernetes.io/aws-load-balancer-listener-attributes.TCP-80": "tcp.idle_timeout.seconds=400",
 				})
-			}
+				Expect(err).NotTo(HaveOccurred())
+
+				lsARN := verifier.GetLoadBalancerListenerARN(ctx, tf, lbARN, "80")
+
+				Eventually(func() bool {
+					return verifier.VerifyListenerAttributes(ctx, tf, lsARN, map[string]string{
+						"tcp.idle_timeout.seconds": "400",
+					}) == nil
+				}, utils.PollTimeoutShort, utils.PollIntervalMedium).Should(BeTrue())
+			})
 		})
 		It("should provision internal load-balancer resources", func() {
 			By("deploying stack", func() {


### PR DESCRIPTION
### Description

We have closed the parity gaps in special AWS partitions, therefore we don't need the check anymore. Also, I refactored the protocol blocking for listener attributes to correctly match what the AWS API allows.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
