### PR TITLE
Fix feature gates string representation

### DIFF
--- a/pkg/config/feature_gates.go
+++ b/pkg/config/feature_gates.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -127,8 +128,9 @@ func (f *defaultFeatureGates) Disable(feature Feature) {
 func (f *defaultFeatureGates) String() string {
 	var featureSettings []string
 	for feature, enabled := range f.featureState {
-		featureSettings = append(featureSettings, fmt.Sprintf("%v=%v", feature, enabled))
+		featureSettings = append(featureSettings, fmt.Sprintf("%v=%v", feature, enabled.Enabled))
 	}
+	sort.Strings(featureSettings)
 	return strings.Join(featureSettings, ",")
 }
 

--- a/pkg/config/feature_gates_test.go
+++ b/pkg/config/feature_gates_test.go
@@ -1,0 +1,33 @@
+package config
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultFeatureGatesString(t *testing.T) {
+	featureGates := NewFeatureGates().(*defaultFeatureGates)
+	require.NoError(t, featureGates.Set("GlobalAcceleratorController=true"))
+
+	raw := featureGates.String()
+	settings, err := featureGates.SplitMapStringBool(raw)
+
+	require.NoError(t, err)
+	assert.Equal(t, featureGates.Enabled(ListenerRulesTagging), settings[string(ListenerRulesTagging)])
+	assert.Equal(t, featureGates.Enabled(GlobalAcceleratorController), settings[string(GlobalAcceleratorController)])
+	assert.True(t, settings[string(GlobalAcceleratorController)])
+	assert.NotContains(t, raw, "{")
+}
+
+func TestDefaultFeatureGatesStringIsSorted(t *testing.T) {
+	featureGates := NewFeatureGates().(*defaultFeatureGates)
+
+	raw := featureGates.String()
+	parts := strings.Split(raw, ",")
+
+	assert.True(t, sort.StringsAreSorted(parts))
+}


### PR DESCRIPTION
### Issue

No related issue found.

### Description

Tiny fix for `FeatureGates.String()`. It was printing the whole `FeatureStatus`, so values looked like `GlobalAcceleratorController={false true}` instead of `GlobalAcceleratorController=false`. That goes sideways when the string is parsed back as `key=bool`, and pflag can hit this path for flag/default rendering.

Repro, before this change:

```
go test ./pkg/config -run TestDefaultFeatureGatesString -count=1
```

It fails with `invalid mapStringBool: GlobalAcceleratorController={false true}`.

Now the output is stable, sorted, and parseable. fwiw this is local CLI/config plumbing, no AWS quota or resource ceiling involved.

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (not needed)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

Tests:

```
go test ./pkg/config -run TestDefaultFeatureGatesString -count=1
go test ./pkg/config ./pkg/algorithm ./webhooks/... -count=1
go test $(go list ./... | rg -v '/test/e2e|/conformance')
```

`go test ./...` also runs conformance/e2e locally and needs kube config plus cluster-name, so that one fails here for env setup only.
