### PR TITLE
[feat i2g] Fix user tag propagation to ListenerRuleConfigurations in lbc-migrate

### DIFF
--- a/pkg/ingress2gateway/translate/httproute.go
+++ b/pkg/ingress2gateway/translate/httproute.go
@@ -35,6 +35,11 @@ type httpRouteTranslator struct {
 	svcRefSeen          sets.Set[string]
 	svcRefs             []serviceRef
 	listenerRuleConfigs []gatewayv1beta1.ListenerRuleConfiguration
+	// userTags is the resolved set of user-facing tags for this ingress, merged
+	// from alb.ingress.kubernetes.io/tags and any IngressClassParams.spec.tags.
+	// When non-empty, each generated HTTPRouteRule gets an ExtensionRef pointing
+	// to an LRC so the tags can propagate to the ListenerRule resource.
+	userTags map[string]string
 }
 
 // trackBackend records a unique service reference for TGC generation.
@@ -48,9 +53,10 @@ func (t *httpRouteTranslator) trackBackend(svcName string, resolvedPort int32) {
 
 // buildHTTPRoutes builds one or more HTTPRoutes from an Ingress resource and collects
 // service refs and ListenerRuleConfigurations. The caller provides parentRefs to control
-// which Gateway listeners the routes attach to (sectionName scoping for groups).
+// which Gateway listeners the routes attach to (sectionName scoping for groups), and
+// userTags — the resolved set of user-facing tags (annotation tags merged with ICP tags)
 // SSL redirect routes are NOT generated here — the caller handles them at group level.
-func buildHTTPRoutes(ing networking.Ingress, namespace string, parentRefs []gwv1.ParentReference, servicesByKey map[string]corev1.Service) ([]gwv1.HTTPRoute, []serviceRef, []gatewayv1beta1.ListenerRuleConfiguration, error) {
+func buildHTTPRoutes(ing networking.Ingress, namespace string, parentRefs []gwv1.ParentReference, servicesByKey map[string]corev1.Service, userTags map[string]string) ([]gwv1.HTTPRoute, []serviceRef, []gatewayv1beta1.ListenerRuleConfiguration, error) {
 	t := &httpRouteTranslator{
 		namespace:      namespace,
 		ingName:        ing.Name,
@@ -58,6 +64,7 @@ func buildHTTPRoutes(ing networking.Ingress, namespace string, parentRefs []gwv1
 		useRegex:       strings.EqualFold(getString(ing.Annotations, annotations.IngressSuffixUseRegexPathMatch), "true"),
 		servicesByKey:  servicesByKey,
 		svcRefSeen:     sets.New[string](),
+		userTags:       userTags,
 	}
 
 	var rules []gwv1.HTTPRouteRule
@@ -142,12 +149,28 @@ func (t *httpRouteTranslator) buildRouteRule(rule networking.IngressRule, path n
 		if err := t.buildTransforms(&routeRule, path.Backend.Service.Name); err != nil {
 			return routeRule, nil, err
 		}
+		// Ensure an LRC exists so user-defined tags (and the migrated-from tag) propagate
+		// to the generated ListenerRule even when the rule has no other LRC-worthy config.
+		t.buildLRCForTags(&routeRule, path.Backend.Service.Name)
 		if hsr != nil {
 			return routeRule, hsr, nil
 		}
 	}
 
 	return routeRule, nil, nil
+}
+
+// buildLRCForTags creates (or reuses) a ListenerRuleConfiguration for the given service
+// when the Ingress carries user-defined tags (from annotations or IngressClassParams).
+// The tag merge in Translate() populates Spec.Tags
+func (t *httpRouteTranslator) buildLRCForTags(routeRule *gwv1.HTTPRouteRule, svcName string) {
+	if len(t.userTags) == 0 {
+		return
+	}
+	lrc := findOrCreateLRC(&t.listenerRuleConfigs, t.namespace, t.ingName, svcName)
+	if !routeRuleHasExtensionRef(*routeRule, lrc.Name) {
+		routeRule.Filters = append(routeRule.Filters, extensionRefFilter(lrc.Name))
+	}
 }
 
 // buildPathMatch builds an HTTPRouteMatch from an Ingress path spec.

--- a/pkg/ingress2gateway/translate/httproute_test.go
+++ b/pkg/ingress2gateway/translate/httproute_test.go
@@ -24,6 +24,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		gwName          string
 		ports           []listenPortEntry
 		sslRedirectPort *int32
+		userTags        map[string]string
 		wantRoutes      int
 		wantErr         string
 		check           func(t *testing.T, routes []gwv1.HTTPRoute)
@@ -624,6 +625,84 @@ func TestBuildHTTPRoutes(t *testing.T) {
 				assert.Equal(t, gatewayv1beta1.ActionTypeJwtValidation, lrcs[0].Spec.Actions[0].Type)
 			},
 		},
+		{
+			name: "simple rule with user tags annotation produces tag-only LRC",
+			ing: networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "tagged",
+					Annotations: map[string]string{
+						"alb.ingress.kubernetes.io/tags": "ManagedBy=platform-team",
+					},
+				},
+				Spec: networking.IngressSpec{
+					Rules: []networking.IngressRule{{
+						Host: "app.example.com",
+						IngressRuleValue: networking.IngressRuleValue{
+							HTTP: &networking.HTTPIngressRuleValue{
+								Paths: []networking.HTTPIngressPath{{
+									Path: "/api", PathType: &pathPrefix,
+									Backend: networking.IngressBackend{
+										Service: &networking.IngressServiceBackend{
+											Name: "api-svc", Port: networking.ServiceBackendPort{Number: 80},
+										},
+									},
+								}},
+							},
+						},
+					}},
+				},
+			},
+			namespace: "default", gwName: "gw",
+			ports:      []listenPortEntry{{Protocol: "HTTP", Port: 80}},
+			userTags:   map[string]string{"ManagedBy": "platform-team"},
+			wantRoutes: 1,
+			check: func(t *testing.T, routes []gwv1.HTTPRoute) {
+				r := routes[0]
+				require.Len(t, r.Spec.Rules, 1)
+				// Rule must reference the LRC so user tags propagate to the ListenerRule.
+				require.Len(t, r.Spec.Rules[0].Filters, 1)
+				f := r.Spec.Rules[0].Filters[0]
+				assert.Equal(t, gwv1.HTTPRouteFilterExtensionRef, f.Type)
+				require.NotNil(t, f.ExtensionRef)
+				assert.Equal(t, gwv1.Kind("ListenerRuleConfiguration"), f.ExtensionRef.Kind)
+			},
+			checkLRCs: func(t *testing.T, lrcs []gatewayv1beta1.ListenerRuleConfiguration) {
+				require.Len(t, lrcs, 1)
+				assert.Empty(t, lrcs[0].Spec.Actions)
+				assert.Empty(t, lrcs[0].Spec.Conditions)
+			},
+		},
+		{
+			name: "simple rule without tags annotation produces no LRC",
+			ing: networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{Name: "untagged"},
+				Spec: networking.IngressSpec{
+					Rules: []networking.IngressRule{{
+						IngressRuleValue: networking.IngressRuleValue{
+							HTTP: &networking.HTTPIngressRuleValue{
+								Paths: []networking.HTTPIngressPath{{
+									Path: "/", PathType: &pathPrefix,
+									Backend: networking.IngressBackend{
+										Service: &networking.IngressServiceBackend{
+											Name: "svc", Port: networking.ServiceBackendPort{Number: 80},
+										},
+									},
+								}},
+							},
+						},
+					}},
+				},
+			},
+			namespace: "default", gwName: "gw",
+			ports:      []listenPortEntry{{Protocol: "HTTP", Port: 80}},
+			wantRoutes: 1,
+			check: func(t *testing.T, routes []gwv1.HTTPRoute) {
+				assert.Empty(t, routes[0].Spec.Rules[0].Filters)
+			},
+			checkLRCs: func(t *testing.T, lrcs []gatewayv1beta1.ListenerRuleConfiguration) {
+				assert.Empty(t, lrcs)
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -636,7 +715,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 			} else {
 				parentRefs = buildParentRefs(tt.gwName, nil)
 			}
-			routes, _, lrcs, err := buildHTTPRoutes(tt.ing, tt.namespace, parentRefs, nil)
+			routes, _, lrcs, err := buildHTTPRoutes(tt.ing, tt.namespace, parentRefs, nil, tt.userTags)
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
@@ -758,7 +837,7 @@ func TestBuildHTTPRoutes_DefaultBackendError(t *testing.T) {
 	}
 	// No services provided — named port resolution for defaultBackend will fail
 	parentRefs := buildParentRefs("gw", nil)
-	_, _, _, err := buildHTTPRoutes(ing, "default", parentRefs, nil)
+	_, _, _, err := buildHTTPRoutes(ing, "default", parentRefs, nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "defaultBackend")
 }

--- a/pkg/ingress2gateway/translate/translate.go
+++ b/pkg/ingress2gateway/translate/translate.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
 	gatewayv1beta1 "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
+	annotations "sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
 	gwconstants "sigs.k8s.io/aws-load-balancer-controller/pkg/gateway/constants"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/ingress2gateway"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/ingress2gateway/utils"
@@ -29,7 +30,12 @@ func Translate(in *ingress2gateway.InputResources) (*ingress2gateway.OutputResou
 	servicesByKey := buildServiceMap(in.Services)
 	ingressClassParamsByClass := buildIngressClassParamsMap(in.IngressClasses, in.IngressClassParams)
 
-	// Track which services we've already created TGCs for (deduplicate)
+	// Track which services we've already created TGCs for (deduplicate).
+	//
+	// TODO: when two ingresses share a service but carry different TG-level annotations
+	// (healthcheck path, tags, etc.), only the first ingress's values are captured here.
+	// Follow-up: emit one RouteConfiguration per (ingress × service) so each HTTPRoute
+	// picks up its originating ingress's props via the controller's longest-match merge.
 	tgcCreated := sets.New[string]()
 
 	// Partition Ingresses into groups (ungrouped become single-member groups)
@@ -107,6 +113,7 @@ func Translate(in *ingress2gateway.InputResources) (*ingress2gateway.OutputResou
 			crossNSGroupName = group.name
 		}
 		gw := buildGateway(gatewayName, group.namespace, lbConfig, allPorts, crossNSGroupName)
+
 		out.Gateways = append(out.Gateways, gw)
 
 		// --- SSL redirect route ---
@@ -128,25 +135,36 @@ func Translate(in *ingress2gateway.InputResources) (*ingress2gateway.OutputResou
 			memberPorts := perMemberPorts[k8s.NamespacedName(&ing).String()]
 			parentRefs := buildMemberParentRefs(gatewayName, group.namespace, ing.Namespace, memberPorts, allPorts, sslRedirectPort)
 
-			routes, svcRefs, lrcs, err := buildHTTPRoutes(ing, ing.Namespace, parentRefs, servicesByKey)
+			// Resolve effective annotations for this member (used for tags and TG config)
+			effectiveAnnotations := resolveAnnotations(ing)
+
+			// Compute the member's effective user tags: annotation tags + ICP tags
+			memberUserTags := resolveMemberUserTags(ing, effectiveAnnotations, ingressClassParamsByClass)
+
+			routes, svcRefs, lrcs, err := buildHTTPRoutes(ing, ing.Namespace, parentRefs, servicesByKey, memberUserTags)
 			if err != nil {
 				return nil, err
 			}
 			out.HTTPRoutes = append(out.HTTPRoutes, routes...)
 
-			// Add migration tags to ListenerRuleConfigurations
+			// Add migration tags and user tags to ListenerRuleConfigurations
 			memberMigrationTag := fmt.Sprintf("ingress/%s/%s", ing.Namespace, ing.Name)
 			for i := range lrcs {
 				if lrcs[i].Spec.Tags == nil {
 					tags := make(map[string]string)
 					lrcs[i].Spec.Tags = &tags
 				}
+				// Merge user-defined tags (from annotation + ICP) onto the LRC.
+				for k, v := range memberUserTags {
+					(*lrcs[i].Spec.Tags)[k] = v
+				}
 				(*lrcs[i].Spec.Tags)[utils.MigrationTagKey] = memberMigrationTag
 			}
 			out.ListenerRuleConfigurations = append(out.ListenerRuleConfigurations, lrcs...)
 
-			// Build TargetGroupConfigurations for each unique service
-			effectiveAnnotations := resolveAnnotations(ing)
+			//  Build TargetGroupConfigurations for each unique service. Dedup happens on
+			//  (namespace, service, port) so only the first ingress processed for a given
+			//  service contributes its annotations. See the TODO at the top of Translate.
 			for _, svcRef := range svcRefs {
 				if tgcCreated.Has(svcRef.getServiceRefKey()) {
 					continue
@@ -168,7 +186,32 @@ func Translate(in *ingress2gateway.InputResources) (*ingress2gateway.OutputResou
 	return out, nil
 }
 
-// resolveAnnotations returns the Ingress annotations map.
+// resolveMemberUserTags returns the effective user-facing tag set for a single
+// ingress member: tags from the alb.ingress.kubernetes.io/tags annotation merged
+// with tags from the IngressClassParams referenced by the member's class.
+// IngressClassParams tags take priority on key conflicts, matching the behavior
+// applied to LoadBalancerConfiguration.Spec.Tags in applyICPSpecOverride.
+func resolveMemberUserTags(ing networking.Ingress, annos map[string]string, icpByClass map[string]*elbv2api.IngressClassParams) map[string]string {
+	tags := getStringMap(annos, annotations.IngressSuffixTags)
+	// Copy to avoid mutating the caller's map (getStringMap may share state).
+	merged := make(map[string]string, len(tags))
+	for k, v := range tags {
+		merged[k] = v
+	}
+
+	if ing.Spec.IngressClassName == nil {
+		return merged
+	}
+	icp, ok := icpByClass[*ing.Spec.IngressClassName]
+	if !ok || icp == nil {
+		return merged
+	}
+	for _, t := range icp.Spec.Tags {
+		merged[t.Key] = t.Value
+	}
+	return merged
+}
+
 func resolveAnnotations(ing networking.Ingress) map[string]string {
 	output := make(map[string]string)
 	for k, v := range ing.Annotations {

--- a/pkg/ingress2gateway/translate/translate_test.go
+++ b/pkg/ingress2gateway/translate/translate_test.go
@@ -588,6 +588,173 @@ func TestTranslate(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "user tags on simple ingress propagate to ListenerRuleConfiguration",
+			input: &ingress2gateway.InputResources{
+				Ingresses: []networking.Ingress{{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "tagged", Namespace: "default",
+						Annotations: map[string]string{
+							"alb.ingress.kubernetes.io/tags": "ManagedBy=platform-team,Env=prod",
+						},
+					},
+					Spec: networking.IngressSpec{
+						Rules: []networking.IngressRule{{
+							Host: "app.example.com",
+							IngressRuleValue: networking.IngressRuleValue{
+								HTTP: &networking.HTTPIngressRuleValue{
+									Paths: []networking.HTTPIngressPath{{
+										Path: "/api", PathType: &pathPrefix,
+										Backend: networking.IngressBackend{
+											Service: &networking.IngressServiceBackend{
+												Name: "api-svc", Port: networking.ServiceBackendPort{Number: 80},
+											},
+										},
+									}},
+								},
+							},
+						}},
+					},
+				}},
+			},
+			wantGatewayCount: 1, wantHTTPRouteCount: 1, wantLBConfigCount: 1, wantTGConfigCount: 1,
+			check: func(t *testing.T, out *ingress2gateway.OutputResources) {
+				require.Len(t, out.ListenerRuleConfigurations, 1)
+				lrc := out.ListenerRuleConfigurations[0]
+				require.NotNil(t, lrc.Spec.Tags)
+				assert.Equal(t, "platform-team", (*lrc.Spec.Tags)["ManagedBy"])
+				assert.Equal(t, "prod", (*lrc.Spec.Tags)["Env"])
+				assert.Equal(t, "ingress/default/tagged", (*lrc.Spec.Tags)[constants.MigrationTagKey])
+			},
+		},
+		{
+			name: "simple ingress without tags annotation produces no ListenerRuleConfiguration",
+			input: &ingress2gateway.InputResources{
+				Ingresses: []networking.Ingress{{
+					ObjectMeta: metav1.ObjectMeta{Name: "untagged", Namespace: "default"},
+					Spec: networking.IngressSpec{
+						Rules: []networking.IngressRule{{
+							IngressRuleValue: networking.IngressRuleValue{
+								HTTP: &networking.HTTPIngressRuleValue{
+									Paths: []networking.HTTPIngressPath{{
+										Path: "/", PathType: &pathPrefix,
+										Backend: networking.IngressBackend{
+											Service: &networking.IngressServiceBackend{
+												Name: "svc", Port: networking.ServiceBackendPort{Number: 80},
+											},
+										},
+									}},
+								},
+							},
+						}},
+					},
+				}},
+			},
+			wantGatewayCount: 1, wantHTTPRouteCount: 1, wantLBConfigCount: 0, wantTGConfigCount: 0,
+			check: func(t *testing.T, out *ingress2gateway.OutputResources) {
+				assert.Empty(t, out.ListenerRuleConfigurations)
+			},
+		},
+		{
+			name: "IngressClassParams tags propagate to ListenerRuleConfiguration (no annotation)",
+			input: &ingress2gateway.InputResources{
+				Ingresses: []networking.Ingress{{
+					ObjectMeta: metav1.ObjectMeta{Name: "icp-tagged", Namespace: "default"},
+					Spec: networking.IngressSpec{
+						IngressClassName: ptr.To("alb"),
+						Rules: []networking.IngressRule{{
+							IngressRuleValue: networking.IngressRuleValue{
+								HTTP: &networking.HTTPIngressRuleValue{
+									Paths: []networking.HTTPIngressPath{{
+										Path: "/", PathType: &pathPrefix,
+										Backend: networking.IngressBackend{
+											Service: &networking.IngressServiceBackend{
+												Name: "svc", Port: networking.ServiceBackendPort{Number: 80},
+											},
+										},
+									}},
+								},
+							},
+						}},
+					},
+				}},
+				IngressClasses: []networking.IngressClass{{
+					ObjectMeta: metav1.ObjectMeta{Name: "alb"},
+					Spec: networking.IngressClassSpec{
+						Parameters: &networking.IngressClassParametersReference{
+							Kind: "IngressClassParams", Name: "alb-params",
+						},
+					},
+				}},
+				IngressClassParams: []elbv2api.IngressClassParams{{
+					ObjectMeta: metav1.ObjectMeta{Name: "alb-params"},
+					Spec: elbv2api.IngressClassParamsSpec{
+						Tags: []elbv2api.Tag{{Key: "ManagedBy", Value: "platform-team"}},
+					},
+				}},
+			},
+			wantGatewayCount: 1, wantHTTPRouteCount: 1, wantLBConfigCount: 1, wantTGConfigCount: 0,
+			check: func(t *testing.T, out *ingress2gateway.OutputResources) {
+				require.Len(t, out.ListenerRuleConfigurations, 1)
+				lrc := out.ListenerRuleConfigurations[0]
+				require.NotNil(t, lrc.Spec.Tags)
+				assert.Equal(t, "platform-team", (*lrc.Spec.Tags)["ManagedBy"])
+				assert.Equal(t, "ingress/default/icp-tagged", (*lrc.Spec.Tags)[constants.MigrationTagKey])
+			},
+		},
+		{
+			name: "annotation tags and IngressClassParams tags merged (ICP wins on conflict)",
+			input: &ingress2gateway.InputResources{
+				Ingresses: []networking.Ingress{{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "both-tagged", Namespace: "default",
+						Annotations: map[string]string{
+							"alb.ingress.kubernetes.io/tags": "ManagedBy=app-team,Env=dev",
+						},
+					},
+					Spec: networking.IngressSpec{
+						IngressClassName: ptr.To("alb"),
+						Rules: []networking.IngressRule{{
+							IngressRuleValue: networking.IngressRuleValue{
+								HTTP: &networking.HTTPIngressRuleValue{
+									Paths: []networking.HTTPIngressPath{{
+										Path: "/", PathType: &pathPrefix,
+										Backend: networking.IngressBackend{
+											Service: &networking.IngressServiceBackend{
+												Name: "svc", Port: networking.ServiceBackendPort{Number: 80},
+											},
+										},
+									}},
+								},
+							},
+						}},
+					},
+				}},
+				IngressClasses: []networking.IngressClass{{
+					ObjectMeta: metav1.ObjectMeta{Name: "alb"},
+					Spec: networking.IngressClassSpec{
+						Parameters: &networking.IngressClassParametersReference{
+							Kind: "IngressClassParams", Name: "alb-params",
+						},
+					},
+				}},
+				IngressClassParams: []elbv2api.IngressClassParams{{
+					ObjectMeta: metav1.ObjectMeta{Name: "alb-params"},
+					Spec: elbv2api.IngressClassParamsSpec{
+						// ICP overrides ManagedBy from annotation.
+						Tags: []elbv2api.Tag{{Key: "ManagedBy", Value: "platform-team"}},
+					},
+				}},
+			},
+			wantGatewayCount: 1, wantHTTPRouteCount: 1, wantLBConfigCount: 1, wantTGConfigCount: 1,
+			check: func(t *testing.T, out *ingress2gateway.OutputResources) {
+				require.Len(t, out.ListenerRuleConfigurations, 1)
+				lrc := out.ListenerRuleConfigurations[0]
+				require.NotNil(t, lrc.Spec.Tags)
+				assert.Equal(t, "platform-team", (*lrc.Spec.Tags)["ManagedBy"]) // ICP wins
+				assert.Equal(t, "dev", (*lrc.Spec.Tags)["Env"])                 // annotation-only key preserved
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/ingress2gateway/utils/helpers.go
+++ b/pkg/ingress2gateway/utils/helpers.go
@@ -73,7 +73,9 @@ func GetTGConfigName(namespace, serviceName string) string {
 // The name is scoped per Ingress+service to avoid collisions when multiple
 // Ingresses reference the same service with different configurations (e.g. auth).
 func GetLRConfigName(namespace, ingressName, actionName string) string {
-	return resourceName(namespace, ingressName+"/"+actionName, "lr-config")
+	// Replace "/" with "-" so the combined ingress/action identifier produces a
+	// valid K8s resource name (RFC 1123) after truncation in resourceName.
+	return resourceName(namespace, ingressName+"-"+actionName, "lr-config")
 }
 
 // GetRedirectHTTPRouteName returns the HTTPRoute name for the SSL redirect route.


### PR DESCRIPTION
### Issue

Bug fix for `lbc-migrate` — user-defined tags were silently dropped during translation.

### Description

- Propagate user-defined tags (from `alb.ingress.kubernetes.io/tags` and `IngressClassParams.spec.tags`) to generated ListenerRuleConfigurations. Previously only the migrated-from tag was written; user tags were silently dropped.
- Create an LRC per HTTPRouteRule when user tags are present, even if the rule has no other LRC-worthy config, so tags propagate to the ListenerRule resource.
- Fix `GetLRConfigName` to use `-` instead of `/` as the separator, producing valid RFC 1123 resource names.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2: