### PR TITLE
fix eni resolution when pod has an ipv6 address

### DIFF
--- a/pkg/k8s/pod_info.go
+++ b/pkg/k8s/pod_info.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,12 +41,16 @@ type PodInfo struct {
 
 // PodENIInfo is a json convertible structure that stores the Branch ENI details that can be
 // used by the CNI plugin or the component consuming the resource
+// This struct is a subset of the fields found here: https://github.com/aws/amazon-vpc-resource-controller-k8s/blob/master/pkg/provider/branch/trunk/trunk.go?#L134
 type PodENIInfo struct {
 	// ENIID is the network interface id of the branch interface
 	ENIID string `json:"eniId"`
 
 	// PrivateIP is the primary IP of the branch Network interface
 	PrivateIP string `json:"privateIp"`
+
+	// IPV6Addr is the IPv6 address associated with the branch network interface
+	IPV6Addr string `json:"ipv6Addr"`
 }
 
 func (i *PodInfo) GetQUICServerID(port int32) *string {

--- a/pkg/k8s/pod_info_test.go
+++ b/pkg/k8s/pod_info_test.go
@@ -596,6 +596,147 @@ func Test_buildPodInfo(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "standard case - with ENIInfo - ipv6",
+			args: args{
+				pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "my-ns",
+						Name:      "pod-1",
+						UID:       "pod-uuid",
+						Annotations: map[string]string{
+							"vpc.amazonaws.com/pod-eni": `[{"eniId":"eni-0c312d68f0609d608","ifAddress":"12:6b:56:93:6e:69","privateIp":"192.168.68.47","ipv6Addr":"2600:1f18:1292:2b02::1ecc","vlanId":1,"subnetCidr":"192.168.64.0/19","subnetV6Cidr":"2600:1f18:1292:2b02::/64","associationID":"trunk-assoc-0fb5d6db1fba4ba79"}]`,
+						},
+						CreationTimestamp: metav1.Time{
+							Time: timeNow,
+						},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "ip-192-168-13-198.us-west-2.compute.internal",
+						Containers: []corev1.Container{
+							{
+								Ports: []corev1.ContainerPort{
+									{
+										Name:          "ssh",
+										ContainerPort: 22,
+									},
+									{
+										Name:          "http",
+										ContainerPort: 8080,
+									},
+								},
+							},
+							{
+								Ports: []corev1.ContainerPort{
+									{
+										Name:          "https",
+										ContainerPort: 8443,
+									},
+								},
+							},
+						},
+						InitContainers: []corev1.Container{
+							{
+								RestartPolicy: &initContainerRestartPolicyAlways,
+								Ports: []corev1.ContainerPort{
+									{
+										Name:          "dns",
+										ContainerPort: 53,
+									},
+									{
+										Name:          "ftp",
+										ContainerPort: 21,
+									},
+								},
+							},
+							{
+								Ports: []corev1.ContainerPort{
+									{
+										Name:          "smtp",
+										ContainerPort: 25,
+									},
+								},
+							},
+						},
+						ReadinessGates: []corev1.PodReadinessGate{
+							{
+								ConditionType: "ingress.k8s.aws/cond-1",
+							},
+							{
+								ConditionType: "ingress.k8s.aws/cond-2",
+							},
+						},
+					},
+					Status: corev1.PodStatus{
+						Conditions: []corev1.PodCondition{
+							{
+								Type:   corev1.ContainersReady,
+								Status: corev1.ConditionFalse,
+							},
+							{
+								Type:   "ingress.k8s.aws/cond-2",
+								Status: corev1.ConditionTrue,
+							},
+						},
+						PodIP: "2600:1f18:1292:2b02::1ecc",
+					},
+				},
+			},
+			want: PodInfo{
+				Key: types.NamespacedName{Namespace: "my-ns", Name: "pod-1"},
+				UID: "pod-uuid",
+				ContainerPorts: []corev1.ContainerPort{
+					{
+						Name:          "ssh",
+						ContainerPort: 22,
+					},
+					{
+						Name:          "http",
+						ContainerPort: 8080,
+					},
+					{
+						Name:          "https",
+						ContainerPort: 8443,
+					},
+					{
+						Name:          "dns",
+						ContainerPort: 53,
+					},
+					{
+						Name:          "ftp",
+						ContainerPort: 21,
+					},
+				},
+				ReadinessGates: []corev1.PodReadinessGate{
+					{
+						ConditionType: "ingress.k8s.aws/cond-1",
+					},
+					{
+						ConditionType: "ingress.k8s.aws/cond-2",
+					},
+				},
+				Conditions: []corev1.PodCondition{
+					{
+						Type:   corev1.ContainersReady,
+						Status: corev1.ConditionFalse,
+					},
+					{
+						Type:   "ingress.k8s.aws/cond-2",
+						Status: corev1.ConditionTrue,
+					},
+				},
+				NodeName:     "ip-192-168-13-198.us-west-2.compute.internal",
+				PodIP:        "2600:1f18:1292:2b02::1ecc",
+				CreationTime: metav1.Time{Time: timeNow},
+				ENIInfos: []PodENIInfo{
+					{
+						ENIID:     "eni-0c312d68f0609d608",
+						PrivateIP: "192.168.68.47",
+						IPV6Addr:  "2600:1f18:1292:2b02::1ecc",
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/networking/pod_eni_info_resolver.go
+++ b/pkg/networking/pod_eni_info_resolver.go
@@ -2,6 +2,11 @@ package networking
 
 import (
 	"context"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	ec2sdk "github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
@@ -11,14 +16,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/cache"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"net"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/algorithm"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws/services"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strings"
-	"sync"
-	"time"
 )
 
 const (
@@ -240,6 +241,12 @@ func (r *defaultPodENIInfoResolver) resolveViaPodENIAnnotation(ctx context.Conte
 		for _, podENIInfo := range pod.ENIInfos {
 			if podENIInfo.PrivateIP == pod.PodIP {
 				eniID = podENIInfo.ENIID
+				break
+			}
+
+			if len(podENIInfo.IPV6Addr) > 0 && pod.PodIP == podENIInfo.IPV6Addr {
+				eniID = podENIInfo.ENIID
+				break
 			}
 		}
 		if len(eniID) == 0 {

--- a/pkg/networking/pod_eni_info_resolver_test.go
+++ b/pkg/networking/pod_eni_info_resolver_test.go
@@ -2,8 +2,9 @@ package networking
 
 import (
 	"context"
-	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"testing"
+
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	ec2sdk "github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -1283,6 +1284,112 @@ func Test_defaultPodENIInfoResolver_resolveViaPodENIAnnotation(t *testing.T) {
 						UID:      types.UID("2d8740a6-f4b1-4074-a91c-f0084ec0bc04"),
 						NodeName: "node-a",
 						PodIP:    "192.168.100.5",
+					},
+				},
+			},
+			want: map[types.NamespacedName]ENIInfo{
+				types.NamespacedName{Namespace: "default", Name: "pod-1"}: {
+					NetworkInterfaceID: "eni-a",
+					SecurityGroups:     []string{"sg-a-1"},
+				},
+				types.NamespacedName{Namespace: "default", Name: "pod-2"}: {
+					NetworkInterfaceID: "eni-a",
+					SecurityGroups:     []string{"sg-a-1"},
+				},
+				types.NamespacedName{Namespace: "default", Name: "pod-3"}: {
+					NetworkInterfaceID: "eni-b",
+					SecurityGroups:     []string{"sg-b-1"},
+				},
+			},
+		},
+		{
+			name: "multiple pods have matching podENI annotation using ipv6 addresses",
+			fields: fields{
+				describeNetworkInterfacesAsListCalls: []describeNetworkInterfacesAsListCall{
+					{
+						req: &ec2sdk.DescribeNetworkInterfacesInput{
+							NetworkInterfaceIds: []string{"eni-a", "eni-b"},
+						},
+						resp: []ec2types.NetworkInterface{
+							{
+								NetworkInterfaceId: awssdk.String("eni-a"),
+								Groups: []ec2types.GroupIdentifier{
+									{
+										GroupId: awssdk.String("sg-a-1"),
+									},
+								},
+							},
+							{
+								NetworkInterfaceId: awssdk.String("eni-b"),
+								Groups: []ec2types.GroupIdentifier{
+									{
+										GroupId: awssdk.String("sg-b-1"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				pods: []k8s.PodInfo{
+					{
+						Key: types.NamespacedName{Namespace: "default", Name: "pod-1"},
+						UID: types.UID("2d8740a6-f4b1-4074-a91c-f0084ec0bc01"),
+						ENIInfos: []k8s.PodENIInfo{
+							{
+								ENIID:     "eni-a",
+								PrivateIP: "192.168.100.1",
+								IPV6Addr:  "2600:1f18:1292:2b02::1ecc",
+							},
+						},
+						NodeName: "node-a",
+						PodIP:    "2600:1f18:1292:2b02::1ecc",
+					},
+					{
+						Key: types.NamespacedName{Namespace: "default", Name: "pod-2"},
+						UID: types.UID("2d8740a6-f4b1-4074-a91c-f0084ec0bc02"),
+						ENIInfos: []k8s.PodENIInfo{
+							{
+								ENIID:     "eni-a",
+								PrivateIP: "192.168.100.2",
+								IPV6Addr:  "2600:1f18:1292:2b02::2ecc",
+							},
+						},
+						NodeName: "node-a",
+						PodIP:    "2600:1f18:1292:2b02::2ecc",
+					},
+					{
+						Key: types.NamespacedName{Namespace: "default", Name: "pod-3"},
+						UID: types.UID("2d8740a6-f4b1-4074-a91c-f0084ec0bc03"),
+						ENIInfos: []k8s.PodENIInfo{
+							{
+								ENIID:     "eni-b",
+								PrivateIP: "192.168.100.3",
+								IPV6Addr:  "2600:1f18:1292:2b02::3ecc",
+							},
+						},
+						NodeName: "node-a",
+						PodIP:    "2600:1f18:1292:2b02::3ecc",
+					},
+					{
+						Key: types.NamespacedName{Namespace: "default", Name: "pod-4"},
+						UID: types.UID("2d8740a6-f4b1-4074-a91c-f0084ec0bc04"),
+						ENIInfos: []k8s.PodENIInfo{
+							{
+								ENIID:     "eni-c",
+								PrivateIP: "192.168.100.1",
+								IPV6Addr:  "2600:1f18:1292:2b02::1ecc",
+							},
+						},
+						NodeName: "node-a",
+						PodIP:    "2600:1f18:1292:2b02::4ecc",
+					},
+					{
+						Key:      types.NamespacedName{Namespace: "default", Name: "pod-5"},
+						UID:      types.UID("2d8740a6-f4b1-4074-a91c-f0084ec0bc04"),
+						NodeName: "node-a",
+						PodIP:    "2600:1f18:1292:2b02::5ecc",
 					},
 				},
 			},


### PR DESCRIPTION
### Issue

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4643

### Description

When a pod has an IPv6 address, the controller is not able to resolve the related ENI. The linked issue describes the issue perfectly.

Tested in my cluster:

```
{"level":"info","ts":"2026-04-24T22:41:32Z","msg":"RESOLVING IPv6 Got this POD INFO!! [{ENIID:eni-0c312d68f0609d608 PrivateIP:192.168.68.47 IPV6Addr:2600:1f18:1292:2b02::1ecc}] comparing against this POD [{Key:echoserver/echoserver-7bf8775f8-6c6mh UID:176f0d29-983c-4a0c-92c6-706381fd84b4 ContainerPorts:[{Name: HostPort:0 ContainerPort:8080 Protocol:TCP HostIP:}] ReadinessGates:[] Conditions:[{Type:PodReadyToStartContainers ObservedGeneration:0 Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2026-04-24 21:58:53 +0000 UTC Reason: Message:} {Type:Initialized ObservedGeneration:0 Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2026-04-24 21:58:48 +0000 UTC Reason: Message:} {Type:Ready ObservedGeneration:0 Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2026-04-24 21:58:53 +0000 UTC Reason: Message:} {Type:ContainersReady ObservedGeneration:0 Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2026-04-24 21:58:53 +0000 UTC Reason: Message:} {Type:PodScheduled ObservedGeneration:0 Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2026-04-24 21:58:48 +0000 UTC Reason: Message:}] NodeName:ip-192-168-83-176.ec2.internal PodIP:2600:1f18:1292:2b02::1ecc CreationTime:2026-04-24 21:58:48 +0000 UTC DefaultQUICServerID:<nil> PerPortServerIds:map[] ENIInfos:[{ENIID:eni-0c312d68f0609d608 PrivateIP:192.168.68.47 IPV6Addr:2600:1f18:1292:2b02::1ecc}]}]"}
{"level":"info","ts":"2026-04-24T22:41:33Z","msg":"authorizing securityGroup ingress","securityGroupID":"sg-0c209a867dde481e1","permission":[{"FromPort":8080,"IpProtocol":"tcp","IpRanges":null,"Ipv6Ranges":null,"PrefixListIds":null,"ToPort":8080,"UserIdGroupPairs":[{"Description":"elbv2.k8s.aws/targetGroupBinding=shared","GroupId":"sg-0193d1875da3bcf57","GroupName":null,"PeeringStatus":null,"UserId":null,"VpcId":null,"VpcPeeringConnectionId":null}]}]}
```

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
