### PR TITLE
Validate load balancer capacity units annotations

### DIFF
--- a/pkg/ingress/model_build_load_balancer_capacity_reservation.go
+++ b/pkg/ingress/model_build_load_balancer_capacity_reservation.go
@@ -19,12 +19,14 @@ func (t *defaultModelBuildTask) buildLoadBalancerMinimumCapacity(_ context.Conte
 		return nil, err
 	}
 	var minimumLoadBalancerCapacity *elbv2model.MinimumLoadBalancerCapacity
-	var capacityUnits int64
 	for key, value := range ingGroupCapacityUnits {
 		if key != elbv2model.CapacityUnits {
 			return nil, errors.Errorf("invalid key to set the capacity: %v, Expected key: %v", key, elbv2model.CapacityUnits)
 		}
-		capacityUnits, _ = strconv.ParseInt(value, 10, 64)
+		capacityUnits, err := strconv.ParseInt(value, 10, 32)
+		if err != nil {
+			return nil, errors.Wrapf(err, "invalid value to set the capacity: %v", value)
+		}
 		minimumLoadBalancerCapacity = &elbv2model.MinimumLoadBalancerCapacity{
 			CapacityUnits: int32(capacityUnits),
 		}

--- a/pkg/ingress/model_build_load_balancer_capacity_reservation_test.go
+++ b/pkg/ingress/model_build_load_balancer_capacity_reservation_test.go
@@ -228,6 +228,31 @@ func Test_defaultModelBuildTask_buildLoadBalancerMinimumCapacity(t *testing.T) {
 			},
 			wantErr: errors.New("invalid key to set the capacity: InvalidUnits, Expected key: CapacityUnits"),
 		},
+		{
+			name: "invalid value to set the capacity reservation",
+			featureGates: map[config.Feature]bool{
+				config.LBCapacityReservation: true,
+			},
+			fields: fields{
+				ingGroup: Group{
+					ID: GroupID{Name: "ig-group-1"},
+					Members: []ClassifiedIngress{
+						{
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "awesome-ns",
+									Name:      "awesome-ing",
+									Annotations: map[string]string{
+										"alb.ingress.kubernetes.io/minimum-load-balancer-capacity": "CapacityUnits=invalid",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: errors.New("invalid value to set the capacity: invalid: strconv.ParseInt: parsing \"invalid\": invalid syntax"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/service/model_build_load_balancer.go
+++ b/pkg/service/model_build_load_balancer.go
@@ -503,12 +503,14 @@ func (t *defaultModelBuildTask) buildLoadBalancerMinimumCapacity(_ context.Conte
 	}
 	// Transform annotation to minimumLoadBalancerCapacity object
 	var minimumLoadBalancerCapacity *elbv2model.MinimumLoadBalancerCapacity
-	var capacityUnits int64
 	for key, value := range loadBalancerMinimumCapacityMap {
 		if key != elbv2model.CapacityUnits {
 			return nil, errors.Errorf("invalid key to set the capacity: %v, Expected key: %v", key, elbv2model.CapacityUnits)
 		}
-		capacityUnits, _ = strconv.ParseInt(value, 10, 64)
+		capacityUnits, err := strconv.ParseInt(value, 10, 32)
+		if err != nil {
+			return nil, errors.Wrapf(err, "invalid value to set the capacity: %v", value)
+		}
 		minimumLoadBalancerCapacity = &elbv2model.MinimumLoadBalancerCapacity{
 			CapacityUnits: int32(capacityUnits),
 		}

--- a/pkg/service/model_build_load_balancer_test.go
+++ b/pkg/service/model_build_load_balancer_test.go
@@ -1849,6 +1849,18 @@ func Test_defaultModelBuilderTask_buildLbCapacity(t *testing.T) {
 			},
 			wantError: true,
 		},
+		{
+			testName: "Annotation invalid value",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/aws-load-balancer-type":                           "nlb-ip",
+						"service.beta.kubernetes.io/aws-load-balancer-minimum-load-balancer-capacity": "CapacityUnits=invalid",
+					},
+				},
+			},
+			wantError: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {


### PR DESCRIPTION
### Issue

No linked issue found.

### Description

Tiny footgun fix: validate `CapacityUnits` for the capacity reservation annotations instead of dropping `strconv.ParseInt` errors.

Repro:
```yaml
alb.ingress.kubernetes.io/minimum-load-balancer-capacity: CapacityUnits=invalid
# or
service.beta.kubernetes.io/aws-load-balancer-minimum-load-balancer-capacity: CapacityUnits=invalid
```

Before this, `invalid` quietly became `0`, and `0` means reset the capacity reservation. That typo path is pretty rough.

Now model build returns an error, same vibe as an invalid key.

Tests:
```
go test ./pkg/ingress ./pkg/service
```

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (not required)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [x] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2: