### PR TITLE
fix: return early in service reconciler when lb is nil

### DIFF
--- a/controllers/service/service_controller.go
+++ b/controllers/service/service_controller.go
@@ -137,6 +137,7 @@ func (r *serviceReconciler) reconcile(ctx context.Context, req reconcile.Request
 		if err != nil {
 			return ctrlerrors.NewErrorWithMetrics(controllerName, "cleanup_load_balancer_error", err, r.metricsCollector)
 		}
+		return nil
 	}
 	return r.reconcileLoadBalancerResources(ctx, svc, stack, lb, backendSGRequired)
 }

--- a/controllers/service/service_controller_test.go
+++ b/controllers/service/service_controller_test.go
@@ -1,11 +1,164 @@
 package service
 
 import (
+	"context"
+	"errors"
 	"testing"
+	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	lbcmetrics "sigs.k8s.io/aws-load-balancer-controller/pkg/metrics/lbc"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/core"
+	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
+
+// --- mocks ---
+
+type mockModelBuilder struct {
+	stack     core.Stack
+	lb        *elbv2model.LoadBalancer
+	backendSG bool
+	err       error
+}
+
+func (m *mockModelBuilder) Build(_ context.Context, _ *corev1.Service, _ lbcmetrics.MetricCollector) (core.Stack, *elbv2model.LoadBalancer, bool, error) {
+	return m.stack, m.lb, m.backendSG, m.err
+}
+
+type mockStackDeployer struct {
+	err           error
+	deployedCount int
+}
+
+func (m *mockStackDeployer) Deploy(_ context.Context, _ core.Stack, _ lbcmetrics.MetricCollector, _ string) error {
+	m.deployedCount++
+	return m.err
+}
+
+type mockStackMarshaller struct{}
+
+func (m *mockStackMarshaller) Marshal(_ core.Stack) (string, error) {
+	return "{}", nil
+}
+
+type mockFinalizerManager struct{}
+
+func (m *mockFinalizerManager) AddFinalizers(_ context.Context, _ client.Object, _ ...string) error {
+	return nil
+}
+
+func (m *mockFinalizerManager) RemoveFinalizers(_ context.Context, _ client.Object, _ ...string) error {
+	return nil
+}
+
+type mockMetricsCollector struct{}
+
+func (m *mockMetricsCollector) ObservePodReadinessGateReady(_ string, _ string, _ time.Duration) {}
+func (m *mockMetricsCollector) ObserveQUICTargetMissingServerId(_ string, _ string)              {}
+func (m *mockMetricsCollector) ObserveControllerReconcileError(_ string, _ string)               {}
+func (m *mockMetricsCollector) ObserveControllerReconcileLatency(_ string, _ string, fn func())  { fn() }
+func (m *mockMetricsCollector) ObserveWebhookValidationError(_ string, _ string)                 {}
+func (m *mockMetricsCollector) ObserveWebhookMutationError(_ string, _ string)                   {}
+func (m *mockMetricsCollector) StartCollectTopTalkers(_ context.Context)                         {}
+func (m *mockMetricsCollector) StartCollectCacheSize(_ context.Context)                          {}
+
+// buildTestReconciler wires up a serviceReconciler with the given mocks and a real fake k8s client
+// pre-populated with svc.
+func buildTestReconciler(svc *corev1.Service, mb *mockModelBuilder, sd *mockStackDeployer) *serviceReconciler {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	k8sClient := testclient.NewClientBuilder().WithScheme(scheme).WithObjects(svc).Build()
+
+	return &serviceReconciler{
+		k8sClient:        k8sClient,
+		eventRecorder:    record.NewFakeRecorder(10),
+		finalizerManager: &mockFinalizerManager{},
+		modelBuilder:     mb,
+		stackMarshaller:  &mockStackMarshaller{},
+		stackDeployer:    sd,
+		logger:           logr.Discard(),
+		metricsCollector: &mockMetricsCollector{},
+	}
+}
+
+// --- reconcile tests ---
+
+func TestReconcile(t *testing.T) {
+	stack := core.NewDefaultStack(core.StackID(types.NamespacedName{Namespace: "default", Name: "my-svc"}))
+	tests := []struct {
+		name         string
+		svc          *corev1.Service
+		lb           *elbv2model.LoadBalancer
+		deployErr    error
+		wantErr      bool
+		wantDeployed int
+	}{
+		{
+			name: "lb nil, no finalizer: cleanup is no-op, returns nil",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-svc", Namespace: "default"},
+			},
+			lb:           nil,
+			wantErr:      false,
+			wantDeployed: 0,
+		},
+		{
+			name: "lb nil, has finalizer, cleanup deploy fails: returns error",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "my-svc",
+					Namespace:  "default",
+					Finalizers: []string{"service.k8s.aws/resources"},
+				},
+			},
+			lb:           nil,
+			deployErr:    errors.New("deploy failed"),
+			wantErr:      true,
+			wantDeployed: 1,
+		},
+		{
+			name: "lb not nil: reconcileLoadBalancerResources is called",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "my-svc",
+					Namespace:  "default",
+					Finalizers: []string{"service.k8s.aws/resources"},
+				},
+			},
+			lb:           &elbv2model.LoadBalancer{},
+			wantErr:      true,
+			wantDeployed: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mb := &mockModelBuilder{stack: stack, lb: tt.lb}
+			sd := &mockStackDeployer{err: tt.deployErr}
+			r := buildTestReconciler(tt.svc, mb, sd)
+
+			err := r.reconcile(context.Background(), reconcile.Request{
+				NamespacedName: types.NamespacedName{Namespace: "default", Name: "my-svc"},
+			})
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantDeployed, sd.deployedCount)
+		})
+	}
+}
 
 func TestBuildPortsForStatus(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
### Issue

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4724

### Description

A bug introduced when adding metrics wrapper.  Should return early in service reconciler when lb is nil



### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
