### PR TITLE
reject multiple l4 routes for same listener

### DIFF
--- a/pkg/gateway/model/model_build_listener.go
+++ b/pkg/gateway/model/model_build_listener.go
@@ -189,12 +189,10 @@ func (l listenerBuilderImpl) buildL4ListenerSpec(ctx context.Context, stack core
 func (l listenerBuilderImpl) buildL4TargetGroupTuples(stack core.Stack, routes []routeutils.RouteDescriptor, gw *gwv1.Gateway, port int32, listenerProtocol elbv2model.Protocol, ipAddressType elbv2model.IPAddressType) ([]elbv2model.TargetGroupTuple, error) {
 	tgTuples := make([]elbv2model.TargetGroupTuple, 0)
 	hasNonZeroWeight := false
-	for routeIndx := range routes {
-		routeDescriptor := routes[routeIndx]
-		if routeDescriptor.GetAttachedRules() == nil || len(routeDescriptor.GetAttachedRules()) == 0 {
-			continue
-		}
 
+	descriptorPtr := pickOneL4Route(routes)
+	if descriptorPtr != nil && (*descriptorPtr).GetAttachedRules() != nil {
+		routeDescriptor := *descriptorPtr
 		for _, rule := range routeDescriptor.GetAttachedRules() {
 			backends := rule.GetBackends()
 			for backendIndx := range backends {
@@ -696,4 +694,45 @@ func mergeProtocols(storedProtocol, proposedProtocol elbv2model.Protocol) (elbv2
 	}
 
 	return elbv2model.ProtocolHTTP, errors.New("unsupported merge")
+}
+
+// L4 listeners should only allow 1 Route;
+/*
+		Because a TCP/UDP listener has no mechanism to distinguish between connections (no
+		hostname, no SNI, no path), attaching multiple [TCP/UDP]Routes to the same listener
+		results in only one route effectively receiving traffic.
+
+		When multiple [TCP/UDP]Routes reference the same listener, the implementation MUST
+		follow the general Gateway API route precedence rules defined in `AllowedRoutes`:
+
+		1. The oldest Route based on `metadata.creationTimestamp`.
+		2. If timestamps are equal, the Route appearing first in alphabetical order
+		   (`namespace/name`).
+
+		All attached [TCP/UDP]Routes are `Accepted`, consistent with how other route types
+		handle precedence in the Gateway API. Only the winning route's backends receive
+		traffic.
+
+
+	As we don't support SNI routing, apply this same logic to TLS routes.
+*/
+func pickOneL4Route(routes []routeutils.RouteDescriptor) *routeutils.RouteDescriptor {
+	if len(routes) == 0 {
+		return nil
+	}
+	toReturn := routes[0]
+	for _, r := range routes[1:] {
+		currentReturnTs := toReturn.GetRouteCreateTimestamp().UnixMilli()
+		toCompareTs := r.GetRouteCreateTimestamp().UnixMilli()
+		if currentReturnTs > toCompareTs {
+			toReturn = r
+		} else if currentReturnTs == toCompareTs {
+			currentReturnNsn := toReturn.GetRouteNamespacedName()
+			toCompareNsn := r.GetRouteNamespacedName()
+			if currentReturnNsn.String() > toCompareNsn.String() {
+				toReturn = r
+			}
+		}
+	}
+	return new(toReturn)
 }

--- a/pkg/gateway/model/model_build_listener_test.go
+++ b/pkg/gateway/model/model_build_listener_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	"time"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	elbv2sdk "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
@@ -2202,15 +2203,14 @@ func Test_buildL4TargetGroupTuples(t *testing.T) {
 			},
 		},
 		{
-			name: "two routes - one rule / two backends each",
+			name: "two routes - take oldest route",
 			targetGroups: []*elbv2model.TargetGroup{
 				tgs[0],
 				tgs[1],
-				tgs[2],
-				tgs[3],
 			},
 			routes: []routeutils.RouteDescriptor{
 				&routeutils.MockRoute{
+					CreationTime: time.Unix(5000, 0),
 					Rules: []routeutils.RouteRule{
 						&routeutils.MockRule{
 							BackendRefs: []routeutils.Backend{
@@ -2225,14 +2225,15 @@ func Test_buildL4TargetGroupTuples(t *testing.T) {
 					},
 				},
 				&routeutils.MockRoute{
+					CreationTime: time.Unix(10000, 0),
 					Rules: []routeutils.RouteRule{
 						&routeutils.MockRule{
 							BackendRefs: []routeutils.Backend{
 								{
-									Weight: 2,
+									Weight: 3,
 								},
 								{
-									Weight: 1,
+									Weight: 4,
 								},
 							},
 						},
@@ -2246,29 +2247,27 @@ func Test_buildL4TargetGroupTuples(t *testing.T) {
 				},
 				{
 					arn:    "arn2",
-					weight: 1,
-				},
-				{
-					arn:    "arn3",
-					weight: 2,
-				},
-				{
-					arn:    "arn4",
 					weight: 1,
 				},
 			},
 		},
 		{
-			name: "two routes - one rule / one backend each",
+			name: "two routes - same age, use alphabetical order to resolve tie",
 			targetGroups: []*elbv2model.TargetGroup{
 				tgs[0],
 				tgs[1],
 			},
 			routes: []routeutils.RouteDescriptor{
 				&routeutils.MockRoute{
+					CreationTime: time.Unix(5000, 0),
+					Namespace:    "a",
+					Name:         "a",
 					Rules: []routeutils.RouteRule{
 						&routeutils.MockRule{
 							BackendRefs: []routeutils.Backend{
+								{
+									Weight: 1,
+								},
 								{
 									Weight: 1,
 								},
@@ -2277,11 +2276,17 @@ func Test_buildL4TargetGroupTuples(t *testing.T) {
 					},
 				},
 				&routeutils.MockRoute{
+					Namespace:    "b",
+					Name:         "a",
+					CreationTime: time.Unix(5000, 0),
 					Rules: []routeutils.RouteRule{
 						&routeutils.MockRule{
 							BackendRefs: []routeutils.Backend{
 								{
-									Weight: 2,
+									Weight: 3,
+								},
+								{
+									Weight: 4,
 								},
 							},
 						},
@@ -2295,7 +2300,60 @@ func Test_buildL4TargetGroupTuples(t *testing.T) {
 				},
 				{
 					arn:    "arn2",
-					weight: 2,
+					weight: 1,
+				},
+			},
+		},
+		{
+			name: "two routes - same age, use alphabetical order to resolve tie - do not use first route",
+			targetGroups: []*elbv2model.TargetGroup{
+				tgs[0],
+				tgs[1],
+			},
+			routes: []routeutils.RouteDescriptor{
+				&routeutils.MockRoute{
+					CreationTime: time.Unix(5000, 0),
+					Namespace:    "b",
+					Name:         "a",
+					Rules: []routeutils.RouteRule{
+						&routeutils.MockRule{
+							BackendRefs: []routeutils.Backend{
+								{
+									Weight: 1,
+								},
+								{
+									Weight: 1,
+								},
+							},
+						},
+					},
+				},
+				&routeutils.MockRoute{
+					Namespace:    "a",
+					Name:         "a",
+					CreationTime: time.Unix(5000, 0),
+					Rules: []routeutils.RouteRule{
+						&routeutils.MockRule{
+							BackendRefs: []routeutils.Backend{
+								{
+									Weight: 3,
+								},
+								{
+									Weight: 4,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []tgValidation{
+				{
+					arn:    "arn1",
+					weight: 3,
+				},
+				{
+					arn:    "arn2",
+					weight: 4,
 				},
 			},
 		},


### PR DESCRIPTION
### Description

Working towards v1 for UDP and TCP route:
https://github.com/kubernetes-sigs/gateway-api/pull/4878
https://github.com/kubernetes-sigs/gateway-api/pull/4879

Part of the spec is that only one route should be eligible for traffic [the oldest]. This PR enforces that change. It passes the new conformance tests added here:
https://github.com/kubernetes-sigs/gateway-api/pull/4884


### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
