### PR TITLE
[feat i2g] bug fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 *.dylib
 bin
 build
-lbc-migrate
+/lbc-migrate
 
 # mkdocs generated live docs
 site

--- a/cmd/lbc-migrate/main.go
+++ b/cmd/lbc-migrate/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/ingress2gateway"
@@ -51,10 +52,12 @@ Input can come from YAML/JSON files, a directory of manifest files, or a live Ku
 		"Read resources from a live Kubernetes cluster")
 
 	// Cluster flags
-	cmd.Flags().StringVar(&opts.Namespace, "namespace", "",
-		"Namespace to read from (only with --from-cluster)")
+	cmd.Flags().StringSliceVar(&opts.Namespaces, "namespaces", nil,
+		"Comma-separated namespaces to read from (e.g. --namespaces ns-a,ns-b; only with --from-cluster)")
 	cmd.Flags().BoolVar(&opts.AllNamespaces, "all-namespaces", false,
 		"Read from all namespaces (only with --from-cluster)")
+	cmd.Flags().StringVar(&opts.IngressName, "ingress-name", "",
+		"Name of a specific Ingress to migrate (requires exactly one --namespaces value; only with --from-cluster)")
 	cmd.Flags().StringVar(&opts.Kubeconfig, "kubeconfig", "",
 		"Path to kubeconfig file (only with --from-cluster, defaults to $KUBECONFIG or ~/.kube/config)")
 
@@ -91,20 +94,36 @@ func validateFlags(opts *ingress2gateway.MigrateOptions) error {
 
 	// Cluster-only flags
 	if !opts.FromCluster {
-		if opts.Namespace != "" {
-			return fmt.Errorf("--namespace can only be used with --from-cluster")
+		if len(opts.Namespaces) > 0 {
+			return fmt.Errorf("--namespaces can only be used with --from-cluster")
 		}
 		if opts.AllNamespaces {
 			return fmt.Errorf("--all-namespaces can only be used with --from-cluster")
+		}
+		if opts.IngressName != "" {
+			return fmt.Errorf("--ingress-name can only be used with --from-cluster")
 		}
 		if opts.Kubeconfig != "" {
 			return fmt.Errorf("--kubeconfig can only be used with --from-cluster")
 		}
 	}
 
-	// --namespace and --all-namespaces are mutually exclusive
-	if opts.Namespace != "" && opts.AllNamespaces {
-		return fmt.Errorf("--namespace and --all-namespaces are mutually exclusive")
+	// --namespaces and --all-namespaces are mutually exclusive
+	if len(opts.Namespaces) > 0 && opts.AllNamespaces {
+		return fmt.Errorf("--namespaces and --all-namespaces are mutually exclusive")
+	}
+
+	// --ingress-name requires exactly one namespace and conflicts with --all-namespaces
+	if opts.IngressName != "" {
+		if strings.Contains(opts.IngressName, ",") {
+			return fmt.Errorf("--ingress-name accepts a single Ingress name, got %q", opts.IngressName)
+		}
+		if opts.AllNamespaces {
+			return fmt.Errorf("--ingress-name and --all-namespaces are mutually exclusive")
+		}
+		if len(opts.Namespaces) != 1 {
+			return fmt.Errorf("--ingress-name requires exactly one --namespaces value")
+		}
 	}
 
 	// Validate output format

--- a/cmd/lbc-migrate/main_test.go
+++ b/cmd/lbc-migrate/main_test.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/ingress2gateway"
+)
+
+func TestValidateFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    *ingress2gateway.MigrateOptions
+		wantErr string
+	}{
+		{
+			name:    "no input mode specified",
+			opts:    &ingress2gateway.MigrateOptions{},
+			wantErr: "must specify at least one of",
+		},
+		{
+			name: "from-cluster with file is invalid",
+			opts: &ingress2gateway.MigrateOptions{
+				FromCluster: true,
+				Files:       []string{"foo.yaml"},
+			},
+			wantErr: "--from-cluster cannot be used with --file or --input-dir",
+		},
+		{
+			name: "from-cluster with input-dir is invalid",
+			opts: &ingress2gateway.MigrateOptions{
+				FromCluster: true,
+				InputDir:    "./manifests",
+			},
+			wantErr: "--from-cluster cannot be used with --file or --input-dir",
+		},
+		{
+			name: "namespaces without from-cluster is invalid",
+			opts: &ingress2gateway.MigrateOptions{
+				Files:      []string{"foo.yaml"},
+				Namespaces: []string{"ns"},
+			},
+			wantErr: "--namespaces can only be used with --from-cluster",
+		},
+		{
+			name: "all-namespaces without from-cluster is invalid",
+			opts: &ingress2gateway.MigrateOptions{
+				Files:         []string{"foo.yaml"},
+				AllNamespaces: true,
+			},
+			wantErr: "--all-namespaces can only be used with --from-cluster",
+		},
+		{
+			name: "ingress-name without from-cluster is invalid",
+			opts: &ingress2gateway.MigrateOptions{
+				Files:       []string{"foo.yaml"},
+				IngressName: "my-ing",
+			},
+			wantErr: "--ingress-name can only be used with --from-cluster",
+		},
+		{
+			name: "kubeconfig without from-cluster is invalid",
+			opts: &ingress2gateway.MigrateOptions{
+				Files:      []string{"foo.yaml"},
+				Kubeconfig: "/path/to/config",
+			},
+			wantErr: "--kubeconfig can only be used with --from-cluster",
+		},
+		{
+			name: "namespaces and all-namespaces are mutually exclusive",
+			opts: &ingress2gateway.MigrateOptions{
+				FromCluster:   true,
+				Namespaces:    []string{"ns"},
+				AllNamespaces: true,
+			},
+			wantErr: "--namespaces and --all-namespaces are mutually exclusive",
+		},
+		{
+			name: "ingress-name with comma is invalid",
+			opts: &ingress2gateway.MigrateOptions{
+				FromCluster: true,
+				Namespaces:  []string{"ns"},
+				IngressName: "foo,bar",
+			},
+			wantErr: "--ingress-name accepts a single Ingress name",
+		},
+		{
+			name: "ingress-name with all-namespaces is invalid",
+			opts: &ingress2gateway.MigrateOptions{
+				FromCluster:   true,
+				AllNamespaces: true,
+				IngressName:   "my-ing",
+			},
+			wantErr: "--ingress-name and --all-namespaces are mutually exclusive",
+		},
+		{
+			name: "ingress-name requires exactly one namespace",
+			opts: &ingress2gateway.MigrateOptions{
+				FromCluster: true,
+				Namespaces:  []string{"ns-a", "ns-b"},
+				IngressName: "my-ing",
+			},
+			wantErr: "--ingress-name requires exactly one --namespaces value",
+		},
+		{
+			name: "ingress-name without namespaces is invalid",
+			opts: &ingress2gateway.MigrateOptions{
+				FromCluster: true,
+				IngressName: "my-ing",
+			},
+			wantErr: "--ingress-name requires exactly one --namespaces value",
+		},
+		{
+			name: "invalid output format",
+			opts: &ingress2gateway.MigrateOptions{
+				FromCluster:   true,
+				OutputFormat:  "xml",
+				AllNamespaces: true,
+			},
+			wantErr: "--output-format must be yaml or json",
+		},
+		{
+			name: "invalid split mode",
+			opts: &ingress2gateway.MigrateOptions{
+				FromCluster:   true,
+				AllNamespaces: true,
+				OutputFormat:  "yaml",
+				Split:         "invalid",
+			},
+			wantErr: "--split must be",
+		},
+		{
+			name: "valid: from-cluster with all-namespaces",
+			opts: &ingress2gateway.MigrateOptions{
+				FromCluster:   true,
+				AllNamespaces: true,
+				OutputFormat:  "yaml",
+			},
+		},
+		{
+			name: "valid: from-cluster with single namespace",
+			opts: &ingress2gateway.MigrateOptions{
+				FromCluster:  true,
+				Namespaces:   []string{"production"},
+				OutputFormat: "yaml",
+			},
+		},
+		{
+			name: "valid: from-cluster with ingress-name",
+			opts: &ingress2gateway.MigrateOptions{
+				FromCluster:  true,
+				Namespaces:   []string{"production"},
+				IngressName:  "my-ing",
+				OutputFormat: "yaml",
+			},
+		},
+		{
+			name: "valid: file input",
+			opts: &ingress2gateway.MigrateOptions{
+				Files:        []string{"foo.yaml"},
+				OutputFormat: "yaml",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateFlags(tt.opts)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/docs/guide/gateway/migrate_from_ingress.md
+++ b/docs/guide/gateway/migrate_from_ingress.md
@@ -56,7 +56,8 @@ lbc-migrate --input-dir ./my-manifests/
 
 ```bash
 lbc-migrate --from-cluster --all-namespaces
-lbc-migrate --from-cluster --namespace production
+lbc-migrate --from-cluster --namespaces production
+lbc-migrate --from-cluster --namespaces production --ingress-name my-ingress
 ```
 
 You can combine `-f` and `--input-dir`, but `--from-cluster` cannot be used with file-based input.
@@ -68,8 +69,9 @@ You can combine `-f` and `--input-dir`, but `--from-cluster` cannot be used with
 | `-f, --file` | One of `-f`, `--input-dir`, or `--from-cluster` is required | Comma-separated input YAML/JSON file paths (e.g. `-f file1.yaml,file2.yaml`) | |
 | `--input-dir` | One of `-f`, `--input-dir`, or `--from-cluster` is required | Directory containing YAML/JSON files | |
 | `--from-cluster` | One of `-f`, `--input-dir`, or `--from-cluster` is required | Read resources from a live Kubernetes cluster | |
-| `--namespace` | Optional | Namespace to read from. Only valid with `--from-cluster`. Mutually exclusive with `--all-namespaces` | Current kubeconfig context namespace |
-| `--all-namespaces` | Optional | Read from all namespaces. Only valid with `--from-cluster`. Mutually exclusive with `--namespace` | |
+| `--namespaces` | Optional | Comma-separated namespaces to read from (e.g. `--namespaces ns-a,ns-b`). Only valid with `--from-cluster`. Mutually exclusive with `--all-namespaces` | |
+| `--all-namespaces` | Optional | Read from all namespaces. Only valid with `--from-cluster`. Mutually exclusive with `--namespaces` | |
+| `--ingress-name` | Optional | Name of a specific Ingress to migrate. Requires exactly one `--namespaces` value. Only valid with `--from-cluster`. Mutually exclusive with `--all-namespaces` | |
 | `--kubeconfig` | Optional | Path to kubeconfig file. Only valid with `--from-cluster` | `$KUBECONFIG` or `~/.kube/config` |
 | `--output-dir` | Optional | Directory to write output manifests | `./gateway-output` |
 | `--output-format` | Optional | Output format: `yaml` or `json` | `yaml` |
@@ -114,7 +116,7 @@ Apply everything recursively:
 kubectl apply -R -f ./gw/
 ```
 
-For cross-namespace IngressGroups (Ingresses in different namespaces sharing a `group.name`), the generated resources naturally split across namespace directories: the shared `Gateway` and `LoadBalancerConfiguration` land in the first member's namespace, while each member's `HTTPRoute` lands in its own namespace. No `ReferenceGrant` is required because HTTPRoutes only reference backends in their own namespace and the generated Gateway sets `allowedRoutes.namespaces.from: All`.
+For cross-namespace IngressGroups (Ingresses in different namespaces sharing a `group.name`), the generated resources naturally split across namespace directories: the shared `Gateway` and `LoadBalancerConfiguration` land in the primary member's namespace (determined by `group.order`, then lexical `namespace/name`), while each member's `HTTPRoute` lands in its own namespace. No `ReferenceGrant` is required because HTTPRoutes only reference backends in their own namespace and the generated Gateway sets `allowedRoutes.namespaces.from: All`.
 
 ### Default Backend Handling
 
@@ -128,7 +130,9 @@ LB-level annotations (scheme, subnets, security groups, tags, etc.) must be cons
 
 Each member's `listen-ports` are unioned to build the shared Gateway's listeners. Each member's HTTPRoutes are scoped to only the listeners that member declared via `sectionName` in `parentRefs`. When `ssl-redirect` is set on any member, it applies group-wide: all members' routes attach to the HTTPS listener only, and a single redirect HTTPRoute is generated for HTTP listeners.
 
-Cross-namespace groups (Ingresses in different namespaces with the same `group.name`) are supported. When detected, the migration tool generates the Gateway in the first member's namespace (based on input file order) and sets `allowedRoutes.namespaces.from: All` on each listener, which permits HTTPRoutes from any namespace to attach. You can move the Gateway to a different namespace after generation if needed.
+Cross-namespace groups (Ingresses in different namespaces with the same `group.name`) are supported. When detected, the migration tool generates the Gateway in the primary member's namespace (determined by `group.order` annotation, then lexical `namespace/name` — matching LBC's runtime behavior) and sets `allowedRoutes.namespaces.from: All` on each listener, which permits HTTPRoutes from any namespace to attach. You can move the Gateway to a different namespace after generation if needed.
+
+For cross-namespace groups, use `--namespaces ns-a,ns-b` (listing all namespaces the group spans) or `--all-namespaces` to ensure all members are included. Using a single `--namespaces` that omits some members will produce incomplete output without warning.
 
 !!! warning "Security consideration"
     `From: All` allows HTTPRoutes from any namespace to attach to the Gateway. If you need tighter scoping, you can manually change `From: All` to `From: Selector` with a label selector after generation.
@@ -208,7 +212,17 @@ lbc-migrate --from-cluster --all-namespaces --output-dir ./gateway-output/
 
 ### From a live cluster (specific namespace)
 ```bash
-lbc-migrate --from-cluster --namespace production --output-dir ./gateway-output/
+lbc-migrate --from-cluster --namespaces production --output-dir ./gateway-output/
+```
+
+### From a live cluster (multiple namespaces)
+```bash
+lbc-migrate --from-cluster --namespaces team-a,team-b --output-dir ./gateway-output/
+```
+
+### From a live cluster (single Ingress)
+```bash
+lbc-migrate --from-cluster --namespaces production --ingress-name my-api --output-dir ./gateway-output/
 ```
 
 ## Missing Resource Warnings
@@ -256,7 +270,7 @@ the generated Gateway manifests:
 ```bash
 lbc-migrate -f ingress.yaml --output-dir ./gw/ --dry-run
 # or from a live cluster
-lbc-migrate --from-cluster --namespace production --output-dir ./gw/ --dry-run
+lbc-migrate --from-cluster --namespaces production --output-dir ./gw/ --dry-run
 ```
 
 Alternatively, add the `gateway.k8s.aws/dry-run: "true"` annotation manually to any Gateway

--- a/pkg/ingress2gateway/reader/cluster_reader.go
+++ b/pkg/ingress2gateway/reader/cluster_reader.go
@@ -55,36 +55,14 @@ func readFromClient(ctx context.Context, k8sClient client.Client, clientSet kube
 		namespaces = nil
 	}
 
-	// When targeting a specific Ingress, fetch it directly instead of listing
 	if opts.IngressName != "" {
 		if len(namespaces) != 1 {
 			return nil, fmt.Errorf("IngressName requires exactly one namespace, got %d", len(namespaces))
 		}
-		ns := namespaces[0]
-		var ing networking.Ingress
-		if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: opts.IngressName}, &ing); err != nil {
-			return nil, fmt.Errorf("failed to get Ingress %s/%s: %w", ns, opts.IngressName, err)
-		}
-		resources.Ingresses = []networking.Ingress{ing}
+	}
 
-		// Still list Services in the namespace for backend resolution
-		serviceList := &corev1.ServiceList{}
-		if err := k8sClient.List(ctx, serviceList, client.InNamespace(ns)); err != nil {
-			return nil, fmt.Errorf("failed to list Services in namespace %q: %w", ns, err)
-		}
-		resources.Services = serviceList.Items
-	} else if len(namespaces) == 0 {
-		// All-namespaces: single list call with no namespace filter
-		if err := listNamespacedResources(ctx, k8sClient, resources, ""); err != nil {
-			return nil, err
-		}
-	} else {
-		// Per-namespace list calls
-		for _, ns := range namespaces {
-			if err := listNamespacedResources(ctx, k8sClient, resources, ns); err != nil {
-				return nil, err
-			}
-		}
+	if err := listNamespacedResources(ctx, k8sClient, resources, namespaces, opts.IngressName); err != nil {
+		return nil, err
 	}
 
 	// Read IngressClasses (cluster-scoped, no namespace filter)
@@ -109,25 +87,50 @@ func readFromClient(ctx context.Context, k8sClient client.Client, clientSet kube
 	return resources, nil
 }
 
-// listNamespacedResources lists Ingresses and Services for a single namespace
-// (or all namespaces if ns is empty) and appends them to resources.
-func listNamespacedResources(ctx context.Context, k8sClient client.Client, resources *ingress2gateway.InputResources, ns string) error {
-	listOpts := []client.ListOption{}
-	if ns != "" {
-		listOpts = append(listOpts, client.InNamespace(ns))
+// listNamespacedResources reads Ingresses and Services into resources.
+//   - If ingressName is set, it fetches that single Ingress by name from namespaces[0].
+//   - If namespaces is empty, it lists across all namespaces.
+//   - Otherwise, it issues per-namespace list calls.
+//
+// Services are always listed per namespace since backends may reference any Service
+// in the same namespace as the Ingress.
+func listNamespacedResources(ctx context.Context, k8sClient client.Client, resources *ingress2gateway.InputResources, namespaces []string, ingressName string) error {
+	queryNamespaces := namespaces
+	if len(queryNamespaces) == 0 {
+		queryNamespaces = []string{""}
 	}
 
-	ingressList := &networking.IngressList{}
-	if err := k8sClient.List(ctx, ingressList, listOpts...); err != nil {
-		return fmt.Errorf("failed to list Ingresses in namespace %q: %w", ns, err)
+	if ingressName != "" {
+		var ing networking.Ingress
+		if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: queryNamespaces[0], Name: ingressName}, &ing); err != nil {
+			return fmt.Errorf("failed to get Ingress %s/%s: %w", queryNamespaces[0], ingressName, err)
+		}
+		resources.Ingresses = []networking.Ingress{ing}
+	} else {
+		for _, ns := range queryNamespaces {
+			var listOpts []client.ListOption
+			if ns != "" {
+				listOpts = append(listOpts, client.InNamespace(ns))
+			}
+			ingressList := &networking.IngressList{}
+			if err := k8sClient.List(ctx, ingressList, listOpts...); err != nil {
+				return fmt.Errorf("failed to list Ingresses in namespace %q: %w", ns, err)
+			}
+			resources.Ingresses = append(resources.Ingresses, ingressList.Items...)
+		}
 	}
-	resources.Ingresses = append(resources.Ingresses, ingressList.Items...)
 
-	serviceList := &corev1.ServiceList{}
-	if err := k8sClient.List(ctx, serviceList, listOpts...); err != nil {
-		return fmt.Errorf("failed to list Services in namespace %q: %w", ns, err)
+	for _, ns := range queryNamespaces {
+		var listOpts []client.ListOption
+		if ns != "" {
+			listOpts = append(listOpts, client.InNamespace(ns))
+		}
+		serviceList := &corev1.ServiceList{}
+		if err := k8sClient.List(ctx, serviceList, listOpts...); err != nil {
+			return fmt.Errorf("failed to list Services in namespace %q: %w", ns, err)
+		}
+		resources.Services = append(resources.Services, serviceList.Items...)
 	}
-	resources.Services = append(resources.Services, serviceList.Items...)
 
 	return nil
 }

--- a/pkg/ingress2gateway/reader/cluster_reader.go
+++ b/pkg/ingress2gateway/reader/cluster_reader.go
@@ -6,6 +6,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -19,8 +20,9 @@ import (
 // ClusterReaderOptions holds options for reading from a live cluster.
 type ClusterReaderOptions struct {
 	Kubeconfig    string
-	Namespace     string
+	Namespaces    []string
 	AllNamespaces bool
+	IngressName   string
 }
 
 // ReadFromCluster reads Ingress, Service, IngressClass, and IngressClassParams
@@ -48,29 +50,42 @@ func ReadFromCluster(ctx context.Context, opts ClusterReaderOptions) (*ingress2g
 func readFromClient(ctx context.Context, k8sClient client.Client, clientSet kubernetes.Interface, opts ClusterReaderOptions) (*ingress2gateway.InputResources, error) {
 	resources := &ingress2gateway.InputResources{}
 
-	namespace := opts.Namespace
+	namespaces := opts.Namespaces
 	if opts.AllNamespaces {
-		namespace = ""
+		namespaces = nil
 	}
 
-	listOpts := []client.ListOption{}
-	if namespace != "" {
-		listOpts = append(listOpts, client.InNamespace(namespace))
-	}
+	// When targeting a specific Ingress, fetch it directly instead of listing
+	if opts.IngressName != "" {
+		if len(namespaces) != 1 {
+			return nil, fmt.Errorf("IngressName requires exactly one namespace, got %d", len(namespaces))
+		}
+		ns := namespaces[0]
+		var ing networking.Ingress
+		if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: opts.IngressName}, &ing); err != nil {
+			return nil, fmt.Errorf("failed to get Ingress %s/%s: %w", ns, opts.IngressName, err)
+		}
+		resources.Ingresses = []networking.Ingress{ing}
 
-	// Read Ingresses
-	ingressList := &networking.IngressList{}
-	if err := k8sClient.List(ctx, ingressList, listOpts...); err != nil {
-		return nil, fmt.Errorf("failed to list Ingresses: %w", err)
+		// Still list Services in the namespace for backend resolution
+		serviceList := &corev1.ServiceList{}
+		if err := k8sClient.List(ctx, serviceList, client.InNamespace(ns)); err != nil {
+			return nil, fmt.Errorf("failed to list Services in namespace %q: %w", ns, err)
+		}
+		resources.Services = serviceList.Items
+	} else if len(namespaces) == 0 {
+		// All-namespaces: single list call with no namespace filter
+		if err := listNamespacedResources(ctx, k8sClient, resources, ""); err != nil {
+			return nil, err
+		}
+	} else {
+		// Per-namespace list calls
+		for _, ns := range namespaces {
+			if err := listNamespacedResources(ctx, k8sClient, resources, ns); err != nil {
+				return nil, err
+			}
+		}
 	}
-	resources.Ingresses = ingressList.Items
-
-	// Read Services
-	serviceList := &corev1.ServiceList{}
-	if err := k8sClient.List(ctx, serviceList, listOpts...); err != nil {
-		return nil, fmt.Errorf("failed to list Services: %w", err)
-	}
-	resources.Services = serviceList.Items
 
 	// Read IngressClasses (cluster-scoped, no namespace filter)
 	ingressClassList := &networking.IngressClassList{}
@@ -92,6 +107,29 @@ func readFromClient(ctx context.Context, k8sClient client.Client, clientSet kube
 	}
 
 	return resources, nil
+}
+
+// listNamespacedResources lists Ingresses and Services for a single namespace
+// (or all namespaces if ns is empty) and appends them to resources.
+func listNamespacedResources(ctx context.Context, k8sClient client.Client, resources *ingress2gateway.InputResources, ns string) error {
+	listOpts := []client.ListOption{}
+	if ns != "" {
+		listOpts = append(listOpts, client.InNamespace(ns))
+	}
+
+	ingressList := &networking.IngressList{}
+	if err := k8sClient.List(ctx, ingressList, listOpts...); err != nil {
+		return fmt.Errorf("failed to list Ingresses in namespace %q: %w", ns, err)
+	}
+	resources.Ingresses = append(resources.Ingresses, ingressList.Items...)
+
+	serviceList := &corev1.ServiceList{}
+	if err := k8sClient.List(ctx, serviceList, listOpts...); err != nil {
+		return fmt.Errorf("failed to list Services in namespace %q: %w", ns, err)
+	}
+	resources.Services = append(resources.Services, serviceList.Items...)
+
+	return nil
 }
 
 // buildRestConfig builds a rest.Config from the given kubeconfig path.

--- a/pkg/ingress2gateway/reader/cluster_reader_test.go
+++ b/pkg/ingress2gateway/reader/cluster_reader_test.go
@@ -9,16 +9,28 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func TestReadFromClient_AllNamespaces(t *testing.T) {
-	ing := &networking.Ingress{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-ing", Namespace: "default"},
-		Spec:       networking.IngressSpec{},
+func TestReadFromClient(t *testing.T) {
+	ingDefault := &networking.Ingress{
+		ObjectMeta: metav1.ObjectMeta{Name: "ing-default", Namespace: "default"},
 	}
-	svc := &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-svc", Namespace: "default"},
+	ingProd := &networking.Ingress{
+		ObjectMeta: metav1.ObjectMeta{Name: "ing-prod", Namespace: "production"},
+	}
+	ingStaging := &networking.Ingress{
+		ObjectMeta: metav1.ObjectMeta{Name: "ing-staging", Namespace: "staging"},
+	}
+	svcDefault := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc-default", Namespace: "default"},
+	}
+	svcProd := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc-prod", Namespace: "production"},
+	}
+	svcStaging := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc-staging", Namespace: "staging"},
 	}
 	ic := &networking.IngressClass{
 		ObjectMeta: metav1.ObjectMeta{Name: "alb"},
@@ -27,59 +39,122 @@ func TestReadFromClient_AllNamespaces(t *testing.T) {
 		},
 	}
 
-	k8sClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(ing, svc, ic).
-		Build()
+	allObjects := []runtime.Object{ingDefault, ingProd, ingStaging, svcDefault, svcProd, svcStaging, ic}
 
-	resources, err := readFromClient(context.Background(), k8sClient, nil, ClusterReaderOptions{
-		AllNamespaces: true,
-	})
-	require.NoError(t, err)
-
-	assert.Len(t, resources.Ingresses, 1)
-	assert.Equal(t, "test-ing", resources.Ingresses[0].Name)
-
-	assert.Len(t, resources.Services, 1)
-	assert.Equal(t, "test-svc", resources.Services[0].Name)
-
-	assert.Len(t, resources.IngressClasses, 1)
-	assert.Equal(t, "alb", resources.IngressClasses[0].Name)
-}
-
-func TestReadFromClient_NamespaceFilter(t *testing.T) {
-	ingDefault := &networking.Ingress{
-		ObjectMeta: metav1.ObjectMeta{Name: "ing-default", Namespace: "default"},
+	tests := []struct {
+		name             string
+		objects          []runtime.Object
+		opts             ClusterReaderOptions
+		wantIngresses    []string
+		wantServices     []string
+		wantIngressClass []string
+		wantErr          string
+	}{
+		{
+			name:             "all namespaces",
+			objects:          allObjects,
+			opts:             ClusterReaderOptions{AllNamespaces: true},
+			wantIngresses:    []string{"ing-default", "ing-prod", "ing-staging"},
+			wantServices:     []string{"svc-default", "svc-prod", "svc-staging"},
+			wantIngressClass: []string{"alb"},
+		},
+		{
+			name:          "single namespace",
+			objects:       allObjects,
+			opts:          ClusterReaderOptions{Namespaces: []string{"production"}},
+			wantIngresses: []string{"ing-prod"},
+			wantServices:  []string{"svc-prod"},
+		},
+		{
+			name:          "multiple namespaces",
+			objects:       allObjects,
+			opts:          ClusterReaderOptions{Namespaces: []string{"production", "staging"}},
+			wantIngresses: []string{"ing-prod", "ing-staging"},
+			wantServices:  []string{"svc-prod", "svc-staging"},
+		},
+		{
+			name:          "ingress-name fetches specific ingress and namespace services",
+			objects:       allObjects,
+			opts:          ClusterReaderOptions{Namespaces: []string{"production"}, IngressName: "ing-prod"},
+			wantIngresses: []string{"ing-prod"},
+			wantServices:  []string{"svc-prod"},
+		},
+		{
+			name:    "ingress-name not found errors",
+			objects: allObjects,
+			opts:    ClusterReaderOptions{Namespaces: []string{"production"}, IngressName: "nonexistent"},
+			wantErr: "failed to get Ingress production/nonexistent",
+		},
+		{
+			name:    "ingress-name with no namespaces errors",
+			objects: allObjects,
+			opts:    ClusterReaderOptions{IngressName: "ing-prod"},
+			wantErr: "IngressName requires exactly one namespace, got 0",
+		},
+		{
+			name:    "ingress-name with multiple namespaces errors",
+			objects: allObjects,
+			opts:    ClusterReaderOptions{Namespaces: []string{"production", "staging"}, IngressName: "ing-prod"},
+			wantErr: "IngressName requires exactly one namespace, got 2",
+		},
+		{
+			name:          "given ingress-name and namespace do not return services from other namespaces",
+			objects:       allObjects,
+			opts:          ClusterReaderOptions{Namespaces: []string{"production"}, IngressName: "ing-prod"},
+			wantIngresses: []string{"ing-prod"},
+			wantServices:  []string{"svc-prod"},
+		},
+		{
+			name:          "empty cluster returns empty results",
+			objects:       nil,
+			opts:          ClusterReaderOptions{AllNamespaces: true},
+			wantIngresses: nil,
+			wantServices:  nil,
+		},
+		{
+			name:             "ingressclass always returned regardless of namespace filter",
+			objects:          allObjects,
+			opts:             ClusterReaderOptions{Namespaces: []string{"production"}},
+			wantIngresses:    []string{"ing-prod"},
+			wantServices:     []string{"svc-prod"},
+			wantIngressClass: []string{"alb"},
+		},
 	}
-	ingProd := &networking.Ingress{
-		ObjectMeta: metav1.ObjectMeta{Name: "ing-prod", Namespace: "production"},
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := fake.NewClientBuilder().WithScheme(scheme)
+			for _, obj := range tt.objects {
+				builder = builder.WithRuntimeObjects(obj)
+			}
+			k8sClient := builder.Build()
+
+			resources, err := readFromClient(context.Background(), k8sClient, nil, tt.opts)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+
+			var gotIngresses []string
+			for _, ing := range resources.Ingresses {
+				gotIngresses = append(gotIngresses, ing.Name)
+			}
+			var gotServices []string
+			for _, svc := range resources.Services {
+				gotServices = append(gotServices, svc.Name)
+			}
+			var gotIngressClasses []string
+			for _, ic := range resources.IngressClasses {
+				gotIngressClasses = append(gotIngressClasses, ic.Name)
+			}
+
+			assert.ElementsMatch(t, tt.wantIngresses, gotIngresses, "ingresses")
+			assert.ElementsMatch(t, tt.wantServices, gotServices, "services")
+			if tt.wantIngressClass != nil {
+				assert.ElementsMatch(t, tt.wantIngressClass, gotIngressClasses, "ingressclasses")
+			}
+		})
 	}
-
-	k8sClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(ingDefault, ingProd).
-		Build()
-
-	resources, err := readFromClient(context.Background(), k8sClient, nil, ClusterReaderOptions{
-		Namespace: "production",
-	})
-	require.NoError(t, err)
-
-	assert.Len(t, resources.Ingresses, 1)
-	assert.Equal(t, "ing-prod", resources.Ingresses[0].Name)
-}
-
-func TestReadFromClient_EmptyCluster(t *testing.T) {
-	k8sClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		Build()
-
-	resources, err := readFromClient(context.Background(), k8sClient, nil, ClusterReaderOptions{
-		AllNamespaces: true,
-	})
-	require.NoError(t, err)
-
-	assert.Len(t, resources.Ingresses, 0)
-	assert.Len(t, resources.Services, 0)
-	assert.Len(t, resources.IngressClasses, 0)
 }

--- a/pkg/ingress2gateway/reader/reader.go
+++ b/pkg/ingress2gateway/reader/reader.go
@@ -13,8 +13,9 @@ func Read(ctx context.Context, opts ingress2gateway.MigrateOptions) (*ingress2ga
 	if opts.FromCluster {
 		return ReadFromCluster(ctx, ClusterReaderOptions{
 			Kubeconfig:    opts.Kubeconfig,
-			Namespace:     opts.Namespace,
+			Namespaces:    opts.Namespaces,
 			AllNamespaces: opts.AllNamespaces,
+			IngressName:   opts.IngressName,
 		})
 	}
 

--- a/pkg/ingress2gateway/translate/group.go
+++ b/pkg/ingress2gateway/translate/group.go
@@ -345,34 +345,13 @@ func resolveGroupSSLRedirect(members []networking.Ingress, icpByClass map[string
 	return result, nil
 }
 
-// listenPortsEqual returns true if two port slices contain the same entries (order-independent).
-func listenPortsEqual(a, b []listenPortEntry) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	set := make(map[listenPortEntry]struct{}, len(a))
-	for _, p := range a {
-		set[listenPortEntry{Protocol: p.Protocol, Port: p.Port}] = struct{}{}
-	}
-	for _, p := range b {
-		if _, ok := set[listenPortEntry{Protocol: p.Protocol, Port: p.Port}]; !ok {
-			return false
-		}
-	}
-	return true
-}
-
 // buildMemberParentRefs builds parentRefs for a member's HTTPRoutes.
 // - 1. sslRedirectPort set: scope to HTTPS listener only.
-// - 2. memberPorts == allPorts: no sectionName (attach to all listeners).
-// - 3. Otherwise: one parentRef per memberPort with sectionName.
-func buildMemberParentRefs(gatewayName, gatewayNamespace, memberNamespace string, memberPorts, allPorts []listenPortEntry, sslRedirectPort *int32) []gwv1.ParentReference {
+// - 2. Otherwise: one parentRef per memberPort with explicit sectionName.
+func buildMemberParentRefs(gatewayName, gatewayNamespace, memberNamespace string, memberPorts []listenPortEntry, sslRedirectPort *int32) []gwv1.ParentReference {
 	if sslRedirectPort != nil {
 		sn := utils.GenerateSectionName(utils.ProtocolHTTPS, *sslRedirectPort)
 		return []gwv1.ParentReference{buildParentRef(gatewayName, gatewayNamespace, memberNamespace, &sn)}
-	}
-	if listenPortsEqual(memberPorts, allPorts) {
-		return []gwv1.ParentReference{buildParentRef(gatewayName, gatewayNamespace, memberNamespace, nil)}
 	}
 	refs := make([]gwv1.ParentReference, 0, len(memberPorts))
 	for _, listenerPortEntry := range memberPorts {

--- a/pkg/ingress2gateway/translate/group.go
+++ b/pkg/ingress2gateway/translate/group.go
@@ -50,6 +50,7 @@ func partitionByGroup(ingresses []networking.Ingress) []ingressGroup {
 
 	for _, name := range slices.Sorted(maps.Keys(explicit)) {
 		members := explicit[name]
+		sortMembers(members)
 		crossNS := isCrossNamespace(members)
 		groups = append(groups, ingressGroup{
 			name:           name,
@@ -69,6 +70,28 @@ func partitionByGroup(ingresses []networking.Ingress) []ingressGroup {
 	}
 
 	return groups
+}
+
+// sortMembers sorts group members by group.order annotation (ascending, default 0),
+// then by namespace/name lexicographically. This matches LBC's runtime ordering and
+// ensures deterministic Gateway namespace placement via members[0].
+func sortMembers(members []networking.Ingress) {
+	sort.SliceStable(members, func(i, j int) bool {
+		orderI := int32(0)
+		if v := getInt32(members[i].Annotations, annotations.IngressSuffixGroupOrder); v != nil {
+			orderI = *v
+		}
+		orderJ := int32(0)
+		if v := getInt32(members[j].Annotations, annotations.IngressSuffixGroupOrder); v != nil {
+			orderJ = *v
+		}
+		if orderI != orderJ {
+			return orderI < orderJ
+		}
+		nameI := k8s.NamespacedName(&members[i]).String()
+		nameJ := k8s.NamespacedName(&members[j]).String()
+		return nameI < nameJ
+	})
 }
 
 // isCrossNamespace returns true if ingresses span multiple namespaces.

--- a/pkg/ingress2gateway/translate/group_test.go
+++ b/pkg/ingress2gateway/translate/group_test.go
@@ -73,6 +73,114 @@ func TestPartitionByGroup(t *testing.T) {
 	}
 }
 
+func TestSortMembers(t *testing.T) {
+	tests := []struct {
+		name      string
+		members   []networking.Ingress
+		wantOrder []string // expected namespace/name order after sort
+	}{
+		{
+			name: "sort by group.order ascending",
+			members: []networking.Ingress{
+				{ObjectMeta: metav1.ObjectMeta{Name: "high", Namespace: "ns", Annotations: map[string]string{"alb.ingress.kubernetes.io/group.order": "10"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "low", Namespace: "ns", Annotations: map[string]string{"alb.ingress.kubernetes.io/group.order": "1"}}},
+			},
+			wantOrder: []string{"ns/low", "ns/high"},
+		},
+		{
+			name: "same group.order tie-breaks by namespace/name",
+			members: []networking.Ingress{
+				{ObjectMeta: metav1.ObjectMeta{Name: "z-ingress", Namespace: "ns"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "a-ingress", Namespace: "ns"}},
+			},
+			wantOrder: []string{"ns/a-ingress", "ns/z-ingress"},
+		},
+		{
+			name: "same group.order tie-breaks by namespace first",
+			members: []networking.Ingress{
+				{ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "team-b"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "team-a"}},
+			},
+			wantOrder: []string{"team-a/app", "team-b/app"},
+		},
+		{
+			name: "mixed: group.order wins over lexical name",
+			members: []networking.Ingress{
+				{ObjectMeta: metav1.ObjectMeta{Name: "aaa", Namespace: "ns", Annotations: map[string]string{"alb.ingress.kubernetes.io/group.order": "100"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "zzz", Namespace: "ns", Annotations: map[string]string{"alb.ingress.kubernetes.io/group.order": "1"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "mmm", Namespace: "ns"}},
+			},
+			wantOrder: []string{"ns/mmm", "ns/zzz", "ns/aaa"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sortMembers(tt.members)
+			var got []string
+			for _, m := range tt.members {
+				got = append(got, m.Namespace+"/"+m.Name)
+			}
+			assert.Equal(t, tt.wantOrder, got)
+		})
+	}
+}
+
+func TestPartitionByGroupDeterministicNamespace(t *testing.T) {
+	tests := []struct {
+		name          string
+		ingresses     []networking.Ingress
+		wantNamespace string // expected Gateway namespace (from sorted members[0])
+	}{
+		{
+			name: "cross-namespace group picks lowest order member namespace",
+			ingresses: []networking.Ingress{
+				{ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "team-b", Annotations: map[string]string{
+					"alb.ingress.kubernetes.io/group.name":  "shared",
+					"alb.ingress.kubernetes.io/group.order": "10",
+				}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "team-a", Annotations: map[string]string{
+					"alb.ingress.kubernetes.io/group.name":  "shared",
+					"alb.ingress.kubernetes.io/group.order": "1",
+				}}},
+			},
+			wantNamespace: "team-a",
+		},
+		{
+			name: "reverse input order produces same result",
+			ingresses: []networking.Ingress{
+				{ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "team-a", Annotations: map[string]string{
+					"alb.ingress.kubernetes.io/group.name":  "shared",
+					"alb.ingress.kubernetes.io/group.order": "1",
+				}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "team-b", Annotations: map[string]string{
+					"alb.ingress.kubernetes.io/group.name":  "shared",
+					"alb.ingress.kubernetes.io/group.order": "10",
+				}}},
+			},
+			wantNamespace: "team-a",
+		},
+		{
+			name: "same group.order falls back to lexical namespace/name",
+			ingresses: []networking.Ingress{
+				{ObjectMeta: metav1.ObjectMeta{Name: "ing", Namespace: "zulu", Annotations: map[string]string{
+					"alb.ingress.kubernetes.io/group.name": "shared",
+				}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "ing", Namespace: "alpha", Annotations: map[string]string{
+					"alb.ingress.kubernetes.io/group.name": "shared",
+				}}},
+			},
+			wantNamespace: "alpha",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			groups := partitionByGroup(tt.ingresses)
+			require.Len(t, groups, 1)
+			assert.Equal(t, tt.wantNamespace, groups[0].namespace)
+		})
+	}
+}
+
 func TestMergeGroupLBAnnotations(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/ingress2gateway/translate/group_test.go
+++ b/pkg/ingress2gateway/translate/group_test.go
@@ -509,58 +509,53 @@ func TestResolveGroupSSLRedirect(t *testing.T) {
 
 func TestBuildMemberParentRefs(t *testing.T) {
 	tests := []struct {
-		name            string
-		memberPorts     []listenPortEntry
-		allPorts        []listenPortEntry
-		sslRedirectPort *int32
-		memberNS        string
-		gatewayNS       string
-		wantCount       int
-		wantSectionName *string
-		wantNamespace   bool
+		name             string
+		memberPorts      []listenPortEntry
+		sslRedirectPort  *int32
+		memberNS         string
+		gatewayNS        string
+		wantCount        int
+		wantSectionNames []string
+		wantNamespace    bool
 	}{
 		{
-			name:        "same ports no sectionName",
+			name:        "single port gets explicit sectionName",
 			memberPorts: []listenPortEntry{{Protocol: "HTTP", Port: 80}},
-			allPorts:    []listenPortEntry{{Protocol: "HTTP", Port: 80}},
 			memberNS:    "ns", gatewayNS: "ns",
-			wantCount: 1,
+			wantCount:        1,
+			wantSectionNames: []string{"http-80"},
 		},
 		{
-			name:        "different ports get sectionName",
-			memberPorts: []listenPortEntry{{Protocol: "HTTP", Port: 80}},
-			allPorts:    []listenPortEntry{{Protocol: "HTTP", Port: 80}, {Protocol: "HTTPS", Port: 443}},
+			name:        "multiple member ports each get sectionName",
+			memberPorts: []listenPortEntry{{Protocol: "HTTP", Port: 80}, {Protocol: "HTTPS", Port: 443}},
 			memberNS:    "ns", gatewayNS: "ns",
-			wantCount:       1,
-			wantSectionName: ptr.To("http-80"),
+			wantCount:        2,
+			wantSectionNames: []string{"http-80", "https-443"},
 		},
 		{
-			name:            "ssl-redirect scopes to HTTPS",
+			name:            "ssl-redirect scopes to HTTPS only",
 			memberPorts:     []listenPortEntry{{Protocol: "HTTP", Port: 80}, {Protocol: "HTTPS", Port: 443}},
-			allPorts:        []listenPortEntry{{Protocol: "HTTP", Port: 80}, {Protocol: "HTTPS", Port: 443}},
 			sslRedirectPort: ptr.To(int32(443)),
 			memberNS:        "ns", gatewayNS: "ns",
-			wantCount:       1,
-			wantSectionName: ptr.To("https-443"),
+			wantCount:        1,
+			wantSectionNames: []string{"https-443"},
 		},
 		{
 			name:        "cross-namespace adds namespace",
 			memberPorts: []listenPortEntry{{Protocol: "HTTP", Port: 80}},
-			allPorts:    []listenPortEntry{{Protocol: "HTTP", Port: 80}},
 			memberNS:    "team-b", gatewayNS: "team-a",
-			wantCount:     1,
-			wantNamespace: true,
+			wantCount:        1,
+			wantSectionNames: []string{"http-80"},
+			wantNamespace:    true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			refs := buildMemberParentRefs("gw", tt.gatewayNS, tt.memberNS, tt.memberPorts, tt.allPorts, tt.sslRedirectPort)
+			refs := buildMemberParentRefs("gw", tt.gatewayNS, tt.memberNS, tt.memberPorts, tt.sslRedirectPort)
 			assert.Len(t, refs, tt.wantCount)
-			if tt.wantSectionName != nil {
-				require.NotNil(t, refs[0].SectionName)
-				assert.Equal(t, gwv1.SectionName(*tt.wantSectionName), *refs[0].SectionName)
-			} else if tt.sslRedirectPort == nil && len(tt.memberPorts) == len(tt.allPorts) {
-				assert.Nil(t, refs[0].SectionName)
+			for i, wantSN := range tt.wantSectionNames {
+				require.NotNil(t, refs[i].SectionName, "parentRef[%d] should have sectionName", i)
+				assert.Equal(t, gwv1.SectionName(wantSN), *refs[i].SectionName)
 			}
 			if tt.wantNamespace {
 				require.NotNil(t, refs[0].Namespace)

--- a/pkg/ingress2gateway/translate/translate.go
+++ b/pkg/ingress2gateway/translate/translate.go
@@ -136,7 +136,7 @@ func Translate(in *ingress2gateway.InputResources) (*ingress2gateway.OutputResou
 		// --- Per-member: HTTPRoutes, LRConfigs, TGC entry accumulation ---
 		for _, ing := range group.members {
 			memberPorts := perMemberPorts[k8s.NamespacedName(&ing).String()]
-			parentRefs := buildMemberParentRefs(gatewayName, group.namespace, ing.Namespace, memberPorts, allPorts, sslRedirectPort)
+			parentRefs := buildMemberParentRefs(gatewayName, group.namespace, ing.Namespace, memberPorts, sslRedirectPort)
 
 			// Resolve effective annotations for this member (used for tags and TG config)
 			effectiveAnnotations := resolveAnnotations(ing)

--- a/pkg/ingress2gateway/types.go
+++ b/pkg/ingress2gateway/types.go
@@ -44,9 +44,10 @@ type MigrateOptions struct {
 	FromCluster bool
 
 	// Cluster options
-	Namespace     string
+	Namespaces    []string
 	AllNamespaces bool
 	Kubeconfig    string
+	IngressName   string
 
 	// Output options
 	OutputDir    string


### PR DESCRIPTION
### Description
  **1. Deterministic group member ordering**
  Sort explicit group members by `group.order` then `namespace/name` before using `members[0]`, matching LBC's runtime `sortGroupMembers` logic.
  **2. `--namespaces` and `--ingress-name` flags**
  - Renamed `--namespace` to `--namespaces` (string slice) for multi-namespace scoping (e.g. `--namespaces team-a,team-b`).
  - Added `--ingress-name` to migrate a single Ingress via direct `Get` call. Requires exactly one `--namespaces` value.
  - see documentation
  **3. Always give explicit `sectionName` in parentRefs**
  ParentRefs now always include explicit `sectionName` per port instead of omitting it when member ports match all Gateway ports. Safer against unintended attachment to future listeners.

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
