### PR TITLE
[feat i2g]support group ingress translate

### DIFF
--- a/docs/guide/gateway/migrate_from_ingress.md
+++ b/docs/guide/gateway/migrate_from_ingress.md
@@ -101,14 +101,11 @@ LB-level annotations (scheme, subnets, security groups, tags, etc.) must be cons
 
 Each member's `listen-ports` are unioned to build the shared Gateway's listeners. Each member's HTTPRoutes are scoped to only the listeners that member declared via `sectionName` in `parentRefs`. When `ssl-redirect` is set on any member, it applies group-wide: all members' routes attach to the HTTPS listener only, and a single redirect HTTPRoute is generated for HTTP listeners.
 
-Cross-namespace groups (Ingresses in different namespaces with the same `group.name`) are supported. When detected, the migration tool generates the Gateway in the first member's namespace (based on input file order) and sets `allowedRoutes.namespaces.from: Selector` on each listener, using a label selector matching `lbc-migrate/ingress-group: <groupName>`. You can move the Gateway to a different namespace after generation if needed. You must label the member namespaces accordingly before applying the generated manifests:
+Cross-namespace groups (Ingresses in different namespaces with the same `group.name`) are supported. When detected, the migration tool generates the Gateway in the first member's namespace (based on input file order) and sets `allowedRoutes.namespaces.from: All` on each listener, which permits HTTPRoutes from any namespace to attach. You can move the Gateway to a different namespace after generation if needed.
 
-```bash
-kubectl label namespace team-a lbc-migrate/ingress-group=shared-alb
-kubectl label namespace team-b lbc-migrate/ingress-group=shared-alb
-```
+!!! warning "Security consideration"
+    `From: All` allows HTTPRoutes from any namespace to attach to the Gateway. If you need tighter scoping, you can manually change `From: All` to `From: Selector` with a label selector after generation.
 
-If you later add a new namespace to the group, you must label it as well. The selector only matches namespaces with the label at the time of route attachment. See the [Gateway API cross-namespace routing guide](https://gateway-api.sigs.k8s.io/guides/multiple-ns/) for details.
 
 ### Known Differences from Ingress
 

--- a/docs/guide/gateway/migrate_from_ingress.md
+++ b/docs/guide/gateway/migrate_from_ingress.md
@@ -126,14 +126,6 @@ The migrated Gateway API manifests may produce more ALB listener rules than the 
 
 Additionally, ALB listener rule priority order may differ between Ingress and Gateway. The Ingress controller assigns priorities based on Ingress spec rule ordering, while the gateway controller follows the [Gateway API precedence specification](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.HTTPRouteRule) (path tyoe, path length, reation timestamp etc). For most configurations this produces equivalent behavior, but users with overlapping rules that depend on specific priority ordering should verify after migration.
 
-#### TargetGroupBinding
-
-If you have user-created `TargetGroupBinding` resources that reference external AWS Target Groups by ARN or name (the "bring your own TG" pattern), these are not affected by the migration. There is no Gateway API equivalent of `TargetGroupBinding` — Gateway API always creates and manages its own target groups.
-
-Standalone TGBs are reconciled independently by the TargetGroupBinding controller and do not depend on Ingress or Gateway resources. They will continue to work as-is after migration. No action is needed.
-
-Note: TargetGroupBindings that were automatically created by LBC to support Ingress or Service resources (visible via `kubectl get targetgroupbindings -n <namespace>`) are controller-managed. These are deleted when the Ingress is removed and recreated by the Gateway controller when it reconciles — you do not need to migrate them manually.
-
 #### Limited Support for Certain Ingress Annotations
 The following Ingress annotation types have limited support in the migration tool and Gatewaty API:
 

--- a/docs/guide/gateway/migrate_from_ingress.md
+++ b/docs/guide/gateway/migrate_from_ingress.md
@@ -93,12 +93,40 @@ Existing `Deployment` and `Service` resources are reused as-is and are not gener
 
 Gateway API has no `defaultBackend` equivalent ([upstream docs](https://gateway-api.sigs.k8s.io/guides/getting-started/migrating-from-ingress/#default-backend)). When an Ingress has both a `defaultBackend` and host-based rules, the tool generates a separate catch-all HTTPRoute with no hostnames or match conditions. This results in one additional ALB listener rule compared to the original Ingress, which is the expected Gateway API behavior. Additionally, the gateway controller scopes target groups per route, so the separate default-backend HTTPRoute creates its own target group even if it points to the same service as other rules. This means the migrated setup may have one extra target group compared to the Ingress setup, where a single target group is shared across all rules for the same service.
 
+### IngressGroup Support
+
+The migration tool detects `alb.ingress.kubernetes.io/group.name` and produces one shared Gateway + LoadBalancerConfiguration per group, with separate HTTPRoutes per member Ingress (preserving team ownership).
+
+LB-level annotations (scheme, subnets, security groups, tags, etc.) must be consistent across all Ingresses in a group — the tool errors if conflicting values are detected. TLS certificates (`certificate-arn`) are unioned across members. Tags and load-balancer-attributes are unioned with per-key conflict detection.
+
+Each member's `listen-ports` are unioned to build the shared Gateway's listeners. Each member's HTTPRoutes are scoped to only the listeners that member declared via `sectionName` in `parentRefs`. When `ssl-redirect` is set on any member, it applies group-wide: all members' routes attach to the HTTPS listener only, and a single redirect HTTPRoute is generated for HTTP listeners.
+
+Cross-namespace groups (Ingresses in different namespaces with the same `group.name`) are supported. When detected, the migration tool generates the Gateway in the first member's namespace (based on input file order) and sets `allowedRoutes.namespaces.from: Selector` on each listener, using a label selector matching `lbc-migrate/ingress-group: <groupName>`. You can move the Gateway to a different namespace after generation if needed. You must label the member namespaces accordingly before applying the generated manifests:
+
+```bash
+kubectl label namespace team-a lbc-migrate/ingress-group=shared-alb
+kubectl label namespace team-b lbc-migrate/ingress-group=shared-alb
+```
+
+If you later add a new namespace to the group, you must label it as well. The selector only matches namespaces with the label at the time of route attachment. See the [Gateway API cross-namespace routing guide](https://gateway-api.sigs.k8s.io/guides/multiple-ns/) for details.
+
 ### Known Differences from Ingress
+
+#### Rule Priority and `group.order`
+
+The `alb.ingress.kubernetes.io/group.order` annotation has no equivalent in Gateway API. In the Ingress model, `group.order` gives explicit control over ALB listener rule priority — rules from a lower-order Ingress always get lower priority numbers (higher precedence). In Gateway API, rule precedence is determined by the [Gateway API specification](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.HTTPRouteRule): hostname specificity, path match type, path length, header/query param count, route creation timestamp, and route name (alphabetical) etc. There is no annotation or field to override this ordering.
+
+For most configurations — where grouped Ingresses have non-overlapping hosts or paths — this produces equivalent behavior. If your Ingresses rely on `group.order` to resolve overlapping rules (same host + same path across different Ingresses), the migrated Gateway API rules may be evaluated in a different order. Review the generated HTTPRoutes and verify with the dry-run feature before switching traffic.
+
+The migration tool emits a warning when `group.order` is detected.
+
+#### ALB Listener Rule Count and Priority Order
 
 The migrated Gateway API manifests may produce more ALB listener rules than the original Ingress. This happens because ALB supports OR within a single condition (e.g., one `http-request-method` condition with values `[GET, HEAD]`), while Gateway API represents OR as separate `HTTPRouteMatch` entries — each becoming its own ALB rule. The routing behavior is functionally equivalent, but the rule count and priority numbers may differ. This affects conditions with multiple values for `path-pattern`, `http-request-method`, and `query-string`.
 
 Additionally, ALB listener rule priority order may differ between Ingress and Gateway. The Ingress controller assigns priorities based on Ingress spec rule ordering, while the gateway controller follows the [Gateway API precedence specification](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.HTTPRouteRule) (path tyoe, path length, reation timestamp etc). For most configurations this produces equivalent behavior, but users with overlapping rules that depend on specific priority ordering should verify after migration.
 
+#### Limited Support for Certain Ingress Annotations
 The following Ingress annotation types have limited support in the migration tool and Gatewaty API:
 
 - `host-header` conditions — values are passed through to Gateway API hostnames. Since hostnames are route-level in Gateway API (not per-rule), rules with host-header conditions are split into separate HTTPRoutes with their own hostnames. Complex wildcards (e.g., `www.*.example.com`) or regex values that don't conform to Gateway API hostname format will be rejected by the K8s API server when the manifest is applied.

--- a/docs/guide/gateway/migrate_from_ingress.md
+++ b/docs/guide/gateway/migrate_from_ingress.md
@@ -126,6 +126,14 @@ The migrated Gateway API manifests may produce more ALB listener rules than the 
 
 Additionally, ALB listener rule priority order may differ between Ingress and Gateway. The Ingress controller assigns priorities based on Ingress spec rule ordering, while the gateway controller follows the [Gateway API precedence specification](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.HTTPRouteRule) (path tyoe, path length, reation timestamp etc). For most configurations this produces equivalent behavior, but users with overlapping rules that depend on specific priority ordering should verify after migration.
 
+#### TargetGroupBinding
+
+If you have user-created `TargetGroupBinding` resources that reference external AWS Target Groups by ARN or name (the "bring your own TG" pattern), these are not affected by the migration. There is no Gateway API equivalent of `TargetGroupBinding` — Gateway API always creates and manages its own target groups.
+
+Standalone TGBs are reconciled independently by the TargetGroupBinding controller and do not depend on Ingress or Gateway resources. They will continue to work as-is after migration. No action is needed.
+
+Note: TargetGroupBindings that were automatically created by LBC to support Ingress or Service resources (visible via `kubectl get targetgroupbindings -n <namespace>`) are controller-managed. These are deleted when the Ingress is removed and recreated by the Gateway controller when it reconciles — you do not need to migrate them manually.
+
 #### Limited Support for Certain Ingress Annotations
 The following Ingress annotation types have limited support in the migration tool and Gatewaty API:
 

--- a/pkg/ingress2gateway/migrate.go
+++ b/pkg/ingress2gateway/migrate.go
@@ -19,6 +19,10 @@ func Migrate(ctx context.Context, opts MigrateOptions, readFunc ReadFunc, transl
 		return nil
 	}
 
+	// Normalize empty namespaces to "default" once, so all downstream code
+	// (warnings, translate, write) can assume Namespace is always non-empty.
+	resources.NormalizeNamespaces()
+
 	fmt.Fprintf(os.Stderr, "Found %d Ingress(es), %d Service(s), %d IngressClass(es), %d IngressClassParams\n",
 		len(resources.Ingresses), len(resources.Services),
 		len(resources.IngressClasses), len(resources.IngressClassParams))

--- a/pkg/ingress2gateway/translate/annotation_coverage_test.go
+++ b/pkg/ingress2gateway/translate/annotation_coverage_test.go
@@ -31,6 +31,10 @@ func TestAllIngressAnnotationsCovered(t *testing.T) {
 
 	// Implemented: annotations handled in the translate package.
 	implemented := map[string][]string{
+		IngressGrouping: {
+			annotations.IngressSuffixGroupName,
+			annotations.IngressSuffixGroupOrder,
+		},
 		LoadBalancerConfig: {
 			annotations.IngressSuffixScheme,
 			annotations.IngressSuffixLoadBalancerName,
@@ -93,10 +97,6 @@ func TestAllIngressAnnotationsCovered(t *testing.T) {
 
 	// Planned: annotations not yet implemented.
 	planned := map[string][]string{
-		IngressGrouping: {
-			annotations.IngressSuffixGroupName,
-			annotations.IngressSuffixGroupOrder,
-		},
 		Routing: {
 			// NOTE: "use-annotation" action backends (alb.ingress.kubernetes.io/actions.{name}),
 			// condition annotations (alb.ingress.kubernetes.io/conditions.{name}), and

--- a/pkg/ingress2gateway/translate/gateway.go
+++ b/pkg/ingress2gateway/translate/gateway.go
@@ -37,17 +37,12 @@ func buildGateway(name, namespace string, lbConfig *gatewayv1beta1.LoadBalancerC
 			Port:     gwv1.PortNumber(lp.Port),
 			Protocol: toALBProtocol(lp.Protocol),
 		}
-		// For cross-namespace groups, allow routes from namespaces matching a label selector.
+		// For cross-namespace groups, allow routes from all namespaces.
 		if crossNamespaceGroupName != "" {
-			fromSelector := gwv1.NamespacesFromSelector
+			fromAll := gwv1.NamespacesFromAll
 			listener.AllowedRoutes = &gwv1.AllowedRoutes{
 				Namespaces: &gwv1.RouteNamespaces{
-					From: &fromSelector,
-					Selector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							utils.CrossNamespaceGroupLabel: crossNamespaceGroupName,
-						},
-					},
+					From: &fromAll,
 				},
 			}
 		}

--- a/pkg/ingress2gateway/translate/gateway.go
+++ b/pkg/ingress2gateway/translate/gateway.go
@@ -1,8 +1,6 @@
 package translate
 
 import (
-	"strings"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1beta1 "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
 	gwconstants "sigs.k8s.io/aws-load-balancer-controller/pkg/gateway/constants"
@@ -29,7 +27,9 @@ func buildGatewayClass() gwv1.GatewayClass {
 
 // buildGateway builds a Gateway resource from listen-ports.
 // If lbConfig is non-nil, the Gateway's infrastructure.parametersRef points to it.
-func buildGateway(name, namespace string, lbConfig *gatewayv1beta1.LoadBalancerConfiguration, listenPorts []listenPortEntry) gwv1.Gateway {
+// If crossNamespaceGroupName is non-empty, each listener gets allowedRoutes with a
+// namespace selector so cross-namespace HTTPRoutes can attach.
+func buildGateway(name, namespace string, lbConfig *gatewayv1beta1.LoadBalancerConfiguration, listenPorts []listenPortEntry, crossNamespaceGroupName string) gwv1.Gateway {
 	var listeners []gwv1.Listener
 	for _, lp := range listenPorts {
 		listener := gwv1.Listener{
@@ -37,13 +37,17 @@ func buildGateway(name, namespace string, lbConfig *gatewayv1beta1.LoadBalancerC
 			Port:     gwv1.PortNumber(lp.Port),
 			Protocol: toALBProtocol(lp.Protocol),
 		}
-		// Gateway API requires a tls section for HTTPS listeners.
-		// The actual certificate is configured via LoadBalancerConfiguration,
-		// but the webhook rejects HTTPS listeners without tls set.
-		if strings.EqualFold(lp.Protocol, utils.ProtocolHTTPS) {
-			listener.TLS = &gwv1.ListenerTLSConfig{
-				CertificateRefs: []gwv1.SecretObjectReference{
-					{Name: utils.PlaceholderTLSSecretName},
+		// For cross-namespace groups, allow routes from namespaces matching a label selector.
+		if crossNamespaceGroupName != "" {
+			fromSelector := gwv1.NamespacesFromSelector
+			listener.AllowedRoutes = &gwv1.AllowedRoutes{
+				Namespaces: &gwv1.RouteNamespaces{
+					From: &fromSelector,
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							utils.CrossNamespaceGroupLabel: crossNamespaceGroupName,
+						},
+					},
 				},
 			}
 		}

--- a/pkg/ingress2gateway/translate/gateway_test.go
+++ b/pkg/ingress2gateway/translate/gateway_test.go
@@ -30,7 +30,6 @@ func TestBuildGateway(t *testing.T) {
 		wantListeners           int
 		wantParamsRef           bool
 		wantAllowedRoutes       bool
-		wantGroupLabel          string
 	}{
 		{
 			name:   "with LB config",
@@ -48,13 +47,12 @@ func TestBuildGateway(t *testing.T) {
 			wantListeners: 2, wantParamsRef: false,
 		},
 		{
-			name:   "cross-namespace group sets allowedRoutes selector",
+			name:   "cross-namespace group sets allowedRoutes to All",
 			gwName: "gw", namespace: "infra-ns",
 			listenPorts:             []listenPortEntry{{Protocol: "HTTP", Port: 80}, {Protocol: "HTTPS", Port: 443}},
 			crossNamespaceGroupName: "shared-alb",
 			wantListeners:           2,
 			wantAllowedRoutes:       true,
-			wantGroupLabel:          "shared-alb",
 		},
 		{
 			name:   "same-namespace group has no allowedRoutes",
@@ -81,9 +79,8 @@ func TestBuildGateway(t *testing.T) {
 					require.NotNil(t, listener.AllowedRoutes, "listener %s should have AllowedRoutes", listener.Name)
 					require.NotNil(t, listener.AllowedRoutes.Namespaces)
 					require.NotNil(t, listener.AllowedRoutes.Namespaces.From)
-					assert.Equal(t, gwv1.NamespacesFromSelector, *listener.AllowedRoutes.Namespaces.From)
-					require.NotNil(t, listener.AllowedRoutes.Namespaces.Selector)
-					assert.Equal(t, tt.wantGroupLabel, listener.AllowedRoutes.Namespaces.Selector.MatchLabels[utils.CrossNamespaceGroupLabel])
+					assert.Equal(t, gwv1.NamespacesFromAll, *listener.AllowedRoutes.Namespaces.From)
+					assert.Nil(t, listener.AllowedRoutes.Namespaces.Selector)
 				} else {
 					assert.Nil(t, listener.AllowedRoutes, "listener %s should not have AllowedRoutes", listener.Name)
 				}

--- a/pkg/ingress2gateway/translate/gateway_test.go
+++ b/pkg/ingress2gateway/translate/gateway_test.go
@@ -21,13 +21,16 @@ func TestBuildGatewayClass(t *testing.T) {
 
 func TestBuildGateway(t *testing.T) {
 	tests := []struct {
-		name          string
-		gwName        string
-		namespace     string
-		lbConfig      *gatewayv1beta1.LoadBalancerConfiguration
-		listenPorts   []listenPortEntry
-		wantListeners int
-		wantParamsRef bool
+		name                    string
+		gwName                  string
+		namespace               string
+		lbConfig                *gatewayv1beta1.LoadBalancerConfiguration
+		listenPorts             []listenPortEntry
+		crossNamespaceGroupName string
+		wantListeners           int
+		wantParamsRef           bool
+		wantAllowedRoutes       bool
+		wantGroupLabel          string
 	}{
 		{
 			name:   "with LB config",
@@ -41,21 +44,49 @@ func TestBuildGateway(t *testing.T) {
 		{
 			name:   "without LB config",
 			gwName: "bare-gw", namespace: "default",
-			lbConfig:      nil,
 			listenPorts:   []listenPortEntry{{Protocol: "HTTP", Port: 80}, {Protocol: "HTTPS", Port: 443}},
 			wantListeners: 2, wantParamsRef: false,
+		},
+		{
+			name:   "cross-namespace group sets allowedRoutes selector",
+			gwName: "gw", namespace: "infra-ns",
+			listenPorts:             []listenPortEntry{{Protocol: "HTTP", Port: 80}, {Protocol: "HTTPS", Port: 443}},
+			crossNamespaceGroupName: "shared-alb",
+			wantListeners:           2,
+			wantAllowedRoutes:       true,
+			wantGroupLabel:          "shared-alb",
+		},
+		{
+			name:   "same-namespace group has no allowedRoutes",
+			gwName: "gw", namespace: "ns",
+			listenPorts:   []listenPortEntry{{Protocol: "HTTP", Port: 80}},
+			wantListeners: 1,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gw := buildGateway(tt.gwName, tt.namespace, tt.lbConfig, tt.listenPorts)
+			gw := buildGateway(tt.gwName, tt.namespace, tt.lbConfig, tt.listenPorts, tt.crossNamespaceGroupName)
 			assert.Equal(t, tt.gwName, gw.Name)
 			require.Len(t, gw.Spec.Listeners, tt.wantListeners)
+
 			if tt.wantParamsRef {
 				require.NotNil(t, gw.Spec.Infrastructure)
 				assert.Equal(t, tt.lbConfig.Name, gw.Spec.Infrastructure.ParametersRef.Name)
 			} else {
 				assert.Nil(t, gw.Spec.Infrastructure)
+			}
+
+			for _, listener := range gw.Spec.Listeners {
+				if tt.wantAllowedRoutes {
+					require.NotNil(t, listener.AllowedRoutes, "listener %s should have AllowedRoutes", listener.Name)
+					require.NotNil(t, listener.AllowedRoutes.Namespaces)
+					require.NotNil(t, listener.AllowedRoutes.Namespaces.From)
+					assert.Equal(t, gwv1.NamespacesFromSelector, *listener.AllowedRoutes.Namespaces.From)
+					require.NotNil(t, listener.AllowedRoutes.Namespaces.Selector)
+					assert.Equal(t, tt.wantGroupLabel, listener.AllowedRoutes.Namespaces.Selector.MatchLabels[utils.CrossNamespaceGroupLabel])
+				} else {
+					assert.Nil(t, listener.AllowedRoutes, "listener %s should not have AllowedRoutes", listener.Name)
+				}
 			}
 		})
 	}

--- a/pkg/ingress2gateway/translate/group.go
+++ b/pkg/ingress2gateway/translate/group.go
@@ -165,7 +165,7 @@ func mergeExactMatchAnnotation(members []networking.Ingress, merged map[string]s
 func mergeCertificateARNs(members []networking.Ingress, merged map[string]string) error {
 	key := ingressAnnotationKeyPrefix + annotations.IngressSuffixCertificateARN
 	seen := make(map[string]struct{}) // for dedupe
-	var ordered []string              // for sorted output
+	var output []string
 	for _, ing := range members {
 		value, exists := ing.Annotations[key]
 		if !exists || value == "" {
@@ -178,12 +178,12 @@ func mergeCertificateARNs(members []networking.Ingress, merged map[string]string
 			}
 			if _, exists := seen[cert]; !exists {
 				seen[cert] = struct{}{}
-				ordered = append(ordered, cert)
+				output = append(output, cert)
 			}
 		}
 	}
-	if len(ordered) > 0 {
-		merged[key] = strings.Join(ordered, ",")
+	if len(output) > 0 {
+		merged[key] = strings.Join(output, ",")
 	}
 	return nil
 }

--- a/pkg/ingress2gateway/translate/group.go
+++ b/pkg/ingress2gateway/translate/group.go
@@ -5,6 +5,7 @@ import (
 	"maps"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 
 	networking "k8s.io/api/networking/v1"
@@ -84,9 +85,8 @@ func isCrossNamespace(ingresses []networking.Ingress) bool {
 	return false
 }
 
-// lbLevelAnnotationSuffixes are the annotation suffixes that apply at the
-// LoadBalancer / listener level. These must be consistent across all Ingresses
-// in a group (LBC errors on conflict at runtime).
+// lbLevelAnnotationSuffixes are the annotation suffixes that must be consistent
+// across all Ingresses in a group. LBC errors on conflict at runtime for these.
 var lbLevelAnnotationSuffixes = []string{
 	annotations.IngressSuffixScheme,
 	annotations.IngressSuffixLoadBalancerName,
@@ -218,7 +218,7 @@ func mergeStringMapAnnotation(members []networking.Ingress, merged map[string]st
 
 // mergeGroupListenPorts unions listen-port entries across group members.
 // Returns allPorts (the union for the shared Gateway) and perIngressPorts
-func mergeGroupListenPorts(members []networking.Ingress, mergedAnnotations map[string]string) ([]listenPortEntry, map[string][]listenPortEntry, error) {
+func mergeGroupListenPorts(members []networking.Ingress) ([]listenPortEntry, map[string][]listenPortEntry, error) {
 	seen := make(map[listenPortEntry]struct{})
 	var allPorts []listenPortEntry
 	perIngressPorts := make(map[string][]listenPortEntry)
@@ -229,7 +229,7 @@ func mergeGroupListenPorts(members []networking.Ingress, mergedAnnotations map[s
 			return nil, nil, fmt.Errorf("failed to parse listen-ports for %s: %w", k8s.NamespacedName(&ing).String(), err)
 		}
 		if len(ports) == 0 {
-			ports = defaultListenPorts(ing.Annotations, mergedAnnotations)
+			ports = defaultListenPorts(ing.Annotations)
 		}
 		perIngressPorts[k8s.NamespacedName(&ing).String()] = ports
 		for _, p := range ports {
@@ -252,19 +252,21 @@ func mergeGroupListenPorts(members []networking.Ingress, mergedAnnotations map[s
 }
 
 // defaultListenPorts returns the default listen-port when no listen-ports annotation is set.
-// HTTPS:443 if certificate-arn is present, otherwise HTTP:80.
-func defaultListenPorts(memberAnnotations, mergedAnnotations map[string]string) []listenPortEntry {
-	if getString(memberAnnotations, annotations.IngressSuffixCertificateARN) != "" ||
-		getString(mergedAnnotations, annotations.IngressSuffixCertificateARN) != "" {
+// HTTPS:443 if certificate-arn is present on the member itself, otherwise HTTP:80.
+func defaultListenPorts(ingressAnnotation map[string]string) []listenPortEntry {
+	if getString(ingressAnnotation, annotations.IngressSuffixCertificateARN) != "" {
 		return []listenPortEntry{{Protocol: utils.ProtocolHTTPS, Port: 443}}
 	}
 	return []listenPortEntry{{Protocol: utils.ProtocolHTTP, Port: 80}}
 }
 
-// resolveGroupICP finds the IngressClassParams for a group.
-// If multiple members reference different ICPs, returns an error.
-func resolveGroupICP(members []networking.Ingress, icpByClass map[string]*elbv2api.IngressClassParams) (*elbv2api.IngressClassParams, error) {
-	var groupICP *elbv2api.IngressClassParams
+// resolveGroupICPs collects all unique IngressClassParams referenced by group members.
+// In LBC, each member's ICP values are collected into per-field sets and conflict-checked
+// at the value level. We return all unique ICPs so the caller can apply them all and
+// let the per-field conflict detection in applyIngressClassParamsToLBConfig catch issues.
+func resolveGroupICPs(members []networking.Ingress, icpByClass map[string]*elbv2api.IngressClassParams) []*elbv2api.IngressClassParams {
+	seen := make(map[string]struct{})
+	var icps []*elbv2api.IngressClassParams
 	for _, ing := range members {
 		if ing.Spec.IngressClassName == nil {
 			continue
@@ -273,22 +275,41 @@ func resolveGroupICP(members []networking.Ingress, icpByClass map[string]*elbv2a
 		if !exist {
 			continue
 		}
-		if groupICP == nil {
-			groupICP = icp
-		} else if groupICP.Name != icp.Name {
-			return nil, fmt.Errorf("conflicting IngressClassParams in group: %q vs %q",
-				groupICP.Name, icp.Name)
+		if _, exists := seen[icp.Name]; !exists {
+			seen[icp.Name] = struct{}{}
+			icps = append(icps, icp)
 		}
 	}
-	return groupICP, nil
+	return icps
 }
 
-// resolveGroupSSLRedirect collects ssl-redirect across all members and ICP.
+// resolveGroupSSLRedirect collects ssl-redirect across all members and ICPs.
 // Returns nil if not set. Errors if >1 distinct value.
-func resolveGroupSSLRedirect(members []networking.Ingress, icp *elbv2api.IngressClassParams) (*int32, error) {
+func resolveGroupSSLRedirect(members []networking.Ingress, icpByClass map[string]*elbv2api.IngressClassParams) (*int32, error) {
+	// Per-member resolution: ICP wins over annotation for each member.
+	// Then group-wide conflict detection across all resolved values.
+	// This matches LBC's buildSSLRedirectConfig behavior.
 	var result *int32
 	for _, ing := range members {
-		p := resolveSSLRedirectPort(ing.Annotations, icp)
+		var p *int32
+
+		// Check if this member's ICP sets ssl-redirect
+		if ing.Spec.IngressClassName != nil {
+			if icp, exist := icpByClass[*ing.Spec.IngressClassName]; exist && icp.Spec.SSLRedirectPort != "" {
+				port, err := strconv.ParseInt(icp.Spec.SSLRedirectPort, 10, 32)
+				if err != nil {
+					return nil, fmt.Errorf("invalid ICP ssl-redirect port %q: %w", icp.Spec.SSLRedirectPort, err)
+				}
+				v := int32(port)
+				p = &v
+			}
+		}
+
+		// If ICP didn't set it for this member, check annotation
+		if p == nil {
+			p = getInt32(ing.Annotations, annotations.IngressSuffixSSLRedirect)
+		}
+
 		if p == nil {
 			continue
 		}

--- a/pkg/ingress2gateway/translate/group.go
+++ b/pkg/ingress2gateway/translate/group.go
@@ -1,0 +1,355 @@
+package translate
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"sort"
+	"strings"
+
+	networking "k8s.io/api/networking/v1"
+	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
+	annotations "sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/ingress2gateway/utils"
+	k8s "sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// ingressAnnotationKeyPrefix is the full annotation key prefix including the trailing slash.
+const ingressAnnotationKeyPrefix = annotations.AnnotationPrefixIngress + "/"
+
+// ingressGroup represents a set of Ingresses that share one ALB.
+// For explicit groups (group.name annotation), multiple Ingresses share one Gateway.
+// For implicit groups (no group.name), each Ingress is a group of 1, which means it has 1 member
+type ingressGroup struct {
+	name           string // group.name for explicit, Ingress name for implicit
+	namespace      string // first member's namespace (Gateway placement)
+	isExplicit     bool
+	crossNamespace bool
+	members        []networking.Ingress
+}
+
+// partitionByGroup splits Ingresses into groups. Ingresses with the same
+// group.name annotation form an explicit group. Ingresses without group.name
+// become implicit single-member groups.
+func partitionByGroup(ingresses []networking.Ingress) []ingressGroup {
+	explicit := make(map[string][]networking.Ingress)
+	var ungrouped []networking.Ingress
+
+	for _, ing := range ingresses {
+		groupName := getString(ing.Annotations, annotations.IngressSuffixGroupName)
+		if groupName != "" {
+			explicit[groupName] = append(explicit[groupName], ing)
+		} else {
+			ungrouped = append(ungrouped, ing)
+		}
+	}
+
+	var groups []ingressGroup
+
+	for _, name := range slices.Sorted(maps.Keys(explicit)) {
+		members := explicit[name]
+		crossNS := isCrossNamespace(members)
+		groups = append(groups, ingressGroup{
+			name:           name,
+			namespace:      members[0].Namespace,
+			isExplicit:     true,
+			crossNamespace: crossNS,
+			members:        members,
+		})
+	}
+
+	for _, ing := range ungrouped {
+		groups = append(groups, ingressGroup{
+			name:      ing.Name,
+			namespace: ing.Namespace,
+			members:   []networking.Ingress{ing},
+		})
+	}
+
+	return groups
+}
+
+// isCrossNamespace returns true if ingresses span multiple namespaces.
+func isCrossNamespace(ingresses []networking.Ingress) bool {
+	if len(ingresses) <= 1 {
+		return false
+	}
+	firstNS := ingresses[0].Namespace
+	for _, m := range ingresses[1:] {
+		if m.Namespace != firstNS {
+			return true
+		}
+	}
+	return false
+}
+
+// lbLevelAnnotationSuffixes are the annotation suffixes that apply at the
+// LoadBalancer / listener level. These must be consistent across all Ingresses
+// in a group (LBC errors on conflict at runtime).
+var lbLevelAnnotationSuffixes = []string{
+	annotations.IngressSuffixScheme,
+	annotations.IngressSuffixLoadBalancerName,
+	annotations.IngressSuffixIPAddressType,
+	annotations.IngressSuffixSubnets,
+	annotations.IngressSuffixCustomerOwnedIPv4Pool,
+	annotations.IngressSuffixIPAMIPv4PoolId,
+	annotations.IngressSuffixSecurityGroups,
+	annotations.IngressSuffixManageSecurityGroupRules,
+	annotations.IngressSuffixInboundCIDRs,
+	annotations.IngressSuffixSecurityGroupPrefixLists,
+	annotations.IngressSuffixSSLPolicy,
+	annotations.IngressSuffixWAFv2ACLARN,
+	annotations.IngressSuffixWAFv2ACLName,
+	annotations.IngressSuffixShieldAdvancedProtection,
+	annotations.IngressSuffixLoadBalancerCapacityReservation,
+	annotations.IngressSuffixMutualAuthentication,
+}
+
+// mergeGroupLBAnnotations merges LB-level annotations across group members.
+// Scalar annotations: error if >1 distinct value.
+// certificate-arn: union. tags / load-balancer-attributes: union keys, error on per-key conflict.
+func mergeGroupLBAnnotations(members []networking.Ingress) (map[string]string, error) {
+	if len(members) == 1 {
+		return resolveAnnotations(members[0]), nil
+	}
+
+	merged := make(map[string]string)
+
+	// Scalar LB-level annotations: error on conflict
+	for _, suffix := range lbLevelAnnotationSuffixes {
+		if err := mergeExactMatchAnnotation(members, merged, suffix); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := mergeCertificateARNs(members, merged); err != nil {
+		return nil, err
+	}
+	if err := mergeStringMapAnnotation(members, merged, annotations.IngressSuffixTags); err != nil {
+		return nil, err
+	}
+	if err := mergeStringMapAnnotation(members, merged, annotations.IngressSuffixLoadBalancerAttributes); err != nil {
+		return nil, err
+	}
+
+	return merged, nil
+}
+
+// mergeExactMatchAnnotation merges an annotation that must have the same value
+// across all members. Errors if two members set different non-empty values.
+func mergeExactMatchAnnotation(members []networking.Ingress, merged map[string]string, suffix string) error {
+	key := ingressAnnotationKeyPrefix + suffix
+	var annotationVal string
+	set := false
+	for _, ing := range members {
+		value, exists := ing.Annotations[key]
+		if !exists || value == "" {
+			continue
+		}
+		if !set {
+			annotationVal = value
+			set = true
+		} else if value != annotationVal {
+			return fmt.Errorf("conflicting annotation %s in group: %q vs %q",
+				key, annotationVal, value)
+		}
+	}
+	if set {
+		merged[key] = annotationVal
+	}
+	return nil
+}
+
+// mergeCertificateARNs unions certificate-arn values across members.
+func mergeCertificateARNs(members []networking.Ingress, merged map[string]string) error {
+	key := ingressAnnotationKeyPrefix + annotations.IngressSuffixCertificateARN
+	seen := make(map[string]struct{}) // for dedupe
+	var ordered []string              // for sorted output
+	for _, ing := range members {
+		value, exists := ing.Annotations[key]
+		if !exists || value == "" {
+			continue
+		}
+		for _, cert := range strings.Split(value, ",") {
+			cert = strings.TrimSpace(cert)
+			if cert == "" {
+				continue
+			}
+			if _, exists := seen[cert]; !exists {
+				seen[cert] = struct{}{}
+				ordered = append(ordered, cert)
+			}
+		}
+	}
+	if len(ordered) > 0 {
+		merged[key] = strings.Join(ordered, ",")
+	}
+	return nil
+}
+
+// mergeStringMapAnnotation merges a stringMap annotation (k1=v1,k2=v2) across members.
+// Union keys; error if same key has different values.
+func mergeStringMapAnnotation(members []networking.Ingress, merged map[string]string, suffix string) error {
+	key := ingressAnnotationKeyPrefix + suffix
+	unionMap := make(map[string]string)
+	for _, ing := range members {
+		var parsed map[string]string
+		if _, err := ingressAnnotationParser.ParseStringMapAnnotation(suffix, &parsed, ing.Annotations); err != nil {
+			return fmt.Errorf("failed to parse %s on %s: %w", key, k8s.NamespacedName(&ing).String(), err)
+		}
+		for mk, mv := range parsed {
+			if existing, exists := unionMap[mk]; exists && existing != mv {
+				return fmt.Errorf("conflicting %s key %q in group: %q vs %q", suffix, mk, existing, mv)
+			}
+			unionMap[mk] = mv
+		}
+	}
+	if len(unionMap) > 0 {
+		var parts []string
+		for k, v := range unionMap {
+			parts = append(parts, k+"="+v)
+		}
+		sort.Strings(parts)
+		merged[key] = strings.Join(parts, ",")
+	}
+	return nil
+}
+
+// mergeGroupListenPorts unions listen-port entries across group members.
+// Returns allPorts (the union for the shared Gateway) and perIngressPorts
+func mergeGroupListenPorts(members []networking.Ingress, mergedAnnotations map[string]string) ([]listenPortEntry, map[string][]listenPortEntry, error) {
+	seen := make(map[listenPortEntry]struct{})
+	var allPorts []listenPortEntry
+	perIngressPorts := make(map[string][]listenPortEntry)
+
+	for _, ing := range members {
+		ports, err := parseListenPorts(ing.Annotations)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to parse listen-ports for %s: %w", k8s.NamespacedName(&ing).String(), err)
+		}
+		if len(ports) == 0 {
+			ports = defaultListenPorts(ing.Annotations, mergedAnnotations)
+		}
+		perIngressPorts[k8s.NamespacedName(&ing).String()] = ports
+		for _, p := range ports {
+			pk := listenPortEntry{Protocol: p.Protocol, Port: p.Port}
+			if _, exists := seen[pk]; !exists {
+				seen[pk] = struct{}{}
+				allPorts = append(allPorts, p)
+			}
+		}
+	}
+
+	sort.Slice(allPorts, func(i, j int) bool {
+		if allPorts[i].Port != allPorts[j].Port {
+			return allPorts[i].Port < allPorts[j].Port
+		}
+		return allPorts[i].Protocol < allPorts[j].Protocol
+	})
+
+	return allPorts, perIngressPorts, nil
+}
+
+// defaultListenPorts returns the default listen-port when no listen-ports annotation is set.
+// HTTPS:443 if certificate-arn is present, otherwise HTTP:80.
+func defaultListenPorts(memberAnnotations, mergedAnnotations map[string]string) []listenPortEntry {
+	if getString(memberAnnotations, annotations.IngressSuffixCertificateARN) != "" ||
+		getString(mergedAnnotations, annotations.IngressSuffixCertificateARN) != "" {
+		return []listenPortEntry{{Protocol: utils.ProtocolHTTPS, Port: 443}}
+	}
+	return []listenPortEntry{{Protocol: utils.ProtocolHTTP, Port: 80}}
+}
+
+// resolveGroupICP finds the IngressClassParams for a group.
+// If multiple members reference different ICPs, returns an error.
+func resolveGroupICP(members []networking.Ingress, icpByClass map[string]*elbv2api.IngressClassParams) (*elbv2api.IngressClassParams, error) {
+	var groupICP *elbv2api.IngressClassParams
+	for _, ing := range members {
+		if ing.Spec.IngressClassName == nil {
+			continue
+		}
+		icp, exist := icpByClass[*ing.Spec.IngressClassName]
+		if !exist {
+			continue
+		}
+		if groupICP == nil {
+			groupICP = icp
+		} else if groupICP.Name != icp.Name {
+			return nil, fmt.Errorf("conflicting IngressClassParams in group: %q vs %q",
+				groupICP.Name, icp.Name)
+		}
+	}
+	return groupICP, nil
+}
+
+// resolveGroupSSLRedirect collects ssl-redirect across all members and ICP.
+// Returns nil if not set. Errors if >1 distinct value.
+func resolveGroupSSLRedirect(members []networking.Ingress, icp *elbv2api.IngressClassParams) (*int32, error) {
+	var result *int32
+	for _, ing := range members {
+		p := resolveSSLRedirectPort(ing.Annotations, icp)
+		if p == nil {
+			continue
+		}
+		if result == nil {
+			result = p
+		} else if *p != *result {
+			return nil, fmt.Errorf("conflicting ssl-redirect ports in group: %d vs %d", *result, *p)
+		}
+	}
+	return result, nil
+}
+
+// listenPortsEqual returns true if two port slices contain the same entries (order-independent).
+func listenPortsEqual(a, b []listenPortEntry) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	set := make(map[listenPortEntry]struct{}, len(a))
+	for _, p := range a {
+		set[listenPortEntry{Protocol: p.Protocol, Port: p.Port}] = struct{}{}
+	}
+	for _, p := range b {
+		if _, ok := set[listenPortEntry{Protocol: p.Protocol, Port: p.Port}]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// buildMemberParentRefs builds parentRefs for a member's HTTPRoutes.
+// - 1. sslRedirectPort set: scope to HTTPS listener only.
+// - 2. memberPorts == allPorts: no sectionName (attach to all listeners).
+// - 3. Otherwise: one parentRef per memberPort with sectionName.
+func buildMemberParentRefs(gatewayName, gatewayNamespace, memberNamespace string, memberPorts, allPorts []listenPortEntry, sslRedirectPort *int32) []gwv1.ParentReference {
+	if sslRedirectPort != nil {
+		sn := utils.GenerateSectionName(utils.ProtocolHTTPS, *sslRedirectPort)
+		return []gwv1.ParentReference{buildParentRef(gatewayName, gatewayNamespace, memberNamespace, &sn)}
+	}
+	if listenPortsEqual(memberPorts, allPorts) {
+		return []gwv1.ParentReference{buildParentRef(gatewayName, gatewayNamespace, memberNamespace, nil)}
+	}
+	refs := make([]gwv1.ParentReference, 0, len(memberPorts))
+	for _, listenerPortEntry := range memberPorts {
+		sn := utils.GenerateSectionName(listenerPortEntry.Protocol, listenerPortEntry.Port)
+		refs = append(refs, buildParentRef(gatewayName, gatewayNamespace, memberNamespace, &sn))
+	}
+	return refs
+}
+
+// buildParentRef creates a single ParentReference, adding namespace if cross-namespace.
+func buildParentRef(gatewayName, gatewayNamespace, memberNamespace string, sectionName *string) gwv1.ParentReference {
+	ref := gwv1.ParentReference{
+		Name: gwv1.ObjectName(gatewayName),
+	}
+	if sectionName != nil {
+		sn := gwv1.SectionName(*sectionName)
+		ref.SectionName = &sn
+	}
+	if gatewayNamespace != memberNamespace {
+		ns := gwv1.Namespace(gatewayNamespace)
+		ref.Namespace = &ns
+	}
+	return ref
+}

--- a/pkg/ingress2gateway/translate/group_test.go
+++ b/pkg/ingress2gateway/translate/group_test.go
@@ -182,7 +182,6 @@ func TestMergeGroupListenPorts(t *testing.T) {
 	tests := []struct {
 		name           string
 		members        []networking.Ingress
-		mergedAnnos    map[string]string
 		wantAllPorts   int
 		wantMemberKeys []string
 	}{
@@ -196,7 +195,6 @@ func TestMergeGroupListenPorts(t *testing.T) {
 					"alb.ingress.kubernetes.io/listen-ports": `[{"HTTPS":443}]`,
 				}}},
 			},
-			mergedAnnos:    map[string]string{},
 			wantAllPorts:   2,
 			wantMemberKeys: []string{"ns/a", "ns/b"},
 		},
@@ -210,7 +208,6 @@ func TestMergeGroupListenPorts(t *testing.T) {
 					"alb.ingress.kubernetes.io/listen-ports": `[{"HTTP":80}]`,
 				}}},
 			},
-			mergedAnnos:  map[string]string{},
 			wantAllPorts: 1,
 		},
 		{
@@ -218,21 +215,21 @@ func TestMergeGroupListenPorts(t *testing.T) {
 			members: []networking.Ingress{
 				{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns"}},
 			},
-			mergedAnnos:  map[string]string{},
 			wantAllPorts: 1, // HTTP:80 default
 		},
 		{
-			name: "default HTTPS when cert-arn in merged",
+			name: "default HTTPS when member has cert-arn",
 			members: []networking.Ingress{
-				{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns", Annotations: map[string]string{
+					"alb.ingress.kubernetes.io/certificate-arn": "arn:cert",
+				}}},
 			},
-			mergedAnnos:  map[string]string{"alb.ingress.kubernetes.io/certificate-arn": "arn:cert"},
 			wantAllPorts: 1, // HTTPS:443 default
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			allPorts, perMember, err := mergeGroupListenPorts(tt.members, tt.mergedAnnos)
+			allPorts, perMember, err := mergeGroupListenPorts(tt.members)
 			require.NoError(t, err)
 			assert.Len(t, allPorts, tt.wantAllPorts)
 			if tt.wantMemberKeys != nil {
@@ -244,26 +241,24 @@ func TestMergeGroupListenPorts(t *testing.T) {
 	}
 }
 
-func TestResolveGroupICP(t *testing.T) {
+func TestResolveGroupICPs(t *testing.T) {
 	icpA := &elbv2api.IngressClassParams{ObjectMeta: metav1.ObjectMeta{Name: "params-a"}}
-	icpB := &elbv2api.IngressClassParams{ObjectMeta: metav1.ObjectMeta{Name: "params-b"}}
 	icpByClass := map[string]*elbv2api.IngressClassParams{
-		"alb":        icpA,
-		"alb-public": icpB,
+		"alb": icpA,
 	}
 
 	tests := []struct {
-		name    string
-		members []networking.Ingress
-		wantICP string // expected ICP name, or "" for nil
-		wantErr string
+		name     string
+		members  []networking.Ingress
+		wantLen  int
+		wantName string // first ICP name if wantLen > 0
 	}{
 		{
 			name: "no ICP",
 			members: []networking.Ingress{
 				{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns"}},
 			},
-			wantICP: "",
+			wantLen: 0,
 		},
 		{
 			name: "one member with ICP",
@@ -271,87 +266,123 @@ func TestResolveGroupICP(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns"}, Spec: networking.IngressSpec{IngressClassName: ptr.To("alb")}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "ns"}},
 			},
-			wantICP: "params-a",
+			wantLen:  1,
+			wantName: "params-a",
 		},
 		{
-			name: "same ICP no conflict",
+			name: "same ICP deduped",
 			members: []networking.Ingress{
 				{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns"}, Spec: networking.IngressSpec{IngressClassName: ptr.To("alb")}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "ns"}, Spec: networking.IngressSpec{IngressClassName: ptr.To("alb")}},
 			},
-			wantICP: "params-a",
-		},
-		{
-			name: "different ICPs conflict",
-			members: []networking.Ingress{
-				{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns"}, Spec: networking.IngressSpec{IngressClassName: ptr.To("alb")}},
-				{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "ns"}, Spec: networking.IngressSpec{IngressClassName: ptr.To("alb-public")}},
-			},
-			wantErr: "conflicting IngressClassParams",
+			wantLen:  1,
+			wantName: "params-a",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			icp, err := resolveGroupICP(tt.members, icpByClass)
-			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
-				return
-			}
-			require.NoError(t, err)
-			if tt.wantICP == "" {
-				assert.Nil(t, icp)
-			} else {
-				require.NotNil(t, icp)
-				assert.Equal(t, tt.wantICP, icp.Name)
+			icps := resolveGroupICPs(tt.members, icpByClass)
+			assert.Len(t, icps, tt.wantLen)
+			if tt.wantLen > 0 {
+				assert.Equal(t, tt.wantName, icps[0].Name)
 			}
 		})
 	}
 }
 
 func TestResolveGroupSSLRedirect(t *testing.T) {
+	icpWithRedirect := &elbv2api.IngressClassParams{
+		ObjectMeta: metav1.ObjectMeta{Name: "params-redirect"},
+		Spec:       elbv2api.IngressClassParamsSpec{SSLRedirectPort: "443"},
+	}
+	icpWithDifferentRedirect := &elbv2api.IngressClassParams{
+		ObjectMeta: metav1.ObjectMeta{Name: "params-redirect-8443"},
+		Spec:       elbv2api.IngressClassParamsSpec{SSLRedirectPort: "8443"},
+	}
+	icpNoRedirect := &elbv2api.IngressClassParams{
+		ObjectMeta: metav1.ObjectMeta{Name: "params-no-redirect"},
+	}
+
 	tests := []struct {
-		name    string
-		members []networking.Ingress
-		wantNil bool
-		wantVal int32
-		wantErr string
+		name       string
+		members    []networking.Ingress
+		icpByClass map[string]*elbv2api.IngressClassParams
+		wantNil    bool
+		wantVal    int32
+		wantErr    string
 	}{
 		{
-			name: "no ssl-redirect",
+			name: "no ssl-redirect anywhere",
 			members: []networking.Ingress{
 				{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns"}},
 			},
-			wantNil: true,
+			icpByClass: map[string]*elbv2api.IngressClassParams{},
+			wantNil:    true,
 		},
 		{
-			name: "one member sets ssl-redirect",
+			name: "one member sets ssl-redirect via annotation",
 			members: []networking.Ingress{
 				{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns", Annotations: map[string]string{"alb.ingress.kubernetes.io/ssl-redirect": "443"}}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "ns"}},
 			},
-			wantVal: 443,
+			icpByClass: map[string]*elbv2api.IngressClassParams{},
+			wantVal:    443,
 		},
 		{
-			name: "same value no conflict",
-			members: []networking.Ingress{
-				{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns", Annotations: map[string]string{"alb.ingress.kubernetes.io/ssl-redirect": "443"}}},
-				{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "ns", Annotations: map[string]string{"alb.ingress.kubernetes.io/ssl-redirect": "443"}}},
-			},
-			wantVal: 443,
-		},
-		{
-			name: "conflicting values",
+			name: "conflicting annotation values",
 			members: []networking.Ingress{
 				{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns", Annotations: map[string]string{"alb.ingress.kubernetes.io/ssl-redirect": "443"}}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "ns", Annotations: map[string]string{"alb.ingress.kubernetes.io/ssl-redirect": "8443"}}},
 			},
+			icpByClass: map[string]*elbv2api.IngressClassParams{},
+			wantErr:    "conflicting ssl-redirect",
+		},
+		{
+			name: "ICP sets ssl-redirect, annotation ignored",
+			members: []networking.Ingress{
+				{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns", Annotations: map[string]string{"alb.ingress.kubernetes.io/ssl-redirect": "8443"}},
+					Spec: networking.IngressSpec{IngressClassName: ptr.To("alb")}},
+			},
+			icpByClass: map[string]*elbv2api.IngressClassParams{"alb": icpWithRedirect},
+			wantVal:    443, // ICP wins over annotation's 8443
+		},
+		{
+			name: "ICP sets ssl-redirect, member B annotation differs — error",
+			members: []networking.Ingress{
+				{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns"},
+					Spec: networking.IngressSpec{IngressClassName: ptr.To("alb")}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "ns", Annotations: map[string]string{"alb.ingress.kubernetes.io/ssl-redirect": "8443"}}},
+			},
+			icpByClass: map[string]*elbv2api.IngressClassParams{"alb": icpWithRedirect},
+			wantErr:    "conflicting ssl-redirect",
+		},
+		{
+			name: "two ICPs with different ssl-redirect — error",
+			members: []networking.Ingress{
+				{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns"},
+					Spec: networking.IngressSpec{IngressClassName: ptr.To("alb")}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "ns"},
+					Spec: networking.IngressSpec{IngressClassName: ptr.To("alb-other")}},
+			},
+			icpByClass: map[string]*elbv2api.IngressClassParams{
+				"alb":       icpWithRedirect,
+				"alb-other": icpWithDifferentRedirect,
+			},
 			wantErr: "conflicting ssl-redirect",
+		},
+		{
+			name: "ICP without ssl-redirect falls through to annotation",
+			members: []networking.Ingress{
+				{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns", Annotations: map[string]string{"alb.ingress.kubernetes.io/ssl-redirect": "443"}},
+					Spec: networking.IngressSpec{IngressClassName: ptr.To("alb")}},
+			},
+			icpByClass: map[string]*elbv2api.IngressClassParams{"alb": icpNoRedirect},
+			wantVal:    443,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := resolveGroupSSLRedirect(tt.members, nil)
+			result, err := resolveGroupSSLRedirect(tt.members, tt.icpByClass)
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)

--- a/pkg/ingress2gateway/translate/group_test.go
+++ b/pkg/ingress2gateway/translate/group_test.go
@@ -1,0 +1,434 @@
+package translate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	networking "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestPartitionByGroup(t *testing.T) {
+	tests := []struct {
+		name              string
+		ingresses         []networking.Ingress
+		wantExplicitCount int // number of explicit groups
+		wantImplicitCount int // number of implicit (single-member) groups
+		wantGroupSizes    map[string]int
+	}{
+		{
+			name: "two ingresses same group, one ungrouped",
+			ingresses: []networking.Ingress{
+				{ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "team-a", Annotations: map[string]string{"alb.ingress.kubernetes.io/group.name": "shared"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "team-b", Annotations: map[string]string{"alb.ingress.kubernetes.io/group.name": "shared"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "solo", Namespace: "default"}},
+			},
+			wantExplicitCount: 1,
+			wantImplicitCount: 1,
+			wantGroupSizes:    map[string]int{"shared": 2},
+		},
+		{
+			name: "all ungrouped",
+			ingresses: []networking.Ingress{
+				{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "default"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "default"}},
+			},
+			wantExplicitCount: 0,
+			wantImplicitCount: 2,
+		},
+		{
+			name: "two different groups",
+			ingresses: []networking.Ingress{
+				{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns", Annotations: map[string]string{"alb.ingress.kubernetes.io/group.name": "g1"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "ns", Annotations: map[string]string{"alb.ingress.kubernetes.io/group.name": "g2"}}},
+			},
+			wantExplicitCount: 2,
+			wantImplicitCount: 0,
+			wantGroupSizes:    map[string]int{"g1": 1, "g2": 1},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			groups := partitionByGroup(tt.ingresses)
+			explicit := 0
+			implicit := 0
+			for _, g := range groups {
+				if g.isExplicit {
+					explicit++
+					if expected, ok := tt.wantGroupSizes[g.name]; ok {
+						assert.Equal(t, expected, len(g.members), "group %s member count", g.name)
+					}
+				} else {
+					implicit++
+					assert.Len(t, g.members, 1)
+				}
+			}
+			assert.Equal(t, tt.wantExplicitCount, explicit, "explicit group count")
+			assert.Equal(t, tt.wantImplicitCount, implicit, "implicit group count")
+		})
+	}
+}
+
+func TestMergeGroupLBAnnotations(t *testing.T) {
+	tests := []struct {
+		name    string
+		members []networking.Ingress
+		wantErr string
+		check   func(t *testing.T, merged map[string]string)
+	}{
+		{
+			name: "single member passthrough",
+			members: []networking.Ingress{
+				{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns", Annotations: map[string]string{
+					"alb.ingress.kubernetes.io/scheme":      "internal",
+					"alb.ingress.kubernetes.io/target-type": "ip",
+				}}},
+			},
+			check: func(t *testing.T, merged map[string]string) {
+				assert.Equal(t, "internal", merged["alb.ingress.kubernetes.io/scheme"])
+				assert.Equal(t, "ip", merged["alb.ingress.kubernetes.io/target-type"])
+			},
+		},
+		{
+			name: "same scheme no conflict",
+			members: []networking.Ingress{
+				{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns", Annotations: map[string]string{"alb.ingress.kubernetes.io/scheme": "internal"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "ns", Annotations: map[string]string{"alb.ingress.kubernetes.io/scheme": "internal"}}},
+			},
+			check: func(t *testing.T, merged map[string]string) {
+				assert.Equal(t, "internal", merged["alb.ingress.kubernetes.io/scheme"])
+			},
+		},
+		{
+			name: "conflicting scheme errors",
+			members: []networking.Ingress{
+				{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns", Annotations: map[string]string{"alb.ingress.kubernetes.io/scheme": "internal"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "ns", Annotations: map[string]string{"alb.ingress.kubernetes.io/scheme": "internet-facing"}}},
+			},
+			wantErr: "conflicting annotation",
+		},
+		{
+			name: "certificate-arn union",
+			members: []networking.Ingress{
+				{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns", Annotations: map[string]string{"alb.ingress.kubernetes.io/certificate-arn": "arn:cert-a"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "ns", Annotations: map[string]string{"alb.ingress.kubernetes.io/certificate-arn": "arn:cert-b"}}},
+			},
+			check: func(t *testing.T, merged map[string]string) {
+				assert.Equal(t, "arn:cert-a,arn:cert-b", merged["alb.ingress.kubernetes.io/certificate-arn"])
+			},
+		},
+		{
+			name: "certificate-arn dedup",
+			members: []networking.Ingress{
+				{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns", Annotations: map[string]string{"alb.ingress.kubernetes.io/certificate-arn": "arn:cert-a,arn:cert-b"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "ns", Annotations: map[string]string{"alb.ingress.kubernetes.io/certificate-arn": "arn:cert-b,arn:cert-c"}}},
+			},
+			check: func(t *testing.T, merged map[string]string) {
+				assert.Equal(t, "arn:cert-a,arn:cert-b,arn:cert-c", merged["alb.ingress.kubernetes.io/certificate-arn"])
+			},
+		},
+		{
+			name: "tags union no conflict",
+			members: []networking.Ingress{
+				{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns", Annotations: map[string]string{"alb.ingress.kubernetes.io/tags": "env=prod"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "ns", Annotations: map[string]string{"alb.ingress.kubernetes.io/tags": "team=platform"}}},
+			},
+			check: func(t *testing.T, merged map[string]string) {
+				v := merged["alb.ingress.kubernetes.io/tags"]
+				assert.Contains(t, v, "env=prod")
+				assert.Contains(t, v, "team=platform")
+			},
+		},
+		{
+			name: "tags conflict errors",
+			members: []networking.Ingress{
+				{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns", Annotations: map[string]string{"alb.ingress.kubernetes.io/tags": "env=prod"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "ns", Annotations: map[string]string{"alb.ingress.kubernetes.io/tags": "env=staging"}}},
+			},
+			wantErr: "conflicting tags",
+		},
+		{
+			name: "one member sets annotation other does not",
+			members: []networking.Ingress{
+				{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns", Annotations: map[string]string{"alb.ingress.kubernetes.io/scheme": "internal"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "ns"}},
+			},
+			check: func(t *testing.T, merged map[string]string) {
+				assert.Equal(t, "internal", merged["alb.ingress.kubernetes.io/scheme"])
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			merged, err := mergeGroupLBAnnotations(tt.members)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			if tt.check != nil {
+				tt.check(t, merged)
+			}
+		})
+	}
+}
+
+func TestMergeGroupListenPorts(t *testing.T) {
+	tests := []struct {
+		name           string
+		members        []networking.Ingress
+		mergedAnnos    map[string]string
+		wantAllPorts   int
+		wantMemberKeys []string
+	}{
+		{
+			name: "union different ports",
+			members: []networking.Ingress{
+				{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns", Annotations: map[string]string{
+					"alb.ingress.kubernetes.io/listen-ports": `[{"HTTP":80}]`,
+				}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "ns", Annotations: map[string]string{
+					"alb.ingress.kubernetes.io/listen-ports": `[{"HTTPS":443}]`,
+				}}},
+			},
+			mergedAnnos:    map[string]string{},
+			wantAllPorts:   2,
+			wantMemberKeys: []string{"ns/a", "ns/b"},
+		},
+		{
+			name: "same ports dedup",
+			members: []networking.Ingress{
+				{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns", Annotations: map[string]string{
+					"alb.ingress.kubernetes.io/listen-ports": `[{"HTTP":80}]`,
+				}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "ns", Annotations: map[string]string{
+					"alb.ingress.kubernetes.io/listen-ports": `[{"HTTP":80}]`,
+				}}},
+			},
+			mergedAnnos:  map[string]string{},
+			wantAllPorts: 1,
+		},
+		{
+			name: "default port when no annotation",
+			members: []networking.Ingress{
+				{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns"}},
+			},
+			mergedAnnos:  map[string]string{},
+			wantAllPorts: 1, // HTTP:80 default
+		},
+		{
+			name: "default HTTPS when cert-arn in merged",
+			members: []networking.Ingress{
+				{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns"}},
+			},
+			mergedAnnos:  map[string]string{"alb.ingress.kubernetes.io/certificate-arn": "arn:cert"},
+			wantAllPorts: 1, // HTTPS:443 default
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			allPorts, perMember, err := mergeGroupListenPorts(tt.members, tt.mergedAnnos)
+			require.NoError(t, err)
+			assert.Len(t, allPorts, tt.wantAllPorts)
+			if tt.wantMemberKeys != nil {
+				for _, key := range tt.wantMemberKeys {
+					assert.Contains(t, perMember, key)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveGroupICP(t *testing.T) {
+	icpA := &elbv2api.IngressClassParams{ObjectMeta: metav1.ObjectMeta{Name: "params-a"}}
+	icpB := &elbv2api.IngressClassParams{ObjectMeta: metav1.ObjectMeta{Name: "params-b"}}
+	icpByClass := map[string]*elbv2api.IngressClassParams{
+		"alb":        icpA,
+		"alb-public": icpB,
+	}
+
+	tests := []struct {
+		name    string
+		members []networking.Ingress
+		wantICP string // expected ICP name, or "" for nil
+		wantErr string
+	}{
+		{
+			name: "no ICP",
+			members: []networking.Ingress{
+				{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns"}},
+			},
+			wantICP: "",
+		},
+		{
+			name: "one member with ICP",
+			members: []networking.Ingress{
+				{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns"}, Spec: networking.IngressSpec{IngressClassName: ptr.To("alb")}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "ns"}},
+			},
+			wantICP: "params-a",
+		},
+		{
+			name: "same ICP no conflict",
+			members: []networking.Ingress{
+				{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns"}, Spec: networking.IngressSpec{IngressClassName: ptr.To("alb")}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "ns"}, Spec: networking.IngressSpec{IngressClassName: ptr.To("alb")}},
+			},
+			wantICP: "params-a",
+		},
+		{
+			name: "different ICPs conflict",
+			members: []networking.Ingress{
+				{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns"}, Spec: networking.IngressSpec{IngressClassName: ptr.To("alb")}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "ns"}, Spec: networking.IngressSpec{IngressClassName: ptr.To("alb-public")}},
+			},
+			wantErr: "conflicting IngressClassParams",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			icp, err := resolveGroupICP(tt.members, icpByClass)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			if tt.wantICP == "" {
+				assert.Nil(t, icp)
+			} else {
+				require.NotNil(t, icp)
+				assert.Equal(t, tt.wantICP, icp.Name)
+			}
+		})
+	}
+}
+
+func TestResolveGroupSSLRedirect(t *testing.T) {
+	tests := []struct {
+		name    string
+		members []networking.Ingress
+		wantNil bool
+		wantVal int32
+		wantErr string
+	}{
+		{
+			name: "no ssl-redirect",
+			members: []networking.Ingress{
+				{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns"}},
+			},
+			wantNil: true,
+		},
+		{
+			name: "one member sets ssl-redirect",
+			members: []networking.Ingress{
+				{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns", Annotations: map[string]string{"alb.ingress.kubernetes.io/ssl-redirect": "443"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "ns"}},
+			},
+			wantVal: 443,
+		},
+		{
+			name: "same value no conflict",
+			members: []networking.Ingress{
+				{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns", Annotations: map[string]string{"alb.ingress.kubernetes.io/ssl-redirect": "443"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "ns", Annotations: map[string]string{"alb.ingress.kubernetes.io/ssl-redirect": "443"}}},
+			},
+			wantVal: 443,
+		},
+		{
+			name: "conflicting values",
+			members: []networking.Ingress{
+				{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns", Annotations: map[string]string{"alb.ingress.kubernetes.io/ssl-redirect": "443"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "ns", Annotations: map[string]string{"alb.ingress.kubernetes.io/ssl-redirect": "8443"}}},
+			},
+			wantErr: "conflicting ssl-redirect",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := resolveGroupSSLRedirect(tt.members, nil)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			if tt.wantNil {
+				assert.Nil(t, result)
+			} else {
+				require.NotNil(t, result)
+				assert.Equal(t, tt.wantVal, *result)
+			}
+		})
+	}
+}
+
+func TestBuildMemberParentRefs(t *testing.T) {
+	tests := []struct {
+		name            string
+		memberPorts     []listenPortEntry
+		allPorts        []listenPortEntry
+		sslRedirectPort *int32
+		memberNS        string
+		gatewayNS       string
+		wantCount       int
+		wantSectionName *string
+		wantNamespace   bool
+	}{
+		{
+			name:        "same ports no sectionName",
+			memberPorts: []listenPortEntry{{Protocol: "HTTP", Port: 80}},
+			allPorts:    []listenPortEntry{{Protocol: "HTTP", Port: 80}},
+			memberNS:    "ns", gatewayNS: "ns",
+			wantCount: 1,
+		},
+		{
+			name:        "different ports get sectionName",
+			memberPorts: []listenPortEntry{{Protocol: "HTTP", Port: 80}},
+			allPorts:    []listenPortEntry{{Protocol: "HTTP", Port: 80}, {Protocol: "HTTPS", Port: 443}},
+			memberNS:    "ns", gatewayNS: "ns",
+			wantCount:       1,
+			wantSectionName: ptr.To("http-80"),
+		},
+		{
+			name:            "ssl-redirect scopes to HTTPS",
+			memberPorts:     []listenPortEntry{{Protocol: "HTTP", Port: 80}, {Protocol: "HTTPS", Port: 443}},
+			allPorts:        []listenPortEntry{{Protocol: "HTTP", Port: 80}, {Protocol: "HTTPS", Port: 443}},
+			sslRedirectPort: ptr.To(int32(443)),
+			memberNS:        "ns", gatewayNS: "ns",
+			wantCount:       1,
+			wantSectionName: ptr.To("https-443"),
+		},
+		{
+			name:        "cross-namespace adds namespace",
+			memberPorts: []listenPortEntry{{Protocol: "HTTP", Port: 80}},
+			allPorts:    []listenPortEntry{{Protocol: "HTTP", Port: 80}},
+			memberNS:    "team-b", gatewayNS: "team-a",
+			wantCount:     1,
+			wantNamespace: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			refs := buildMemberParentRefs("gw", tt.gatewayNS, tt.memberNS, tt.memberPorts, tt.allPorts, tt.sslRedirectPort)
+			assert.Len(t, refs, tt.wantCount)
+			if tt.wantSectionName != nil {
+				require.NotNil(t, refs[0].SectionName)
+				assert.Equal(t, gwv1.SectionName(*tt.wantSectionName), *refs[0].SectionName)
+			} else if tt.sslRedirectPort == nil && len(tt.memberPorts) == len(tt.allPorts) {
+				assert.Nil(t, refs[0].SectionName)
+			}
+			if tt.wantNamespace {
+				require.NotNil(t, refs[0].Namespace)
+				assert.Equal(t, gwv1.Namespace(tt.gatewayNS), *refs[0].Namespace)
+			} else {
+				assert.Nil(t, refs[0].Namespace)
+			}
+		})
+	}
+}

--- a/pkg/ingress2gateway/translate/httproute.go
+++ b/pkg/ingress2gateway/translate/httproute.go
@@ -47,18 +47,10 @@ func (t *httpRouteTranslator) trackBackend(svcName string, resolvedPort int32) {
 }
 
 // buildHTTPRoutes builds one or more HTTPRoutes from an Ingress resource and collects
-func buildHTTPRoutes(ing networking.Ingress, namespace, gatewayName string, listenPorts []listenPortEntry, servicesByKey map[string]corev1.Service, sslRedirectPort *int32) ([]gwv1.HTTPRoute, []serviceRef, []gatewayv1beta1.ListenerRuleConfiguration, error) {
-	// Determine parentRefs based on ssl-redirect.
-	// When ssl-redirect is set, the rules route attaches only to the HTTPS listener.
-	// When not set, the route attaches to all listeners (no sectionName).
-	var parentRefs []gwv1.ParentReference
-	if sslRedirectPort != nil {
-		sectionName := utils.GenerateSectionName(utils.ProtocolHTTPS, *sslRedirectPort)
-		parentRefs = buildParentRefs(gatewayName, &sectionName)
-	} else {
-		parentRefs = buildParentRefs(gatewayName, nil)
-	}
-
+// service refs and ListenerRuleConfigurations. The caller provides parentRefs to control
+// which Gateway listeners the routes attach to (sectionName scoping for groups).
+// SSL redirect routes are NOT generated here — the caller handles them at group level.
+func buildHTTPRoutes(ing networking.Ingress, namespace string, parentRefs []gwv1.ParentReference, servicesByKey map[string]corev1.Service) ([]gwv1.HTTPRoute, []serviceRef, []gatewayv1beta1.ListenerRuleConfiguration, error) {
 	t := &httpRouteTranslator{
 		namespace:      namespace,
 		ingName:        ing.Name,
@@ -104,20 +96,6 @@ func buildHTTPRoutes(ing networking.Ingress, namespace, gatewayName string, list
 		ing.Spec.DefaultBackend, t)
 	if err != nil {
 		return nil, nil, nil, err
-	}
-
-	// When ssl-redirect is set, generate a redirect route for each HTTP listener.
-	if sslRedirectPort != nil {
-		for _, lp := range listenPorts {
-			if strings.EqualFold(lp.Protocol, utils.ProtocolHTTP) {
-				redirectRoute := buildSSLRedirectRoute(
-					namespace, ing.Name, gatewayName,
-					utils.GenerateSectionName(lp.Protocol, lp.Port),
-					*sslRedirectPort,
-				)
-				routes = append(routes, redirectRoute)
-			}
-		}
 	}
 
 	return routes, t.svcRefs, t.listenerRuleConfigs, nil
@@ -409,13 +387,13 @@ func assembleRoutes(namespace, ingName string, parentRefs []gwv1.ParentReference
 
 // buildSSLRedirectRoute creates an HTTPRoute that redirects all HTTP traffic to HTTPS.
 // It attaches only to the specified HTTP listener via sectionName.
-func buildSSLRedirectRoute(namespace, ingName, gatewayName, httpSectionName string, sslPort int32) gwv1.HTTPRoute {
+func buildSSLRedirectRoute(namespace, name, gatewayName, httpSectionName string, sslPort int32) gwv1.HTTPRoute {
 	parentRefs := buildParentRefs(gatewayName, &httpSectionName)
 	httpsScheme := "https"
 	port := gwv1.PortNumber(sslPort)
 	statusCode := 301
 	return newHTTPRoute(
-		utils.GetRedirectHTTPRouteName(namespace, ingName),
+		utils.GetRedirectHTTPRouteName(namespace, name),
 		namespace, parentRefs, nil,
 		[]gwv1.HTTPRouteRule{{
 			Filters: []gwv1.HTTPRouteFilter{{

--- a/pkg/ingress2gateway/translate/httproute_test.go
+++ b/pkg/ingress2gateway/translate/httproute_test.go
@@ -9,6 +9,7 @@ import (
 	networking "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1beta1 "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/ingress2gateway/utils"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -476,25 +477,14 @@ func TestBuildHTTPRoutes(t *testing.T) {
 				{Protocol: "HTTPS", Port: 443},
 			},
 			sslRedirectPort: int32Ptr(443),
-			wantRoutes:      2, // rules route + redirect route
+			wantRoutes:      1, // rules route only; redirect route is now generated at group level
 			check: func(t *testing.T, routes []gwv1.HTTPRoute) {
-				// First route: rules, attached to HTTPS listener only
+				// Rules route: attached to HTTPS listener only
 				rulesRoute := routes[0]
 				require.NotNil(t, rulesRoute.Spec.ParentRefs[0].SectionName)
 				assert.Equal(t, gwv1.SectionName("https-443"), *rulesRoute.Spec.ParentRefs[0].SectionName)
 				assert.Len(t, rulesRoute.Spec.Rules, 1)
 				assert.Equal(t, "/api", *rulesRoute.Spec.Rules[0].Matches[0].Path.Value)
-
-				// Second route: redirect, attached to HTTP listener only
-				redirectRoute := routes[1]
-				require.NotNil(t, redirectRoute.Spec.ParentRefs[0].SectionName)
-				assert.Equal(t, gwv1.SectionName("http-80"), *redirectRoute.Spec.ParentRefs[0].SectionName)
-				require.Len(t, redirectRoute.Spec.Rules, 1)
-				require.Len(t, redirectRoute.Spec.Rules[0].Filters, 1)
-				assert.Equal(t, gwv1.HTTPRouteFilterRequestRedirect, redirectRoute.Spec.Rules[0].Filters[0].Type)
-				assert.Equal(t, "https", *redirectRoute.Spec.Rules[0].Filters[0].RequestRedirect.Scheme)
-				assert.Equal(t, gwv1.PortNumber(443), *redirectRoute.Spec.Rules[0].Filters[0].RequestRedirect.Port)
-				assert.Equal(t, 301, *redirectRoute.Spec.Rules[0].Filters[0].RequestRedirect.StatusCode)
 			},
 		},
 		{
@@ -638,7 +628,15 @@ func TestBuildHTTPRoutes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			routes, _, lrcs, err := buildHTTPRoutes(tt.ing, tt.namespace, tt.gwName, tt.ports, nil, tt.sslRedirectPort)
+			// Compute parentRefs from test parameters (matching old buildHTTPRoutes behavior)
+			var parentRefs []gwv1.ParentReference
+			if tt.sslRedirectPort != nil {
+				sectionName := utils.GenerateSectionName(utils.ProtocolHTTPS, *tt.sslRedirectPort)
+				parentRefs = buildParentRefs(tt.gwName, &sectionName)
+			} else {
+				parentRefs = buildParentRefs(tt.gwName, nil)
+			}
+			routes, _, lrcs, err := buildHTTPRoutes(tt.ing, tt.namespace, parentRefs, nil)
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
@@ -759,8 +757,8 @@ func TestBuildHTTPRoutes_DefaultBackendError(t *testing.T) {
 		},
 	}
 	// No services provided — named port resolution for defaultBackend will fail
-	_, _, _, err := buildHTTPRoutes(ing, "default", "gw",
-		[]listenPortEntry{{Protocol: "HTTP", Port: 80}}, nil, nil)
+	parentRefs := buildParentRefs("gw", nil)
+	_, _, _, err := buildHTTPRoutes(ing, "default", parentRefs, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "defaultBackend")
 }

--- a/pkg/ingress2gateway/translate/icp_overrides.go
+++ b/pkg/ingress2gateway/translate/icp_overrides.go
@@ -2,6 +2,7 @@ package translate
 
 import (
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -11,38 +12,50 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/ingress2gateway/utils"
 )
 
-// applyIngressClassParamsToLBConfig applies IngressClassParams overrides directly to a LoadBalancerConfigurationSpec.
-// ICP fields take highest priority — they override any annotation-derived values.
+// applyIngressClassParamsToLBConfig applies IngressClassParams overrides to a LoadBalancerConfigurationSpec.
+// When called multiple times on the same spec (for multiple ICPs in a group), it detects
+// per-field conflicts: if a field was already set by a previous ICP to a different value, it errors.
 // Fields intentionally not mapped to LB config:
 // - NamespaceSelector: cluster policy, not a LB setting
 // - TargetType: TG-level, handled in applyIngressClassParamsToTGProps
-// - Group: handled at Ingress grouping level task (TO-DO)
-// - SSLRedirectPort: handled in buildHTTPRoutes via resolveSSLRedirectPort
-func applyIngressClassParamsToLBConfig(spec *gatewayv1beta1.LoadBalancerConfigurationSpec, icp *elbv2api.IngressClassParams) {
+// - Group: handled at Ingress grouping level
+// - SSLRedirectPort: handled via resolveSSLRedirectPort
+func applyIngressClassParamsToLBConfig(spec *gatewayv1beta1.LoadBalancerConfigurationSpec, icp *elbv2api.IngressClassParams) error {
 	if icp == nil {
-		return
+		return nil
 	}
 
 	if icp.Spec.Scheme != nil {
 		scheme := gatewayv1beta1.LoadBalancerScheme(*icp.Spec.Scheme)
+		if spec.Scheme != nil && *spec.Scheme != scheme {
+			return fmt.Errorf("conflicting IngressClassParams scheme: %q vs %q", *spec.Scheme, scheme)
+		}
 		spec.Scheme = &scheme
 	}
 
 	if icp.Spec.IPAddressType != nil {
 		ipType := gatewayv1beta1.LoadBalancerIpAddressType(*icp.Spec.IPAddressType)
+		if spec.IpAddressType != nil && *spec.IpAddressType != ipType {
+			return fmt.Errorf("conflicting IngressClassParams ip-address-type: %q vs %q", *spec.IpAddressType, ipType)
+		}
 		spec.IpAddressType = &ipType
 	}
 
 	if icp.Spec.LoadBalancerName != "" {
+		if spec.LoadBalancerName != nil && *spec.LoadBalancerName != icp.Spec.LoadBalancerName {
+			return fmt.Errorf("conflicting IngressClassParams load-balancer-name: %q vs %q", *spec.LoadBalancerName, icp.Spec.LoadBalancerName)
+		}
 		spec.LoadBalancerName = &icp.Spec.LoadBalancerName
 	}
 
 	if icp.Spec.SSLPolicy != "" {
-		// SSL policy only applies to secure listeners
 		if spec.ListenerConfigurations != nil {
 			lcs := *spec.ListenerConfigurations
 			for i := range lcs {
 				if strings.HasPrefix(string(lcs[i].ProtocolPort), utils.ProtocolHTTPS) {
+					if lcs[i].SslPolicy != nil && *lcs[i].SslPolicy != icp.Spec.SSLPolicy {
+						return fmt.Errorf("conflicting IngressClassParams ssl-policy: %q vs %q", *lcs[i].SslPolicy, icp.Spec.SSLPolicy)
+					}
 					lcs[i].SslPolicy = &icp.Spec.SSLPolicy
 				}
 			}
@@ -50,8 +63,8 @@ func applyIngressClassParamsToLBConfig(spec *gatewayv1beta1.LoadBalancerConfigur
 		}
 	}
 
+	// CertificateArn: union across ICPs (same as annotation cert-arn merge)
 	if len(icp.Spec.CertificateArn) > 0 {
-		// Certificate ARNs apply to secure listener configs
 		if spec.ListenerConfigurations != nil {
 			first := icp.Spec.CertificateArn[0]
 			lcs := *spec.ListenerConfigurations
@@ -70,9 +83,13 @@ func applyIngressClassParamsToLBConfig(spec *gatewayv1beta1.LoadBalancerConfigur
 	}
 
 	if len(icp.Spec.InboundCIDRs) > 0 {
+		if spec.SourceRanges != nil && !reflect.DeepEqual(*spec.SourceRanges, icp.Spec.InboundCIDRs) {
+			return fmt.Errorf("conflicting IngressClassParams inbound-cidrs")
+		}
 		spec.SourceRanges = &icp.Spec.InboundCIDRs
 	}
 
+	// Tags: union with per-key conflict detection
 	if len(icp.Spec.Tags) > 0 {
 		tags := make(map[string]string)
 		if spec.Tags != nil {
@@ -81,21 +98,32 @@ func applyIngressClassParamsToLBConfig(spec *gatewayv1beta1.LoadBalancerConfigur
 			}
 		}
 		for _, t := range icp.Spec.Tags {
+			if existing, exists := tags[t.Key]; exists && existing != t.Value {
+				return fmt.Errorf("conflicting IngressClassParams tag %q: %q vs %q", t.Key, existing, t.Value)
+			}
 			tags[t.Key] = t.Value
 		}
 		spec.Tags = &tags
 	}
 
+	// LoadBalancerAttributes: union with per-key conflict detection
 	if len(icp.Spec.LoadBalancerAttributes) > 0 {
-		// ICP attributes override — replace any existing
-		var attrs []gatewayv1beta1.LoadBalancerAttribute
-		for _, a := range icp.Spec.LoadBalancerAttributes {
-			attrs = append(attrs, gatewayv1beta1.LoadBalancerAttribute{
-				Key:   a.Key,
-				Value: a.Value,
-			})
+		existingAttrs := make(map[string]string)
+		for _, a := range spec.LoadBalancerAttributes {
+			existingAttrs[a.Key] = a.Value
 		}
-		spec.LoadBalancerAttributes = attrs
+		for _, a := range icp.Spec.LoadBalancerAttributes {
+			if existing, exists := existingAttrs[a.Key]; exists && existing != a.Value {
+				return fmt.Errorf("conflicting IngressClassParams load-balancer-attribute %q: %q vs %q", a.Key, existing, a.Value)
+			}
+			if _, exists := existingAttrs[a.Key]; !exists {
+				spec.LoadBalancerAttributes = append(spec.LoadBalancerAttributes, gatewayv1beta1.LoadBalancerAttribute{
+					Key:   a.Key,
+					Value: a.Value,
+				})
+				existingAttrs[a.Key] = a.Value
+			}
+		}
 	}
 
 	if icp.Spec.Subnets != nil {
@@ -106,32 +134,59 @@ func applyIngressClassParamsToLBConfig(spec *gatewayv1beta1.LoadBalancerConfigur
 					Identifier: string(id),
 				})
 			}
+			if spec.LoadBalancerSubnets != nil && !reflect.DeepEqual(*spec.LoadBalancerSubnets, subnetConfigs) {
+				return fmt.Errorf("conflicting IngressClassParams subnets")
+			}
 			spec.LoadBalancerSubnets = &subnetConfigs
 		} else if len(icp.Spec.Subnets.Tags) > 0 {
+			if spec.LoadBalancerSubnetsSelector != nil && !reflect.DeepEqual(*spec.LoadBalancerSubnetsSelector, icp.Spec.Subnets.Tags) {
+				return fmt.Errorf("conflicting IngressClassParams subnet selectors")
+			}
 			spec.LoadBalancerSubnetsSelector = &icp.Spec.Subnets.Tags
 		}
 	}
 
 	if len(icp.Spec.PrefixListsIDs) > 0 {
+		if spec.SecurityGroupPrefixes != nil && !reflect.DeepEqual(*spec.SecurityGroupPrefixes, icp.Spec.PrefixListsIDs) {
+			return fmt.Errorf("conflicting IngressClassParams prefix-lists")
+		}
 		spec.SecurityGroupPrefixes = &icp.Spec.PrefixListsIDs
 	} else if len(icp.Spec.PrefixListsIDsLegacy) > 0 {
+		if spec.SecurityGroupPrefixes != nil && !reflect.DeepEqual(*spec.SecurityGroupPrefixes, icp.Spec.PrefixListsIDsLegacy) {
+			return fmt.Errorf("conflicting IngressClassParams prefix-lists")
+		}
 		spec.SecurityGroupPrefixes = &icp.Spec.PrefixListsIDsLegacy
 	}
 
 	if icp.Spec.WAFv2ACLArn != "" {
-		spec.WAFv2 = &gatewayv1beta1.WAFv2Configuration{ACL: icp.Spec.WAFv2ACLArn}
+		newACL := icp.Spec.WAFv2ACLArn
+		if spec.WAFv2 != nil && spec.WAFv2.ACL != newACL {
+			return fmt.Errorf("conflicting IngressClassParams wafv2-acl: %q vs %q", spec.WAFv2.ACL, newACL)
+		}
+		spec.WAFv2 = &gatewayv1beta1.WAFv2Configuration{ACL: newACL}
 	} else if icp.Spec.WAFv2ACLName != "" {
-		spec.WAFv2 = &gatewayv1beta1.WAFv2Configuration{ACL: icp.Spec.WAFv2ACLName}
+		newACL := icp.Spec.WAFv2ACLName
+		if spec.WAFv2 != nil && spec.WAFv2.ACL != newACL {
+			return fmt.Errorf("conflicting IngressClassParams wafv2-acl: %q vs %q", spec.WAFv2.ACL, newACL)
+		}
+		spec.WAFv2 = &gatewayv1beta1.WAFv2Configuration{ACL: newACL}
 	}
 
 	if icp.Spec.MinimumLoadBalancerCapacity != nil {
-		spec.MinimumLoadBalancerCapacity = &gatewayv1beta1.MinimumLoadBalancerCapacity{
-			CapacityUnits: icp.Spec.MinimumLoadBalancerCapacity.CapacityUnits,
+		newCap := icp.Spec.MinimumLoadBalancerCapacity.CapacityUnits
+		if spec.MinimumLoadBalancerCapacity != nil && spec.MinimumLoadBalancerCapacity.CapacityUnits != newCap {
+			return fmt.Errorf("conflicting IngressClassParams minimum-load-balancer-capacity: %d vs %d",
+				spec.MinimumLoadBalancerCapacity.CapacityUnits, newCap)
 		}
+		spec.MinimumLoadBalancerCapacity = &gatewayv1beta1.MinimumLoadBalancerCapacity{CapacityUnits: newCap}
 	}
 
 	if icp.Spec.IPAMConfiguration != nil && icp.Spec.IPAMConfiguration.IPv4IPAMPoolId != nil {
-		spec.IPv4IPAMPoolId = icp.Spec.IPAMConfiguration.IPv4IPAMPoolId
+		newPool := *icp.Spec.IPAMConfiguration.IPv4IPAMPoolId
+		if spec.IPv4IPAMPoolId != nil && *spec.IPv4IPAMPoolId != newPool {
+			return fmt.Errorf("conflicting IngressClassParams ipam-ipv4-pool-id: %q vs %q", *spec.IPv4IPAMPoolId, newPool)
+		}
+		spec.IPv4IPAMPoolId = &newPool
 	}
 
 	// Listeners — apply listener attributes from ICP to matching listener configurations
@@ -142,18 +197,75 @@ func applyIngressClassParamsToLBConfig(spec *gatewayv1beta1.LoadBalancerConfigur
 				lcProtoPort := string(lcs[i].ProtocolPort)
 				icpProtoPort := fmt.Sprintf("%s:%d", icpListener.Protocol, icpListener.Port)
 				if lcProtoPort == icpProtoPort && len(icpListener.ListenerAttributes) > 0 {
-					// ICP listener attributes override
-					lcs[i].ListenerAttributes = nil
+					// Per-key conflict detection for listener attributes
+					existingAttrs := make(map[string]string)
+					for _, a := range lcs[i].ListenerAttributes {
+						existingAttrs[a.Key] = a.Value
+					}
 					for _, attr := range icpListener.ListenerAttributes {
-						lcs[i].ListenerAttributes = append(lcs[i].ListenerAttributes, gatewayv1beta1.ListenerAttribute{
-							Key:   attr.Key,
-							Value: attr.Value,
-						})
+						if existing, exists := existingAttrs[attr.Key]; exists && existing != attr.Value {
+							return fmt.Errorf("conflicting IngressClassParams listener-attribute %q on %s: %q vs %q",
+								attr.Key, icpProtoPort, existing, attr.Value)
+						}
+						if _, exists := existingAttrs[attr.Key]; !exists {
+							lcs[i].ListenerAttributes = append(lcs[i].ListenerAttributes, gatewayv1beta1.ListenerAttribute{
+								Key:   attr.Key,
+								Value: attr.Value,
+							})
+							existingAttrs[attr.Key] = attr.Value
+						}
 					}
 				}
 			}
 		}
 		spec.ListenerConfigurations = &lcs
+	}
+
+	return nil
+}
+
+// applyICPSpecOverride copies non-nil/non-zero fields from src to dst.
+// This is used to apply the merged ICP spec on top of the annotation-derived LBConfig.
+// ICP always has higher priority than annotations.
+func applyICPSpecOverride(dst, src *gatewayv1beta1.LoadBalancerConfigurationSpec) {
+	if src.Scheme != nil {
+		dst.Scheme = src.Scheme
+	}
+	if src.IpAddressType != nil {
+		dst.IpAddressType = src.IpAddressType
+	}
+	if src.LoadBalancerName != nil {
+		dst.LoadBalancerName = src.LoadBalancerName
+	}
+	if src.SourceRanges != nil {
+		dst.SourceRanges = src.SourceRanges
+	}
+	if src.Tags != nil {
+		dst.Tags = src.Tags
+	}
+	if len(src.LoadBalancerAttributes) > 0 {
+		dst.LoadBalancerAttributes = src.LoadBalancerAttributes
+	}
+	if src.LoadBalancerSubnets != nil {
+		dst.LoadBalancerSubnets = src.LoadBalancerSubnets
+	}
+	if src.LoadBalancerSubnetsSelector != nil {
+		dst.LoadBalancerSubnetsSelector = src.LoadBalancerSubnetsSelector
+	}
+	if src.SecurityGroupPrefixes != nil {
+		dst.SecurityGroupPrefixes = src.SecurityGroupPrefixes
+	}
+	if src.WAFv2 != nil {
+		dst.WAFv2 = src.WAFv2
+	}
+	if src.MinimumLoadBalancerCapacity != nil {
+		dst.MinimumLoadBalancerCapacity = src.MinimumLoadBalancerCapacity
+	}
+	if src.IPv4IPAMPoolId != nil {
+		dst.IPv4IPAMPoolId = src.IPv4IPAMPoolId
+	}
+	if src.ListenerConfigurations != nil {
+		dst.ListenerConfigurations = src.ListenerConfigurations
 	}
 }
 
@@ -162,7 +274,6 @@ func applyIngressClassParamsToTGProps(props *gatewayv1beta1.TargetGroupProps, ic
 	if icp == nil {
 		return
 	}
-
 	if icp.Spec.TargetType != "" {
 		tt := gatewayv1beta1.TargetType(icp.Spec.TargetType)
 		props.TargetType = &tt

--- a/pkg/ingress2gateway/translate/icp_overrides_test.go
+++ b/pkg/ingress2gateway/translate/icp_overrides_test.go
@@ -64,7 +64,7 @@ func TestAllIngressClassParamsFieldsHandled(t *testing.T) {
 	lcs := []gatewayv1beta1.ListenerConfiguration{{ProtocolPort: "HTTPS:443"}}
 	lbSpec.ListenerConfigurations = &lcs
 
-	applyIngressClassParamsToLBConfig(&lbSpec, icp)
+	require.NoError(t, applyIngressClassParamsToLBConfig(&lbSpec, icp))
 
 	tgProps := gatewayv1beta1.TargetGroupProps{}
 	applyIngressClassParamsToTGProps(&tgProps, icp)
@@ -188,6 +188,135 @@ func TestResolveSSLRedirectPort(t *testing.T) {
 			} else {
 				require.NotNil(t, result)
 				assert.Equal(t, tt.wantPort, *result)
+			}
+		})
+	}
+}
+
+func TestApplyIngressClassParamsToLBConfig_MultiICP_Conflict(t *testing.T) {
+	tests := []struct {
+		name    string
+		icps    []*elbv2api.IngressClassParams
+		wantErr string
+	}{
+		{
+			name: "non-overlapping fields combine",
+			icps: []*elbv2api.IngressClassParams{
+				{Spec: elbv2api.IngressClassParamsSpec{
+					Scheme: ptr.To(elbv2api.LoadBalancerSchemeInternal),
+				}},
+				{Spec: elbv2api.IngressClassParamsSpec{
+					IPAddressType: ptr.To(elbv2api.IPAddressTypeDualStack),
+				}},
+			},
+		},
+		{
+			name: "same value no conflict",
+			icps: []*elbv2api.IngressClassParams{
+				{Spec: elbv2api.IngressClassParamsSpec{
+					Scheme: ptr.To(elbv2api.LoadBalancerSchemeInternal),
+				}},
+				{Spec: elbv2api.IngressClassParamsSpec{
+					Scheme: ptr.To(elbv2api.LoadBalancerSchemeInternal),
+				}},
+			},
+		},
+		{
+			name: "conflicting scheme errors",
+			icps: []*elbv2api.IngressClassParams{
+				{Spec: elbv2api.IngressClassParamsSpec{
+					Scheme: ptr.To(elbv2api.LoadBalancerSchemeInternal),
+				}},
+				{Spec: elbv2api.IngressClassParamsSpec{
+					Scheme: ptr.To(elbv2api.LoadBalancerSchemeInternetFacing),
+				}},
+			},
+			wantErr: "conflicting IngressClassParams scheme",
+		},
+		{
+			name: "conflicting tags per-key errors",
+			icps: []*elbv2api.IngressClassParams{
+				{Spec: elbv2api.IngressClassParamsSpec{
+					Tags: []elbv2api.Tag{{Key: "env", Value: "prod"}},
+				}},
+				{Spec: elbv2api.IngressClassParamsSpec{
+					Tags: []elbv2api.Tag{{Key: "env", Value: "staging"}},
+				}},
+			},
+			wantErr: "conflicting IngressClassParams tag",
+		},
+		{
+			name: "non-overlapping tags combine",
+			icps: []*elbv2api.IngressClassParams{
+				{Spec: elbv2api.IngressClassParamsSpec{
+					Tags: []elbv2api.Tag{{Key: "env", Value: "prod"}},
+				}},
+				{Spec: elbv2api.IngressClassParamsSpec{
+					Tags: []elbv2api.Tag{{Key: "team", Value: "platform"}},
+				}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var spec gatewayv1beta1.LoadBalancerConfigurationSpec
+			var lastErr error
+			for _, icp := range tt.icps {
+				if err := applyIngressClassParamsToLBConfig(&spec, icp); err != nil {
+					lastErr = err
+					break
+				}
+			}
+			if tt.wantErr != "" {
+				require.Error(t, lastErr)
+				assert.Contains(t, lastErr.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, lastErr)
+			}
+		})
+	}
+}
+
+func TestApplyICPSpecOverride(t *testing.T) {
+	internalScheme := gatewayv1beta1.LoadBalancerSchemeInternal
+	dualStack := gatewayv1beta1.LoadBalancerIpAddressTypeDualstack
+
+	tests := []struct {
+		name       string
+		dst        gatewayv1beta1.LoadBalancerConfigurationSpec
+		src        gatewayv1beta1.LoadBalancerConfigurationSpec
+		wantScheme *gatewayv1beta1.LoadBalancerScheme
+		wantIPType *gatewayv1beta1.LoadBalancerIpAddressType
+	}{
+		{
+			name:       "ICP overrides annotation-derived value",
+			dst:        gatewayv1beta1.LoadBalancerConfigurationSpec{Scheme: ptr.To(gatewayv1beta1.LoadBalancerSchemeInternetFacing)},
+			src:        gatewayv1beta1.LoadBalancerConfigurationSpec{Scheme: &internalScheme},
+			wantScheme: &internalScheme,
+		},
+		{
+			name:       "ICP sets field not in annotations",
+			dst:        gatewayv1beta1.LoadBalancerConfigurationSpec{},
+			src:        gatewayv1beta1.LoadBalancerConfigurationSpec{IpAddressType: &dualStack},
+			wantIPType: &dualStack,
+		},
+		{
+			name:       "ICP nil field does not overwrite annotation",
+			dst:        gatewayv1beta1.LoadBalancerConfigurationSpec{Scheme: ptr.To(gatewayv1beta1.LoadBalancerSchemeInternetFacing)},
+			src:        gatewayv1beta1.LoadBalancerConfigurationSpec{},
+			wantScheme: ptr.To(gatewayv1beta1.LoadBalancerSchemeInternetFacing),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			applyICPSpecOverride(&tt.dst, &tt.src)
+			if tt.wantScheme != nil {
+				require.NotNil(t, tt.dst.Scheme)
+				assert.Equal(t, *tt.wantScheme, *tt.dst.Scheme)
+			}
+			if tt.wantIPType != nil {
+				require.NotNil(t, tt.dst.IpAddressType)
+				assert.Equal(t, *tt.wantIPType, *tt.dst.IpAddressType)
 			}
 		})
 	}

--- a/pkg/ingress2gateway/translate/translate.go
+++ b/pkg/ingress2gateway/translate/translate.go
@@ -2,6 +2,8 @@ package translate
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1"
@@ -9,10 +11,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
 	gatewayv1beta1 "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
-	annotations "sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
 	gwconstants "sigs.k8s.io/aws-load-balancer-controller/pkg/gateway/constants"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/ingress2gateway"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/ingress2gateway/utils"
+	k8s "sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	sharedconstants "sigs.k8s.io/aws-load-balancer-controller/pkg/shared_constants"
 )
 
@@ -30,43 +32,49 @@ func Translate(in *ingress2gateway.InputResources) (*ingress2gateway.OutputResou
 	// Track which services we've already created TGCs for (deduplicate)
 	tgcCreated := sets.New[string]()
 
-	for _, ing := range in.Ingresses {
-		namespace := ing.Namespace
-		if namespace == "" {
-			namespace = "default"
+	// Partition Ingresses into groups (ungrouped become single-member groups)
+	groups := partitionByGroup(in.Ingresses)
+
+	for _, group := range groups {
+		var gatewayName, lbConfigName, lbMigrationTag string
+		if group.isExplicit {
+			gatewayName = utils.GetGroupGatewayName(group.name)
+			lbConfigName = utils.GetGroupLBConfigName(group.name)
+			lbMigrationTag = fmt.Sprintf("ingress-group/%s", group.name)
+		} else {
+			gatewayName = utils.GetGatewayName(group.namespace, group.name)
+			lbConfigName = utils.GetLBConfigName(group.namespace, group.name)
+			lbMigrationTag = fmt.Sprintf("ingress/%s/%s", group.namespace, group.name)
 		}
 
-		// Resolve effective annotations (Ingress < Service < IngressClassParams)
-		effectiveAnnotations := resolveAnnotations(ing)
+		// Warn about cross-namespace groups
+		if group.crossNamespace {
+			fmt.Fprintf(os.Stderr, utils.WarnCrossNamespaceGroupFormat, group.name)
+		}
 
-		// Parse listen-ports
-		listenPorts, err := parseListenPorts(effectiveAnnotations)
+		// --- Group-level: merge annotations, resolve ports, ICP, ssl-redirect ---
+		mergedAnnotations, err := mergeGroupLBAnnotations(group.members)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse listen ports for ingress %s/%s: %w", namespace, ing.Name, err)
+			return nil, fmt.Errorf("error in mergeGroupLBAnnotations for group %q: %w", group.name, err)
 		}
 
-		// Set default listen ports
-		// If no listen-ports but certificate-arn is set, default to HTTPS:443
-		if len(listenPorts) == 0 {
-			if getString(effectiveAnnotations, annotations.IngressSuffixCertificateARN) != "" {
-				listenPorts = []listenPortEntry{{Protocol: "HTTPS", Port: 443}}
-			} else {
-				listenPorts = []listenPortEntry{{Protocol: "HTTP", Port: 80}}
-			}
+		allPorts, perMemberPorts, err := mergeGroupListenPorts(group.members, mergedAnnotations)
+		if err != nil {
+			return nil, fmt.Errorf("error in mergeGroupListenPorts for group %q: %w", group.name, err)
 		}
 
-		// Build LoadBalancerConfiguration (only if there are LB-level annotations)
-		gatewayName := utils.GetGatewayName(namespace, ing.Name)
-		lbConfigName := utils.GetLBConfigName(namespace, ing.Name)
-		migrationTag := fmt.Sprintf("ingress/%s/%s", namespace, ing.Name)
-
-		lbConfig := buildLoadBalancerConfigResource(lbConfigName, namespace, effectiveAnnotations, listenPorts, migrationTag)
-
-		// Apply IngressClassParams overrides directly to the LB config (highest priority)
-		var icp *elbv2api.IngressClassParams
-		if ing.Spec.IngressClassName != nil {
-			icp = ingressClassParamsByClass[*ing.Spec.IngressClassName]
+		icp, err := resolveGroupICP(group.members, ingressClassParamsByClass)
+		if err != nil {
+			return nil, fmt.Errorf("error in resolveGroupICP for group %q: %w", group.name, err)
 		}
+
+		sslRedirectPort, err := resolveGroupSSLRedirect(group.members, icp)
+		if err != nil {
+			return nil, fmt.Errorf("error in resolveGroupSSLRedirect for group %q: %w", group.name, err)
+		}
+
+		// --- Build LoadBalancerConfiguration ---
+		lbConfig := buildLoadBalancerConfigResource(lbConfigName, group.namespace, mergedAnnotations, allPorts, lbMigrationTag)
 		if icp != nil {
 			if lbConfig == nil {
 				lbConfig = &gatewayv1beta1.LoadBalancerConfiguration{
@@ -76,52 +84,76 @@ func Translate(in *ingress2gateway.InputResources) (*ingress2gateway.OutputResou
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      lbConfigName,
-						Namespace: namespace,
+						Namespace: group.namespace,
 					},
 				}
 			}
 			applyIngressClassParamsToLBConfig(&lbConfig.Spec, icp)
 		}
-
 		if lbConfig != nil {
 			out.LoadBalancerConfigurations = append(out.LoadBalancerConfigurations, *lbConfig)
 		}
 
-		// Build Gateway
-		gw := buildGateway(gatewayName, namespace, lbConfig, listenPorts)
+		// --- Build Gateway ---
+		crossNSGroupName := ""
+		if group.crossNamespace {
+			crossNSGroupName = group.name
+		}
+		gw := buildGateway(gatewayName, group.namespace, lbConfig, allPorts, crossNSGroupName)
 		out.Gateways = append(out.Gateways, gw)
 
-		// Build HTTPRoute(s), collect unique service refs, and collect ListenerRuleConfigurations
-		sslRedirectPort := resolveSSLRedirectPort(ing.Annotations, icp)
-		routes, svcRefs, lrcs, err := buildHTTPRoutes(ing, namespace, gatewayName, listenPorts, servicesByKey, sslRedirectPort)
-		if err != nil {
-			return nil, err
-		}
-		out.HTTPRoutes = append(out.HTTPRoutes, routes...)
-		// Add migration tags to listenerRuleConfig
-		for i := range lrcs {
-			if lrcs[i].Spec.Tags == nil {
-				tags := make(map[string]string)
-				lrcs[i].Spec.Tags = &tags
-			}
-			(*lrcs[i].Spec.Tags)[utils.MigrationTagKey] = migrationTag
-		}
-		out.ListenerRuleConfigurations = append(out.ListenerRuleConfigurations, lrcs...)
-
-		// Build TargetGroupConfigurations for each unique service
-		for _, svcRef := range svcRefs {
-			if tgcCreated.Has(svcRef.getServiceRefKey()) {
-				continue
-			}
-			tgcCreated.Insert(svcRef.getServiceRefKey())
-
-			tgAnnotations := mergeTGAnnotations(effectiveAnnotations, servicesByKey, svcRef.namespace, svcRef.name)
-			tgc := buildTargetGroupConfig(svcRef, tgAnnotations, migrationTag)
-			if tgc != nil {
-				if icp != nil {
-					applyIngressClassParamsToTGProps(&tgc.Spec.DefaultConfiguration, icp)
+		// --- SSL redirect route ---
+		if sslRedirectPort != nil {
+			for _, lp := range allPorts {
+				if strings.EqualFold(lp.Protocol, utils.ProtocolHTTP) {
+					redirectRoute := buildSSLRedirectRoute(
+						group.namespace, group.name, gatewayName,
+						utils.GenerateSectionName(lp.Protocol, lp.Port),
+						*sslRedirectPort,
+					)
+					out.HTTPRoutes = append(out.HTTPRoutes, redirectRoute)
 				}
-				out.TargetGroupConfigurations = append(out.TargetGroupConfigurations, *tgc)
+			}
+		}
+
+		// --- Per-member: HTTPRoutes, TGConfigs, LRConfigs ---
+		for _, ing := range group.members {
+			memberPorts := perMemberPorts[k8s.NamespacedName(&ing).String()]
+			parentRefs := buildMemberParentRefs(gatewayName, group.namespace, ing.Namespace, memberPorts, allPorts, sslRedirectPort)
+
+			routes, svcRefs, lrcs, err := buildHTTPRoutes(ing, ing.Namespace, parentRefs, servicesByKey)
+			if err != nil {
+				return nil, err
+			}
+			out.HTTPRoutes = append(out.HTTPRoutes, routes...)
+
+			// Add migration tags to ListenerRuleConfigurations
+			memberMigrationTag := fmt.Sprintf("ingress/%s/%s", ing.Namespace, ing.Name)
+			for i := range lrcs {
+				if lrcs[i].Spec.Tags == nil {
+					tags := make(map[string]string)
+					lrcs[i].Spec.Tags = &tags
+				}
+				(*lrcs[i].Spec.Tags)[utils.MigrationTagKey] = memberMigrationTag
+			}
+			out.ListenerRuleConfigurations = append(out.ListenerRuleConfigurations, lrcs...)
+
+			// Build TargetGroupConfigurations for each unique service
+			effectiveAnnotations := resolveAnnotations(ing)
+			for _, svcRef := range svcRefs {
+				if tgcCreated.Has(svcRef.getServiceRefKey()) {
+					continue
+				}
+				tgcCreated.Insert(svcRef.getServiceRefKey())
+
+				tgAnnotations := mergeTGAnnotations(effectiveAnnotations, servicesByKey, svcRef.namespace, svcRef.name)
+				tgc := buildTargetGroupConfig(svcRef, tgAnnotations, memberMigrationTag)
+				if tgc != nil {
+					if icp != nil {
+						applyIngressClassParamsToTGProps(&tgc.Spec.DefaultConfiguration, icp)
+					}
+					out.TargetGroupConfigurations = append(out.TargetGroupConfigurations, *tgc)
+				}
 			}
 		}
 	}
@@ -129,14 +161,13 @@ func Translate(in *ingress2gateway.InputResources) (*ingress2gateway.OutputResou
 	return out, nil
 }
 
-// resolveAnnotations returns the Ingress annotations as the effective annotation map.
-// IngressClassParams overrides are applied directly to the output CRD structs, not via annotations.
+// resolveAnnotations returns the Ingress annotations map.
 func resolveAnnotations(ing networking.Ingress) map[string]string {
-	effective := make(map[string]string)
+	output := make(map[string]string)
 	for k, v := range ing.Annotations {
-		effective[k] = v
+		output[k] = v
 	}
-	return effective
+	return output
 }
 
 // mergeTGAnnotations merges service-level annotations over ingress annotations.
@@ -175,11 +206,7 @@ func (s serviceRef) getServiceRefKey() string {
 func buildServiceMap(services []corev1.Service) map[string]corev1.Service {
 	serviceMap := make(map[string]corev1.Service, len(services))
 	for _, svc := range services {
-		ns := svc.Namespace
-		if ns == "" {
-			ns = "default"
-		}
-		serviceMap[fmt.Sprintf("%s/%s", ns, svc.Name)] = svc
+		serviceMap[fmt.Sprintf("%s/%s", svc.Namespace, svc.Name)] = svc
 	}
 	return serviceMap
 }

--- a/pkg/ingress2gateway/translate/translate.go
+++ b/pkg/ingress2gateway/translate/translate.go
@@ -58,24 +58,23 @@ func Translate(in *ingress2gateway.InputResources) (*ingress2gateway.OutputResou
 			return nil, fmt.Errorf("error in mergeGroupLBAnnotations for group %q: %w", group.name, err)
 		}
 
-		allPorts, perMemberPorts, err := mergeGroupListenPorts(group.members, mergedAnnotations)
+		allPorts, perMemberPorts, err := mergeGroupListenPorts(group.members)
 		if err != nil {
 			return nil, fmt.Errorf("error in mergeGroupListenPorts for group %q: %w", group.name, err)
 		}
 
-		icp, err := resolveGroupICP(group.members, ingressClassParamsByClass)
-		if err != nil {
-			return nil, fmt.Errorf("error in resolveGroupICP for group %q: %w", group.name, err)
-		}
+		icps := resolveGroupICPs(group.members, ingressClassParamsByClass)
 
-		sslRedirectPort, err := resolveGroupSSLRedirect(group.members, icp)
+		sslRedirectPort, err := resolveGroupSSLRedirect(group.members, ingressClassParamsByClass)
 		if err != nil {
 			return nil, fmt.Errorf("error in resolveGroupSSLRedirect for group %q: %w", group.name, err)
 		}
 
 		// --- Build LoadBalancerConfiguration ---
 		lbConfig := buildLoadBalancerConfigResource(lbConfigName, group.namespace, mergedAnnotations, allPorts, lbMigrationTag)
-		if icp != nil {
+
+		// Apply ICP overrides: merge all ICPs with conflict detection, then override annotation-derived values
+		if len(icps) > 0 {
 			if lbConfig == nil {
 				lbConfig = &gatewayv1beta1.LoadBalancerConfiguration{
 					TypeMeta: metav1.TypeMeta{
@@ -88,7 +87,15 @@ func Translate(in *ingress2gateway.InputResources) (*ingress2gateway.OutputResou
 					},
 				}
 			}
-			applyIngressClassParamsToLBConfig(&lbConfig.Spec, icp)
+			// Step 1: Merge all ICPs into a fresh spec with conflict detection (ICP-vs-ICP)
+			var mergedICPSpec gatewayv1beta1.LoadBalancerConfigurationSpec
+			for _, icp := range icps {
+				if err := applyIngressClassParamsToLBConfig(&mergedICPSpec, icp); err != nil {
+					return nil, fmt.Errorf("group %q: %w", group.name, err)
+				}
+			}
+			// Step 2: Apply merged ICP spec on top of annotation-derived LBConfig (ICP wins over annotations)
+			applyICPSpecOverride(&lbConfig.Spec, &mergedICPSpec)
 		}
 		if lbConfig != nil {
 			out.LoadBalancerConfigurations = append(out.LoadBalancerConfigurations, *lbConfig)
@@ -149,7 +156,7 @@ func Translate(in *ingress2gateway.InputResources) (*ingress2gateway.OutputResou
 				tgAnnotations := mergeTGAnnotations(effectiveAnnotations, servicesByKey, svcRef.namespace, svcRef.name)
 				tgc := buildTargetGroupConfig(svcRef, tgAnnotations, memberMigrationTag)
 				if tgc != nil {
-					if icp != nil {
+					for _, icp := range icps {
 						applyIngressClassParamsToTGProps(&tgc.Spec.DefaultConfiguration, icp)
 					}
 					out.TargetGroupConfigurations = append(out.TargetGroupConfigurations, *tgc)

--- a/pkg/ingress2gateway/translate/translate_test.go
+++ b/pkg/ingress2gateway/translate/translate_test.go
@@ -484,7 +484,7 @@ func TestTranslate(t *testing.T) {
 			},
 		},
 		{
-			name: "cross-namespace group gets allowedRoutes selector",
+			name: "cross-namespace group gets allowedRoutes All",
 			input: &ingress2gateway.InputResources{
 				Ingresses: []networking.Ingress{
 					{
@@ -540,12 +540,12 @@ func TestTranslate(t *testing.T) {
 			wantGatewayCount: 1, wantHTTPRouteCount: 2, wantLBConfigCount: 0, wantTGConfigCount: 0,
 			check: func(t *testing.T, out *ingress2gateway.OutputResources) {
 				gw := out.Gateways[0]
-				// Gateway should have allowedRoutes with selector
+				// Gateway should have allowedRoutes with From: All
 				require.Len(t, gw.Spec.Listeners, 1)
 				require.NotNil(t, gw.Spec.Listeners[0].AllowedRoutes)
 				require.NotNil(t, gw.Spec.Listeners[0].AllowedRoutes.Namespaces)
-				assert.Equal(t, gwv1.NamespacesFromSelector, *gw.Spec.Listeners[0].AllowedRoutes.Namespaces.From)
-				assert.Equal(t, "cross-ns", gw.Spec.Listeners[0].AllowedRoutes.Namespaces.Selector.MatchLabels["lbc-migrate/ingress-group"])
+				assert.Equal(t, gwv1.NamespacesFromAll, *gw.Spec.Listeners[0].AllowedRoutes.Namespaces.From)
+				assert.Nil(t, gw.Spec.Listeners[0].AllowedRoutes.Namespaces.Selector)
 
 				// Cross-namespace HTTPRoute should have namespace in parentRef
 				for _, route := range out.HTTPRoutes {

--- a/pkg/ingress2gateway/translate/translate_test.go
+++ b/pkg/ingress2gateway/translate/translate_test.go
@@ -416,10 +416,184 @@ func TestTranslate(t *testing.T) {
 				assert.True(t, found, "HTTPRoute rule should have ExtensionRef filter for LRC %s", lrc.Name)
 			},
 		},
+		{
+			name: "grouped ingresses produce one shared Gateway",
+			input: &ingress2gateway.InputResources{
+				Ingresses: []networking.Ingress{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "api", Namespace: "demo",
+							Annotations: map[string]string{
+								"alb.ingress.kubernetes.io/group.name": "shared-alb",
+								"alb.ingress.kubernetes.io/scheme":     "internet-facing",
+							},
+						},
+						Spec: networking.IngressSpec{
+							Rules: []networking.IngressRule{{
+								Host: "api.example.com",
+								IngressRuleValue: networking.IngressRuleValue{
+									HTTP: &networking.HTTPIngressRuleValue{
+										Paths: []networking.HTTPIngressPath{{
+											Path: "/api", PathType: &pathPrefix,
+											Backend: networking.IngressBackend{
+												Service: &networking.IngressServiceBackend{
+													Name: "api-svc", Port: networking.ServiceBackendPort{Number: 8080},
+												},
+											},
+										}},
+									},
+								},
+							}},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "web", Namespace: "demo",
+							Annotations: map[string]string{
+								"alb.ingress.kubernetes.io/group.name": "shared-alb",
+								"alb.ingress.kubernetes.io/scheme":     "internet-facing",
+							},
+						},
+						Spec: networking.IngressSpec{
+							Rules: []networking.IngressRule{{
+								Host: "web.example.com",
+								IngressRuleValue: networking.IngressRuleValue{
+									HTTP: &networking.HTTPIngressRuleValue{
+										Paths: []networking.HTTPIngressPath{{
+											Path: "/", PathType: &pathPrefix,
+											Backend: networking.IngressBackend{
+												Service: &networking.IngressServiceBackend{
+													Name: "web-svc", Port: networking.ServiceBackendPort{Number: 80},
+												},
+											},
+										}},
+									},
+								},
+							}},
+						},
+					},
+				},
+			},
+			wantGatewayCount: 1, wantHTTPRouteCount: 2, wantLBConfigCount: 1, wantTGConfigCount: 0,
+			check: func(t *testing.T, out *ingress2gateway.OutputResources) {
+				// One shared Gateway
+				assert.Contains(t, out.Gateways[0].Name, "grp-gw")
+				// Two separate HTTPRoutes
+				assert.Len(t, out.HTTPRoutes[0].Spec.Hostnames, 1)
+				assert.Len(t, out.HTTPRoutes[1].Spec.Hostnames, 1)
+			},
+		},
+		{
+			name: "cross-namespace group gets allowedRoutes selector",
+			input: &ingress2gateway.InputResources{
+				Ingresses: []networking.Ingress{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "api", Namespace: "team-a",
+							Annotations: map[string]string{
+								"alb.ingress.kubernetes.io/group.name": "cross-ns",
+							},
+						},
+						Spec: networking.IngressSpec{
+							Rules: []networking.IngressRule{{
+								IngressRuleValue: networking.IngressRuleValue{
+									HTTP: &networking.HTTPIngressRuleValue{
+										Paths: []networking.HTTPIngressPath{{
+											Path: "/api", PathType: &pathPrefix,
+											Backend: networking.IngressBackend{
+												Service: &networking.IngressServiceBackend{
+													Name: "api-svc", Port: networking.ServiceBackendPort{Number: 80},
+												},
+											},
+										}},
+									},
+								},
+							}},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "web", Namespace: "team-b",
+							Annotations: map[string]string{
+								"alb.ingress.kubernetes.io/group.name": "cross-ns",
+							},
+						},
+						Spec: networking.IngressSpec{
+							Rules: []networking.IngressRule{{
+								IngressRuleValue: networking.IngressRuleValue{
+									HTTP: &networking.HTTPIngressRuleValue{
+										Paths: []networking.HTTPIngressPath{{
+											Path: "/web", PathType: &pathPrefix,
+											Backend: networking.IngressBackend{
+												Service: &networking.IngressServiceBackend{
+													Name: "web-svc", Port: networking.ServiceBackendPort{Number: 80},
+												},
+											},
+										}},
+									},
+								},
+							}},
+						},
+					},
+				},
+			},
+			wantGatewayCount: 1, wantHTTPRouteCount: 2, wantLBConfigCount: 0, wantTGConfigCount: 0,
+			check: func(t *testing.T, out *ingress2gateway.OutputResources) {
+				gw := out.Gateways[0]
+				// Gateway should have allowedRoutes with selector
+				require.Len(t, gw.Spec.Listeners, 1)
+				require.NotNil(t, gw.Spec.Listeners[0].AllowedRoutes)
+				require.NotNil(t, gw.Spec.Listeners[0].AllowedRoutes.Namespaces)
+				assert.Equal(t, gwv1.NamespacesFromSelector, *gw.Spec.Listeners[0].AllowedRoutes.Namespaces.From)
+				assert.Equal(t, "cross-ns", gw.Spec.Listeners[0].AllowedRoutes.Namespaces.Selector.MatchLabels["lbc-migrate/ingress-group"])
+
+				// Cross-namespace HTTPRoute should have namespace in parentRef
+				for _, route := range out.HTTPRoutes {
+					if route.Namespace != gw.Namespace {
+						require.NotNil(t, route.Spec.ParentRefs[0].Namespace)
+						assert.Equal(t, gwv1.Namespace(gw.Namespace), *route.Spec.ParentRefs[0].Namespace)
+					}
+				}
+			},
+		},
+		{
+			name: "conflicting scheme in group errors",
+			input: &ingress2gateway.InputResources{
+				Ingresses: []networking.Ingress{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "a", Namespace: "ns",
+							Annotations: map[string]string{
+								"alb.ingress.kubernetes.io/group.name": "conflict",
+								"alb.ingress.kubernetes.io/scheme":     "internal",
+							},
+						},
+						Spec: networking.IngressSpec{DefaultBackend: &networking.IngressBackend{
+							Service: &networking.IngressServiceBackend{Name: "svc", Port: networking.ServiceBackendPort{Number: 80}},
+						}},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "b", Namespace: "ns",
+							Annotations: map[string]string{
+								"alb.ingress.kubernetes.io/group.name": "conflict",
+								"alb.ingress.kubernetes.io/scheme":     "internet-facing",
+							},
+						},
+						Spec: networking.IngressSpec{DefaultBackend: &networking.IngressBackend{
+							Service: &networking.IngressServiceBackend{Name: "svc", Port: networking.ServiceBackendPort{Number: 80}},
+						}},
+					},
+				},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Normalize namespaces like Migrate() does
+			tt.input.NormalizeNamespaces()
 			out, err := Translate(tt.input)
 			if tt.wantErr {
 				require.Error(t, err)

--- a/pkg/ingress2gateway/types.go
+++ b/pkg/ingress2gateway/types.go
@@ -43,3 +43,20 @@ type MigrateOptions struct {
 	OutputDir    string
 	OutputFormat string
 }
+
+// NormalizeNamespaces sets empty namespace fields to "default" on all input
+// resources. This mirrors the K8s API server behavior (which defaults namespace
+// during admission) for offline/file-based input where no admission runs.
+// After this call, downstream code can assume Namespace is always non-empty.
+func (r *InputResources) NormalizeNamespaces() {
+	for i := range r.Ingresses {
+		if r.Ingresses[i].Namespace == "" {
+			r.Ingresses[i].Namespace = "default"
+		}
+	}
+	for i := range r.Services {
+		if r.Services[i].Namespace == "" {
+			r.Services[i].Namespace = "default"
+		}
+	}
+}

--- a/pkg/ingress2gateway/utils/constants.go
+++ b/pkg/ingress2gateway/utils/constants.go
@@ -16,6 +16,12 @@ const (
 	// MigrationTagKey is the AWS tag key used to track migration source.
 	MigrationTagKey = "gateway.k8s.aws/migrated-from"
 
+	// CrossNamespaceGroupLabel is the namespace label key used for cross-namespace
+	// IngressGroup migration. When a group spans multiple namespaces, the generated
+	// Gateway uses allowedRoutes with a selector matching this label. Users must
+	// label their namespaces with this key set to the group name.
+	CrossNamespaceGroupLabel = "lbc-migrate/ingress-group"
+
 	// ProtocolHTTP is the HTTP protocol string used in listen-ports and ProtocolPort.
 	ProtocolHTTP = "HTTP"
 
@@ -65,4 +71,17 @@ const (
 		Tip: Use --from-cluster to automatically read all referenced resources,
 			or include Service/IngressClass/IngressClassParams files in your input.
 		`
+
+	// WarnGroupOrderMessage is the warning shown when group.order is detected.
+	WarnGroupOrderMessage = `
+		WARNING: group.order annotation detected. Gateway API has no equivalent of group.order.
+		Rule precedence will be determined by Gateway API definitions. Review generated HTTPRoutes to verify
+		expected behavior matches current Ingress rule ordering.
+		`
+
+	// WarnCrossNamespaceGroupFormat is the warning format for cross-namespace groups.
+	WarnCrossNamespaceGroupFormat = "WARNING: IngressGroup %q has members in different namespaces. " +
+		"The generated Gateway uses allowedRoutes with a namespace selector matching label " +
+		"'lbc-migrate/ingress-group: <groupName>'. You must label the member namespaces before applying: " +
+		"kubectl label namespace <ns> lbc-migrate/ingress-group=<groupName>\n"
 )

--- a/pkg/ingress2gateway/utils/constants.go
+++ b/pkg/ingress2gateway/utils/constants.go
@@ -16,12 +16,6 @@ const (
 	// MigrationTagKey is the AWS tag key used to track migration source.
 	MigrationTagKey = "gateway.k8s.aws/migrated-from"
 
-	// CrossNamespaceGroupLabel is the namespace label key used for cross-namespace
-	// IngressGroup migration. When a group spans multiple namespaces, the generated
-	// Gateway uses allowedRoutes with a selector matching this label. Users must
-	// label their namespaces with this key set to the group name.
-	CrossNamespaceGroupLabel = "lbc-migrate/ingress-group"
-
 	// ProtocolHTTP is the HTTP protocol string used in listen-ports and ProtocolPort.
 	ProtocolHTTP = "HTTP"
 
@@ -81,7 +75,6 @@ const (
 
 	// WarnCrossNamespaceGroupFormat is the warning format for cross-namespace groups.
 	WarnCrossNamespaceGroupFormat = "WARNING: IngressGroup %q has members in different namespaces. " +
-		"The generated Gateway uses allowedRoutes with a namespace selector matching label " +
-		"'lbc-migrate/ingress-group: <groupName>'. You must label the member namespaces before applying: " +
-		"kubectl label namespace <ns> lbc-migrate/ingress-group=<groupName>\n"
+		"The generated Gateway uses allowedRoutes with From: All, which permits HTTPRoutes from any namespace " +
+		"to attach. To restrict this, change From: All to From: Selector with a namespace label selector.\n"
 )

--- a/pkg/ingress2gateway/utils/helpers.go
+++ b/pkg/ingress2gateway/utils/helpers.go
@@ -80,3 +80,15 @@ func GetLRConfigName(namespace, ingressName, actionName string) string {
 func GetRedirectHTTPRouteName(namespace, ingressName string) string {
 	return resourceName(namespace, ingressName, "redirect")
 }
+
+// GetGroupGatewayName returns the Gateway resource name for an explicit IngressGroup.
+// Uses a distinct suffix ("grp-gw") to avoid hash collision with per-Ingress names.
+// Namespace is empty for explicit groups (group identity is just the group name).
+func GetGroupGatewayName(groupName string) string {
+	return resourceName("", groupName, "grp-gw")
+}
+
+// GetGroupLBConfigName returns the LoadBalancerConfiguration resource name for an explicit IngressGroup.
+func GetGroupLBConfigName(groupName string) string {
+	return resourceName("", groupName, "grp-lb")
+}

--- a/pkg/ingress2gateway/warnings/warnings.go
+++ b/pkg/ingress2gateway/warnings/warnings.go
@@ -12,7 +12,8 @@ import (
 
 // CheckInputResources inspects the InputResources for missing referenced
 // resources and writes warnings to the provided writer (typically os.Stderr).
-// It also detects external target group references in action annotations.
+// It also detects external target group references in action annotations
+// and warns about group.order usage.
 // It returns the total number of warnings emitted.
 func CheckInputResources(resources *ingress2gateway.InputResources, w io.Writer) int {
 	warningCount := 0
@@ -22,11 +23,15 @@ func CheckInputResources(resources *ingress2gateway.InputResources, w io.Writer)
 	ingressClassNames := buildIngressClassNameSet(resources)
 
 	hasExternalTG := false
+	hasGroupOrder := false
 	for _, ing := range resources.Ingresses {
 		warningCount += checkMissingServices(ing, serviceNames, w)
 		warningCount += checkMissingIngressClass(ing, ingressClassNames, w)
 		if !hasExternalTG {
 			hasExternalTG = checkExternalTargetGroups(ing)
+		}
+		if !hasGroupOrder {
+			hasGroupOrder = checkGroupOrder(ing)
 		}
 	}
 
@@ -36,6 +41,10 @@ func CheckInputResources(resources *ingress2gateway.InputResources, w io.Writer)
 
 	if hasExternalTG {
 		fmt.Fprintln(w, utils.WarnExternalTargetGroupMessage)
+	}
+
+	if hasGroupOrder {
+		fmt.Fprintln(w, utils.WarnGroupOrderMessage)
 	}
 
 	return warningCount
@@ -61,9 +70,6 @@ func buildIngressClassNameSet(resources *ingress2gateway.InputResources) map[str
 func checkMissingServices(ing networking.Ingress, serviceNames map[string]struct{}, w io.Writer) int {
 	warningCount := 0
 	namespace := ing.Namespace
-	if namespace == "" {
-		namespace = "default"
-	}
 
 	// Check default backend
 	if ing.Spec.DefaultBackend != nil && ing.Spec.DefaultBackend.Service != nil {
@@ -103,9 +109,6 @@ func checkMissingServices(ing networking.Ingress, serviceNames map[string]struct
 
 func checkMissingIngressClass(ing networking.Ingress, ingressClassNames map[string]struct{}, w io.Writer) int {
 	namespace := ing.Namespace
-	if namespace == "" {
-		namespace = "default"
-	}
 
 	if ing.Spec.IngressClassName == nil {
 		return 0
@@ -131,4 +134,10 @@ func checkExternalTargetGroups(ing networking.Ingress) bool {
 		}
 	}
 	return false
+}
+
+// checkGroupOrder returns true if the Ingress has a group.order annotation.
+func checkGroupOrder(ing networking.Ingress) bool {
+	_, ok := ing.Annotations["alb.ingress.kubernetes.io/group.order"]
+	return ok
 }


### PR DESCRIPTION
### Description
- support translate for group ingress. there are some edge cases worth calling out, it is documented in documentation, please see that for details
- main logic change/add is in group.go and translate.go
- refactor translate.go to work for both group ingress and regular individual ingress
- refactor a test file to table-driven format 

i will handle TGB in another PR 

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested

tested with group-ingress.yaml
```
# IngressGroup example: cross-namespace group with ssl-redirect.
# Three Ingresses share group.name "shared-alb" across two namespaces.
# api-ingress sets ssl-redirect, which applies group-wide.
# admin-ingress is in a different namespace (team-ops), triggering cross-namespace handling.
#
# Usage:
#   kubectl apply -f examples/migrate/group-ingress.yaml
#   lbc-migrate -f examples/migrate/group-ingress.yaml --output-dir ./out/
---
apiVersion: v1
kind: Namespace
metadata:
  name: team-app
---
apiVersion: v1
kind: Namespace
metadata:
  name: team-ops
---
# --- team-app: api workload ---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: api-svc
  namespace: team-app
spec:
  replicas: 2
  selector:
    matchLabels:
      app: api-svc
  template:
    metadata:
      labels:
        app: api-svc
    spec:
      containers:
        - name: app
          image: public.ecr.aws/nginx/nginx:latest
          ports:
            - containerPort: 8080
---
apiVersion: v1
kind: Service
metadata:
  name: api-svc
  namespace: team-app
spec:
  selector:
    app: api-svc
  ports:
    - port: 8080
      targetPort: 8080
---
# --- team-app: web workload ---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: web-svc
  namespace: team-app
spec:
  replicas: 2
  selector:
    matchLabels:
      app: web-svc
  template:
    metadata:
      labels:
        app: web-svc
    spec:
      containers:
        - name: app
          image: public.ecr.aws/nginx/nginx:latest
          ports:
            - containerPort: 80
---
apiVersion: v1
kind: Service
metadata:
  name: web-svc
  namespace: team-app
spec:
  selector:
    app: web-svc
  ports:
    - port: 80
      targetPort: 80
---
# --- team-ops: admin workload ---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: admin-svc
  namespace: team-ops
spec:
  replicas: 1
  selector:
    matchLabels:
      app: admin-svc
  template:
    metadata:
      labels:
        app: admin-svc
    spec:
      containers:
        - name: app
          image: public.ecr.aws/nginx/nginx:latest
          ports:
            - containerPort: 9090
---
apiVersion: v1
kind: Service
metadata:
  name: admin-svc
  namespace: team-ops
spec:
  selector:
    app: admin-svc
  ports:
    - port: 9090
      targetPort: 9090
---
# --- Ingress resources ---
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: api-ingress
  namespace: team-app
  annotations:
    alb.ingress.kubernetes.io/group.name: "shared-alb"
    alb.ingress.kubernetes.io/group.order: "1"
    alb.ingress.kubernetes.io/scheme: "internet-facing"
    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-west-2::certificate/
    alb.ingress.kubernetes.io/ssl-redirect: "443"
    alb.ingress.kubernetes.io/target-type: "ip"
    alb.ingress.kubernetes.io/tags: "env=prod"
spec:
  ingressClassName: alb
  rules:
    - host: api.example.com
      http:
        paths:
          - path: /api
            pathType: Prefix
            backend:
              service:
                name: api-svc
                port:
                  number: 8080
          - path: /health
            pathType: Exact
            backend:
              service:
                name: api-svc
                port:
                  number: 8080
---
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: web-ingress
  namespace: team-app
  annotations:
    alb.ingress.kubernetes.io/group.name: "shared-alb"
    alb.ingress.kubernetes.io/group.order: "2"
    alb.ingress.kubernetes.io/scheme: "internet-facing"
    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-west-2::certificate/
    alb.ingress.kubernetes.io/target-type: "ip"
    alb.ingress.kubernetes.io/tags: "env=prod"
spec:
  ingressClassName: alb
  rules:
    - host: www.example.com
      http:
        paths:
          - path: /
            pathType: Prefix
            backend:
              service:
                name: web-svc
                port:
                  number: 80
---
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: admin-ingress
  namespace: team-ops
  annotations:
    alb.ingress.kubernetes.io/group.name: "shared-alb"
    alb.ingress.kubernetes.io/group.order: "3"
    alb.ingress.kubernetes.io/scheme: "internet-facing"
    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-west-2::certificate/
    alb.ingress.kubernetes.io/target-type: "ip"
    alb.ingress.kubernetes.io/tags: "env=prod"
spec:
  ingressClassName: alb
  rules:
    - host: admin.example.com
      http:
        paths:
          - path: /admin
            pathType: Prefix
            backend:
              service:
                name: admin-svc
                port:
                  number: 9090

```

generated gateway api manifest
```
apiVersion: gateway.networking.k8s.io/v1
kind: GatewayClass
metadata:
  name: aws-alb
spec:
  controllerName: gateway.k8s.aws/alb
---
apiVersion: gateway.k8s.aws/v1beta1
kind: LoadBalancerConfiguration
metadata:
  name: shared-a-grp-lb-81f22e924c
  namespace: team-app
spec:
  listenerConfigurations:
  - defaultCertificate: arn:aws:acm:us-west-2::certificate/
    protocolPort: HTTPS:443
  scheme: internet-facing
  tags:
    env: prod
    gateway.k8s.aws/migrated-from: ingress-group/shared-alb
---
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: shared-a-grp-gw-bda860d35a
  namespace: team-app
spec:
  gatewayClassName: aws-alb
  infrastructure:
    parametersRef:
      group: gateway.k8s.aws
      kind: LoadBalancerConfiguration
      name: shared-a-grp-lb-81f22e924c
  listeners:
  - allowedRoutes:
      namespaces:
        from: Selector
        selector:
          matchLabels:
            lbc-migrate/ingress-group: shared-alb
    name: http-80
    port: 80
    protocol: HTTP
  - allowedRoutes:
      namespaces:
        from: Selector
        selector:
          matchLabels:
            lbc-migrate/ingress-group: shared-alb
    name: https-443
    port: 443
    protocol: HTTPS
---
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: shared-a-redirect-60f4bf0e27
  namespace: team-app
spec:
  parentRefs:
  - name: shared-a-grp-gw-bda860d35a
    sectionName: http-80
  rules:
  - filters:
    - requestRedirect:
        port: 443
        scheme: https
        statusCode: 301
      type: RequestRedirect
---
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: api-ingr-route-e0d507bedd
  namespace: team-app
spec:
  hostnames:
  - api.example.com
  parentRefs:
  - name: shared-a-grp-gw-bda860d35a
    sectionName: https-443
  rules:
  - backendRefs:
    - name: api-svc
      port: 8080
    matches:
    - path:
        type: PathPrefix
        value: /api
  - backendRefs:
    - name: api-svc
      port: 8080
    matches:
    - path:
        type: Exact
        value: /health
---
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: web-ingr-route-81ee0fb5d5
  namespace: team-app
spec:
  hostnames:
  - www.example.com
  parentRefs:
  - name: shared-a-grp-gw-bda860d35a
    sectionName: https-443
  rules:
  - backendRefs:
    - name: web-svc
      port: 80
    matches:
    - path:
        type: PathPrefix
        value: /
---
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: admin-in-route-b36f4da6aa
  namespace: team-ops
spec:
  hostnames:
  - admin.example.com
  parentRefs:
  - name: shared-a-grp-gw-bda860d35a
    namespace: team-app
    sectionName: https-443
  rules:
  - backendRefs:
    - name: admin-svc
      port: 9090
    matches:
    - path:
        type: PathPrefix
        value: /admin
---
apiVersion: gateway.k8s.aws/v1beta1
kind: TargetGroupConfiguration
metadata:
  name: api-svc-tg-confi-073dc0103e
  namespace: team-app
spec:
  defaultConfiguration:
    tags:
      env: prod
      gateway.k8s.aws/migrated-from: ingress/team-app/api-ingress
    targetType: ip
  targetReference:
    name: api-svc
---
apiVersion: gateway.k8s.aws/v1beta1
kind: TargetGroupConfiguration
metadata:
  name: web-svc-tg-confi-81f42e18af
  namespace: team-app
spec:
  defaultConfiguration:
    tags:
      env: prod
      gateway.k8s.aws/migrated-from: ingress/team-app/web-ingress
    targetType: ip
  targetReference:
    name: web-svc
---
apiVersion: gateway.k8s.aws/v1beta1
kind: TargetGroupConfiguration
metadata:
  name: admin-sv-tg-confi-01a21c31d0
  namespace: team-ops
spec:
  defaultConfiguration:
    tags:
      env: prod
      gateway.k8s.aws/migrated-from: ingress/team-ops/admin-ingress
    targetType: ip
  targetReference:
    name: admin-svc

```
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:
