### PR TITLE
ci(test): declare contents: read on the unit-test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,10 @@ name: Unit Test
 on:
   - push
   - pull_request
+
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to read-only for the `Unit Test` workflow. The two jobs only run `make test` / `make quick-ci` and upload coverage through `codecov/codecov-action`, which authenticates via `CODECOV_TOKEN`.

Sibling workflows (`ci.yaml`, `scripts.yaml`, `update-base-image.yaml`) already declare their permissions. YAML validated locally.