### PR TITLE
[feat i2g]support dry-run mode for gateway api controller

### DIFF
--- a/cmd/lbc-migrate/main.go
+++ b/cmd/lbc-migrate/main.go
@@ -64,6 +64,10 @@ Input can come from YAML/JSON files, a directory of manifest files, or a live Ku
 	cmd.Flags().StringVar(&opts.OutputFormat, "output-format", "yaml",
 		"Output format: yaml or json")
 
+	// Dry-run flag
+	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false,
+		"Add gateway.k8s.aws/dry-run annotation to generated Gateway manifests so LBC previews the generated AWS resources without creating them")
+
 	return cmd
 }
 

--- a/controllers/gateway/dryrun.go
+++ b/controllers/gateway/dryrun.go
@@ -1,0 +1,79 @@
+package gateway
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	gateway_constants "sigs.k8s.io/aws-load-balancer-controller/pkg/gateway/constants"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/core"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// isDryRunEnabled returns true when the Gateway requests dry-run mode via annotation.
+func isDryRunEnabled(gw *gwv1.Gateway) bool {
+	if gw == nil {
+		return false
+	}
+	return gw.Annotations[gateway_constants.AnnotationDryRun] == gateway_constants.AnnotationDryRunEnabledValue
+}
+
+// hasDryRunPlanAnnotation returns true if the Gateway already carries a prior dry-run plan
+// written by the controller.
+func hasDryRunPlanAnnotation(gw *gwv1.Gateway) bool {
+	if gw == nil {
+		return false
+	}
+	_, exists := gw.Annotations[gateway_constants.AnnotationDryRunPlan]
+	return exists
+}
+
+// reconcileDryRun handles the dry-run branch for the Gateway reconciler. It marshals the
+// already-built stack and writes the JSON to the Gateway's dry-run-plan annotation.
+// It intentionally skips all AWS deploy side-effects (finalizers, SG release, secrets
+// monitoring, addon persistence, service reference counting).
+func (r *gatewayReconciler) reconcileDryRun(ctx context.Context, gw *gwv1.Gateway, stack core.Stack) error {
+	planJSON, err := r.stackMarshaller.Marshal(stack)
+	if err != nil {
+		return err
+	}
+
+	if err := r.patchDryRunPlanAnnotation(ctx, gw, planJSON); err != nil {
+		return err
+	}
+
+	r.logger.Info("dry-run plan generated", "gateway", k8s.NamespacedName(gw))
+	return nil
+}
+
+// patchDryRunPlanAnnotation writes the serialized stack JSON to the Gateway's dry-run-plan
+// annotation. Returns early if the value is unchanged to avoid reconcile loops.
+func (r *gatewayReconciler) patchDryRunPlanAnnotation(ctx context.Context, gw *gwv1.Gateway, planJSON string) error {
+	if gw.Annotations[gateway_constants.AnnotationDryRunPlan] == planJSON {
+		return nil
+	}
+	gwOld := gw.DeepCopy()
+	if gw.Annotations == nil {
+		gw.Annotations = map[string]string{}
+	}
+	gw.Annotations[gateway_constants.AnnotationDryRunPlan] = planJSON
+	if err := r.k8sClient.Patch(ctx, gw, client.MergeFrom(gwOld)); err != nil {
+		return errors.Wrapf(err, "failed to patch dry-run plan annotation on gateway %s", k8s.NamespacedName(gw))
+	}
+	return nil
+}
+
+// cleanupDryRunState removes the dry-run-plan annotation from a Gateway that no longer has
+// dry-run enabled. It is a no-op if the annotation is not present.
+func (r *gatewayReconciler) cleanupDryRunState(ctx context.Context, gw *gwv1.Gateway) error {
+	if !hasDryRunPlanAnnotation(gw) {
+		return nil
+	}
+	gwOld := gw.DeepCopy()
+	delete(gw.Annotations, gateway_constants.AnnotationDryRunPlan)
+	if err := r.k8sClient.Patch(ctx, gw, client.MergeFrom(gwOld)); err != nil {
+		return errors.Wrapf(err, "failed to remove dry-run plan annotation on gateway %s", k8s.NamespacedName(gw))
+	}
+	return nil
+}

--- a/controllers/gateway/dryrun.go
+++ b/controllers/gateway/dryrun.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gateway_constants "sigs.k8s.io/aws-load-balancer-controller/pkg/gateway/constants"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/core"
@@ -17,6 +18,17 @@ func isDryRunEnabled(gw *gwv1.Gateway) bool {
 		return false
 	}
 	return gw.Annotations[gateway_constants.AnnotationDryRun] == gateway_constants.AnnotationDryRunEnabledValue
+}
+
+// isGatewayStatusProgrammed returns true if the Gateway's status has Programmed=True,
+// indicating that AWS resources have been successfully created and are active.
+func isGatewayStatusProgrammed(gw *gwv1.Gateway) bool {
+	for _, c := range gw.Status.Conditions {
+		if c.Type == string(gwv1.GatewayConditionProgrammed) && c.Status == metav1.ConditionTrue {
+			return true
+		}
+	}
+	return false
 }
 
 // hasDryRunPlanAnnotation returns true if the Gateway already carries a prior dry-run plan

--- a/controllers/gateway/dryrun_test.go
+++ b/controllers/gateway/dryrun_test.go
@@ -1,0 +1,279 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy"
+	gateway_constants "sigs.k8s.io/aws-load-balancer-controller/pkg/gateway/constants"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/core"
+	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/testutils"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func newDryRunTestReconciler(t *testing.T, gw *gwv1.Gateway) *gatewayReconciler {
+	t.Helper()
+	k8sClient := testutils.GenerateTestClient()
+	if gw != nil {
+		assert.NoError(t, k8sClient.Create(context.Background(), gw))
+	}
+	return &gatewayReconciler{
+		k8sClient:       k8sClient,
+		logger:          logr.Discard(),
+		eventRecorder:   record.NewFakeRecorder(10),
+		stackMarshaller: deploy.NewDefaultStackMarshaller(),
+	}
+}
+
+func Test_isDryRunEnabled(t *testing.T) {
+	tests := []struct {
+		name string
+		gw   *gwv1.Gateway
+		want bool
+	}{
+		{
+			name: "nil gateway",
+			gw:   nil,
+			want: false,
+		},
+		{
+			name: "no annotations",
+			gw:   &gwv1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: "gw"}},
+			want: false,
+		},
+		{
+			name: "annotation set to true",
+			gw: &gwv1.Gateway{ObjectMeta: metav1.ObjectMeta{
+				Name:        "gw",
+				Annotations: map[string]string{gateway_constants.AnnotationDryRun: "true"},
+			}},
+			want: true,
+		},
+		{
+			name: "annotation set to non-true value",
+			gw: &gwv1.Gateway{ObjectMeta: metav1.ObjectMeta{
+				Name:        "gw",
+				Annotations: map[string]string{gateway_constants.AnnotationDryRun: "yes"},
+			}},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isDryRunEnabled(tt.gw))
+		})
+	}
+}
+
+func Test_hasDryRunPlanAnnotation(t *testing.T) {
+	tests := []struct {
+		name string
+		gw   *gwv1.Gateway
+		want bool
+	}{
+		{
+			name: "nil gateway",
+			gw:   nil,
+			want: false,
+		},
+		{
+			name: "annotation absent",
+			gw:   &gwv1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: "gw"}},
+			want: false,
+		},
+		{
+			name: "annotation present",
+			gw: &gwv1.Gateway{ObjectMeta: metav1.ObjectMeta{
+				Name:        "gw",
+				Annotations: map[string]string{gateway_constants.AnnotationDryRunPlan: "{}"},
+			}},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, hasDryRunPlanAnnotation(tt.gw))
+		})
+	}
+}
+
+func Test_reconcileDryRun(t *testing.T) {
+	tests := []struct {
+		name               string
+		gw                 *gwv1.Gateway
+		buildStack         func(gw *gwv1.Gateway) core.Stack
+		wantErr            bool
+		wantPlanAnnotation bool
+		wantPlanStackID    string
+		wantTags           map[string]string
+	}{
+		{
+			name: "empty stack writes annotation",
+			gw: &gwv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "gw-1",
+					Namespace:   "ns-1",
+					Annotations: map[string]string{gateway_constants.AnnotationDryRun: "true"},
+				},
+			},
+			buildStack: func(gw *gwv1.Gateway) core.Stack {
+				return core.NewDefaultStack(core.StackID(k8s.NamespacedName(gw)))
+			},
+			wantPlanAnnotation: true,
+			wantPlanStackID:    "ns-1/gw-1",
+		},
+		{
+			name: "stack with tagged LoadBalancer includes tags in plan",
+			gw: &gwv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "gw-tags",
+					Namespace:   "ns-tags",
+					Annotations: map[string]string{gateway_constants.AnnotationDryRun: "true"},
+				},
+			},
+			buildStack: func(gw *gwv1.Gateway) core.Stack {
+				stack := core.NewDefaultStack(core.StackID(k8s.NamespacedName(gw)))
+				elbv2model.NewLoadBalancer(stack, "LoadBalancer", elbv2model.LoadBalancerSpec{
+					Name:   "k8s-nstags-gwtags-abc123",
+					Type:   elbv2model.LoadBalancerTypeApplication,
+					Scheme: elbv2model.LoadBalancerSchemeInternetFacing,
+					Tags: map[string]string{
+						"gateway.k8s.aws/migrated-from": "ingress/ns-tags/my-ingress",
+						"Environment":                   "production",
+					},
+				})
+				return stack
+			},
+			wantPlanAnnotation: true,
+			wantPlanStackID:    "ns-tags/gw-tags",
+			wantTags: map[string]string{
+				"gateway.k8s.aws/migrated-from": "ingress/ns-tags/my-ingress",
+				"Environment":                   "production",
+			},
+		},
+		{
+			name: "idempotent: second run produces identical plan",
+			gw: &gwv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "gw-2",
+					Namespace:   "ns-2",
+					Annotations: map[string]string{gateway_constants.AnnotationDryRun: "true"},
+				},
+			},
+			buildStack: func(gw *gwv1.Gateway) core.Stack {
+				return core.NewDefaultStack(core.StackID(k8s.NamespacedName(gw)))
+			},
+			wantPlanAnnotation: true,
+			wantPlanStackID:    "ns-2/gw-2",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newDryRunTestReconciler(t, tt.gw)
+
+			current := &gwv1.Gateway{}
+			assert.NoError(t, r.k8sClient.Get(context.Background(), k8s.NamespacedName(tt.gw), current))
+
+			stack := tt.buildStack(tt.gw)
+			err := r.reconcileDryRun(context.Background(), current, stack)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+
+			stored := &gwv1.Gateway{}
+			assert.NoError(t, r.k8sClient.Get(context.Background(), k8s.NamespacedName(tt.gw), stored))
+
+			planJSON, ok := stored.Annotations[gateway_constants.AnnotationDryRunPlan]
+			assert.Equal(t, tt.wantPlanAnnotation, ok, "dry-run-plan annotation presence")
+			if tt.wantPlanAnnotation {
+				assert.NotEmpty(t, planJSON)
+				var payload map[string]interface{}
+				assert.NoError(t, json.Unmarshal([]byte(planJSON), &payload))
+				assert.Equal(t, tt.wantPlanStackID, payload["id"])
+			}
+
+			if tt.wantTags != nil {
+				var payload map[string]interface{}
+				assert.NoError(t, json.Unmarshal([]byte(planJSON), &payload))
+				resources := payload["resources"].(map[string]interface{})
+				lbType := resources["AWS::ElasticLoadBalancingV2::LoadBalancer"].(map[string]interface{})
+				lb := lbType["LoadBalancer"].(map[string]interface{})
+				spec := lb["spec"].(map[string]interface{})
+				tags, ok := spec["tags"].(map[string]interface{})
+				assert.True(t, ok, "LoadBalancer spec must contain tags")
+				for k, v := range tt.wantTags {
+					assert.Equal(t, v, tags[k])
+				}
+			}
+
+			// Idempotency check
+			if tt.name == "idempotent: second run produces identical plan" {
+				current2 := &gwv1.Gateway{}
+				assert.NoError(t, r.k8sClient.Get(context.Background(), k8s.NamespacedName(tt.gw), current2))
+				assert.NoError(t, r.reconcileDryRun(context.Background(), current2, stack))
+				stored2 := &gwv1.Gateway{}
+				assert.NoError(t, r.k8sClient.Get(context.Background(), k8s.NamespacedName(tt.gw), stored2))
+				assert.Equal(t, planJSON, stored2.Annotations[gateway_constants.AnnotationDryRunPlan],
+					"identical stacks should produce identical dry-run plans")
+			}
+		})
+	}
+}
+
+func Test_cleanupDryRunState(t *testing.T) {
+	tests := []struct {
+		name                   string
+		gw                     *gwv1.Gateway
+		wantPlanAnnotationGone bool
+	}{
+		{
+			name: "removes annotation",
+			gw: &gwv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gw-3",
+					Namespace: "ns-3",
+					Annotations: map[string]string{
+						gateway_constants.AnnotationDryRunPlan: `{"id":"ns-3/gw-3","resources":{}}`,
+					},
+				},
+			},
+			wantPlanAnnotationGone: true,
+		},
+		{
+			name: "no-op when nothing to clean",
+			gw: &gwv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gw-4",
+					Namespace: "ns-4",
+				},
+			},
+			wantPlanAnnotationGone: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newDryRunTestReconciler(t, tt.gw)
+
+			current := &gwv1.Gateway{}
+			assert.NoError(t, r.k8sClient.Get(context.Background(), k8s.NamespacedName(tt.gw), current))
+			assert.NoError(t, r.cleanupDryRunState(context.Background(), current))
+
+			stored := &gwv1.Gateway{}
+			assert.NoError(t, r.k8sClient.Get(context.Background(), k8s.NamespacedName(tt.gw), stored))
+
+			if tt.wantPlanAnnotationGone {
+				_, ok := stored.Annotations[gateway_constants.AnnotationDryRunPlan]
+				assert.False(t, ok, "dry-run-plan annotation should be removed")
+			}
+		})
+	}
+}

--- a/controllers/gateway/gateway_controller.go
+++ b/controllers/gateway/gateway_controller.go
@@ -274,12 +274,19 @@ func (r *gatewayReconciler) reconcileHelper(ctx context.Context, req reconcile.R
 	}
 	r.logger.V(1).Info("Got this addon config", "current", currentAddOns, "new addon", newAddOnConfig)
 
-	// If the Gateway requests dry-run, skip all AWS deploy side-effects
-	// (finalizers, SG release, deploy, secrets, addon persistence, service reference counting)
-	// and only persist the serialized stack plan in the dry-run-plan annotation.
-	// Skip dry-run when the Gateway is being deleted — there's nothing to plan and the object
+	// Dry-run short-circuit: if the Gateway requests dry-run and has not yet been provisioned
+	// skip all AWS deploy side-effects and only persist the serialized stack plan in the dry-run-plan
+	// annotation.
+	// If the Gateway already has a finalizer, it means reconcileUpdate was called at least once
+	// so AWS resources may exist or be provisioning.
+	// In that case, ignore the dry-run annotation and proceed with normal reconciliation.
+	// Skip dry-run when the Gateway is being deleted.
 	if isDryRunEnabled(gw) && !isDeleting {
-		return r.reconcileDryRun(ctx, gw, stack)
+		if k8s.HasFinalizer(gw, r.finalizer) {
+			r.logger.Info("Ignoring dry-run annotation on already-provisioned Gateway", "gateway", k8s.NamespacedName(gw))
+		} else {
+			return r.reconcileDryRun(ctx, gw, stack)
+		}
 	}
 
 	// If the Gateway previously had dry-run enabled, clean up stale dry-run state before

--- a/controllers/gateway/gateway_controller.go
+++ b/controllers/gateway/gateway_controller.go
@@ -274,6 +274,21 @@ func (r *gatewayReconciler) reconcileHelper(ctx context.Context, req reconcile.R
 	}
 	r.logger.V(1).Info("Got this addon config", "current", currentAddOns, "new addon", newAddOnConfig)
 
+	// If the Gateway requests dry-run, skip all AWS deploy side-effects
+	// (finalizers, SG release, deploy, secrets, addon persistence, service reference counting)
+	// and only persist the serialized stack plan in the dry-run-plan annotation.
+	// Skip dry-run when the Gateway is being deleted — there's nothing to plan and the object
+	if isDryRunEnabled(gw) && !isDeleting {
+		return r.reconcileDryRun(ctx, gw, stack)
+	}
+
+	// If the Gateway previously had dry-run enabled, clean up stale dry-run state before
+	// proceeding with normal reconciliation.
+	if err := r.cleanupDryRunState(ctx, gw); err != nil {
+		r.logger.Error(err, "Failed to clean up stale dry-run state", "gateway", k8s.NamespacedName(gw))
+		return err
+	}
+
 	// To accurately track the set of enabled addons, we need to figure out if any addons were added / removed during this run.
 	addOnAdditions, addOnRemovals := diffAddOns(currentAddOns, newAddOnConfig)
 

--- a/docs/guide/gateway/migrate_from_ingress.md
+++ b/docs/guide/gateway/migrate_from_ingress.md
@@ -73,6 +73,7 @@ You can combine `-f` and `--input-dir`, but `--from-cluster` cannot be used with
 | `--kubeconfig` | Optional | Path to kubeconfig file. Only valid with `--from-cluster` | `$KUBECONFIG` or `~/.kube/config` |
 | `--output-dir` | Optional | Directory to write output manifests | `./gateway-output` |
 | `--output-format` | Optional | Output format: `yaml` or `json` | `yaml` |
+| `--dry-run` | Optional | Add `gateway.k8s.aws/dry-run` annotation to generated Gateway manifests so LBC previews the plan without creating AWS resources | `false` |
 
 ## Output Resources
 
@@ -200,3 +201,177 @@ Tip: Use --from-cluster to automatically read all referenced resources,
 ```
 
 These warnings are informational — the tool still generates output. For the most accurate results, use `--from-cluster` which automatically fetches all referenced resources.
+
+## Preview Gateway resources with Dry-Run
+
+Before applying the generated Gateway manifests to create real AWS resources, you can use
+dry-run mode to preview exactly what the AWS Load Balancer Controller would create. When a
+Gateway is annotated with `gateway.k8s.aws/dry-run: "true"`, LBC builds its internal model
+stack and writes the serialized plan back to the Gateway as an annotation — **without
+creating any AWS resources**.
+
+### How it works
+
+1. Apply a Gateway with the `gateway.k8s.aws/dry-run: "true"` annotation.
+2. LBC resolves the GatewayClass, LoadBalancerConfiguration, and attached routes as usual.
+3. LBC builds the internal resource model (LoadBalancer, Listeners, ListenerRules,
+   TargetGroups, and all their configuration including tags, health checks, attributes,
+   and security groups).
+4. Instead of calling AWS to create resources, LBC marshals the model to JSON and writes it to
+   the Gateway's `gateway.k8s.aws/dry-run-plan` annotation.
+5. When you remove the `gateway.k8s.aws/dry-run` annotation, LBC cleans up the `dry-run-plan`
+   annotation, then proceeds with normal reconciliation (creating the ALB).
+
+### Enabling dry-run on a Gateway
+
+Use the `--dry-run` flag when running `lbc-migrate` to automatically add the annotation to
+the generated Gateway manifests:
+
+```bash
+lbc-migrate -f ingress.yaml --output-dir ./gw/ --dry-run
+# or from a live cluster
+lbc-migrate --from-cluster --namespace production --output-dir ./gw/ --dry-run
+```
+
+Alternatively, add the `gateway.k8s.aws/dry-run: "true"` annotation manually to any Gateway
+manifest:
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: my-gateway
+  namespace: default
+  annotations:
+    gateway.k8s.aws/dry-run: "true"
+spec:
+  gatewayClassName: aws-alb
+  listeners:
+    - name: https
+      port: 443
+      protocol: HTTPS
+      tls:
+        certificateRefs:
+          - name: tls-secret
+```
+
+Apply it:
+
+```bash
+kubectl apply -f my-gateway.yaml
+```
+
+### Viewing the dry-run plan
+
+Check that the dry-run plan annotation is populated:
+
+```bash
+kubectl get gateway my-gateway \
+  -o jsonpath='{.metadata.annotations.gateway\.k8s\.aws/dry-run-plan}' | jq .
+```
+
+Example output:
+
+```json
+{
+  "id": "default/my-gateway",
+  "resources": {
+    "AWS::ElasticLoadBalancingV2::LoadBalancer": {
+      "LoadBalancer": {
+        "spec": {
+          "name": "k8s-default-mygatew-abc123",
+          "type": "application",
+          "scheme": "internet-facing",
+          "ipAddressType": "ipv4",
+          "subnetMapping": [
+            {"subnetID": "subnet-aaa"},
+            {"subnetID": "subnet-bbb"}
+          ],
+          "securityGroups": ["sg-xxx"]
+        }
+      }
+    },
+    "AWS::ElasticLoadBalancingV2::Listener": {
+      "443": {
+        "spec": {
+          "port": 443,
+          "protocol": "HTTPS",
+          "sslPolicy": "ELBSecurityPolicy-TLS-1-2-2017-01",
+          "certificates": [
+            {"certificateARN": "arn:aws:acm:us-west-2:123:cert/abc"}
+          ]
+        }
+      }
+    },
+    "AWS::ElasticLoadBalancingV2::TargetGroup": {
+      "default-api-service-8080": {
+        "spec": {
+          "name": "k8s-default-apisvc-xyz789",
+          "targetType": "ip",
+          "port": 8080,
+          "protocol": "HTTP",
+          "healthCheckConfig": {
+            "path": "/health",
+            "intervalSeconds": 15
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Confirm no AWS resources were created:
+
+```bash
+aws elbv2 describe-load-balancers --names k8s-default-mygatew-abc123
+# → "LoadBalancer not found" (expected: dry-run did not deploy)
+```
+
+### Troubleshooting
+
+If the `gateway.k8s.aws/dry-run-plan` annotation is empty after applying the Gateway, the
+model build failed before reaching the dry-run step. Debug with:
+
+1. Check Gateway events for build errors
+
+2. Check Gateway status conditions for validation errors
+
+3. Check controller logs for detailed errors
+
+### Deploying after review
+
+When the plan looks correct, remove the dry-run annotation to let LBC create the actual AWS
+resources. The trailing `-` on the annotation key is `kubectl annotate` syntax for removing
+an annotation:
+
+```bash
+# The trailing `-` tells kubectl to remove (not set) the annotation.
+kubectl annotate -n <NAMESPACE> gateway <GATEWAY_NAME> gateway.k8s.aws/dry-run- 
+```
+
+This triggers a normal reconciliation:
+
+- The `gateway.k8s.aws/dry-run-plan` annotation is cleared.
+- LBC creates the ALB, listeners, target groups, and attaches routes.
+- Once the ALB is active, the `Programmed` condition is set to `True` and the ALB DNS appears
+  in `status.addresses`.
+
+### What dry-run does NOT do
+
+Dry-run intentionally skips every action that would touch AWS or cluster state beyond the
+Gateway annotation/status it owns:
+
+- No AWS resources are created, updated, or deleted.
+- No finalizer is added to the Gateway.
+- No backend security group is allocated or released.
+- No Kubernetes Secrets are monitored for certificate rotation.
+- No add-on state (WAF, Shield) is persisted.
+- No `serviceReferenceCounter` relations are updated.
+
+### Annotation reference
+
+| Annotation                              | Set by     | Description                                                                 |
+| --------------------------------------- | ---------- | --------------------------------------------------------------------------- |
+| `gateway.k8s.aws/dry-run`               | User       | Set to `"true"` to enable dry-run mode on a Gateway.                        |
+| `gateway.k8s.aws/dry-run-plan`          | Controller | Serialized stack JSON written by LBC when dry-run is enabled. Do not edit. |

--- a/docs/guide/gateway/migrate_from_ingress.md
+++ b/docs/guide/gateway/migrate_from_ingress.md
@@ -359,6 +359,12 @@ This triggers a normal reconciliation:
 
 ### What dry-run does NOT do
 
+Dry-run is only effective on Gateways that have not yet been deployed. If the Gateway already
+has AWS resources (indicated by the presence of a controller finalizer), the
+`gateway.k8s.aws/dry-run` annotation is ignored and normal reconciliation proceeds.
+This prevents accidentally freezing a live or provisioning ALB by adding the dry-run annotation
+after deployment.
+
 Dry-run intentionally skips every action that would touch AWS or cluster state beyond the
 Gateway annotation/status it owns:
 

--- a/pkg/gateway/constants/controller_constants.go
+++ b/pkg/gateway/constants/controller_constants.go
@@ -86,3 +86,20 @@ const (
 	ListenerResolvedRefMessage       = "Listener has all refs resolved."
 	ListenerPendingProgrammedMessage = "Listener is pending to be programmed."
 )
+
+/*
+   Dry-run constants
+*/
+
+const (
+	// AnnotationDryRun when set to "true" on a Gateway, LBC builds the model but skips AWS deployment.
+	// The resulting planned stack JSON is written back to the Gateway via AnnotationDryRunPlan.
+	AnnotationDryRun = "gateway.k8s.aws/dry-run"
+
+	// AnnotationDryRunPlan is the annotation written by LBC that holds the serialized planned
+	// stack JSON when the Gateway has dry-run enabled.
+	AnnotationDryRunPlan = "gateway.k8s.aws/dry-run-plan"
+
+	// AnnotationDryRunEnabledValue is the value that enables dry-run mode on a Gateway.
+	AnnotationDryRunEnabledValue = "true"
+)

--- a/pkg/ingress2gateway/migrate.go
+++ b/pkg/ingress2gateway/migrate.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+
+	gateway_constants "sigs.k8s.io/aws-load-balancer-controller/pkg/gateway/constants"
 )
 
 // Migrate is the top-level orchestrator that reads input resources,
@@ -30,6 +32,17 @@ func Migrate(ctx context.Context, opts MigrateOptions, readFunc ReadFunc, transl
 	output, err := translateFunc(resources)
 	if err != nil {
 		return fmt.Errorf("failed to translate resources: %w", err)
+	}
+
+	// When --dry-run is set, inject the dry-run annotation onto every generated Gateway
+	// so LBC builds the model without creating AWS resources.
+	if opts.DryRun {
+		for i := range output.Gateways {
+			if output.Gateways[i].Annotations == nil {
+				output.Gateways[i].Annotations = map[string]string{}
+			}
+			output.Gateways[i].Annotations[gateway_constants.AnnotationDryRun] = gateway_constants.AnnotationDryRunEnabledValue
+		}
 	}
 
 	if err := writeFunc(output, opts.OutputDir, opts.OutputFormat); err != nil {

--- a/pkg/ingress2gateway/translate/icp_overrides.go
+++ b/pkg/ingress2gateway/translate/icp_overrides.go
@@ -241,7 +241,13 @@ func applyICPSpecOverride(dst, src *gatewayv1beta1.LoadBalancerConfigurationSpec
 		dst.SourceRanges = src.SourceRanges
 	}
 	if src.Tags != nil {
-		dst.Tags = src.Tags
+		if dst.Tags == nil {
+			dst.Tags = src.Tags
+		} else {
+			for k, v := range *src.Tags {
+				(*dst.Tags)[k] = v
+			}
+		}
 	}
 	if len(src.LoadBalancerAttributes) > 0 {
 		dst.LoadBalancerAttributes = src.LoadBalancerAttributes

--- a/pkg/ingress2gateway/types.go
+++ b/pkg/ingress2gateway/types.go
@@ -42,6 +42,10 @@ type MigrateOptions struct {
 	// Output options
 	OutputDir    string
 	OutputFormat string
+
+	// Dry-run: when true, the generated Gateway manifests include the
+	// gateway.k8s.aws/dry-run annotation so LBC builds the model without deploying.
+	DryRun bool
 }
 
 // NormalizeNamespaces sets empty namespace fields to "default" on all input


### PR DESCRIPTION
### Description
- Add dry-run support for the Gateway API controller. When a Gateway is annotated with gateway.k8s.aws/dry-run: "true", LBC builds the full internal model (LoadBalancer, Listeners, ListenerRules, TargetGroups, SecurityGroups, tags, etc.) but skips all AWS deployment. The serialized model stack JSON is written back to the Gateway's gateway.k8s.aws/dry-run-plan annotation, allowing users to preview exactly what AWS resources would be created before committing. For all details, see documentation
- fixed a tag bug existed before
- this PR does not take comparison with ingress into consideration for now. only trying to get dry-run mode working for gateway controller
- annotation is minified json format. for this example below, it is around 7000bytes. annotation upper limit is 256KB. takes about 3%

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
original ingress YAML
```
# This example demonstrates the annotation priority chain:
# IngressClassParams > Service annotations > Ingress annotations
#
# - Ingress says scheme=internal, but IngressClassParams overrides to internet-facing
# - Ingress says target-type=instance, but Service overrides to ip
# - healthcheck-path comes from Ingress (no override)
---
apiVersion: v1
kind: Namespace
metadata:
  name: demo
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: echoserver
  namespace: demo
spec:
  replicas: 2
  selector:
    matchLabels:
      app: echoserver
  template:
    metadata:
      labels:
        app: echoserver
    spec:
      containers:
        - name: echoserver
          image: public.ecr.aws/docker/library/httpd:2.4
          ports:
            - containerPort: 80
---
apiVersion: v1
kind: Service
metadata:
  name: echoserver
  namespace: demo
  annotations:
    # Service overrides Ingress: target-type ip wins over instance
    alb.ingress.kubernetes.io/target-type: ip
spec:
  type: NodePort
  selector:
    app: echoserver
  ports:
    - name: http
      port: 80
      targetPort: 80
      protocol: TCP
---
apiVersion: networking.k8s.io/v1
kind: IngressClass
metadata:
  name: alb
spec:
  controller: ingress.k8s.aws/alb
  parameters:
    apiGroup: elbv2.k8s.aws
    kind: IngressClassParams
    name: alb-params
---
apiVersion: elbv2.k8s.aws/v1beta1
kind: IngressClassParams
metadata:
  name: alb-params
spec:
  # IngressClassParams overrides Ingress: internet-facing wins over internal
  scheme: internet-facing
  tags:
    - key: ManagedBy
      value: platform-team
---
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: echo
  namespace: demo
  annotations:
    # This will be overridden by IngressClassParams → internet-facing
    alb.ingress.kubernetes.io/scheme: internal
    # This will be overridden by Service annotation → ip
    alb.ingress.kubernetes.io/target-type: instance
    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80},{"HTTP": 81}]'
    alb.ingress.kubernetes.io/healthcheck-path: /migrate
    alb.ingress.kubernetes.io/healthcheck-interval-seconds: "30"
    alb.ingress.kubernetes.io/load-balancer-attributes: idle_timeout.timeout_seconds=120
    alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=30
    alb.ingress.kubernetes.io/tags: App=echo
spec:
  ingressClassName: alb
  # defaultBackend: catch-all for requests not matching any rule
  defaultBackend:
    service:
      name: echoserver
      port:
        number: 80
  rules:
    - host: echo.example.com
      http:
        paths:
          - path: /migrate
            pathType: Prefix
            backend:
              service:
                name: echoserver
                port:
                  number: 80
          - path: /health
            pathType: Exact
            backend:
              service:
                name: echoserver
                port:
                  name: http

```

generated gateway api YAML (with dry-run annotation)
```
apiVersion: gateway.networking.k8s.io/v1
kind: GatewayClass
metadata:
  name: aws-alb
spec:
  controllerName: gateway.k8s.aws/alb
---
apiVersion: gateway.k8s.aws/v1beta1
kind: LoadBalancerConfiguration
metadata:
  name: echo-lb-confi-ad8c9c7aee
  namespace: demo
spec:
  loadBalancerAttributes:
  - key: idle_timeout.timeout_seconds
    value: "120"
  scheme: internet-facing
  tags:
    App: echo
    ManagedBy: platform-team
    gateway.k8s.aws/migrated-from: ingress/demo/echo
---
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  annotations:
    gateway.k8s.aws/dry-run: "true"
  name: echo-gateway-de5d75dc9e
  namespace: demo
spec:
  gatewayClassName: aws-alb
  infrastructure:
    parametersRef:
      group: gateway.k8s.aws
      kind: LoadBalancerConfiguration
      name: echo-lb-confi-ad8c9c7aee
  listeners:
  - name: http-80
    port: 80
    protocol: HTTP
  - name: http-81
    port: 81
    protocol: HTTP
---
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: echo-route-793e7248e5
  namespace: demo
spec:
  hostnames:
  - echo.example.com
  parentRefs:
  - name: echo-gateway-de5d75dc9e
  rules:
  - backendRefs:
    - name: echoserver
      port: 80
    matches:
    - path:
        type: PathPrefix
        value: /migrate
  - backendRefs:
    - name: echoserver
      port: 80
    matches:
    - path:
        type: Exact
        value: /health
---
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: echo-default-9aeb32758f
  namespace: demo
spec:
  parentRefs:
  - name: echo-gateway-de5d75dc9e
  rules:
  - backendRefs:
    - name: echoserver
      port: 80
---
apiVersion: gateway.k8s.aws/v1beta1
kind: TargetGroupConfiguration
metadata:
  name: echoserv-tg-confi-05e819a62c
  namespace: demo
spec:
  defaultConfiguration:
    healthCheckConfig:
      healthCheckInterval: 30
      healthCheckPath: /migrate
    tags:
      App: echo
      gateway.k8s.aws/migrated-from: ingress/demo/echo
    targetGroupAttributes:
    - key: deregistration_delay.timeout_seconds
      value: "30"
    targetType: ip
  targetReference:
    name: echoserver
```
Gateway status in dry-run mode 
<img width="1082" height="936" alt="Screenshot 2026-04-27 at 4 33 16 PM" src="https://github.com/user-attachments/assets/25c8294c-b213-4ee8-b565-c2c0141c325d" />

Confirmed no ALB is created during dry-run mode 
Confirmed once remove annotation, ALB is created and works as before
Complete dry-run-plan annotation 
```
    ~ % kubectl get gateway echo-gateway-de5d75dc9e -n demo -o jsonpath='{.metadata.annotations.gateway\.k8s\.aws/dry-run-plan}' | jq .
    {
      "id": "demo/echo-gateway-de5d75dc9e",
      "resources": {
        "AWS::EC2::SecurityGroup": {
          "ManagedLBSecurityGroup": {
            "spec": {
              "groupName": "k8s-demo-echogate-be17f9d3c3",
              "description": "[k8s] Managed SecurityGroup for LoadBalancer",
              "tags": {
                "App": "echo",
                "ManagedBy": "platform-team",
                "gateway.k8s.aws/migrated-from": "ingress/demo/echo"
              },
              "ingress": [
                {
                  "ipProtocol": "tcp",
                  "fromPort": 80,
                  "toPort": 80,
                  "ipRanges": [
                    {
                      "cidrIP": "0.0.0.0/0"
                    }
                  ]
                },
                {
                  "ipProtocol": "tcp",
                  "fromPort": 81,
                  "toPort": 81,
                  "ipRanges": [
                    {
                      "cidrIP": "0.0.0.0/0"
                    }
                  ]
                }
              ]
            }
          }
        },
        "AWS::ElasticLoadBalancingV2::Listener": {
          "80": {
            "spec": {
              "loadBalancerARN": {
                "$ref": "#/resources/AWS::ElasticLoadBalancingV2::LoadBalancer/LoadBalancer/status/loadBalancerARN"
              },
              "port": 80,
              "protocol": "HTTP",
              "defaultActions": [
                {
                  "type": "fixed-response",
                  "fixedResponseConfig": {
                    "contentType": "text/plain",
                    "statusCode": "404"
                  }
                }
              ],
              "tags": {
                "App": "echo",
                "ManagedBy": "platform-team",
                "gateway.k8s.aws/migrated-from": "ingress/demo/echo"
              }
            }
          },
          "81": {
            "spec": {
              "loadBalancerARN": {
                "$ref": "#/resources/AWS::ElasticLoadBalancingV2::LoadBalancer/LoadBalancer/status/loadBalancerARN"
              },
              "port": 81,
              "protocol": "HTTP",
              "defaultActions": [
                {
                  "type": "fixed-response",
                  "fixedResponseConfig": {
                    "contentType": "text/plain",
                    "statusCode": "404"
                  }
                }
              ],
              "tags": {
                "App": "echo",
                "ManagedBy": "platform-team",
                "gateway.k8s.aws/migrated-from": "ingress/demo/echo"
              }
            }
          }
        },
        "AWS::ElasticLoadBalancingV2::ListenerRule": {
          "80:1": {
            "spec": {
              "listenerARN": {
                "$ref": "#/resources/AWS::ElasticLoadBalancingV2::Listener/80/status/listenerARN"
              },
              "priority": 1,
              "actions": [
                {
                  "type": "forward",
                  "forwardConfig": {
                    "targetGroups": [
                      {
                        "targetGroupARN": {
                          "$ref": "#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/demo/echo-gateway-de5d75dc9e:demo-echo-route-793e7248e5:HTTPRoute-demo-echoserver:80/status/targetGroupARN"
                        },
                        "weight": 1
                      }
                    ]
                  }
                }
              ],
              "conditions": [
                {
                  "field": "host-header",
                  "hostHeaderConfig": {
                    "values": [
                      "echo.example.com"
                    ]
                  }
                },
                {
                  "field": "path-pattern",
                  "pathPatternConfig": {
                    "values": [
                      "/health"
                    ]
                  }
                }
              ]
            }
          },
          "80:2": {
            "spec": {
              "listenerARN": {
                "$ref": "#/resources/AWS::ElasticLoadBalancingV2::Listener/80/status/listenerARN"
              },
              "priority": 2,
              "actions": [
                {
                  "type": "forward",
                  "forwardConfig": {
                    "targetGroups": [
                      {
                        "targetGroupARN": {
                          "$ref": "#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/demo/echo-gateway-de5d75dc9e:demo-echo-route-793e7248e5:HTTPRoute-demo-echoserver:80/status/targetGroupARN"
                        },
                        "weight": 1
                      }
                    ]
                  }
                }
              ],
              "conditions": [
                {
                  "field": "host-header",
                  "hostHeaderConfig": {
                    "values": [
                      "echo.example.com"
                    ]
                  }
                },
                {
                  "field": "path-pattern",
                  "pathPatternConfig": {
                    "values": [
                      "/migrate",
                      "/migrate/*"
                    ]
                  }
                }
              ]
            }
          },
          "80:3": {
            "spec": {
              "listenerARN": {
                "$ref": "#/resources/AWS::ElasticLoadBalancingV2::Listener/80/status/listenerARN"
              },
              "priority": 3,
              "actions": [
                {
                  "type": "forward",
                  "forwardConfig": {
                    "targetGroups": [
                      {
                        "targetGroupARN": {
                          "$ref": "#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/demo/echo-gateway-de5d75dc9e:demo-echo-default-9aeb32758f:HTTPRoute-demo-echoserver:80/status/targetGroupARN"
                        },
                        "weight": 1
                      }
                    ]
                  }
                }
              ],
              "conditions": [
                {
                  "field": "path-pattern",
                  "pathPatternConfig": {
                    "values": [
                      "/*"
                    ]
                  }
                }
              ]
            }
          },
          "81:1": {
            "spec": {
              "listenerARN": {
                "$ref": "#/resources/AWS::ElasticLoadBalancingV2::Listener/81/status/listenerARN"
              },
              "priority": 1,
              "actions": [
                {
                  "type": "forward",
                  "forwardConfig": {
                    "targetGroups": [
                      {
                        "targetGroupARN": {
                          "$ref": "#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/demo/echo-gateway-de5d75dc9e:demo-echo-route-793e7248e5:HTTPRoute-demo-echoserver:80/status/targetGroupARN"
                        },
                        "weight": 1
                      }
                    ]
                  }
                }
              ],
              "conditions": [
                {
                  "field": "host-header",
                  "hostHeaderConfig": {
                    "values": [
                      "echo.example.com"
                    ]
                  }
                },
                {
                  "field": "path-pattern",
                  "pathPatternConfig": {
                    "values": [
                      "/health"
                    ]
                  }
                }
              ]
            }
          },
          "81:2": {
            "spec": {
              "listenerARN": {
                "$ref": "#/resources/AWS::ElasticLoadBalancingV2::Listener/81/status/listenerARN"
              },
              "priority": 2,
              "actions": [
                {
                  "type": "forward",
                  "forwardConfig": {
                    "targetGroups": [
                      {
                        "targetGroupARN": {
                          "$ref": "#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/demo/echo-gateway-de5d75dc9e:demo-echo-route-793e7248e5:HTTPRoute-demo-echoserver:80/status/targetGroupARN"
                        },
                        "weight": 1
                      }
                    ]
                  }
                }
              ],
              "conditions": [
                {
                  "field": "host-header",
                  "hostHeaderConfig": {
                    "values": [
                      "echo.example.com"
                    ]
                  }
                },
                {
                  "field": "path-pattern",
                  "pathPatternConfig": {
                    "values": [
                      "/migrate",
                      "/migrate/*"
                    ]
                  }
                }
              ]
            }
          },
          "81:3": {
            "spec": {
              "listenerARN": {
                "$ref": "#/resources/AWS::ElasticLoadBalancingV2::Listener/81/status/listenerARN"
              },
              "priority": 3,
              "actions": [
                {
                  "type": "forward",
                  "forwardConfig": {
                    "targetGroups": [
                      {
                        "targetGroupARN": {
                          "$ref": "#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/demo/echo-gateway-de5d75dc9e:demo-echo-default-9aeb32758f:HTTPRoute-demo-echoserver:80/status/targetGroupARN"
                        },
                        "weight": 1
                      }
                    ]
                  }
                }
              ],
              "conditions": [
                {
                  "field": "path-pattern",
                  "pathPatternConfig": {
                    "values": [
                      "/*"
                    ]
                  }
                }
              ]
            }
          }
        },
        "AWS::ElasticLoadBalancingV2::LoadBalancer": {
          "LoadBalancer": {
            "spec": {
              "name": "k8s-demo-echogate-1141f0d7cc",
              "type": "application",
              "scheme": "internet-facing",
              "ipAddressType": "ipv4",
              "subnetMapping": [
                {
                  "subnetID": "subnet-00601653a10b6b9d0"
                },
                {
                  "subnetID": "subnet-069233ffb2fd8e084"
                },
                {
                  "subnetID": "subnet-0e03303ee232d9acb"
                }
              ],
              "securityGroups": [
                {
                  "$ref": "#/resources/AWS::EC2::SecurityGroup/ManagedLBSecurityGroup/status/groupID"
                },
                "sg-0c99ae0f0a14f267c"
              ],
              "loadBalancerAttributes": [
                {
                  "key": "idle_timeout.timeout_seconds",
                  "value": "120"
                }
              ],
              "tags": {
                "App": "echo",
                "ManagedBy": "platform-team",
                "gateway.k8s.aws/migrated-from": "ingress/demo/echo"
              }
            }
          }
        },
        "AWS::ElasticLoadBalancingV2::TargetGroup": {
          "demo/echo-gateway-de5d75dc9e:demo-echo-default-9aeb32758f:HTTPRoute-demo-echoserver:80": {
            "spec": {
              "name": "k8s-demo-echodefa-270340566b",
              "targetType": "ip",
              "port": 80,
              "protocol": "HTTP",
              "protocolVersion": "HTTP1",
              "ipAddressType": "ipv4",
              "healthCheckConfig": {
                "port": "traffic-port",
                "protocol": "HTTP",
                "path": "/migrate",
                "matcher": {
                  "httpCode": "200-399"
                },
                "intervalSeconds": 30,
                "timeoutSeconds": 5,
                "healthyThresholdCount": 3,
                "unhealthyThresholdCount": 3
              },
              "targetGroupAttributes": [
                {
                  "key": "deregistration_delay.timeout_seconds",
                  "value": "30"
                }
              ],
              "tags": {
                "App": "echo",
                "gateway.k8s.aws/migrated-from": "ingress/demo/echo"
              }
            }
          },
          "demo/echo-gateway-de5d75dc9e:demo-echo-route-793e7248e5:HTTPRoute-demo-echoserver:80": {
            "spec": {
              "name": "k8s-demo-echorout-34ca409c1b",
              "targetType": "ip",
              "port": 80,
              "protocol": "HTTP",
              "protocolVersion": "HTTP1",
              "ipAddressType": "ipv4",
              "healthCheckConfig": {
                "port": "traffic-port",
                "protocol": "HTTP",
                "path": "/migrate",
                "matcher": {
                  "httpCode": "200-399"
                },
                "intervalSeconds": 30,
                "timeoutSeconds": 5,
                "healthyThresholdCount": 3,
                "unhealthyThresholdCount": 3
              },
              "targetGroupAttributes": [
                {
                  "key": "deregistration_delay.timeout_seconds",
                  "value": "30"
                }
              ],
              "tags": {
                "App": "echo",
                "gateway.k8s.aws/migrated-from": "ingress/demo/echo"
              }
            }
          }
        },
        "FrontendNLBTargetGroup": {
          "FrontendNLBTargetGroup": {
            "TargetGroups": {}
          }
        },
        "K8S::ElasticLoadBalancingV2::TargetGroupBinding": {
          "demo/echo-gateway-de5d75dc9e:demo-echo-default-9aeb32758f:HTTPRoute-demo-echoserver:80": {
            "spec": {
              "template": {
                "metadata": {
                  "name": "k8s-demo-echodefa-270340566b",
                  "namespace": "demo"
                },
                "spec": {
                  "targetGroupARN": {
                    "$ref": "#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/demo/echo-gateway-de5d75dc9e:demo-echo-default-9aeb32758f:HTTPRoute-demo-echoserver:80/status/targetGroupARN"
                  },
                  "targetType": "ip",
                  "serviceRef": {
                    "name": "echoserver",
                    "port": 80
                  },
                  "networking": {
                    "ingress": [
                      {
                        "from": [
                          {
                            "securityGroup": {
                              "groupID": "sg-0c99ae0f0a14f267c"
                            }
                          }
                        ],
                        "ports": [
                          {
                            "protocol": "TCP",
                            "port": 80
                          }
                        ]
                      }
                    ]
                  },
                  "ipAddressType": "ipv4",
                  "vpcID": "vpc-0e69795471f0bd457",
                  "targetGroupProtocol": "HTTP"
                }
              }
            }
          },
          "demo/echo-gateway-de5d75dc9e:demo-echo-route-793e7248e5:HTTPRoute-demo-echoserver:80": {
            "spec": {
              "template": {
                "metadata": {
                  "name": "k8s-demo-echorout-34ca409c1b",
                  "namespace": "demo"
                },
                "spec": {
                  "targetGroupARN": {
                    "$ref": "#/resources/AWS::ElasticLoadBalancingV2::TargetGroup/demo/echo-gateway-de5d75dc9e:demo-echo-route-793e7248e5:HTTPRoute-demo-echoserver:80/status/targetGroupARN"
                  },
                  "targetType": "ip",
                  "serviceRef": {
                    "name": "echoserver",
                    "port": 80
                  },
                  "networking": {
                    "ingress": [
                      {
                        "from": [
                          {
                            "securityGroup": {
                              "groupID": "sg-0c99ae0f0a14f267c"
                            }
                          }
                        ],
                        "ports": [
                          {
                            "protocol": "TCP",
                            "port": 80
                          }
                        ]
                      }
                    ]
                  },
                  "ipAddressType": "ipv4",
                  "vpcID": "vpc-0e69795471f0bd457",
                  "targetGroupProtocol": "HTTP"
                }
              }
            }
          }
        }
      }
    }
```

- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
