### PR TITLE
fix: ignore top-level RegexValues mirrored by AWS in DescribeRules response

### DIFF
--- a/pkg/equality/elbv2/compare_option_for_rule_conditions.go
+++ b/pkg/equality/elbv2/compare_option_for_rule_conditions.go
@@ -17,7 +17,7 @@ func CompareOptionForRuleCondition() cmp.Option {
 		cmpopts.IgnoreUnexported(elbv2types.QueryStringConditionConfig{}),
 		cmpopts.IgnoreUnexported(elbv2types.QueryStringKeyValuePair{}),
 		cmpopts.IgnoreUnexported(elbv2types.SourceIpConditionConfig{}),
-		cmpopts.IgnoreFields(elbv2types.RuleCondition{}, "Values"),
+		cmpopts.IgnoreFields(elbv2types.RuleCondition{}, "Values", "RegexValues"),
 	}
 }
 

--- a/pkg/equality/elbv2/compare_option_for_rule_conditions_test.go
+++ b/pkg/equality/elbv2/compare_option_for_rule_conditions_test.go
@@ -79,6 +79,60 @@ func Test_CompareOptionForRuleConditions(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			name: "equal - regex path pattern with AWS-mirrored top-level RegexValues",
+			desiredRuleCondition: []types.RuleCondition{
+				{
+					Field: awssdk.String("host-header"),
+					HostHeaderConfig: &types.HostHeaderConditionConfig{
+						Values: []string{"example.com"},
+					},
+				},
+				{
+					Field: awssdk.String("path-pattern"),
+					PathPatternConfig: &types.PathPatternConditionConfig{
+						RegexValues: []string{"^/api/v1/.*"},
+					},
+				},
+			},
+			actualRuleCondition: []types.RuleCondition{
+				{
+					Field: awssdk.String("host-header"),
+					HostHeaderConfig: &types.HostHeaderConditionConfig{
+						Values: []string{"example.com"},
+					},
+				},
+				{
+					Field: awssdk.String("path-pattern"),
+					PathPatternConfig: &types.PathPatternConditionConfig{
+						RegexValues: []string{"^/api/v1/.*"},
+					},
+					RegexValues: []string{"^/api/v1/.*"},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "not equal - different regex path pattern",
+			desiredRuleCondition: []types.RuleCondition{
+				{
+					Field: awssdk.String("path-pattern"),
+					PathPatternConfig: &types.PathPatternConditionConfig{
+						RegexValues: []string{"^/api/v1/.*"},
+					},
+				},
+			},
+			actualRuleCondition: []types.RuleCondition{
+				{
+					Field: awssdk.String("path-pattern"),
+					PathPatternConfig: &types.PathPatternConditionConfig{
+						RegexValues: []string{"^/api/v2/.*"},
+					},
+					RegexValues: []string{"^/api/v2/.*"},
+				},
+			},
+			expected: false,
+		},
 	}
 
 	for _, tc := range testCase {


### PR DESCRIPTION
### Issue

[Fixes #4744](https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4744)

### Description

When using regex path patterns, AWS `DescribeRules` mirrors `PathPatternConfig.RegexValues`
into the top-level `RuleCondition.RegexValues` field in its response. LBC's desired model
never sets this top-level field, so every reconcile sees a diff and calls `ModifyRule`
unnecessarily, causing a perpetual reconcile loop.

This fix adds `RegexValues` to the ignored top-level `RuleCondition` fields, consistent
with how `Values` is already handled.

Root cause confirmed on v3.1.0 with Gateway API routes using `RegularExpression` match
type — controller called `ModifyRule` on every reconcile cycle despite no actual changes
to the desired state. The same bug exists for Ingress regex path patterns.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2: