### PR TITLE
Fix error when updating health check settings in TGC for Gateway API ALB target groups

### DIFF
--- a/pkg/deploy/elbv2/target_group_synthesizer.go
+++ b/pkg/deploy/elbv2/target_group_synthesizer.go
@@ -180,11 +180,9 @@ func isSDKTargetGroupRequiresReplacement(sdkTG TargetGroupWithTags, resTG *elbv2
 }
 
 // most of the healthCheck settings for NLB targetGroups cannot be changed for now.
+// Only L4 (NLB) target groups require replacement when health check settings change if NLBHealthCheckAdvancedConfig is enabled.
 func isSDKTargetGroupRequiresReplacementDueToNLBHealthCheck(sdkTG TargetGroupWithTags, resTG *elbv2model.TargetGroup, featureGates config.FeatureGates) bool {
-	if resTG.Spec.HealthCheckConfig == nil || featureGates.Enabled(config.NLBHealthCheckAdvancedConfig) {
-		return false
-	}
-	if isL4TargetGroup(resTG.Spec.Protocol) {
+	if !isL4TargetGroup(resTG.Spec.Protocol) || resTG.Spec.HealthCheckConfig == nil || featureGates.Enabled(config.NLBHealthCheckAdvancedConfig) {
 		return false
 	}
 	sdkObj := sdkTG.TargetGroup
@@ -206,17 +204,16 @@ func isSDKTargetGroupRequiresReplacementDueToNLBHealthCheck(sdkTG TargetGroupWit
 
 func isL4TargetGroup(protocol elbv2model.Protocol) bool {
 	switch protocol {
-	case elbv2model.ProtocolTCP:
-	case elbv2model.ProtocolUDP:
-	case elbv2model.ProtocolTLS:
-	case elbv2model.ProtocolQUIC:
-	case elbv2model.ProtocolTCP_QUIC:
-	case elbv2model.ProtocolTCP_UDP:
+	case elbv2model.ProtocolTCP,
+		elbv2model.ProtocolUDP,
+		elbv2model.ProtocolTLS,
+		elbv2model.ProtocolQUIC,
+		elbv2model.ProtocolTCP_QUIC,
+		elbv2model.ProtocolTCP_UDP:
 		return true
 	default:
 		return false
 	}
-	return false
 }
 
 func isSDKTargetGroupTargetControlPortDrifted(tgSpec elbv2model.TargetGroupSpec, sdkTG TargetGroupWithTags) bool {

--- a/pkg/deploy/elbv2/target_group_synthesizer_test.go
+++ b/pkg/deploy/elbv2/target_group_synthesizer_test.go
@@ -1051,6 +1051,82 @@ func Test_isSDKTargetGroupRequiresReplacementDueToNLBHealthCheck(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "ALB TargetGroup healthCheck protocol change does not require replacement",
+			args: args{
+				sdkTG: TargetGroupWithTags{
+					TargetGroup: &elbv2types.TargetGroup{
+						Protocol:            elbv2types.ProtocolEnumHttps,
+						HealthCheckEnabled:  awssdk.Bool(true),
+						HealthCheckPort:     awssdk.String("8080"),
+						HealthCheckProtocol: elbv2types.ProtocolEnumHttps,
+						HealthCheckPath:     awssdk.String("/readyz"),
+						Matcher: &elbv2types.Matcher{
+							HttpCode: awssdk.String("200"),
+						},
+						HealthCheckIntervalSeconds: awssdk.Int32(10),
+						HealthCheckTimeoutSeconds:  awssdk.Int32(5),
+						HealthyThresholdCount:      awssdk.Int32(3),
+						UnhealthyThresholdCount:    awssdk.Int32(2),
+					},
+				},
+				resTG: &elbv2model.TargetGroup{
+					Spec: elbv2model.TargetGroupSpec{
+						Protocol: elbv2model.ProtocolHTTPS,
+						HealthCheckConfig: &elbv2model.TargetGroupHealthCheckConfig{
+							Port:                    &port8080,
+							Protocol:                protocolHTTP,
+							Path:                    awssdk.String("/readyz"),
+							Matcher:                 &elbv2model.HealthCheckMatcher{HTTPCode: awssdk.String("200")},
+							IntervalSeconds:         awssdk.Int32(10),
+							TimeoutSeconds:          awssdk.Int32(5),
+							HealthyThresholdCount:   awssdk.Int32(3),
+							UnhealthyThresholdCount: awssdk.Int32(2),
+						},
+					},
+				},
+				disableAdvancedNLBHealthCheckConfig: true,
+			},
+			want: false,
+		},
+		{
+			name: "ALB TargetGroup healthCheck interval change does not require replacement",
+			args: args{
+				sdkTG: TargetGroupWithTags{
+					TargetGroup: &elbv2types.TargetGroup{
+						Protocol:            elbv2types.ProtocolEnumHttp,
+						HealthCheckEnabled:  awssdk.Bool(true),
+						HealthCheckPort:     awssdk.String("8080"),
+						HealthCheckProtocol: elbv2types.ProtocolEnumHttp,
+						HealthCheckPath:     awssdk.String("/"),
+						Matcher: &elbv2types.Matcher{
+							HttpCode: awssdk.String("200"),
+						},
+						HealthCheckIntervalSeconds: awssdk.Int32(30),
+						HealthCheckTimeoutSeconds:  awssdk.Int32(5),
+						HealthyThresholdCount:      awssdk.Int32(3),
+						UnhealthyThresholdCount:    awssdk.Int32(2),
+					},
+				},
+				resTG: &elbv2model.TargetGroup{
+					Spec: elbv2model.TargetGroupSpec{
+						Protocol: elbv2model.ProtocolHTTP,
+						HealthCheckConfig: &elbv2model.TargetGroupHealthCheckConfig{
+							Port:                    &port8080,
+							Protocol:                protocolHTTP,
+							Path:                    awssdk.String("/"),
+							Matcher:                 &elbv2model.HealthCheckMatcher{HTTPCode: awssdk.String("200")},
+							IntervalSeconds:         awssdk.Int32(10),
+							TimeoutSeconds:          awssdk.Int32(5),
+							HealthyThresholdCount:   awssdk.Int32(3),
+							UnhealthyThresholdCount: awssdk.Int32(2),
+						},
+					},
+				},
+				disableAdvancedNLBHealthCheckConfig: true,
+			},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1059,6 +1135,61 @@ func Test_isSDKTargetGroupRequiresReplacementDueToNLBHealthCheck(t *testing.T) {
 				featureGates.Disable(config.NLBHealthCheckAdvancedConfig)
 			}
 			got := isSDKTargetGroupRequiresReplacementDueToNLBHealthCheck(tt.args.sdkTG, tt.args.resTG, featureGates)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_isL4TargetGroup(t *testing.T) {
+	tests := []struct {
+		name     string
+		protocol elbv2model.Protocol
+		want     bool
+	}{
+		{
+			name:     "TCP is L4",
+			protocol: elbv2model.ProtocolTCP,
+			want:     true,
+		},
+		{
+			name:     "UDP is L4",
+			protocol: elbv2model.ProtocolUDP,
+			want:     true,
+		},
+		{
+			name:     "TLS is L4",
+			protocol: elbv2model.ProtocolTLS,
+			want:     true,
+		},
+		{
+			name:     "QUIC is L4",
+			protocol: elbv2model.ProtocolQUIC,
+			want:     true,
+		},
+		{
+			name:     "TCP_QUIC is L4",
+			protocol: elbv2model.ProtocolTCP_QUIC,
+			want:     true,
+		},
+		{
+			name:     "TCP_UDP is L4",
+			protocol: elbv2model.ProtocolTCP_UDP,
+			want:     true,
+		},
+		{
+			name:     "HTTP is not L4",
+			protocol: elbv2model.ProtocolHTTP,
+			want:     false,
+		},
+		{
+			name:     "HTTPS is not L4",
+			protocol: elbv2model.ProtocolHTTPS,
+			want:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isL4TargetGroup(tt.protocol)
 			assert.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION


### Issue

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4740

### Description

Two bugs in `isSDKTargetGroupRequiresReplacementDueToNLBHealthCheck`:
1.  `isL4TargetGroup` switch had empty case bodies that did not fall through (Go semantics), so only TCP_UDP returned true
2.  Guard logic was inverted — skipped replacement for NLB and forced replacement for ALB

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [x] Backfilled missing tests for code in same general area :tada:
- [x] Refactored something and made the world a better place :star2:
