### PR TITLE
add externalId into cache key

### DIFF
--- a/pkg/aws/cloud.go
+++ b/pkg/aws/cloud.go
@@ -228,14 +228,26 @@ type defaultCloud struct {
 	logger             logr.Logger
 }
 
+// assumedRoleCacheKey identifies a cached assumed-role ELBv2 client.
+// Both fields are included so that sessions assumed with different ExternalId
+// values are never shared.  Using only the ARN would let the first caller's
+// ExternalId win for the lifetime of the cached session, breaking the
+// confused-deputy protection that ExternalId provides.
+type assumedRoleCacheKey struct {
+	roleArn    string
+	externalId string
+}
+
 // GetAssumedRoleELBV2 returns ELBV2 client for the given assumeRoleArn, or the default ELBV2 client if assumeRoleArn is empty
 func (c *defaultCloud) GetAssumedRoleELBV2(ctx context.Context, assumeRoleArn string, externalId string) (services.ELBV2, error) {
 	if assumeRoleArn == "" {
 		return c.elbv2, nil
 	}
 
+	cacheKey := assumedRoleCacheKey{roleArn: assumeRoleArn, externalId: externalId}
+
 	c.assumeRoleElbV2CacheMutex.RLock()
-	assumedRoleELBV2, exists := c.assumeRoleElbV2Cache.Get(assumeRoleArn)
+	assumedRoleELBV2, exists := c.assumeRoleElbV2Cache.Get(cacheKey)
 	c.assumeRoleElbV2CacheMutex.RUnlock()
 
 	if exists {
@@ -274,7 +286,7 @@ func (c *defaultCloud) GetAssumedRoleELBV2(ctx context.Context, assumeRoleArn st
 
 	c.assumeRoleElbV2CacheMutex.Lock()
 	defer c.assumeRoleElbV2CacheMutex.Unlock()
-	c.assumeRoleElbV2Cache.Set(assumeRoleArn, elbv2WithAssumedRole, cacheTTL-cacheTTLBufferTime)
+	c.assumeRoleElbV2Cache.Set(cacheKey, elbv2WithAssumedRole, cacheTTL-cacheTTLBufferTime)
 	return elbv2WithAssumedRole, nil
 }
 

--- a/pkg/aws/cloud_test.go
+++ b/pkg/aws/cloud_test.go
@@ -136,3 +136,53 @@ func Test_getVpcID(t *testing.T) {
 		})
 	}
 }
+
+func Test_assumedRoleCacheKey(t *testing.T) {
+	tests := []struct {
+		name string
+		a    assumedRoleCacheKey
+		b    assumedRoleCacheKey
+		same bool
+	}{
+		{
+			name: "identical keys are equal",
+			a:    assumedRoleCacheKey{roleArn: "arn:aws:iam::123456789012:role/MyRole", externalId: "ext-abc"},
+			b:    assumedRoleCacheKey{roleArn: "arn:aws:iam::123456789012:role/MyRole", externalId: "ext-abc"},
+			same: true,
+		},
+		{
+			name: "same ARN different externalId are not equal",
+			a:    assumedRoleCacheKey{roleArn: "arn:aws:iam::123456789012:role/Shared", externalId: "tenant-A"},
+			b:    assumedRoleCacheKey{roleArn: "arn:aws:iam::123456789012:role/Shared", externalId: "tenant-B"},
+			same: false,
+		},
+		{
+			name: "different ARN same externalId are not equal",
+			a:    assumedRoleCacheKey{roleArn: "arn:aws:iam::111111111111:role/RoleA", externalId: "ext-1"},
+			b:    assumedRoleCacheKey{roleArn: "arn:aws:iam::222222222222:role/RoleB", externalId: "ext-1"},
+			same: false,
+		},
+		{
+			name: "empty externalId matches empty externalId",
+			a:    assumedRoleCacheKey{roleArn: "arn:aws:iam::123456789012:role/MyRole", externalId: ""},
+			b:    assumedRoleCacheKey{roleArn: "arn:aws:iam::123456789012:role/MyRole", externalId: ""},
+			same: true,
+		},
+		{
+			name: "empty vs non-empty externalId are not equal",
+			a:    assumedRoleCacheKey{roleArn: "arn:aws:iam::123456789012:role/MyRole", externalId: ""},
+			b:    assumedRoleCacheKey{roleArn: "arn:aws:iam::123456789012:role/MyRole", externalId: "ext-1"},
+			same: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.same {
+				assert.Equal(t, tt.a, tt.b)
+			} else {
+				assert.NotEqual(t, tt.a, tt.b)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Issue

### Description
- add externalId as part of cache key

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
created cross account tgb scenario and verified 2 log entries when externalId are different
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
