### PR TITLE
enhance gateway auto detection logic for CRD

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
 
     - name: Run unit tests
       run: |
-        sudo snap install yq
+        go install github.com/mikefarah/yq/v4@v4.6.1
         make test
 
     - name: Codecov

--- a/docs/guide/gateway/gateway.md
+++ b/docs/guide/gateway/gateway.md
@@ -40,10 +40,12 @@ To explicitly disable these controllers, use the following feature gates:
 ```--feature-gates=NLBGatewayAPI=false,ALBGatewayAPI=false,GatewayListenerSet=false```
 
 For the NLB Gateway controller (Layer 4) to be enabled, ensure the following CRDs are installed:
-`Gateway`, `GatewayClass`, `TCPRoute`, `UDPRoute`, and `TLSRoute`
+`Gateway`, `GatewayClass`, `TCPRoute`, `UDPRoute`, `TLSRoute`, and the LBC-specific CRDs: `TargetGroupConfiguration`, `LoadBalancerConfiguration`, `ListenerRuleConfiguration`
 
 For the ALB Gateway controller (Layer 7) to be enabled, ensure the following CRDs are installed:
-`Gateway`, `GatewayClass`, `HTTPRoute`, and `GRPCRoute`
+`Gateway`, `GatewayClass`, `HTTPRoute`, `GRPCRoute`, and the LBC-specific CRDs: `TargetGroupConfiguration`, `LoadBalancerConfiguration`, `ListenerRuleConfiguration`
+
+To install CRDs, see the [Prerequisites](#prerequisites) section.
 
 ## Subnet tagging requirements
 See [Subnet Discovery](../../deploy/subnet_discovery.md) for details on configuring Elastic Load Balancing for public or private placement.

--- a/docs/guide/gateway/gateway.md
+++ b/docs/guide/gateway/gateway.md
@@ -40,10 +40,10 @@ To explicitly disable these controllers, use the following feature gates:
 ```--feature-gates=NLBGatewayAPI=false,ALBGatewayAPI=false,GatewayListenerSet=false```
 
 For the NLB Gateway controller (Layer 4) to be enabled, ensure the following CRDs are installed:
-`Gateway`, `GatewayClass`, `TCPRoute`, `UDPRoute`, `TLSRoute`, and the LBC-specific CRDs: `TargetGroupConfiguration`, `LoadBalancerConfiguration`, `ListenerRuleConfiguration`
+`Gateway`, `GatewayClass`, `TCPRoute`, `UDPRoute`, `TLSRoute`, and the AWS vended CRDs: `TargetGroupConfiguration`, `LoadBalancerConfiguration`, `ListenerRuleConfiguration`
 
 For the ALB Gateway controller (Layer 7) to be enabled, ensure the following CRDs are installed:
-`Gateway`, `GatewayClass`, `HTTPRoute`, `GRPCRoute`, and the LBC-specific CRDs: `TargetGroupConfiguration`, `LoadBalancerConfiguration`, `ListenerRuleConfiguration`
+`Gateway`, `GatewayClass`, `HTTPRoute`, `GRPCRoute`, and the AWS vended CRDs: `TargetGroupConfiguration`, `LoadBalancerConfiguration`, `ListenerRuleConfiguration`
 
 To install CRDs, see the [Prerequisites](#prerequisites) section.
 

--- a/docs/guide/gateway/gateway.md
+++ b/docs/guide/gateway/gateway.md
@@ -37,7 +37,7 @@ The Load Balancer Controller (LBC) will attempt to detect Gateway CRDs.
 If they are present, the respective controller will be enabled. 
 To explicitly disable these controllers, use the following feature gates:
 
-```--feature-gates=NLBGatewayAPI=false,ALBGatewayAPI=false```
+```--feature-gates=NLBGatewayAPI=false,ALBGatewayAPI=false,GatewayListenerSet=false```
 
 For the NLB Gateway controller (Layer 4) to be enabled, ensure the following CRDs are installed:
 `Gateway`, `GatewayClass`, `TCPRoute`, `UDPRoute`, and `TLSRoute`

--- a/helm/aws-load-balancer-controller/crds/kustomization.yaml
+++ b/helm/aws-load-balancer-controller/crds/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - crds.yaml
+- gateway-crds.yaml

--- a/helm/aws-load-balancer-controller/crds/kustomization.yaml
+++ b/helm/aws-load-balancer-controller/crds/kustomization.yaml
@@ -2,4 +2,3 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - crds.yaml
-- gateway-crds.yaml

--- a/pkg/gateway/crddetect/gateway_feature_flags.go
+++ b/pkg/gateway/crddetect/gateway_feature_flags.go
@@ -12,11 +12,16 @@ const (
 	GatewayV1GroupVersion = "gateway.networking.k8s.io/v1"
 	// GatewayV1Alpha2GroupVersion is the experimental Gateway API group version.
 	GatewayV1Alpha2GroupVersion = "gateway.networking.k8s.io/v1alpha2"
+	// LBCGatewayGroupVersion is the LBC-specific Gateway CRD group version.
+	LBCGatewayGroupVersion = "gateway.k8s.aws/v1beta1"
 )
 
 var (
-	albKinds         = map[string][]string{GatewayV1GroupVersion: {"Gateway", "GatewayClass", "HTTPRoute", "GRPCRoute"}}
-	nlbKinds         = map[string][]string{GatewayV1GroupVersion: {"Gateway", "GatewayClass", "TLSRoute"}, GatewayV1Alpha2GroupVersion: {"TCPRoute", "UDPRoute"}}
+	// lbcGatewayKinds are the LBC-specific CRDs required by both ALB and NLB gateway controllers.
+	lbcGatewayKinds = []string{"TargetGroupConfiguration", "LoadBalancerConfiguration", "ListenerRuleConfiguration"}
+
+	albKinds         = map[string][]string{GatewayV1GroupVersion: {"Gateway", "GatewayClass", "HTTPRoute", "GRPCRoute"}, LBCGatewayGroupVersion: lbcGatewayKinds}
+	nlbKinds         = map[string][]string{GatewayV1GroupVersion: {"Gateway", "GatewayClass", "TLSRoute"}, GatewayV1Alpha2GroupVersion: {"TCPRoute", "UDPRoute"}, LBCGatewayGroupVersion: lbcGatewayKinds}
 	listenerSetKinds = map[string][]string{GatewayV1GroupVersion: {"ListenerSet"}}
 )
 
@@ -35,7 +40,7 @@ func ApplyGatewayCRDDetection(client k8s.DiscoveryClient, featureGates config.Fe
 		return nil
 	}
 
-	availableResources, err := k8s.DetectCRDs(client, sets.New(GatewayV1Alpha2GroupVersion, GatewayV1GroupVersion))
+	availableResources, err := k8s.DetectCRDs(client, sets.New(GatewayV1Alpha2GroupVersion, GatewayV1GroupVersion, LBCGatewayGroupVersion))
 	if err != nil {
 		return err
 	}
@@ -48,21 +53,21 @@ func applyGatewayFeatureFlags(availableResources map[string]sets.Set[string], fe
 
 	albMissingKinds := missingKinds(albKinds, availableResources)
 	if len(albMissingKinds) > 0 {
-		logger.Info("Disabling ALBGatewayAPI: missing standard Gateway API CRDs",
+		logger.Info("Disabling ALBGatewayAPI: missing required CRDs",
 			"missing", albMissingKinds)
 		featureGates.Disable(config.ALBGatewayAPI)
 	}
 
 	nlbMissingKinds := missingKinds(nlbKinds, availableResources)
 	if len(nlbMissingKinds) > 0 && featureGates.GetFeatureStatus(config.NLBGatewayAPI).IsDefaulted {
-		logger.Info("Disabling NLBGatewayAPI: missing required Gateway API CRDs",
+		logger.Info("Disabling NLBGatewayAPI: missing required CRDs",
 			"missing", nlbMissingKinds)
 		featureGates.Disable(config.NLBGatewayAPI)
 	}
 
 	listenerSetMissing := missingKinds(listenerSetKinds, availableResources)
 	if len(listenerSetMissing) > 0 && featureGates.GetFeatureStatus(config.GatewayListenerSet).IsDefaulted {
-		logger.Info("Disabling ListenerSet: missing required Gateway API CRDs", "missing", listenerSetMissing)
+		logger.Info("Disabling GatewayListenerSet: missing required CRDs", "missing", listenerSetMissing)
 		featureGates.Disable(config.GatewayListenerSet)
 	}
 }

--- a/pkg/gateway/crddetect/gateway_feature_flags.go
+++ b/pkg/gateway/crddetect/gateway_feature_flags.go
@@ -17,7 +17,7 @@ const (
 )
 
 var (
-	// lbcGatewayKinds are the LBC-specific CRDs required by both ALB and NLB gateway controllers.
+	// lbcGatewayKinds are the AWS vended CRDs required by both ALB and NLB gateway controllers.
 	lbcGatewayKinds = []string{"TargetGroupConfiguration", "LoadBalancerConfiguration", "ListenerRuleConfiguration"}
 
 	albKinds         = map[string][]string{GatewayV1GroupVersion: {"Gateway", "GatewayClass", "HTTPRoute", "GRPCRoute"}, LBCGatewayGroupVersion: lbcGatewayKinds}

--- a/pkg/gateway/crddetect/gateway_feature_flags_test.go
+++ b/pkg/gateway/crddetect/gateway_feature_flags_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestApplyGatewayFeatureFlags(t *testing.T) {
+	lbcKinds := sets.New[string]("TargetGroupConfiguration", "LoadBalancerConfiguration", "ListenerRuleConfiguration")
+
 	testCases := []struct {
 		name               string
 		presentKinds       map[string]sets.Set[string]
@@ -25,9 +27,19 @@ func TestApplyGatewayFeatureFlags(t *testing.T) {
 			listenerSetEnabled: false,
 		},
 		{
-			name: "v1 present",
+			name: "v1 present but LBC CRDs missing",
 			presentKinds: map[string]sets.Set[string]{
 				GatewayV1GroupVersion: sets.New[string]("Gateway", "GatewayClass", "HTTPRoute", "GRPCRoute", "TLSRoute"),
+			},
+			albEnabled:         false,
+			nlbEnabled:         false,
+			listenerSetEnabled: false,
+		},
+		{
+			name: "v1 and LBC CRDs present",
+			presentKinds: map[string]sets.Set[string]{
+				GatewayV1GroupVersion:  sets.New[string]("Gateway", "GatewayClass", "HTTPRoute", "GRPCRoute", "TLSRoute"),
+				LBCGatewayGroupVersion: lbcKinds,
 			},
 			albEnabled:         true,
 			nlbEnabled:         false,
@@ -43,20 +55,32 @@ func TestApplyGatewayFeatureFlags(t *testing.T) {
 			listenerSetEnabled: false,
 		},
 		{
-			name: "all present",
+			name: "all standard CRDs present but LBC CRDs missing",
 			presentKinds: map[string]sets.Set[string]{
 				GatewayV1GroupVersion:       sets.New[string]("Gateway", "GatewayClass", "HTTPRoute", "GRPCRoute", "TLSRoute"),
 				GatewayV1Alpha2GroupVersion: sets.New[string]("TCPRoute", "UDPRoute"),
+			},
+			albEnabled:         false,
+			nlbEnabled:         false,
+			listenerSetEnabled: false,
+		},
+		{
+			name: "all present including LBC CRDs but ListenerSet missing",
+			presentKinds: map[string]sets.Set[string]{
+				GatewayV1GroupVersion:       sets.New[string]("Gateway", "GatewayClass", "HTTPRoute", "GRPCRoute", "TLSRoute"),
+				GatewayV1Alpha2GroupVersion: sets.New[string]("TCPRoute", "UDPRoute"),
+				LBCGatewayGroupVersion:      lbcKinds,
 			},
 			albEnabled:         true,
 			nlbEnabled:         true,
 			listenerSetEnabled: false,
 		},
 		{
-			name: "all present including ListenerSet",
+			name: "all present including ListenerSet and LBC CRDs",
 			presentKinds: map[string]sets.Set[string]{
 				GatewayV1GroupVersion:       sets.New[string]("Gateway", "GatewayClass", "HTTPRoute", "GRPCRoute", "TLSRoute", "ListenerSet"),
 				GatewayV1Alpha2GroupVersion: sets.New[string]("TCPRoute", "UDPRoute"),
+				LBCGatewayGroupVersion:      lbcKinds,
 			},
 			albEnabled:         true,
 			nlbEnabled:         true,
@@ -67,6 +91,7 @@ func TestApplyGatewayFeatureFlags(t *testing.T) {
 			presentKinds: map[string]sets.Set[string]{
 				GatewayV1GroupVersion:       sets.New[string]("GatewayClass", "HTTPRoute", "GRPCRoute", "TLSRoute"),
 				GatewayV1Alpha2GroupVersion: sets.New[string]("TCPRoute", "UDPRoute"),
+				LBCGatewayGroupVersion:      lbcKinds,
 			},
 			albEnabled:         false,
 			nlbEnabled:         false,
@@ -77,6 +102,7 @@ func TestApplyGatewayFeatureFlags(t *testing.T) {
 			presentKinds: map[string]sets.Set[string]{
 				GatewayV1GroupVersion:       sets.New[string]("Gateway", "HTTPRoute", "GRPCRoute", "TLSRoute"),
 				GatewayV1Alpha2GroupVersion: sets.New[string]("TCPRoute", "UDPRoute"),
+				LBCGatewayGroupVersion:      lbcKinds,
 			},
 			albEnabled:         false,
 			nlbEnabled:         false,
@@ -87,6 +113,7 @@ func TestApplyGatewayFeatureFlags(t *testing.T) {
 			presentKinds: map[string]sets.Set[string]{
 				GatewayV1GroupVersion:       sets.New[string]("Gateway", "GatewayClass", "GRPCRoute", "TLSRoute"),
 				GatewayV1Alpha2GroupVersion: sets.New[string]("TCPRoute", "UDPRoute"),
+				LBCGatewayGroupVersion:      lbcKinds,
 			},
 			albEnabled:         false,
 			nlbEnabled:         true,
@@ -97,6 +124,7 @@ func TestApplyGatewayFeatureFlags(t *testing.T) {
 			presentKinds: map[string]sets.Set[string]{
 				GatewayV1GroupVersion:       sets.New[string]("Gateway", "GatewayClass", "HTTPRoute", "TLSRoute"),
 				GatewayV1Alpha2GroupVersion: sets.New[string]("TCPRoute", "UDPRoute"),
+				LBCGatewayGroupVersion:      lbcKinds,
 			},
 			albEnabled:         false,
 			nlbEnabled:         true,
@@ -107,6 +135,7 @@ func TestApplyGatewayFeatureFlags(t *testing.T) {
 			presentKinds: map[string]sets.Set[string]{
 				GatewayV1GroupVersion:       sets.New[string]("Gateway", "GatewayClass", "HTTPRoute", "GRPCRoute"),
 				GatewayV1Alpha2GroupVersion: sets.New[string]("TCPRoute", "UDPRoute"),
+				LBCGatewayGroupVersion:      lbcKinds,
 			},
 			albEnabled:         true,
 			nlbEnabled:         false,
@@ -117,6 +146,7 @@ func TestApplyGatewayFeatureFlags(t *testing.T) {
 			presentKinds: map[string]sets.Set[string]{
 				GatewayV1GroupVersion:       sets.New[string]("Gateway", "GatewayClass", "HTTPRoute", "GRPCRoute", "TLSRoute"),
 				GatewayV1Alpha2GroupVersion: sets.New[string]("UDPRoute"),
+				LBCGatewayGroupVersion:      lbcKinds,
 			},
 			albEnabled:         true,
 			nlbEnabled:         false,
@@ -127,6 +157,7 @@ func TestApplyGatewayFeatureFlags(t *testing.T) {
 			presentKinds: map[string]sets.Set[string]{
 				GatewayV1GroupVersion:       sets.New[string]("Gateway", "GatewayClass", "HTTPRoute", "GRPCRoute", "TLSRoute"),
 				GatewayV1Alpha2GroupVersion: sets.New[string]("TCPRoute"),
+				LBCGatewayGroupVersion:      lbcKinds,
 			},
 			albEnabled:         true,
 			nlbEnabled:         false,
@@ -140,6 +171,25 @@ func TestApplyGatewayFeatureFlags(t *testing.T) {
 			albEnabled:         false,
 			nlbEnabled:         false,
 			listenerSetEnabled: true,
+		},
+		{
+			name: "LBC CRDs present but no standard gateway CRDs",
+			presentKinds: map[string]sets.Set[string]{
+				LBCGatewayGroupVersion: lbcKinds,
+			},
+			albEnabled:         false,
+			nlbEnabled:         false,
+			listenerSetEnabled: false,
+		},
+		{
+			name: "partial LBC CRDs - TargetGroupConfiguration missing",
+			presentKinds: map[string]sets.Set[string]{
+				GatewayV1GroupVersion:  sets.New[string]("Gateway", "GatewayClass", "HTTPRoute", "GRPCRoute"),
+				LBCGatewayGroupVersion: sets.New[string]("LoadBalancerConfiguration", "ListenerRuleConfiguration"),
+			},
+			albEnabled:         false,
+			nlbEnabled:         false,
+			listenerSetEnabled: false,
 		},
 	}
 


### PR DESCRIPTION
### Issue

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4712

### Description
1. we require all 3 feature gates to be explicitly set to skip auto detection logic. 
https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/f8ea884ce6c6b19c91a290ed3e786f3a9ad68c0d/pkg/gateway/crddetect/gateway_feature_flags.go#L29 so updating documentation to include all 3 feature gates 
2. enhance CRD auto detection logic to include LBC gateway specific CRDs

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
