### PR TITLE
Add multiple ingress test that sorts rules based on priority

### DIFF
--- a/test/e2e/ingress/vanilla_ingress_test.go
+++ b/test/e2e/ingress/vanilla_ingress_test.go
@@ -1007,7 +1007,6 @@ var _ = Describe("vanilla ingress tests", func() {
 				Build(sandboxNS.Name, "ing-z")
 			err = tf.K8sClient.Create(ctx, ingZ)
 			Expect(err).NotTo(HaveOccurred())
-			defer func() { _ = tf.K8sClient.Delete(ctx, ingZ) }()
 
 			lbARN1, _ := ExpectOneLBProvisionedForIngress(ctx, tf, ingZ)
 
@@ -1018,7 +1017,6 @@ var _ = Describe("vanilla ingress tests", func() {
 				Build(sandboxNS.Name, "ing-a")
 			err = tf.K8sClient.Create(ctx, ingA)
 			Expect(err).NotTo(HaveOccurred())
-			defer func() { _ = tf.K8sClient.Delete(ctx, ingA) }()
 
 			lbARN2, _ := ExpectOneLBProvisionedForIngress(ctx, tf, ingA)
 			Expect(lbARN2).To(Equal(lbARN1), "both ingresses should share the same ALB via IngressGroup")
@@ -1034,6 +1032,16 @@ var _ = Describe("vanilla ingress tests", func() {
 				}
 			}
 			Expect(failedEvents).To(BeEmpty(), "expected no FailedDeployModel errors, got:\n%s", strings.Join(failedEvents, "\n"))
+
+			By("cleaning up ingresses before IngressClass deletion")
+			err = tf.K8sClient.Delete(ctx, ingA)
+			Expect(err).NotTo(HaveOccurred())
+			err = tf.K8sClient.Delete(ctx, ingZ)
+			Expect(err).NotTo(HaveOccurred())
+			err = tf.INGManager.WaitUntilIngressDeleted(ctx, ingA)
+			Expect(err).NotTo(HaveOccurred())
+			err = tf.INGManager.WaitUntilIngressDeleted(ctx, ingZ)
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 

--- a/test/e2e/ingress/vanilla_ingress_test.go
+++ b/test/e2e/ingress/vanilla_ingress_test.go
@@ -22,6 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework"
@@ -29,6 +30,7 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework/manifest"
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework/utils"
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework/verifier"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("vanilla ingress tests", func() {
@@ -940,6 +942,97 @@ var _ = Describe("vanilla ingress tests", func() {
 			nlbHttpExp.GET("/path").Expect().
 				Status(http.StatusOK).
 				Body().Equal("Hello World!")
+		})
+	})
+
+	Context("with ALB listener rule priority reordering", func() {
+		It("[rule-priority] adding a second ingress that sorts before the first triggers SetRulePriorities", func() {
+			prefix := networking.PathTypePrefix
+
+			By("creating IngressClassParams with a shared group")
+			icpName := sandboxNS.Name + "-shared"
+			scheme := elbv2api.LoadBalancerSchemeInternetFacing
+			ipAddrType := elbv2api.IPAddressTypeIPV4
+			if tf.Options.IPFamily == framework.IPv6 {
+				ipAddrType = elbv2api.IPAddressTypeDualStack
+			}
+			icp := &elbv2api.IngressClassParams{
+				ObjectMeta: metav1.ObjectMeta{Name: icpName},
+				Spec: elbv2api.IngressClassParamsSpec{
+					Group:         &elbv2api.IngressGroup{Name: sandboxNS.Name + "-group"},
+					Scheme:        &scheme,
+					IPAddressType: &ipAddrType,
+				},
+			}
+			err := tf.K8sClient.Create(ctx, icp)
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = tf.K8sClient.Delete(ctx, icp) }()
+
+			By("creating IngressClass referencing IngressClassParams")
+			apiGroup := "elbv2.k8s.aws"
+			ingClass := &networking.IngressClass{
+				ObjectMeta: metav1.ObjectMeta{Name: icpName},
+				Spec: networking.IngressClassSpec{
+					Controller: "ingress.k8s.aws/alb",
+					Parameters: &networking.IngressClassParametersReference{
+						APIGroup: &apiGroup,
+						Kind:     "IngressClassParams",
+						Name:     icpName,
+					},
+				},
+			}
+			err = tf.K8sClient.Create(ctx, ingClass)
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = tf.K8sClient.Delete(ctx, ingClass) }()
+
+			By("creating backend deployment and service")
+			appBuilder := manifest.NewFixedResponseServiceBuilder()
+			dp, svc := appBuilder.Build(sandboxNS.Name, "app", tf.Options.TestImageRegistry)
+			resStack := fixture.NewK8SResourceStack(tf, dp, svc)
+			err = resStack.Setup(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			defer resStack.TearDown(ctx)
+
+			ingBackend := networking.IngressBackend{
+				Service: &networking.IngressServiceBackend{
+					Name: svc.Name,
+					Port: networking.ServiceBackendPort{Number: 80},
+				},
+			}
+
+			By("creating ingress 'ing-z' with path /z to establish ALB with rule at priority 1")
+			ingZ := manifest.NewIngressBuilder().
+				AddHTTPRoute("", networking.HTTPIngressPath{Path: "/z", PathType: &prefix, Backend: ingBackend}).
+				WithIngressClassName(ingClass.Name).
+				Build(sandboxNS.Name, "ing-z")
+			err = tf.K8sClient.Create(ctx, ingZ)
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = tf.K8sClient.Delete(ctx, ingZ) }()
+
+			ExpectOneLBProvisionedForIngress(ctx, tf, ingZ)
+
+			By("creating ingress 'ing-a' which sorts before 'ing-z' — forces rule reordering (triggers SetRulePriorities)")
+			ingA := manifest.NewIngressBuilder().
+				AddHTTPRoute("", networking.HTTPIngressPath{Path: "/a", PathType: &prefix, Backend: ingBackend}).
+				WithIngressClassName(ingClass.Name).
+				Build(sandboxNS.Name, "ing-a")
+			err = tf.K8sClient.Create(ctx, ingA)
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = tf.K8sClient.Delete(ctx, ingA) }()
+
+			ExpectOneLBProvisionedForIngress(ctx, tf, ingA)
+
+			By("checking for FailedDeployModel errors indicating permission gaps")
+			eventList := &corev1.EventList{}
+			err = tf.K8sClient.List(ctx, eventList, &client.ListOptions{Namespace: sandboxNS.Name})
+			Expect(err).NotTo(HaveOccurred())
+			var failedEvents []string
+			for _, event := range eventList.Items {
+				if event.Reason == "FailedDeployModel" {
+					failedEvents = append(failedEvents, fmt.Sprintf("%s: %s", event.InvolvedObject.Name, event.Message))
+				}
+			}
+			Expect(failedEvents).To(BeEmpty(), "expected no FailedDeployModel errors, got:\n%s", strings.Join(failedEvents, "\n"))
 		})
 	})
 

--- a/test/e2e/ingress/vanilla_ingress_test.go
+++ b/test/e2e/ingress/vanilla_ingress_test.go
@@ -1009,7 +1009,7 @@ var _ = Describe("vanilla ingress tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 			defer func() { _ = tf.K8sClient.Delete(ctx, ingZ) }()
 
-			ExpectOneLBProvisionedForIngress(ctx, tf, ingZ)
+			lbARN1, _ := ExpectOneLBProvisionedForIngress(ctx, tf, ingZ)
 
 			By("creating ingress 'ing-a' which sorts before 'ing-z' — forces rule reordering (triggers SetRulePriorities)")
 			ingA := manifest.NewIngressBuilder().
@@ -1020,7 +1020,8 @@ var _ = Describe("vanilla ingress tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 			defer func() { _ = tf.K8sClient.Delete(ctx, ingA) }()
 
-			ExpectOneLBProvisionedForIngress(ctx, tf, ingA)
+			lbARN2, _ := ExpectOneLBProvisionedForIngress(ctx, tf, ingA)
+			Expect(lbARN2).To(Equal(lbARN1), "both ingresses should share the same ALB via IngressGroup")
 
 			By("checking for FailedDeployModel errors indicating permission gaps")
 			eventList := &corev1.EventList{}


### PR DESCRIPTION
### Issue
Adding test coverage for https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4039
<!-- Please link the GitHub issues related to this PR, if available -->

### Description

<!--
Please explain the changes you made here.

Help your reviewers by guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

Added a test that triggers sorting of rules based on priority when a new ingress is added in the same group.

```
Ran it against by local eks cluster - test passed successfully 

 go test -v -timeout 30m ./test/e2e/ingress/ \
    -run "TestIngress" \
    -ginkgo.focus="rule-priority" \
    -- \
    --kubeconfig=$KUBECONFIG \
    --cluster-name=$CLUSTER_NAME \
    --aws-region=$AWS_REGION \
    --aws-vpc-id=$VPC_ID \
    --helm-chart=helm/aws-load-balancer-controller

Running Suite: Ingress Suite - /home/kaposmee/oss-lb/up/aws-load-balancer-controller/test/e2e/ingress
=====================================================================================================
Random Seed: 1779903251

Will run 1 of 24 specs
------------------------------
[SynchronizedBeforeSuite] 
/home/kaposmee/oss-lb/up/aws-load-balancer-controller/test/e2e/ingress/ingress_suite_test.go:19
[SynchronizedBeforeSuite] PASSED [0.043 seconds]
------------------------------
SSSSSSSSSSSSSSSSSSSS
------------------------------
vanilla ingress tests with ALB listener rule priority reordering [rule-priority] adding a second ingress that sorts before the first triggers SetRulePriorities
/home/kaposmee/oss-lb/up/aws-load-balancer-controller/test/e2e/ingress/vanilla_ingress_test.go:949
  STEP: setup sandbox namespace @ 05/27/26 17:34:21.034
  {"level":"info","ts":1779903261.0343645,"msg":"allocating namespace"}
  {"level":"info","ts":1779903261.8586,"msg":"allocated namespace","name":"aws-lb-e2e-a9d99c"}
  STEP: creating IngressClassParams with a shared group @ 05/27/26 17:34:21.858
  STEP: creating IngressClass referencing IngressClassParams @ 05/27/26 17:34:21.873
  STEP: creating backend deployment and service @ 05/27/26 17:34:21.88
  {"level":"info","ts":1779903261.8802829,"msg":"creating resource","kind":"Service","key":{"name":"app","namespace":"aws-lb-e2e-a9d99c"}}
  {"level":"info","ts":1779903261.904513,"msg":"created resource","kind":"Service","key":{"name":"app","namespace":"aws-lb-e2e-a9d99c"}}
  {"level":"info","ts":1779903261.9045973,"msg":"creating resource","kind":"Deployment","key":{"name":"app","namespace":"aws-lb-e2e-a9d99c"}}
  {"level":"info","ts":1779903261.9142275,"msg":"created resource","kind":"Deployment","key":{"name":"app","namespace":"aws-lb-e2e-a9d99c"}}
  STEP: creating ingress 'ing-z' with path /z to establish ALB with rule at priority 1 @ 05/27/26 17:34:21.914
  {"level":"info","ts":1779903265.9498317,"msg":"ingress DNS populated","dnsName":"k8s-awslbe2ea9d99cgro-e918ac1792-1011441043.us-west-2.elb.amazonaws.com"}
  {"level":"info","ts":1779903266.0260522,"msg":"ALB provisioned","arn":"arn:aws:elasticloadbalancing:us-west-2:711387134148:loadbalancer/app/k8s-awslbe2ea9d99cgro-e918ac1792/8ae6de44ca2911d7"}
  STEP: creating ingress 'ing-a' which sorts before 'ing-z' — forces rule reordering (triggers SetRulePriorities) @ 05/27/26 17:34:26.026
  {"level":"info","ts":1779903508.9879982,"msg":"ingress DNS populated","dnsName":"k8s-awslbe2ea9d99cgro-e918ac1792-1011441043.us-west-2.elb.amazonaws.com"}
  {"level":"info","ts":1779903509.055372,"msg":"ALB provisioned","arn":"arn:aws:elasticloadbalancing:us-west-2:711387134148:loadbalancer/app/k8s-awslbe2ea9d99cgro-e918ac1792/8ae6de44ca2911d7"}
  STEP: checking for FailedDeployModel errors indicating permission gaps @ 05/27/26 17:38:29.055
  STEP: cleaning up ingresses before IngressClass deletion @ 05/27/26 17:38:29.071
  {"level":"info","ts":1779903549.1098988,"msg":"deleting resource","kind":"Deployment","key":{"name":"app","namespace":"aws-lb-e2e-a9d99c"}}
  {"level":"info","ts":1779903549.117953,"msg":"deleted resource","kind":"Deployment","key":{"name":"app","namespace":"aws-lb-e2e-a9d99c"}}
  {"level":"info","ts":1779903549.117977,"msg":"wait resource becomes deleted","kind":"Deployment","key":{"name":"app","namespace":"aws-lb-e2e-a9d99c"}}
  {"level":"info","ts":1779903549.1263204,"msg":"resource becomes deleted","kind":"Deployment","key":{"name":"app","namespace":"aws-lb-e2e-a9d99c"}}
  {"level":"info","ts":1779903549.1263785,"msg":"deleting resource","kind":"Service","key":{"name":"app","namespace":"aws-lb-e2e-a9d99c"}}
  {"level":"info","ts":1779903549.1749187,"msg":"deleted resource","kind":"Service","key":{"name":"app","namespace":"aws-lb-e2e-a9d99c"}}
  {"level":"info","ts":1779903549.174988,"msg":"wait resource becomes deleted","kind":"Service","key":{"name":"app","namespace":"aws-lb-e2e-a9d99c"}}
  {"level":"info","ts":1779903549.1797113,"msg":"resource becomes deleted","kind":"Service","key":{"name":"app","namespace":"aws-lb-e2e-a9d99c"}}
  STEP: teardown sandbox namespace @ 05/27/26 17:39:09.196
  {"level":"info","ts":1779903549.1966324,"msg":"deleting namespace","name":"aws-lb-e2e-a9d99c"}
  {"level":"info","ts":1779903549.2055817,"msg":"deleted namespace","name":"aws-lb-e2e-a9d99c"}
  {"level":"info","ts":1779903549.205608,"msg":"waiting namespace becomes deleted","name":"aws-lb-e2e-a9d99c"}
  {"level":"info","ts":1779903555.2282538,"msg":"namespace becomes deleted","name":"aws-lb-e2e-a9d99c"}
• [294.194 seconds]
------------------------------
SSS

Ran 1 of 24 Specs in 294.237 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 23 Skipped
PASS

Ginkgo ran 1 suite in 5m3.605300119s
Test Suite Passed

```

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:

Ran test against my local cluster `arn:aws:eks:us-west-2:711387134148:cluster/oss-lbc-test`