### PR TITLE
[feat i2g] multi-ingress TGC with RouteConfigurations

### DIFF
--- a/pkg/ingress2gateway/translate/icp_overrides.go
+++ b/pkg/ingress2gateway/translate/icp_overrides.go
@@ -284,6 +284,15 @@ func applyIngressClassParamsToTGProps(props *gatewayv1beta1.TargetGroupProps, ic
 		tt := gatewayv1beta1.TargetType(icp.Spec.TargetType)
 		props.TargetType = &tt
 	}
+	if len(icp.Spec.Tags) > 0 {
+		if props.Tags == nil {
+			tags := make(map[string]string)
+			props.Tags = &tags
+		}
+		for _, t := range icp.Spec.Tags {
+			(*props.Tags)[t.Key] = t.Value
+		}
+	}
 }
 
 // resolveSSLRedirectPort returns the SSL redirect port if configured.

--- a/pkg/ingress2gateway/translate/tg_config.go
+++ b/pkg/ingress2gateway/translate/tg_config.go
@@ -8,6 +8,7 @@ import (
 	gatewayv1beta1 "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
 	annotations "sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/ingress2gateway/utils"
+	sharedconstants "sigs.k8s.io/aws-load-balancer-controller/pkg/shared_constants"
 )
 
 // buildTargetGroupConfig builds a TargetGroupConfiguration for a given service from annotations.
@@ -44,6 +45,76 @@ func buildTargetGroupConfig(svcRef serviceRef, annos map[string]string, migratio
 			DefaultConfiguration: props,
 		},
 	}
+}
+
+// buildTargetGroupConfigFromEntries builds a TargetGroupConfiguration from one or more
+// ingress entries referencing the same service. A single entry uses DefaultConfiguration.
+// Multiple entries always emit RouteConfigurations keyed by the generated HTTPRoute name,
+// so the controller's longest-match merge assigns each HTTPRoute its own TG settings.
+func buildTargetGroupConfigFromEntries(entries []tgcEntry) *gatewayv1beta1.TargetGroupConfiguration {
+	if len(entries) == 0 {
+		return nil
+	}
+
+	// All entries share the same svcRef (grouped by namespace/name:port).
+	svcRef := entries[0].svcRef
+
+	// Single entry — use DefaultConfiguration (simple path).
+	if len(entries) == 1 {
+		tgc := buildTargetGroupConfig(svcRef, entries[0].annotations, entries[0].migrationTag)
+		if tgc != nil {
+			for _, icp := range entries[0].icps {
+				applyIngressClassParamsToTGProps(&tgc.Spec.DefaultConfiguration, icp)
+			}
+		}
+		return tgc
+	}
+
+	// Multiple entries — emit a RouteConfiguration per ingress.
+	tgc := &gatewayv1beta1.TargetGroupConfiguration{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: utils.LBConfigAPIVersion,
+			Kind:       utils.TGConfigKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      utils.GetTGConfigName(svcRef.namespace, svcRef.name),
+			Namespace: svcRef.namespace,
+		},
+		Spec: gatewayv1beta1.TargetGroupConfigurationSpec{
+			TargetReference: &gatewayv1beta1.Reference{
+				Name: svcRef.name,
+			},
+		},
+	}
+
+	for _, entry := range entries {
+		props := buildTargetGroupProps(entry.annotations, svcRef.name, svcRef.port)
+
+		// Apply ICP overrides from this entry's group.
+		for _, icp := range entry.icps {
+			applyIngressClassParamsToTGProps(&props, icp)
+		}
+
+		// Add migration tag.
+		if entry.migrationTag != "" {
+			if props.Tags == nil {
+				tags := make(map[string]string)
+				props.Tags = &tags
+			}
+			(*props.Tags)[utils.MigrationTagKey] = entry.migrationTag
+		}
+
+		tgc.Spec.RouteConfigurations = append(tgc.Spec.RouteConfigurations, gatewayv1beta1.RouteConfiguration{
+			RouteIdentifier: gatewayv1beta1.RouteIdentifier{
+				RouteKind:      sharedconstants.HTTPRouteKind,
+				RouteNamespace: svcRef.namespace,
+				RouteName:      entry.routeName,
+			},
+			TargetGroupProps: props,
+		})
+	}
+
+	return tgc
 }
 
 // buildTargetGroupProps builds TargetGroupProps from annotations.

--- a/pkg/ingress2gateway/translate/tg_config_test.go
+++ b/pkg/ingress2gateway/translate/tg_config_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	gatewayv1beta1 "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/ingress2gateway/utils"
+	sharedconstants "sigs.k8s.io/aws-load-balancer-controller/pkg/shared_constants"
 )
 
 func TestBuildTargetGroupConfig(t *testing.T) {
@@ -114,6 +115,187 @@ func TestBuildTargetGroupConfig(t *testing.T) {
 				return
 			}
 			require.NotNil(t, result)
+			if tt.check != nil {
+				tt.check(t, result)
+			}
+		})
+	}
+}
+
+func TestBuildTargetGroupConfigFromEntries(t *testing.T) {
+	svcRef := serviceRef{namespace: "default", name: "my-svc", port: 8080}
+
+	tests := []struct {
+		name    string
+		entries []tgcEntry
+		wantNil bool
+		check   func(t *testing.T, tgc *gatewayv1beta1.TargetGroupConfiguration)
+	}{
+		{
+			name:    "no entries returns nil",
+			entries: nil,
+			wantNil: true,
+		},
+		{
+			name: "single entry with config uses DefaultConfiguration",
+			entries: []tgcEntry{
+				{
+					svcRef:       svcRef,
+					annotations:  map[string]string{"alb.ingress.kubernetes.io/target-type": "ip"},
+					migrationTag: "ingress/default/ing-a",
+					routeName:    "default-ing-a-route-abc123",
+				},
+			},
+			check: func(t *testing.T, tgc *gatewayv1beta1.TargetGroupConfiguration) {
+				require.NotNil(t, tgc.Spec.DefaultConfiguration.TargetType)
+				assert.Equal(t, gatewayv1beta1.TargetTypeIP, *tgc.Spec.DefaultConfiguration.TargetType)
+				assert.Empty(t, tgc.Spec.RouteConfigurations)
+			},
+		},
+		{
+			name: "multiple entries with identical config",
+			entries: []tgcEntry{
+				{
+					svcRef:       svcRef,
+					annotations:  map[string]string{"alb.ingress.kubernetes.io/target-type": "ip"},
+					migrationTag: "ingress/default/ing-a",
+					routeName:    "default-ing-a-route-abc123",
+				},
+				{
+					svcRef:       svcRef,
+					annotations:  map[string]string{"alb.ingress.kubernetes.io/target-type": "ip"},
+					migrationTag: "ingress/default/ing-b",
+					routeName:    "default-ing-b-route-def456",
+				},
+			},
+			check: func(t *testing.T, tgc *gatewayv1beta1.TargetGroupConfiguration) {
+				require.Len(t, tgc.Spec.RouteConfigurations, 2)
+				require.NotNil(t, tgc.Spec.RouteConfigurations[0].TargetGroupProps.TargetType)
+				assert.Equal(t, gatewayv1beta1.TargetTypeIP, *tgc.Spec.RouteConfigurations[0].TargetGroupProps.TargetType)
+				require.NotNil(t, tgc.Spec.RouteConfigurations[1].TargetGroupProps.TargetType)
+				assert.Equal(t, gatewayv1beta1.TargetTypeIP, *tgc.Spec.RouteConfigurations[1].TargetGroupProps.TargetType)
+			},
+		},
+		{
+			name: "multiple entries with different config",
+			entries: []tgcEntry{
+				{
+					svcRef: svcRef,
+					annotations: map[string]string{
+						"alb.ingress.kubernetes.io/backend-protocol": "HTTP",
+						"alb.ingress.kubernetes.io/healthcheck-path": "/healthz",
+					},
+					migrationTag: "ingress/default/ing-a",
+					routeName:    "default-ing-a-route-abc123",
+				},
+				{
+					svcRef: svcRef,
+					annotations: map[string]string{
+						"alb.ingress.kubernetes.io/backend-protocol": "HTTPS",
+						"alb.ingress.kubernetes.io/healthcheck-path": "/ready",
+					},
+					migrationTag: "ingress/default/ing-b",
+					routeName:    "default-ing-b-route-def456",
+				},
+			},
+			check: func(t *testing.T, tgc *gatewayv1beta1.TargetGroupConfiguration) {
+				// DefaultConfiguration should be empty since configs differ.
+				assert.Nil(t, tgc.Spec.DefaultConfiguration.Protocol)
+				// Should have two RouteConfigurations.
+				require.Len(t, tgc.Spec.RouteConfigurations, 2)
+
+				rc0 := tgc.Spec.RouteConfigurations[0]
+				assert.Equal(t, sharedconstants.HTTPRouteKind, rc0.RouteIdentifier.RouteKind)
+				assert.Equal(t, "default", rc0.RouteIdentifier.RouteNamespace)
+				assert.Equal(t, "default-ing-a-route-abc123", rc0.RouteIdentifier.RouteName)
+				require.NotNil(t, rc0.TargetGroupProps.Protocol)
+				assert.Equal(t, gatewayv1beta1.ProtocolHTTP, *rc0.TargetGroupProps.Protocol)
+				require.NotNil(t, rc0.TargetGroupProps.HealthCheckConfig)
+				assert.Equal(t, "/healthz", *rc0.TargetGroupProps.HealthCheckConfig.HealthCheckPath)
+
+				rc1 := tgc.Spec.RouteConfigurations[1]
+				assert.Equal(t, "default-ing-b-route-def456", rc1.RouteIdentifier.RouteName)
+				require.NotNil(t, rc1.TargetGroupProps.Protocol)
+				assert.Equal(t, gatewayv1beta1.ProtocolHTTPS, *rc1.TargetGroupProps.Protocol)
+				require.NotNil(t, rc1.TargetGroupProps.HealthCheckConfig)
+				assert.Equal(t, "/ready", *rc1.TargetGroupProps.HealthCheckConfig.HealthCheckPath)
+			},
+		},
+		{
+			name: "entries with one empty config emit RouteConfigurations for all entries",
+			entries: []tgcEntry{
+				{
+					svcRef:       svcRef,
+					annotations:  map[string]string{"alb.ingress.kubernetes.io/target-type": "ip"},
+					migrationTag: "ingress/default/ing-a",
+					routeName:    "default-ing-a-route-abc123",
+				},
+				{
+					svcRef:       svcRef,
+					annotations:  map[string]string{},
+					migrationTag: "ingress/default/ing-b",
+					routeName:    "default-ing-b-route-def456",
+				},
+			},
+			check: func(t *testing.T, tgc *gatewayv1beta1.TargetGroupConfiguration) {
+				// Both entries get RouteConfigurations (even the empty one gets migration tag).
+				require.Len(t, tgc.Spec.RouteConfigurations, 2)
+				assert.Equal(t, "default-ing-a-route-abc123", tgc.Spec.RouteConfigurations[0].RouteIdentifier.RouteName)
+				require.NotNil(t, tgc.Spec.RouteConfigurations[0].TargetGroupProps.TargetType)
+				assert.Equal(t, gatewayv1beta1.TargetTypeIP, *tgc.Spec.RouteConfigurations[0].TargetGroupProps.TargetType)
+				assert.Equal(t, "default-ing-b-route-def456", tgc.Spec.RouteConfigurations[1].RouteIdentifier.RouteName)
+			},
+		},
+		{
+			name: "all entries empty still creates TGC with migration tags",
+			entries: []tgcEntry{
+				{svcRef: svcRef, annotations: map[string]string{}, migrationTag: "ingress/default/ing-a", routeName: "r1"},
+				{svcRef: svcRef, annotations: map[string]string{}, migrationTag: "ingress/default/ing-b", routeName: "r2"},
+			},
+			check: func(t *testing.T, tgc *gatewayv1beta1.TargetGroupConfiguration) {
+				require.Len(t, tgc.Spec.RouteConfigurations, 2)
+				require.NotNil(t, tgc.Spec.RouteConfigurations[0].TargetGroupProps.Tags)
+				assert.Equal(t, "ingress/default/ing-a", (*tgc.Spec.RouteConfigurations[0].TargetGroupProps.Tags)[utils.MigrationTagKey])
+				require.NotNil(t, tgc.Spec.RouteConfigurations[1].TargetGroupProps.Tags)
+				assert.Equal(t, "ingress/default/ing-b", (*tgc.Spec.RouteConfigurations[1].TargetGroupProps.Tags)[utils.MigrationTagKey])
+			},
+		},
+		{
+			name: "migration tags are set on each RouteConfiguration",
+			entries: []tgcEntry{
+				{
+					svcRef:       svcRef,
+					annotations:  map[string]string{"alb.ingress.kubernetes.io/target-type": "ip"},
+					migrationTag: "ingress/default/ing-a",
+					routeName:    "route-a",
+				},
+				{
+					svcRef:       svcRef,
+					annotations:  map[string]string{"alb.ingress.kubernetes.io/target-type": "instance"},
+					migrationTag: "ingress/default/ing-b",
+					routeName:    "route-b",
+				},
+			},
+			check: func(t *testing.T, tgc *gatewayv1beta1.TargetGroupConfiguration) {
+				require.Len(t, tgc.Spec.RouteConfigurations, 2)
+				require.NotNil(t, tgc.Spec.RouteConfigurations[0].TargetGroupProps.Tags)
+				assert.Equal(t, "ingress/default/ing-a", (*tgc.Spec.RouteConfigurations[0].TargetGroupProps.Tags)[utils.MigrationTagKey])
+				require.NotNil(t, tgc.Spec.RouteConfigurations[1].TargetGroupProps.Tags)
+				assert.Equal(t, "ingress/default/ing-b", (*tgc.Spec.RouteConfigurations[1].TargetGroupProps.Tags)[utils.MigrationTagKey])
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildTargetGroupConfigFromEntries(tt.entries)
+			if tt.wantNil {
+				assert.Nil(t, result)
+				return
+			}
+			require.NotNil(t, result)
+			assert.Equal(t, utils.GetTGConfigName("default", "my-svc"), result.Name)
+			assert.Equal(t, "my-svc", result.Spec.TargetReference.Name)
 			if tt.check != nil {
 				tt.check(t, result)
 			}

--- a/pkg/ingress2gateway/translate/translate.go
+++ b/pkg/ingress2gateway/translate/translate.go
@@ -8,7 +8,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
 	gatewayv1beta1 "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
 	annotations "sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
@@ -18,6 +17,15 @@ import (
 	k8s "sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	sharedconstants "sigs.k8s.io/aws-load-balancer-controller/pkg/shared_constants"
 )
+
+// tgcEntry holds per-ingress data needed to build a TargetGroupConfiguration.
+type tgcEntry struct {
+	svcRef       serviceRef
+	annotations  map[string]string
+	migrationTag string
+	routeName    string
+	icps         []*elbv2api.IngressClassParams
+}
 
 // Translate converts InputResources into OutputResources (Gateway API manifests).
 func Translate(in *ingress2gateway.InputResources) (*ingress2gateway.OutputResources, error) {
@@ -30,16 +38,11 @@ func Translate(in *ingress2gateway.InputResources) (*ingress2gateway.OutputResou
 	servicesByKey := buildServiceMap(in.Services)
 	ingressClassParamsByClass := buildIngressClassParamsMap(in.IngressClasses, in.IngressClassParams)
 
-	// Track which services we've already created TGCs for (deduplicate).
-	//
-	// TODO: when two ingresses share a service but carry different TG-level annotations
-	// (healthcheck path, tags, etc.), only the first ingress's values are captured here.
-	// Follow-up: emit one RouteConfiguration per (ingress × service) so each HTTPRoute
-	// picks up its originating ingress's props via the controller's longest-match merge.
-	tgcCreated := sets.New[string]()
-
 	// Partition Ingresses into groups (ungrouped become single-member groups)
 	groups := partitionByGroup(in.Ingresses)
+
+	// key: "namespace/serviceName:port", value: per-ingress TGC entries for that service
+	tgcEntries := make(map[string][]tgcEntry)
 
 	for _, group := range groups {
 		var gatewayName, lbConfigName, lbMigrationTag string
@@ -130,7 +133,7 @@ func Translate(in *ingress2gateway.InputResources) (*ingress2gateway.OutputResou
 			}
 		}
 
-		// --- Per-member: HTTPRoutes, TGConfigs, LRConfigs ---
+		// --- Per-member: HTTPRoutes, LRConfigs, TGC entry accumulation ---
 		for _, ing := range group.members {
 			memberPorts := perMemberPorts[k8s.NamespacedName(&ing).String()]
 			parentRefs := buildMemberParentRefs(gatewayName, group.namespace, ing.Namespace, memberPorts, allPorts, sslRedirectPort)
@@ -162,24 +165,27 @@ func Translate(in *ingress2gateway.InputResources) (*ingress2gateway.OutputResou
 			}
 			out.ListenerRuleConfigurations = append(out.ListenerRuleConfigurations, lrcs...)
 
-			//  Build TargetGroupConfigurations for each unique service. Dedup happens on
-			//  (namespace, service, port) so only the first ingress processed for a given
-			//  service contributes its annotations. See the TODO at the top of Translate.
+			// Accumulate TGC entries for each service referenced by this member.
 			for _, svcRef := range svcRefs {
-				if tgcCreated.Has(svcRef.getServiceRefKey()) {
-					continue
-				}
-				tgcCreated.Insert(svcRef.getServiceRefKey())
-
+				key := svcRef.getServiceRefKey()
 				tgAnnotations := mergeTGAnnotations(effectiveAnnotations, servicesByKey, svcRef.namespace, svcRef.name)
-				tgc := buildTargetGroupConfig(svcRef, tgAnnotations, memberMigrationTag)
-				if tgc != nil {
-					for _, icp := range icps {
-						applyIngressClassParamsToTGProps(&tgc.Spec.DefaultConfiguration, icp)
-					}
-					out.TargetGroupConfigurations = append(out.TargetGroupConfigurations, *tgc)
-				}
+				routeName := utils.GetHTTPRouteName(ing.Namespace, ing.Name)
+				tgcEntries[key] = append(tgcEntries[key], tgcEntry{
+					svcRef:       svcRef,
+					annotations:  tgAnnotations,
+					migrationTag: memberMigrationTag,
+					routeName:    routeName,
+					icps:         icps,
+				})
 			}
+		}
+	}
+
+	// Build TargetGroupConfigurations from accumulated entries.
+	for _, entries := range tgcEntries {
+		tgc := buildTargetGroupConfigFromEntries(entries)
+		if tgc != nil {
+			out.TargetGroupConfigurations = append(out.TargetGroupConfigurations, *tgc)
 		}
 	}
 

--- a/pkg/ingress2gateway/translate/translate_test.go
+++ b/pkg/ingress2gateway/translate/translate_test.go
@@ -557,6 +557,160 @@ func TestTranslate(t *testing.T) {
 			},
 		},
 		{
+			name: "grouped ingresses with different TG annotations produce RouteConfigurations",
+			input: &ingress2gateway.InputResources{
+				Ingresses: []networking.Ingress{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ing-a", Namespace: "demo",
+							Annotations: map[string]string{
+								"alb.ingress.kubernetes.io/group.name":       "shared-alb",
+								"alb.ingress.kubernetes.io/backend-protocol": "HTTP",
+								"alb.ingress.kubernetes.io/healthcheck-path": "/healthz",
+							},
+						},
+						Spec: networking.IngressSpec{
+							Rules: []networking.IngressRule{{
+								Host: "a.example.com",
+								IngressRuleValue: networking.IngressRuleValue{
+									HTTP: &networking.HTTPIngressRuleValue{
+										Paths: []networking.HTTPIngressPath{{
+											Path: "/a", PathType: &pathPrefix,
+											Backend: networking.IngressBackend{
+												Service: &networking.IngressServiceBackend{
+													Name: "shared-svc", Port: networking.ServiceBackendPort{Number: 8080},
+												},
+											},
+										}},
+									},
+								},
+							}},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ing-b", Namespace: "demo",
+							Annotations: map[string]string{
+								"alb.ingress.kubernetes.io/group.name":       "shared-alb",
+								"alb.ingress.kubernetes.io/backend-protocol": "HTTPS",
+								"alb.ingress.kubernetes.io/healthcheck-path": "/ready",
+							},
+						},
+						Spec: networking.IngressSpec{
+							Rules: []networking.IngressRule{{
+								Host: "b.example.com",
+								IngressRuleValue: networking.IngressRuleValue{
+									HTTP: &networking.HTTPIngressRuleValue{
+										Paths: []networking.HTTPIngressPath{{
+											Path: "/b", PathType: &pathPrefix,
+											Backend: networking.IngressBackend{
+												Service: &networking.IngressServiceBackend{
+													Name: "shared-svc", Port: networking.ServiceBackendPort{Number: 8080},
+												},
+											},
+										}},
+									},
+								},
+							}},
+						},
+					},
+				},
+			},
+			wantGatewayCount: 1, wantHTTPRouteCount: 2, wantLBConfigCount: 0, wantTGConfigCount: 1,
+			check: func(t *testing.T, out *ingress2gateway.OutputResources) {
+				tgc := out.TargetGroupConfigurations[0]
+				assert.Equal(t, "shared-svc", tgc.Spec.TargetReference.Name)
+				// DefaultConfiguration should be empty since entries differ.
+				assert.Nil(t, tgc.Spec.DefaultConfiguration.Protocol)
+				// Should have RouteConfigurations for each ingress.
+				require.Len(t, tgc.Spec.RouteConfigurations, 2)
+
+				rc0 := tgc.Spec.RouteConfigurations[0]
+				assert.Equal(t, constants.GetHTTPRouteName("demo", "ing-a"), rc0.RouteIdentifier.RouteName)
+				require.NotNil(t, rc0.TargetGroupProps.Protocol)
+				assert.Equal(t, gatewayv1beta1.ProtocolHTTP, *rc0.TargetGroupProps.Protocol)
+				require.NotNil(t, rc0.TargetGroupProps.HealthCheckConfig)
+				assert.Equal(t, "/healthz", *rc0.TargetGroupProps.HealthCheckConfig.HealthCheckPath)
+
+				rc1 := tgc.Spec.RouteConfigurations[1]
+				assert.Equal(t, constants.GetHTTPRouteName("demo", "ing-b"), rc1.RouteIdentifier.RouteName)
+				require.NotNil(t, rc1.TargetGroupProps.Protocol)
+				assert.Equal(t, gatewayv1beta1.ProtocolHTTPS, *rc1.TargetGroupProps.Protocol)
+				require.NotNil(t, rc1.TargetGroupProps.HealthCheckConfig)
+				assert.Equal(t, "/ready", *rc1.TargetGroupProps.HealthCheckConfig.HealthCheckPath)
+			},
+		},
+		{
+			name: "grouped ingresses with same TG annotations produce RouteConfigurations for each",
+			input: &ingress2gateway.InputResources{
+				Ingresses: []networking.Ingress{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ing-a", Namespace: "demo",
+							Annotations: map[string]string{
+								"alb.ingress.kubernetes.io/group.name":  "shared-alb",
+								"alb.ingress.kubernetes.io/target-type": "ip",
+							},
+						},
+						Spec: networking.IngressSpec{
+							Rules: []networking.IngressRule{{
+								Host: "a.example.com",
+								IngressRuleValue: networking.IngressRuleValue{
+									HTTP: &networking.HTTPIngressRuleValue{
+										Paths: []networking.HTTPIngressPath{{
+											Path: "/a", PathType: &pathPrefix,
+											Backend: networking.IngressBackend{
+												Service: &networking.IngressServiceBackend{
+													Name: "shared-svc", Port: networking.ServiceBackendPort{Number: 8080},
+												},
+											},
+										}},
+									},
+								},
+							}},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "ing-b", Namespace: "demo",
+							Annotations: map[string]string{
+								"alb.ingress.kubernetes.io/group.name":  "shared-alb",
+								"alb.ingress.kubernetes.io/target-type": "ip",
+							},
+						},
+						Spec: networking.IngressSpec{
+							Rules: []networking.IngressRule{{
+								Host: "b.example.com",
+								IngressRuleValue: networking.IngressRuleValue{
+									HTTP: &networking.HTTPIngressRuleValue{
+										Paths: []networking.HTTPIngressPath{{
+											Path: "/b", PathType: &pathPrefix,
+											Backend: networking.IngressBackend{
+												Service: &networking.IngressServiceBackend{
+													Name: "shared-svc", Port: networking.ServiceBackendPort{Number: 8080},
+												},
+											},
+										}},
+									},
+								},
+							}},
+						},
+					},
+				},
+			},
+			wantGatewayCount: 1, wantHTTPRouteCount: 2, wantLBConfigCount: 0, wantTGConfigCount: 1,
+			check: func(t *testing.T, out *ingress2gateway.OutputResources) {
+				tgc := out.TargetGroupConfigurations[0]
+				assert.Equal(t, "shared-svc", tgc.Spec.TargetReference.Name)
+				// Multiple entries always produce RouteConfigurations.
+				require.Len(t, tgc.Spec.RouteConfigurations, 2)
+				require.NotNil(t, tgc.Spec.RouteConfigurations[0].TargetGroupProps.TargetType)
+				assert.Equal(t, gatewayv1beta1.TargetTypeIP, *tgc.Spec.RouteConfigurations[0].TargetGroupProps.TargetType)
+				require.NotNil(t, tgc.Spec.RouteConfigurations[1].TargetGroupProps.TargetType)
+				assert.Equal(t, gatewayv1beta1.TargetTypeIP, *tgc.Spec.RouteConfigurations[1].TargetGroupProps.TargetType)
+			},
+		},
+		{
 			name: "conflicting scheme in group errors",
 			input: &ingress2gateway.InputResources{
 				Ingresses: []networking.Ingress{


### PR DESCRIPTION
### Description

**Problem:**
- When multiple Ingress resources reference the same backend Service with different TG-level annotations, the migration tool previously only captured the first Ingress's values — silently dropping the rest and emitting duplicate TGC resources with the same name.

**Fix:**
- Accumulate all per-ingress TGC entries across all groups before building TGCs.
- Single entry → `DefaultConfiguration` (simple path, same as before).
- Multiple entries → emit per-ingress `RouteConfigurations` keyed by the generated HTTPRoute name, so the controller's longest-match merge assigns each HTTPRoute its own TG settings.
- Also fixed `applyIngressClassParamsToTGProps` to propagate `icp.Spec.Tags` to TG props (was only handling `TargetType`).

**Key decisions:**
- TLDR: No `reflect.DeepEqual` comparison to detect identical configs — multiple entries always produce RouteConfigurations to avoid subtle equality bugs with pointer-heavy structs.
DETAILS 
```
i was thinking to check if all Ingresses produced identical TargetGroupProps
   using reflect.DeepEqual. If identical, it would collapse them into a single
  DefaultConfiguration instead of emitting RouteConfigurations.

  The problem: TargetGroupProps has fields like Tags *map[string]string, HealthCheckConfig
  *HealthCheckConfiguration, slices, etc. reflect.DeepEqual can report two logically
  equivalent values as different — for example nil vs &map[string]string{}, or nil slice vs
  empty slice. So the "are these identical?" check could give wrong answers, causing the code
   to emit RouteConfigurations when it shouldn't or vice versa.

  so decided it's simpler to skip that comparison entirely: if multiple Ingresses reference
  the same Service, always emit RouteConfigurations regardless of whether the configs match.
  The controller handles this correctly either way — there's no functional downside to having
   RouteConfigurations with identical values.
```
- The controller handles redundant RouteConfigurations with identical values correctly via its longest-match resolution.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
applied same yaml file i used to find the bug and showed in from in-cluster console, it is fixed
- [x] Made sure the title of the PR is a good description that can go into the release notes