### PR TITLE
fix: ipam-ipv4-pool-id example, tip and note block spacing

### DIFF
--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -276,17 +276,17 @@ Traffic Routing can be controlled with following annotations:
 
 - <a name="ipam-ipv4-pool-id">`alb.ingress.kubernetes.io/ipam-ipv4-pool-id`</a> Specifies the [IPv4 IPAM Pool ID](https://docs.aws.amazon.com/vpc/latest/ipam/tutorials-byoip-ipam-console-ipv4.html) which will be used by your load balancer to assign IP addresses.
 
-  !!!note ""
-  The chosen IPAM pool is always the prioritized source when assigning public IPv4 addresses.
-  If there are no more assignable IP addresses in the IPAM pool, AWS managed IPv4 addresses are assigned.
+    !!!note ""
+        The chosen IPAM pool is always the prioritized source when assigning public IPv4 addresses.
+        If there are no more assignable IP addresses in the IPAM pool, AWS managed IPv4 addresses are assigned.
 
-  !!!tip
-  To remove an IPAM pool associated to your ALB, remove the annotation from your ingress.
+    !!!tip
+        To remove an IPAM pool associated to your ALB, remove the annotation from your ingress.
 
-  !!!example
-  ```
-  alb.ingress.kubernetes.io/ipam-ipv4-pool-id: ipam-pool-0f995c17c00375b48
-  ```
+    !!!example
+        ```
+        alb.ingress.kubernetes.io/ipam-ipv4-pool-id: ipam-pool-0f995c17c00375b48
+        ```
 
 - <a name="actions">`alb.ingress.kubernetes.io/actions.${action-name}`</a> Provides a method for configuring custom actions on a listener, such as Redirect Actions.
 


### PR DESCRIPTION
### Description
Spacing was incorrect which cause the docs to not render corretly

Old:
<img width="846" height="374" alt="image" src="https://github.com/user-attachments/assets/27e69079-a3a7-4291-b0bb-8ea617915e19" />

New:
<img width="838" height="434" alt="image" src="https://github.com/user-attachments/assets/3ae60dfb-052b-46e2-8e33-be976a4ac4f1" />


### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes