### PR TITLE
[feat acm-certs-mgmt] bug fixes and doc improvements

### DIFF
--- a/docs/guide/ingress/certificate_management.md
+++ b/docs/guide/ingress/certificate_management.md
@@ -38,6 +38,29 @@ Amazon Issued certificates are currently validated using DNS Method and Route53 
 E-Mail validation is not supported due to significant higher delays between requesting a certificate and it's issuance. 
 When using a PCA, certificates don't have to be validated.
 
+## Ingress Group Behavior
+
+When using certificate management with [IngressGroups](ingress_class.md#specgroup), each ingress in the group gets its own certificate based on its own hostnames. All certificates are attached to the shared ALB's HTTPS listener.
+
+For example, if an ingress group has three members:
+
+- Ingress A with `create-acm-cert: "true"` and host `app-a.example.com`
+- Ingress B with `create-acm-cert: "true"` and host `app-b.example.com`
+- Ingress C with `certificate-arn` pointing to an existing cert
+
+The controller creates two managed certificates (for A and B) and uses the manually specified cert for C. All three certificates are attached to the same HTTPS:443 listener on the shared ALB.
+
+Each ingress in the group can independently choose its certificate strategy:
+
+- `create-acm-cert: "true"` — controller creates and manages a certificate
+- `certificate-arn` — use a manually specified certificate (takes precedence over `create-acm-cert`)
+- Neither — use certificate discovery (existing behavior)
+
+Deleting one ingress from the group removes only its managed certificate. The other ingresses and their certificates remain unaffected.
+
+!!!note "Same hostname across multiple ingresses"
+    Each ingress in a group gets its own certificate, even if multiple ingresses share the same hostname. If two ingresses both have `create-acm-cert: "true"` with the same host, two separate certificates are created and both are attached to the listener. To avoid duplicate certificates for the same domain, only enable `create-acm-cert` on one ingress per hostname — the other ingresses with the same hostname can omit the annotation and will still have their listener rules created on the shared ALB.
+
 ## PCA-Support
 
 If you don't want Amazon Issued certificates you can issue certificates from an existing PCA in your AWS account.
@@ -54,3 +77,48 @@ For platform operators who want to rotate PCAs without interaction from ingress 
 ## Limitations
 
 By using this feature the number of hostnames (Subject Alternative Names) you can specify in `spec.tls[].hosts` on a single ingress resource is limited by your AWS account's ACM SAN quota. The [default limit](https://docs.aws.amazon.com/acm/latest/userguide/acm-limits.html#general-limits) is 10 SANs per certificate. If you need more, request a quota increase via the AWS Service Quotas console.
+
+## Security Considerations
+
+The controller operates with a single IAM role at the cluster level and does not enforce namespace-level domain restrictions. Any namespace with Ingress creation permissions can request certificates for any domain. This is consistent with how `certificate-arn` annotations and certificate discovery work — they also operate without namespace-level domain isolation.
+
+ACM DNS validation provides the primary security boundary: a certificate is only issued if the controller can create validation records in a Route53 hosted zone, which requires the appropriate IAM permissions configured on the controller's role.
+
+For multi-tenant clusters, consider the following mitigations:
+
+- **Kubernetes RBAC**: Restrict which namespaces or users can create Ingress resources
+- **Route53 IAM scoping**: Scope the controller's Route53 permissions to specific hosted zone ARNs (e.g., `arn:aws:route53:::hostedzone/ZXXXXX`) rather than `Resource: "*"` to limit which domains can be validated
+
+### IAM Policy Scoping
+
+The sample IAM policy provided with this feature uses `Resource: "*"` for Route53 and PCA operations for simplicity. In production, you should scope these permissions to reduce the blast radius:
+
+**Route53** — Restrict `route53:ChangeResourceRecordSets` to specific hosted zones:
+
+```json
+{
+    "Effect": "Allow",
+    "Action": [
+        "route53:ChangeResourceRecordSets",
+        "route53:ListResourceRecordSets"
+    ],
+    "Resource": "arn:aws:route53:::hostedzone/<YOUR_ZONE_ID>"
+}
+```
+
+This ensures the controller can only create DNS validation records in the hosted zones you explicitly allow, preventing modification of unrelated DNS records in the account.
+
+**PCA** — If using private certificates, restrict `acm-pca:IssueCertificate` to specific certificate authorities:
+
+```json
+{
+    "Effect": "Allow",
+    "Action": ["acm-pca:IssueCertificate"],
+    "Resource": "arn:aws:acm-pca:<region>:<account>:certificate-authority/<YOUR_CA_ID>"
+}
+```
+
+This prevents the controller from issuing certificates from any PCA in the account other than the one you designate.
+
+!!!warning "Default policy is permissive"
+    The default IAM policy uses `Resource: "*"` for Route53 and PCA operations. This means the controller can modify DNS records in **any** hosted zone and issue certificates from **any** PCA in the account. Always scope these permissions in production environments.

--- a/pkg/deploy/acm/certificate_manager.go
+++ b/pkg/deploy/acm/certificate_manager.go
@@ -74,6 +74,22 @@ func (c *defaultCertificateManager) Create(ctx context.Context, certModel *acmMo
 }
 
 func (c *defaultCertificateManager) CreateWithValidationRecords(ctx context.Context, certModel *acmModel.Certificate) (*acmModel.CertificateStatus, error) {
+	// Pre-check: verify hosted zones exist for all domains before requesting the certificate.
+	// This prevents creating orphaned PENDING_VALIDATION certs in ACM that can never be issued.
+	hostedZoneByDomain := make(map[string]*string)
+	allHosts := []string{certModel.Spec.DomainName}
+	allHosts = append(allHosts, certModel.Spec.SubjectAlternativeNames...)
+	for _, host := range allHosts {
+		if _, checked := hostedZoneByDomain[host]; checked {
+			continue
+		}
+		zoneID, err := c.route53Client.GetHostedZoneID(ctx, host)
+		if err != nil {
+			return nil, fmt.Errorf("pre-check failed for domain %q: %w", host, err)
+		}
+		hostedZoneByDomain[host] = zoneID
+	}
+
 	resp, err := c.create(ctx, certModel)
 	if err != nil {
 		return &acmModel.CertificateStatus{}, err
@@ -109,10 +125,7 @@ func (c *defaultCertificateManager) CreateWithValidationRecords(ctx context.Cont
 	for _, opts := range desc.Certificate.DomainValidationOptions {
 		if opts.ValidationMethod == acmtypes.ValidationMethodDns {
 			c.logger.Info("creating validation record", "certificateARN", resp.CertificateArn, "record", opts.ResourceRecord)
-			id, err := c.route53Client.GetHostedZoneID(ctx, awssdk.ToString(opts.DomainName))
-			if err != nil {
-				return nil, err
-			}
+			id := hostedZoneByDomain[awssdk.ToString(opts.DomainName)]
 			if opts.ResourceRecord == nil {
 				// this should no longer happen since we retry the describe above until the records have been populated by AWS
 				return nil, fmt.Errorf("resource record to create was nil but validation method was DNS")
@@ -216,6 +229,12 @@ func (c *defaultCertificateManager) DeleteWithValidationRecords(ctx context.Cont
 			c.logger.Info("deleting validation records for certificate", "certificateARN", arn)
 			id, err := c.route53Client.GetHostedZoneID(ctx, awssdk.ToString(opts.DomainName))
 			if err != nil {
+				// If no hosted zone exists for this domain, skip validation records cleanup and
+				// proceed to delete the certificate itself.
+				if strings.Contains(err.Error(), "no hosted zone found") {
+					c.logger.Info("no hosted zone found for domain, skipping validation record cleanup", "domain", awssdk.ToString(opts.DomainName))
+					continue
+				}
 				return err
 			}
 			input := &route53sdk.ChangeResourceRecordSetsInput{

--- a/pkg/deploy/acm/certificate_synthesizer_test.go
+++ b/pkg/deploy/acm/certificate_synthesizer_test.go
@@ -1,6 +1,7 @@
 package acm
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -490,6 +491,40 @@ func Test_Synthesizer(t *testing.T) {
 				},
 				Tags: map[string]string{"foo": "amazon_issued/example.com"},
 			}},
+		},
+		{
+			name: "pre-check fails when hosted zone not found — no cert created in ACM",
+			setup: func(s core.Stack, mockACM *services.MockACM, mockRoute53 *services.MockRoute53, mockTracking *tracking.MockProvider) {
+				acmModel.NewCertificate(s, "amazon_issued/wrong.nonexistent-domain.com", acmModel.CertificateSpec{
+					Type:                    acmtypes.CertificateTypeAmazonIssued,
+					DomainName:              "wrong.nonexistent-domain.com",
+					SubjectAlternativeNames: []string{"wrong.nonexistent-domain.com"},
+					ValidationMethod:        acmtypes.ValidationMethodDns,
+					Tags:                    map[string]string{},
+				})
+
+				mockTracking.EXPECT().ResourceIDTagKey().Return("foo")
+				mockTracking.EXPECT().StackTags(gomock.Any()).Return(map[string]string(nil))
+				mockTracking.EXPECT().StackTagsLegacy(gomock.Any()).Return(map[string]string(nil))
+
+				mockACM.EXPECT().ListCertificatesAsList(gomock.Any(), gomock.Eq(&acm.ListCertificatesInput{})).
+					Return([]acmtypes.CertificateSummary{}, nil)
+
+				// Pre-check: GetHostedZoneID fails — no cert should be requested
+				mockRoute53.EXPECT().GetHostedZoneID(gomock.Any(), gomock.Eq("wrong.nonexistent-domain.com")).
+					Return(nil, fmt.Errorf("no hosted zone found for validation records"))
+
+				// RequestCertificate should NOT be called
+			},
+			checkStack: func(s core.Stack) {
+				var resCerts []*acmModel.Certificate
+				_ = s.ListResources(&resCerts)
+				for _, cert := range resCerts {
+					assert.Nil(t, cert.Status, "cert status should not be set when pre-check fails")
+				}
+			},
+			wantErr:                  fmt.Errorf("pre-check failed for domain \"wrong.nonexistent-domain.com\": no hosted zone found for validation records"),
+			wantToDeleteCertificates: nil,
 		},
 	}
 

--- a/pkg/ingress/model_build_certificates.go
+++ b/pkg/ingress/model_build_certificates.go
@@ -2,6 +2,7 @@ package ingress
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"strings"
 
@@ -26,21 +27,23 @@ func (t *defaultModelBuildTask) buildACMCertificates(ctx context.Context, ing *C
 	}
 
 	if certSpec == nil {
-		return nil, nil
+		// No hostnames found — can't create a certificate without at least one hostname.
+		ingKey := fmt.Sprintf("%s/%s", ing.Ing.Namespace, ing.Ing.Name)
+		return nil, fmt.Errorf("ingress %v has create-acm-cert enabled but no hostnames defined in spec.rules[].host or spec.tls[].hosts — cannot create a certificate without at least one hostname", ingKey)
 	}
 
-	certID := t.buildCertificateResourceID(certSpec)
+	certID := t.buildCertificateResourceID(certSpec, ing)
 
 	cert := acmModel.NewCertificate(t.stack, certID, *certSpec)
 	return cert, nil
 }
 
-func (t *defaultModelBuildTask) buildCertificateResourceID(spec *acmModel.CertificateSpec) string {
-	if spec.CertificateAuthorityARN == "" {
-		return fmt.Sprintf("%s/%s", strings.ToLower(string(spec.Type)), spec.DomainName)
-	} else {
-		return fmt.Sprintf("%s/%s-%s", strings.ToLower(string(spec.Type)), spec.DomainName, spec.CertificateAuthorityARN)
-	}
+// buildCertificateResourceID builds a unique resource ID for a certificate.
+// The ID includes a hash of the ingress namespace/name to ensure each ingress gets its own certificate
+func (t *defaultModelBuildTask) buildCertificateResourceID(spec *acmModel.CertificateSpec, ing *ClassifiedIngress) string {
+	ingKey := fmt.Sprintf("%s/%s", ing.Ing.Namespace, ing.Ing.Name)
+	ingHash := fmt.Sprintf("%x", sha256.Sum256([]byte(ingKey)))[:8]
+	return fmt.Sprintf("%s/%s-%s", strings.ToLower(string(spec.Type)), spec.DomainName, ingHash)
 }
 
 func (t *defaultModelBuildTask) buildCertificateSpec(ctx context.Context, ing *ClassifiedIngress) (*acmModel.CertificateSpec, error) {

--- a/pkg/ingress/model_build_certificates_test.go
+++ b/pkg/ingress/model_build_certificates_test.go
@@ -27,7 +27,7 @@ func Test_buildACMCertificates(t *testing.T) {
 		wantNilCert  bool
 	}{
 		{
-			name: "Build certificate for catch-all ingress",
+			name: "Build certificate fails when no hostnames defined",
 			fields: fields{
 				ingGroup: Group{
 					ID: GroupID{Name: "explicit-group"},
@@ -47,7 +47,7 @@ func Test_buildACMCertificates(t *testing.T) {
 					},
 				},
 			},
-			wantNilCert: true,
+			wantErr: true,
 		},
 		{
 			name: "Build certificate for regular ingress",

--- a/pkg/ingress/model_builder.go
+++ b/pkg/ingress/model_builder.go
@@ -2,6 +2,7 @@ package ingress
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"sort"
 	"strconv"
@@ -379,7 +380,7 @@ func (t *defaultModelBuildTask) run(ctx context.Context) error {
 	return nil
 }
 
-func (t *defaultModelBuildTask) mergeListenPortConfigs(_ context.Context, listenPortConfigs []listenPortConfigWithIngress) (listenPortConfig, error) {
+func (t *defaultModelBuildTask) mergeListenPortConfigs(ctx context.Context, listenPortConfigs []listenPortConfigWithIngress) (listenPortConfig, error) {
 	var mergedProtocolProvider *types.NamespacedName
 	var mergedProtocol elbv2model.Protocol
 
@@ -455,15 +456,22 @@ func (t *defaultModelBuildTask) mergeListenPortConfigs(_ context.Context, listen
 		}
 
 		for j, cert := range cfg.listenPortConfig.tlsCerts {
-			c, _ := cert.Resolve(context.TODO())
+			// Use resource identity for dedup when available (auto-created certs),
+			// fall back to resolved ARN for literal tokens (e.g. certificate-arn).
+			var certKey string
+			if deps := cert.Dependencies(); len(deps) > 0 && deps[0].Type() != "" && deps[0].ID() != "" {
+				certKey = fmt.Sprintf("%s/%s", deps[0].Type(), deps[0].ID())
+			} else {
+				certKey, _ = cert.Resolve(ctx)
+			}
 			// The first certificate is ignored as it is the default certificate, which has already been added to the mergedTLSCerts.
 			if i == defaultCertMemberIndex && j == 0 {
 				continue
 			}
-			if mergedTLSCertsSet.Has(c) {
+			if mergedTLSCertsSet.Has(certKey) {
 				continue
 			}
-			mergedTLSCertsSet.Insert(c)
+			mergedTLSCertsSet.Insert(certKey)
 			mergedTLSCerts = append(mergedTLSCerts, cert)
 		}
 

--- a/pkg/ingress/model_builder_test.go
+++ b/pkg/ingress/model_builder_test.go
@@ -23,6 +23,7 @@ import (
 	networking "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
@@ -34,6 +35,8 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/elbv2"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/tracking"
 	lbcmetrics "sigs.k8s.io/aws-load-balancer-controller/pkg/metrics/lbc"
+	acmModel "sigs.k8s.io/aws-load-balancer-controller/pkg/model/acm"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/core"
 	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
 	networkingpkg "sigs.k8s.io/aws-load-balancer-controller/pkg/networking"
 	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -6271,6 +6274,128 @@ func Test_defaultModelBuildTask_buildResourceTagsPriority(t *testing.T) {
 					assert.Contains(t, got, key)
 					assert.Equal(t, value, got[key])
 				}
+			}
+		})
+	}
+}
+
+func Test_mergeListenPortConfigs_CertDedup(t *testing.T) {
+	tests := []struct {
+		name              string
+		configs           []listenPortConfigWithIngress
+		expectedCertCount int
+		wantErr           bool
+	}{
+		{
+			name: "two ingresses with different literal cert tokens should merge both",
+			configs: []listenPortConfigWithIngress{
+				{
+					ingKey: types.NamespacedName{Namespace: "ns", Name: "ing-a"},
+					listenPortConfig: listenPortConfig{
+						protocol: elbv2model.ProtocolHTTPS,
+						tlsCerts: []core.StringToken{
+							core.LiteralStringToken("arn:aws:acm:us-east-1:123456789:certificate/cert-a"),
+						},
+					},
+				},
+				{
+					ingKey: types.NamespacedName{Namespace: "ns", Name: "ing-b"},
+					listenPortConfig: listenPortConfig{
+						protocol: elbv2model.ProtocolHTTPS,
+						tlsCerts: []core.StringToken{
+							core.LiteralStringToken("arn:aws:acm:us-east-1:123456789:certificate/cert-b"),
+						},
+					},
+				},
+			},
+			expectedCertCount: 2,
+		},
+		{
+			name: "two ingresses with resource-backed cert tokens (auto-created) should merge both",
+			configs: func() []listenPortConfigWithIngress {
+				stack := core.NewDefaultStack(core.StackID{Namespace: "ns", Name: "test-group"})
+				certA := acmModel.NewCertificate(stack, "amazon_issued/app-a.example.com", acmModel.CertificateSpec{
+					DomainName:              "app-a.example.com",
+					SubjectAlternativeNames: []string{"app-a.example.com"},
+				})
+				certB := acmModel.NewCertificate(stack, "amazon_issued/app-b.example.com", acmModel.CertificateSpec{
+					DomainName:              "app-b.example.com",
+					SubjectAlternativeNames: []string{"app-b.example.com"},
+				})
+				return []listenPortConfigWithIngress{
+					{
+						ingKey: types.NamespacedName{Namespace: "ns", Name: "ing-a"},
+						listenPortConfig: listenPortConfig{
+							protocol: elbv2model.ProtocolHTTPS,
+							tlsCerts: []core.StringToken{certA.CertificateARN()},
+						},
+					},
+					{
+						ingKey: types.NamespacedName{Namespace: "ns", Name: "ing-b"},
+						listenPortConfig: listenPortConfig{
+							protocol: elbv2model.ProtocolHTTPS,
+							tlsCerts: []core.StringToken{certB.CertificateARN()},
+						},
+					},
+				}
+			}(),
+			expectedCertCount: 2,
+		},
+		{
+			name: "three ingresses mixing resource-backed and literal tokens should merge all",
+			configs: func() []listenPortConfigWithIngress {
+				stack := core.NewDefaultStack(core.StackID{Namespace: "ns", Name: "test-group"})
+				certA := acmModel.NewCertificate(stack, "amazon_issued/app-a.example.com", acmModel.CertificateSpec{
+					DomainName:              "app-a.example.com",
+					SubjectAlternativeNames: []string{"app-a.example.com"},
+				})
+				certB := acmModel.NewCertificate(stack, "amazon_issued/app-b.example.com", acmModel.CertificateSpec{
+					DomainName:              "app-b.example.com",
+					SubjectAlternativeNames: []string{"app-b.example.com"},
+				})
+				return []listenPortConfigWithIngress{
+					{
+						ingKey: types.NamespacedName{Namespace: "ns", Name: "ing-a"},
+						listenPortConfig: listenPortConfig{
+							protocol: elbv2model.ProtocolHTTPS,
+							tlsCerts: []core.StringToken{certA.CertificateARN()},
+						},
+					},
+					{
+						ingKey: types.NamespacedName{Namespace: "ns", Name: "ing-b"},
+						listenPortConfig: listenPortConfig{
+							protocol: elbv2model.ProtocolHTTPS,
+							tlsCerts: []core.StringToken{certB.CertificateARN()},
+						},
+					},
+					{
+						ingKey: types.NamespacedName{Namespace: "ns", Name: "ing-c"},
+						listenPortConfig: listenPortConfig{
+							protocol: elbv2model.ProtocolHTTPS,
+							tlsCerts: []core.StringToken{
+								core.LiteralStringToken("arn:aws:acm:us-east-1:123456789:certificate/manual-cert"),
+							},
+						},
+					},
+				}
+			}(),
+			expectedCertCount: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := &defaultModelBuildTask{
+				annotationParser: annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io"),
+				defaultSSLPolicy: "ELBSecurityPolicy-2016-08",
+			}
+			got, err := task.mergeListenPortConfigs(t.Context(), tt.configs)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedCertCount, len(got.tlsCerts),
+					"expected %d certs but got %d", tt.expectedCertCount, len(got.tlsCerts))
 			}
 		})
 	}


### PR DESCRIPTION
### Issue

Bug 1: Certificate dedup drops certs in ingress groups : For auto-created certs (ResourceFieldStringToken), Resolve() returns "" because the cert status isn't set until the synthesizer runs. This caused all auto-created certs after the first to be silently dropped in ingress groups.
Fix: Use resource identity (Type()/ID() from Dependencies()) for dedup on auto-created certs. Fall back to Resolve() only for literal tokens (e.g. certificate-arn), which always resolve to the actual ARN string.

Bug 2: Same hostname across ingresses in a group produces only one cert
Fix: Include a hash of the ingress namespace/name in the resource ID, ensuring each ingress gets its own cert even with shared hostnames.

Bug 3: Orphaned certs when hosted zone doesn't exist :  certificate was requested from ACM before checking if a Route53 hosted zone exists. If no zone was found, the cert was left in PENDING_VALIDATION state for 30 minutes, blocking the reconcile loop.

Fix: Pre-check that hosted zones exist for all domains before calling RequestCertificate. 

Bug 4: No hostname in Ingress provides weird error message : when create-acm-cert are set and ingress does not have any hostname, the API was called and failed requesting the new cert. 

Fix: Added a check in builder before calling the API to fail fast when no hostname are specified. 

### Documentation updates
- Added Ingress Group Behavior section with examples of mixed cert strategies
- Added Security Considerations section covering multi-tenant isolation and IAM policy scoping
- Added note about same-hostname behavior in ingress groups

### Manual testing 

Single ingress: amazon-issued, PCA, cert-arn, cert discovery, multi-SAN, SAN update
Ingress groups: mixed strategies, dedup with different hostnames, same hostname, cert-arn backward compat
Error cases: no hostname, wrong domain pre-check, SAN quota exceeded, cert-arn precedence
Lifecycle: delete ingress → cert cleanup, switch create-acm-cert → certificate-arn

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
