### PR TITLE
Omit redundant catch-all path-pattern on ALB listener rules

### DIFF
--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -646,6 +646,8 @@ Traffic Routing can be controlled with following annotations:
          - By default, additional `path-pattern` conditions **must** use `values`.
         
             This is because the AWS Load Balancer Controller automatically adds `path-pattern` conditions using `values` according to your [Ingress specification](../spec/).
+
+            When an Ingress rule specifies a catch-all path (for example, `path: /` with `pathType: Prefix`), the controller omits the redundant `/*` `path-pattern` condition when other rule conditions are present, freeing a match evaluation for additional conditions (such as more `source-ip` CIDRs via [`alb.ingress.kubernetes.io/conditions.${conditions-name}`](#conditions)).
             
             To configure additional `path-pattern` conditions using `regexValues`, configure the [`alb.ingress.kubernetes.io/use-regex-path-match`](#use-regex-path-match) annotation. When this annotation is set to `"true"`, the AWS Load Balancer Controller can add `path-pattern` conditions with `regexValues`.
         

--- a/pkg/ingress/model_build_listener_rules.go
+++ b/pkg/ingress/model_build_listener_rules.go
@@ -214,7 +214,7 @@ func (t *defaultModelBuildTask) buildRuleConditions(ctx context.Context, ing Cla
 	if len(hostRegexValues) != 0 {
 		conditions = append(conditions, t.buildHostHeaderRegexValuesCondition(ctx, hostRegexValues))
 	}
-	if len(pathValues) != 0 {
+	if len(pathValues) != 0 && !isCatchAllPathPattern(pathValues, pathRegexValues) {
 		conditions = append(conditions, t.buildPathValuesCondition(ctx, pathValues))
 	}
 	if len(pathRegexValues) != 0 {
@@ -224,6 +224,11 @@ func (t *defaultModelBuildTask) buildRuleConditions(ctx context.Context, ing Cla
 		conditions = append(conditions, t.buildPathValuesCondition(ctx, []string{"/*"}))
 	}
 	return conditions, nil
+}
+
+// isCatchAllPathPattern checks whether the path patterns match all paths.
+func isCatchAllPathPattern(pathValues []string, pathRegexValues []string) bool {
+	return len(pathRegexValues) == 0 && len(pathValues) == 1 && pathValues[0] == "/*"
 }
 
 // buildPathPatterns will build ELBv2's path patterns for given path and pathType.

--- a/pkg/ingress/model_build_listener_rules_test.go
+++ b/pkg/ingress/model_build_listener_rules_test.go
@@ -1119,6 +1119,78 @@ func Test_defaultModelBuildTask_buildRuleConditions(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "host with catch-all prefix path omits redundant path-pattern condition",
+			ing:  MockIngress,
+			rule: networking.IngressRule{
+				Host: "example.com",
+			},
+			path: networking.HTTPIngressPath{
+				Path:     "/",
+				PathType: &pathTypePrefix,
+			},
+			backend: EnhancedBackend{
+				Conditions: []RuleCondition{},
+			},
+			want: []elbv2model.RuleCondition{
+				{
+					Field: elbv2model.RuleConditionFieldHostHeader,
+					HostHeaderConfig: &elbv2model.HostHeaderConditionConfig{
+						Values: []string{"example.com"},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "catch-all prefix path without host keeps path-pattern condition",
+			ing:  MockIngress,
+			rule: networking.IngressRule{},
+			path: networking.HTTPIngressPath{
+				Path:     "/",
+				PathType: &pathTypePrefix,
+			},
+			backend: EnhancedBackend{
+				Conditions: []RuleCondition{},
+			},
+			want: []elbv2model.RuleCondition{
+				{
+					Field: elbv2model.RuleConditionFieldPathPattern,
+					PathPatternConfig: &elbv2model.PathPatternConditionConfig{
+						Values: []string{"/*"},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "catch-all prefix path without host with source-ip omits redundant path-pattern condition",
+			ing:  MockIngress,
+			rule: networking.IngressRule{},
+			path: networking.HTTPIngressPath{
+				Path:     "/",
+				PathType: &pathTypePrefix,
+			},
+			backend: EnhancedBackend{
+				Conditions: []RuleCondition{
+					{
+						Field: RuleConditionFieldSourceIP,
+						SourceIPConfig: &SourceIPConditionConfig{
+							Values: []string{"192.168.0.0/16"},
+						},
+					},
+				},
+			},
+			want: []elbv2model.RuleCondition{
+				{
+					Field: elbv2model.RuleConditionFieldSourceIP,
+					SourceIPConfig: &elbv2model.SourceIPConditionConfig{
+						Values: []string{"192.168.0.0/16"},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "host and host header condition (values)",
 			ing:  MockIngress,
 			rule: networking.IngressRule{
@@ -1286,6 +1358,41 @@ func Test_defaultModelBuildTask_buildRuleConditions(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.want, got)
 			}
+		})
+	}
+}
+
+func Test_isCatchAllPathPattern(t *testing.T) {
+	tests := []struct {
+		name            string
+		pathValues      []string
+		pathRegexValues []string
+		want            bool
+	}{
+		{
+			name:       "catch-all path pattern",
+			pathValues: []string{"/*"},
+			want:       true,
+		},
+		{
+			name:       "specific path pattern",
+			pathValues: []string{"/api"},
+			want:       false,
+		},
+		{
+			name:            "regex path pattern",
+			pathRegexValues: []string{"^/.*$"},
+			want:            false,
+		},
+		{
+			name:       "multiple path patterns",
+			pathValues: []string{"/*", "/api"},
+			want:       false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isCatchAllPathPattern(tt.pathValues, tt.pathRegexValues))
 		})
 	}
 }


### PR DESCRIPTION
ALB listener rules allow at most five match evaluations per rule. For catch-all Ingress paths (`path: /`, `pathType: Prefix` -> `/*`), the controller always added `path-pattern: /*`, which is redundant when other conditions already define the rule and uses a match evaluation (e.g. only four `source-ip` CIDRs fit).

Omit redundant `/*` when the path is catch-all only. If no other conditions remain, the controller still adds `/*` as before.

Also resolves #3541

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the README.md, or the docs directory)
- [ ] Manually tested - only did unit testing
- [x] Made sure the title of the PR is a good description that can go into the release notes


Test plan
```shell
go test ./pkg/ingress/... -run 'Test_defaultModelBuildTask_buildRuleConditions|Test_isCatchAllPathPattern' -count=1 -v
```
