### PR TITLE
docs(subnet-discovery): mention manual subnet annotations

### DIFF
--- a/docs/deploy/subnet_discovery.md
+++ b/docs/deploy/subnet_discovery.md
@@ -5,6 +5,14 @@ The AWS Load Balancer Controller (LBC) automatically discovers subnets for creat
 2. **Subnet Filtering**: The controller filters these candidates based on eligibility criteria
 3. **Final Selection**: The controller selects one subnet per availability zone
 
+!!!tip "Manual override"
+    Auto-discovery is a default — you can always pin a load balancer to a specific set of subnets with annotations:
+
+    * Ingress: [`alb.ingress.kubernetes.io/subnets`](../guide/ingress/annotations.md#subnets)
+    * Service: [`service.beta.kubernetes.io/aws-load-balancer-subnets`](../guide/service/annotations.md#subnets)
+
+    When either annotation is set, auto-discovery is skipped and the controller uses exactly the subnets you list.
+
 ## Candidate Subnet Determination
 The controller determines candidate subnets using the following process:
 


### PR DESCRIPTION
### Issue

Fixes #3776

### Description

The subnet auto-discovery guide currently doesn't mention that subnets can be set explicitly via annotations, so users who want to override discovery (the original reporter's case: limiting an LB to specific subnets) have to dig through both the Ingress and Service annotation pages to find the right option.

This adds a short \"Manual override\" tip box at the top of the page with direct links to:

- \`alb.ingress.kubernetes.io/subnets\` (Ingress annotation reference)
- \`service.beta.kubernetes.io/aws-load-balancer-subnets\` (Service annotation reference)

…and notes that setting either annotation skips auto-discovery entirely.

The other half of the issue (a unified, searchable annotation list) is a larger docs restructuring; this PR only addresses the discoverability problem the reporter explicitly called out.

### Checklist
- [x] Added/modified documentation as required (such as the \`README.md\`, or the \`docs\` directory)
- [x] Made sure the title of the PR is a good description that can go into the release notes