### PR TITLE
fix: return early in service reconciler when lb is nil

### DIFF
--- a/controllers/service/service_controller.go
+++ b/controllers/service/service_controller.go
@@ -137,6 +137,7 @@ func (r *serviceReconciler) reconcile(ctx context.Context, req reconcile.Request
 		if err != nil {
 			return ctrlerrors.NewErrorWithMetrics(controllerName, "cleanup_load_balancer_error", err, r.metricsCollector)
 		}
+		return nil
 	}
 	return r.reconcileLoadBalancerResources(ctx, svc, stack, lb, backendSGRequired)
 }


### PR DESCRIPTION
## What does this PR do?

Fixes a nil pointer dereference panic in the service reconciler that fires when `buildModel` returns `lb == nil` — for example, when a `ClusterIP`-typed Service is reconciled (such as one created by Istio Gateway API via `networking.istio.io/service-type: ClusterIP`).

## Root cause

In `reconcile()`, when `lb == nil`, the reconciler correctly enters the cleanup branch and calls `cleanupLoadBalancerResources`. However, on successful cleanup it **falls through** to `reconcileLoadBalancerResources(ctx, svc, stack, lb, backendSGRequired)` with `lb` still `nil`. This causes a nil pointer dereference inside `reconcileLoadBalancerResources` at:

```go
lbDNS, err = lb.DNSName().Resolve(ctx) // panic: lb is nil
```

The panic is recovered by `runtime.HandleReconcileError`, so it manifests as repeated error log noise rather than a crash. Load balancer provisioning is unaffected.

## Fix

Add `return nil` after the successful cleanup path when `lb == nil`, so the reconciler exits cleanly:

```go
if lb == nil {
    // ... cleanup ...
    if err != nil {
        return ctrlerrors.NewErrorWithMetrics(...)
    }
    return nil // <-- added
}
return r.reconcileLoadBalancerResources(ctx, svc, stack, lb, backendSGRequired)
```

## How to reproduce

1. Install Istio with Gateway API support.
2. Create a Gateway with `networking.istio.io/service-type: ClusterIP` (used to suppress NLB provisioning when an external ALB is managed separately via a Kubernetes Ingress resource).
3. Observe repeated panic logs from the service reconciler for the `<gateway-name>-istio` ClusterIP service in the controller's namespace.

## Testing

Existing unit tests pass. The code path is straightforward: the only change is the addition of `return nil` to prevent the fall-through.

Closes #4724

---

**Release note**:
```
Fix nil pointer dereference panic in service reconciler when reconciling a ClusterIP service (e.g. created by Istio Gateway API with networking.istio.io/service-type: ClusterIP) where buildModel returns lb == nil.
```