### PR TITLE
[fix]allow weight zero in NLB target group

### DIFF
--- a/pkg/gateway/model/model_build_listener.go
+++ b/pkg/gateway/model/model_build_listener.go
@@ -188,6 +188,7 @@ func (l listenerBuilderImpl) buildL4ListenerSpec(ctx context.Context, stack core
 
 func (l listenerBuilderImpl) buildL4TargetGroupTuples(stack core.Stack, routes []routeutils.RouteDescriptor, gw *gwv1.Gateway, port int32, listenerProtocol elbv2model.Protocol, ipAddressType elbv2model.IPAddressType) ([]elbv2model.TargetGroupTuple, error) {
 	tgTuples := make([]elbv2model.TargetGroupTuple, 0)
+	hasNonZeroWeight := false
 	for routeIndx := range routes {
 		routeDescriptor := routes[routeIndx]
 		if routeDescriptor.GetAttachedRules() == nil || len(routeDescriptor.GetAttachedRules()) == 0 {
@@ -198,10 +199,6 @@ func (l listenerBuilderImpl) buildL4TargetGroupTuples(stack core.Stack, routes [
 			backends := rule.GetBackends()
 			for backendIndx := range backends {
 				backend := backends[backendIndx]
-				if backend.Weight == 0 {
-					l.logger.Info("Ignoring NLB backend with 0 weight.", "route", routeDescriptor.GetRouteNamespacedName())
-					continue
-				}
 
 				arn, tgErr := l.tgBuilder.buildTargetGroup(stack, gw, port, listenerProtocol, ipAddressType, routeDescriptor, backend)
 				if tgErr != nil {
@@ -218,9 +215,17 @@ func (l listenerBuilderImpl) buildL4TargetGroupTuples(stack core.Stack, routes [
 					tuple.Weight = nil
 				}
 
+				if backend.Weight > 0 {
+					hasNonZeroWeight = true
+				}
+
 				tgTuples = append(tgTuples, tuple)
 			}
 		}
+	}
+	if len(tgTuples) > 0 && !hasNonZeroWeight {
+		l.logger.Info("Skipping listener creation due to all backends having 0 weight", "gateway", k8s.NamespacedName(gw))
+		return nil, nil
 	}
 	return tgTuples, nil
 }

--- a/pkg/gateway/model/model_build_listener_test.go
+++ b/pkg/gateway/model/model_build_listener_test.go
@@ -2299,6 +2299,63 @@ func Test_buildL4TargetGroupTuples(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "one route - one rule - two backends with one at weight 0",
+			targetGroups: []*elbv2model.TargetGroup{
+				tgs[0],
+				tgs[1],
+			},
+			routes: []routeutils.RouteDescriptor{
+				&routeutils.MockRoute{
+					Rules: []routeutils.RouteRule{
+						&routeutils.MockRule{
+							BackendRefs: []routeutils.Backend{
+								{
+									Weight: 100,
+								},
+								{
+									Weight: 0,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []tgValidation{
+				{
+					arn:    "arn1",
+					weight: 100,
+				},
+				{
+					arn:    "arn2",
+					weight: 0,
+				},
+			},
+		},
+		{
+			name: "all backends weight 0 returns nil",
+			targetGroups: []*elbv2model.TargetGroup{
+				tgs[0],
+				tgs[1],
+			},
+			routes: []routeutils.RouteDescriptor{
+				&routeutils.MockRoute{
+					Rules: []routeutils.RouteRule{
+						&routeutils.MockRule{
+							BackendRefs: []routeutils.Backend{
+								{
+									Weight: 0,
+								},
+								{
+									Weight: 0,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: nil,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
### Issue
https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4732

### Description
- allow weight 0 for NLB weighted target group 
- add guard and unit test to verify there should be at least 1 non-zero weight

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
deployed test yaml with 
```
apiVersion: gateway.networking.k8s.io/v1alpha2
kind: TCPRoute
metadata:
  name: echo-route
  namespace: issue-4732
spec:
  parentRefs:
    - group: gateway.networking.k8s.io
      kind: Gateway
      name: nlb-repro
      sectionName: tcp
  rules:
    - backendRefs:
        - name: echo-active
          port: 5678
          weight: 100
        - name: echo-preview
          port: 5678
          weight: 0
```
got 
<img width="507" height="332" alt="Screenshot 2026-05-14 at 12 39 48 PM" src="https://github.com/user-attachments/assets/def0370f-c60f-4c8f-a5f0-420aaf4adb38" />


- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
