### PR TITLE
fix: tag frontend NLB target groups and listeners

### DIFF
--- a/pkg/ingress/model_build_frontend_nlb.go
+++ b/pkg/ingress/model_build_frontend_nlb.go
@@ -607,6 +607,11 @@ func (t *defaultModelBuildTask) buildFrontendNlbListenerSpec(ctx context.Context
 
 	defaultActions := t.buildFrontendNlbListenerDefaultActions(ctx, targetGroup)
 
+	tags, err := t.buildFrontendNlbTags(ctx, nil)
+	if err != nil {
+		return elbv2model.ListenerSpec{}, err
+	}
+
 	t.localFrontendNlbData[targetGroup.Spec.Name] = &elbv2model.FrontendNlbTargetGroupState{
 		Name:       targetGroup.Spec.Name,
 		ARN:        targetGroup.TargetGroupARN(),
@@ -620,6 +625,7 @@ func (t *defaultModelBuildTask) buildFrontendNlbListenerSpec(ctx context.Context
 		Port:            port,
 		Protocol:        listenerProtocol,
 		DefaultActions:  defaultActions,
+		Tags:            tags,
 	}, nil
 }
 

--- a/pkg/ingress/model_build_frontend_nlb.go
+++ b/pkg/ingress/model_build_frontend_nlb.go
@@ -792,6 +792,11 @@ func (t *defaultModelBuildTask) buildFrontendNlbTargetGroupSpec(ctx context.Cont
 
 	tgName := t.buildFrontendNlbTargetGroupName(ctx, port, elbv2model.TargetTypeALB, tgProtocol, healthCheckConfig)
 
+	tags, err := t.buildFrontendNlbTags(ctx, nil)
+	if err != nil {
+		return elbv2model.TargetGroupSpec{}, err
+	}
+
 	return elbv2model.TargetGroupSpec{
 		Name:              tgName,
 		TargetType:        elbv2model.TargetTypeALB,
@@ -799,6 +804,7 @@ func (t *defaultModelBuildTask) buildFrontendNlbTargetGroupSpec(ctx context.Cont
 		Protocol:          tgProtocol,
 		IPAddressType:     elbv2model.TargetGroupIPAddressTypeIPv4,
 		HealthCheckConfig: healthCheckConfig,
+		Tags:              tags,
 	}, nil
 }
 

--- a/pkg/ingress/model_build_frontend_nlb_test.go
+++ b/pkg/ingress/model_build_frontend_nlb_test.go
@@ -1086,6 +1086,68 @@ func Test_buildFrontendNlbTargetGroupSpecTags(t *testing.T) {
 	}
 }
 
+func Test_buildFrontendNlbListenerSpecTags(t *testing.T) {
+	// Regression guard: the NLB listener spec must carry tags so that
+	// kops's IAM policy (which requires aws:RequestTag/KubernetesCluster on
+	// CreateListener) accepts the call. Tag-resolution rules are covered by
+	// Test_buildFrontendNlbTags; this just verifies the listener spec pipes
+	// tags through.
+	stack := core.NewDefaultStack(core.StackID{Name: "awesome-stack"})
+	mockFrontendNlb := elbv2model.NewLoadBalancer(stack, "FrontendNlb", elbv2model.LoadBalancerSpec{
+		IPAddressType: elbv2model.IPAddressTypeIPV4,
+	})
+	mockLoadBalancer := elbv2model.NewLoadBalancer(stack, "LoadBalancer", elbv2model.LoadBalancerSpec{
+		IPAddressType: elbv2model.IPAddressTypeIPV4,
+	})
+
+	task := &defaultModelBuildTask{
+		clusterName: "test-cluster",
+		ingGroup: Group{
+			ID: GroupID{
+				Namespace: "awesome-ns",
+				Name:      "ing",
+			},
+			Members: []ClassifiedIngress{
+				{
+					Ing: &networking.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "awesome-ns",
+							Name:      "ing",
+						},
+					},
+				},
+			},
+		},
+		annotationParser: annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io"),
+		defaultTags: map[string]string{
+			"KubernetesCluster": "test-cluster",
+			"group":             "sig-cluster-lifecycle",
+			"subproject":        "kops",
+		},
+		featureGates:         config.NewFeatureGates(),
+		stack:                stack,
+		frontendNlb:          mockFrontendNlb,
+		loadBalancer:         mockLoadBalancer,
+		localFrontendNlbData: make(map[string]*elbv2model.FrontendNlbTargetGroupState),
+	}
+
+	got, err := task.buildFrontendNlbListenerSpec(context.Background(), 80, FrontendNlbListenerConfig{
+		Port:       80,
+		Protocol:   "TCP",
+		TargetPort: 80,
+		HealthCheckConfig: elbv2model.TargetGroupHealthCheckConfig{
+			Protocol: elbv2model.ProtocolHTTP,
+		},
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"KubernetesCluster": "test-cluster",
+		"group":             "sig-cluster-lifecycle",
+		"subproject":        "kops",
+	}, got.Tags)
+}
+
 func Test_mergeFrontendNlbListenPortConfigs(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/pkg/ingress/model_build_frontend_nlb_test.go
+++ b/pkg/ingress/model_build_frontend_nlb_test.go
@@ -1010,6 +1010,82 @@ func Test_buildFrontendNlbTags(t *testing.T) {
 	}
 }
 
+func Test_buildFrontendNlbTargetGroupSpecTags(t *testing.T) {
+	healthCheckPort := intstr.FromString("traffic-port")
+	healthCheckConfig := &elbv2model.TargetGroupHealthCheckConfig{
+		Port:     &healthCheckPort,
+		Protocol: elbv2model.ProtocolHTTP,
+	}
+
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		defaultTags map[string]string
+		wantTags    map[string]string
+	}{
+		{
+			name:        "default tags are applied",
+			annotations: map[string]string{},
+			defaultTags: map[string]string{
+				"KubernetesCluster": "test-cluster",
+				"group":             "sig-cluster-lifecycle",
+				"subproject":        "kops",
+			},
+			wantTags: map[string]string{
+				"KubernetesCluster": "test-cluster",
+				"group":             "sig-cluster-lifecycle",
+				"subproject":        "kops",
+			},
+		},
+		{
+			name: "frontend-nlb-tags are applied instead of ALB tags",
+			annotations: map[string]string{
+				"alb.ingress.kubernetes.io/frontend-nlb-tags": "frontend=nlb",
+				"alb.ingress.kubernetes.io/tags":              "alb=tag",
+			},
+			defaultTags: map[string]string{
+				"default": "tag",
+			},
+			wantTags: map[string]string{
+				"frontend": "nlb",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := &defaultModelBuildTask{
+				clusterName: "test-cluster",
+				ingGroup: Group{
+					ID: GroupID{
+						Namespace: "awesome-ns",
+						Name:      "ing",
+					},
+					Members: []ClassifiedIngress{
+						{
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace:   "awesome-ns",
+									Name:        "ing",
+									Annotations: tt.annotations,
+								},
+							},
+						},
+					},
+				},
+				annotationParser: annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io"),
+				defaultTags:      tt.defaultTags,
+				featureGates:     config.NewFeatureGates(),
+			}
+
+			got, err := task.buildFrontendNlbTargetGroupSpec(context.Background(), elbv2model.ProtocolTCP, 80, healthCheckConfig)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantTags, got.Tags)
+		})
+	}
+}
+
 func Test_mergeFrontendNlbListenPortConfigs(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -1332,6 +1408,7 @@ func Test_defaultModelBuildTask_buildFrontendNlbListeners(t *testing.T) {
 				frontendNlb:          mockLoadBalancer,
 				stack:                stack,
 				localFrontendNlbData: make(map[string]*elbv2model.FrontendNlbTargetGroupState),
+				featureGates:         config.NewFeatureGates(),
 			}
 
 			err := task.buildFrontendNlbListeners(context.Background(), tt.listenerPortConfigByIngress)


### PR DESCRIPTION
### Issue

n/a

### Description

The current patch matches the Prow failure mode for `Ingress Suite: [It] vanilla ingress tests with frontend NLB enabled should create a frontend NLB and route traffic correctly` and the added tests cover the missing case.

Without the fix, the test tails: [pull-kops-e2e-aws-load-balancer-controller](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kops/18221/pull-kops-e2e-aws-load-balancer-controller/2046210613700464640).

With the fix, the test passes [pull-kops-e2e-aws-load-balancer-controller](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kops/18224/pull-kops-e2e-aws-load-balancer-controller/2046452646214111232).

The controller log showed `CreateTargetGroup` failing with `AccessDenied`. In the rendered model, the frontend NLB had the expected tags, but `AWS::ElasticLoadBalancingV2::TargetGroup.FrontendNlb-tg-TCP-80` had no `spec.tags`. That lines up with the kOps IAM policy requiring request/resource tags for `elasticloadbalancing:CreateTargetGroup`.

I also fixed one existing frontend NLB listener test fixture to initialize `featureGates`, because the new tag path now exercises `buildLoadBalancerTags`.

Related context checked:
- Issue: https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4279
- PR: https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4328

PR written with some assistance from Claude Opus for the tests.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2: