### PR TITLE
fix checkpoint early-exit

### DIFF
--- a/pkg/targetgroupbinding/resource_manager.go
+++ b/pkg/targetgroupbinding/resource_manager.go
@@ -192,9 +192,13 @@ func (m *defaultResourceManager) reconcileWithIPTargetType(ctx context.Context, 
 		return "", "", false, ctrlerrors.NewErrorWithMetrics(controllerName, "calculate_tgb_reconcile_checkpoint_error", err, m.metricsCollector)
 	}
 
+	// Block the checkpoint early-exit if any pod has a pending readiness gate condition in cache.
+	// Only compute when checkpoints match — if they differ the early-exit won't fire anyway.
 	if !containsPotentialReadyEndpoints && oldCheckPoint == newCheckPoint {
-		tgbScopedLogger.Info("Skipping targetgroupbinding reconcile", "calculated hash", newCheckPoint)
-		return newCheckPoint, oldCheckPoint, true, nil
+		if !needReadinessGateFlip(endpoints, targetHealthCondType) {
+			tgbScopedLogger.Info("Skipping targetgroupbinding reconcile", "calculated hash", newCheckPoint)
+			return newCheckPoint, oldCheckPoint, true, nil
+		}
 	}
 
 	targets, err := m.targetsManager.ListTargets(ctx, tgb)
@@ -760,6 +764,17 @@ func (m *defaultResourceManager) generateOverrideAzFn(ctx context.Context, vpcID
 type podEndpointAndTargetPair struct {
 	endpoint backend.PodEndpoint
 	target   TargetInfo
+}
+
+// needReadinessGateFlip returns true if any endpoint's pod has the readiness gate condition
+// written but not yet True.
+func needReadinessGateFlip(endpoints []backend.PodEndpoint, targetHealthCondType corev1.PodConditionType) bool {
+	for _, ep := range endpoints {
+		if cond, exists := ep.Pod.GetPodCondition(targetHealthCondType); exists && cond.Status != corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
 }
 
 func partitionTargetsByDrainingStatus(targets []TargetInfo) ([]TargetInfo, []TargetInfo) {

--- a/pkg/targetgroupbinding/resource_manager_test.go
+++ b/pkg/targetgroupbinding/resource_manager_test.go
@@ -1282,3 +1282,162 @@ func Test_defaultResourceManager_prepareRegistrationCall(t *testing.T) {
 		})
 	}
 }
+
+// Test_needReadinessGateFlip tests that needReadinessGateFlip correctly
+// identifies pods with a written but not-yet-True readiness gate condition.
+func Test_needReadinessGateFlip(t *testing.T) {
+	condType := corev1.PodConditionType("target-health.elbv2.k8s.aws/my-tgb")
+
+	tests := []struct {
+		name      string
+		endpoints []backend.PodEndpoint
+		want      bool
+	}{
+		{
+			name: "all pods have target health condition True — no flip needed",
+			endpoints: []backend.PodEndpoint{
+				{Pod: k8s.PodInfo{
+					Key: types.NamespacedName{Name: "pod-1"},
+					Conditions: []corev1.PodCondition{
+						{Type: condType, Status: corev1.ConditionTrue},
+					},
+				}},
+				{Pod: k8s.PodInfo{
+					Key: types.NamespacedName{Name: "pod-2"},
+					Conditions: []corev1.PodCondition{
+						{Type: condType, Status: corev1.ConditionTrue},
+					},
+				}},
+			},
+			want: false,
+		},
+		{
+			name: "one pod has target health condition False (target unhealthy) — flip needed",
+			endpoints: []backend.PodEndpoint{
+				{Pod: k8s.PodInfo{
+					Key: types.NamespacedName{Name: "pod-1"},
+					Conditions: []corev1.PodCondition{
+						{Type: condType, Status: corev1.ConditionTrue},
+					},
+				}},
+				{Pod: k8s.PodInfo{
+					Key: types.NamespacedName{Name: "pod-2"},
+					Conditions: []corev1.PodCondition{
+						{Type: condType, Status: corev1.ConditionFalse},
+					},
+				}},
+			},
+			want: true,
+		},
+		{
+			name: "pod has no target health condition written yet — no flip needed (requeue after condition is first written handles it)",
+			endpoints: []backend.PodEndpoint{
+				{Pod: k8s.PodInfo{
+					Key:        types.NamespacedName{Name: "pod-1"},
+					Conditions: []corev1.PodCondition{},
+				}},
+			},
+			want: false,
+		},
+		{
+			name:      "no endpoints — no flip needed",
+			endpoints: []backend.PodEndpoint{},
+			want:      false,
+		},
+		{
+			name: "pod has no target health condition and no readiness gate configured — no flip needed",
+			endpoints: []backend.PodEndpoint{
+				{Pod: k8s.PodInfo{
+					Key:        types.NamespacedName{Name: "pod-1"},
+					Conditions: []corev1.PodCondition{},
+				}},
+			},
+			want: false,
+		},
+		{
+			name: "mix — one pod target health condition True, one pod condition not yet written — no flip needed",
+			endpoints: []backend.PodEndpoint{
+				{Pod: k8s.PodInfo{
+					Key: types.NamespacedName{Name: "pod-target-healthy"},
+					Conditions: []corev1.PodCondition{
+						{Type: condType, Status: corev1.ConditionTrue},
+					},
+				}},
+				{Pod: k8s.PodInfo{
+					Key:        types.NamespacedName{Name: "pod-no-condition-yet"},
+					Conditions: []corev1.PodCondition{},
+				}},
+			},
+			want: false,
+		},
+		{
+			name: "mix — one pod target health condition True, one pod target health condition False (target unhealthy) — flip needed",
+			endpoints: []backend.PodEndpoint{
+				{Pod: k8s.PodInfo{
+					Key: types.NamespacedName{Name: "pod-target-healthy"},
+					Conditions: []corev1.PodCondition{
+						{Type: condType, Status: corev1.ConditionTrue},
+					},
+				}},
+				{Pod: k8s.PodInfo{
+					Key: types.NamespacedName{Name: "pod-target-unhealthy"},
+					Conditions: []corev1.PodCondition{
+						{Type: condType, Status: corev1.ConditionFalse},
+					},
+				}},
+			},
+			want: true,
+		},
+		{
+			name: "all pods have target health condition False (all targets unhealthy) — flip needed",
+			endpoints: []backend.PodEndpoint{
+				{Pod: k8s.PodInfo{
+					Key: types.NamespacedName{Name: "pod-1"},
+					Conditions: []corev1.PodCondition{
+						{Type: condType, Status: corev1.ConditionFalse},
+					},
+				}},
+				{Pod: k8s.PodInfo{
+					Key: types.NamespacedName{Name: "pod-2"},
+					Conditions: []corev1.PodCondition{
+						{Type: condType, Status: corev1.ConditionFalse},
+					},
+				}},
+			},
+			want: true,
+		},
+		{
+			name: "pod has multiple TGB conditions — current TGB condition True, other TGB condition False — no flip needed",
+			endpoints: []backend.PodEndpoint{
+				{Pod: k8s.PodInfo{
+					Key: types.NamespacedName{Name: "pod-1"},
+					Conditions: []corev1.PodCondition{
+						{Type: condType, Status: corev1.ConditionTrue},
+						{Type: corev1.PodConditionType("target-health.elbv2.k8s.aws/other-tgb"), Status: corev1.ConditionFalse},
+					},
+				}},
+			},
+			want: false, // only condType is checked; the other TGB's condition is irrelevant
+		},
+		{
+			name: "pod has multiple TGB conditions — current TGB condition False, other TGB condition True — flip needed",
+			endpoints: []backend.PodEndpoint{
+				{Pod: k8s.PodInfo{
+					Key: types.NamespacedName{Name: "pod-1"},
+					Conditions: []corev1.PodCondition{
+						{Type: condType, Status: corev1.ConditionFalse},
+						{Type: corev1.PodConditionType("target-health.elbv2.k8s.aws/other-tgb"), Status: corev1.ConditionTrue},
+					},
+				}},
+			},
+			want: true, // condType is False regardless of other TGB conditions
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := needReadinessGateFlip(tt.endpoints, condType)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
### Issue

fix checkpoint early-exit

### Description
The controller has a performance optimization that skips work when it believes nothing has changed, tracked via a saved checkpoint. Due to a race between two reconcile execution order, one reconcile read a stale pod condition (True) from its local cache — the other reconcile's update to False had not yet propagated. Seeing no change needed, it saved the checkpoint as clean. The scheduled follow-up reconcile that was supposed to update the condition to True then hit the checkpoint early-exit and skipped. 

This bug requires all of following conditions simultaneously:
* Pod readiness gates enabled 
* Same-IP re-registration

This fix is to add a check to the checkpoint early-exit logic, ensuring pods with pending readiness gates are always reconciled




### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
