### PR TITLE
[feat i2g] add e2e tests for ingress2gateway migration tool

### DIFF
--- a/controllers/ingress/dryrun_test.go
+++ b/controllers/ingress/dryrun_test.go
@@ -14,6 +14,144 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+func Test_clearDryRunPlanAnnotation(t *testing.T) {
+	tests := []struct {
+		name           string
+		ingAnnotations map[string]string
+	}{
+		{
+			name: "removes annotation when present",
+			ingAnnotations: map[string]string{
+				dryRunPlanAnnotation:               `{"id":"test-stack"}`,
+				"alb.ingress.kubernetes.io/scheme": "internet-facing",
+			},
+		},
+		{
+			name: "no-op when annotation absent",
+			ingAnnotations: map[string]string{
+				"alb.ingress.kubernetes.io/scheme": "internet-facing",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ing := &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-ingress",
+					Namespace:   "default",
+					Annotations: tt.ingAnnotations,
+				},
+			}
+
+			scheme := runtime.NewScheme()
+			require.NoError(t, clientgoscheme.AddToScheme(scheme))
+
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(ing).
+				Build()
+
+			err := clearDryRunPlanAnnotation(context.Background(), k8sClient, ing)
+			require.NoError(t, err)
+
+			updatedIng := &networking.Ingress{}
+			err = k8sClient.Get(context.Background(), types.NamespacedName{
+				Name:      "test-ingress",
+				Namespace: "default",
+			}, updatedIng)
+			require.NoError(t, err)
+			_, hasPlan := updatedIng.Annotations[dryRunPlanAnnotation]
+			assert.False(t, hasPlan, "dry-run-plan annotation should be absent after clear")
+			assert.Equal(t, "internet-facing", updatedIng.Annotations["alb.ingress.kubernetes.io/scheme"])
+		})
+	}
+}
+
+func Test_clearDryRunPlanAnnotation_standaloneIngress(t *testing.T) {
+	ing := &networking.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "standalone",
+			Namespace: "default",
+			Annotations: map[string]string{
+				dryRunPlanAnnotation:               `{"id":"old-plan"}`,
+				"alb.ingress.kubernetes.io/scheme": "internal",
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(ing).
+		Build()
+
+	err := clearDryRunPlanAnnotation(context.Background(), k8sClient, ing)
+	require.NoError(t, err)
+
+	updatedIng := &networking.Ingress{}
+	err = k8sClient.Get(context.Background(), types.NamespacedName{
+		Name:      "standalone",
+		Namespace: "default",
+	}, updatedIng)
+	require.NoError(t, err)
+	_, hasPlan := updatedIng.Annotations[dryRunPlanAnnotation]
+	assert.False(t, hasPlan, "dry-run-plan annotation should be removed from standalone ingress")
+	assert.Equal(t, "internal", updatedIng.Annotations["alb.ingress.kubernetes.io/scheme"])
+}
+
+func Test_clearDryRunPlanAnnotation_multiMemberGroup(t *testing.T) {
+	primary := &networking.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "member-1",
+			Namespace: "default",
+			Annotations: map[string]string{
+				dryRunPlanAnnotation:                    `{"id":"group-plan"}`,
+				"alb.ingress.kubernetes.io/group.name":  "my-group",
+				"alb.ingress.kubernetes.io/group.order": "1",
+			},
+		},
+	}
+	secondary := &networking.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "member-2",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"alb.ingress.kubernetes.io/group.name":  "my-group",
+				"alb.ingress.kubernetes.io/group.order": "2",
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(primary, secondary).
+		Build()
+
+	for _, ing := range []*networking.Ingress{primary, secondary} {
+		err := clearDryRunPlanAnnotation(context.Background(), k8sClient, ing)
+		require.NoError(t, err)
+	}
+
+	updatedPrimary := &networking.Ingress{}
+	err := k8sClient.Get(context.Background(), types.NamespacedName{Name: "member-1", Namespace: "default"}, updatedPrimary)
+	require.NoError(t, err)
+	_, hasPlan := updatedPrimary.Annotations[dryRunPlanAnnotation]
+	assert.False(t, hasPlan, "primary should have dry-run-plan removed")
+	assert.Equal(t, "my-group", updatedPrimary.Annotations["alb.ingress.kubernetes.io/group.name"])
+
+	updatedSecondary := &networking.Ingress{}
+	err = k8sClient.Get(context.Background(), types.NamespacedName{Name: "member-2", Namespace: "default"}, updatedSecondary)
+	require.NoError(t, err)
+	_, hasPlan = updatedSecondary.Annotations[dryRunPlanAnnotation]
+	assert.False(t, hasPlan, "secondary should remain without dry-run-plan")
+}
+
 func Test_patchDryRunPlanAnnotation(t *testing.T) {
 	tests := []struct {
 		name                 string

--- a/controllers/ingress/group_controller.go
+++ b/controllers/ingress/group_controller.go
@@ -248,6 +248,12 @@ func (r *groupReconciler) buildAndDeployModel(ctx context.Context, ingGroup ingr
 				r.logger.Error(err, "failed to clear stale dry-run plan annotation", "ingress", k8s.NamespacedName(m.Ing))
 			}
 		}
+	} else if !r.featureGates.Enabled(config.IngressPlanAnnotation) && len(ingGroup.Members) > 0 {
+		for _, m := range ingGroup.Members {
+			if err := clearDryRunPlanAnnotation(ctx, r.k8sClient, m.Ing); err != nil {
+				r.logger.Error(err, "failed to clear dry-run plan annotation after feature disable", "ingress", k8s.NamespacedName(m.Ing))
+			}
+		}
 	}
 
 	deployModelFn := func() {

--- a/pkg/ingress2gateway/console/classify.go
+++ b/pkg/ingress2gateway/console/classify.go
@@ -157,9 +157,9 @@ func isTargetGroupRef(s string) bool {
 	return strings.HasPrefix(s, "#/resources/"+utils.StackResTypeTargetGroup+"/")
 }
 
-// buildUserSpecifiedFields scans Ingress annotations and returns the set of
+// BuildUserSpecifiedFields scans Ingress annotations and returns the set of
 // model field paths that were explicitly configured by the user.
-func buildUserSpecifiedFields(ingressAnnotations map[string]string) UserSpecifiedFields {
+func BuildUserSpecifiedFields(ingressAnnotations map[string]string) UserSpecifiedFields {
 	usf := make(UserSpecifiedFields)
 	for suffix, fieldPath := range annotationToFieldPath {
 		key := annotations.AnnotationPrefixIngress + "/" + suffix

--- a/pkg/ingress2gateway/console/classify_test.go
+++ b/pkg/ingress2gateway/console/classify_test.go
@@ -418,7 +418,7 @@ func TestBuildUserSpecifiedFields(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := buildUserSpecifiedFields(tt.annotations)
+			got := BuildUserSpecifiedFields(tt.annotations)
 			assert.Equal(t, tt.wantFields, got)
 		})
 	}

--- a/pkg/ingress2gateway/console/server.go
+++ b/pkg/ingress2gateway/console/server.go
@@ -89,7 +89,7 @@ func (s *ConsoleServer) handleGateways(w http.ResponseWriter, r *http.Request) {
 			inTree, err1 := ParseStack(gw.IngressPlan)
 			gwTree, err2 := ParseStack(gw.GatewayPlan)
 			if err1 == nil && err2 == nil {
-				userSpecified := buildUserSpecifiedFields(gw.IngressAnnotations)
+				userSpecified := BuildUserSpecifiedFields(gw.IngressAnnotations)
 				diff := Diff(inTree, gwTree, userSpecified)
 				item.Summary = diff.Summary
 			}
@@ -135,7 +135,7 @@ func (s *ConsoleServer) handleDiff(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userSpecified := buildUserSpecifiedFields(info.IngressAnnotations)
+	userSpecified := BuildUserSpecifiedFields(info.IngressAnnotations)
 	diff := Diff(inTree, gwTree, userSpecified)
 
 	writeJSON(w, diff)

--- a/pkg/ingress2gateway/translate/httproute.go
+++ b/pkg/ingress2gateway/translate/httproute.go
@@ -375,6 +375,7 @@ func assembleRoutes(namespace, ingName string, parentRefs []gwv1.ParentReference
 				},
 			},
 		}
+		t.buildLRCForTags(defaultRule, defaultBackend.Service.Name)
 	}
 
 	// When no hostnames, the default backend can live in the same route.

--- a/test/e2e/ingress2gateway/builders.go
+++ b/test/e2e/ingress2gateway/builders.go
@@ -1,6 +1,7 @@
 package ingress2gateway
 
 import (
+	"fmt"
 	"maps"
 
 	networking "k8s.io/api/networking/v1"
@@ -109,6 +110,199 @@ func ingressBackend(svcName string) networking.IngressBackend {
 		Service: &networking.IngressServiceBackend{
 			Name: svcName,
 			Port: networking.ServiceBackendPort{Number: 80},
+		},
+	}
+}
+
+func actionBackend(actionName string) networking.IngressBackend {
+	return networking.IngressBackend{
+		Service: &networking.IngressServiceBackend{
+			Name: actionName,
+			Port: networking.ServiceBackendPort{Name: "use-annotation"},
+		},
+	}
+}
+
+// buildComplexSingleIngress builds a single Ingress that exercises many annotation categories:
+// - HTTP-only listen-ports, scheme, LB attributes, tags
+// - Health check overrides, TG attributes
+// - Action annotation (fixed-response) on one path
+// - source-ip condition on the action path (restricts which clients hit the action)
+// - Paths ordered longest-first to match Gateway API precedence
+func buildComplexSingleIngress(namespace, ingressClassName string) *networking.Ingress {
+	pathPrefix := networking.PathTypePrefix
+	return &networking.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "complex-single",
+			Namespace: namespace,
+			Annotations: map[string]string{
+				annotationScheme:      "internet-facing",
+				annotationTargetType:  "ip",
+				annotationListenPorts: `[{"HTTP":80}]`,
+				"alb.ingress.kubernetes.io/load-balancer-attributes": "idle_timeout.timeout_seconds=120",
+				annotationTags:            "Env=prod,Team=platform",
+				annotationHealthCheckPath: "/health",
+				"alb.ingress.kubernetes.io/healthcheck-interval-seconds": "10",
+				"alb.ingress.kubernetes.io/healthcheck-timeout-seconds":  "3",
+				"alb.ingress.kubernetes.io/healthy-threshold-count":      "3",
+				"alb.ingress.kubernetes.io/unhealthy-threshold-count":    "2",
+				"alb.ingress.kubernetes.io/success-codes":                "200-299",
+				"alb.ingress.kubernetes.io/target-group-attributes":      "deregistration_delay.timeout_seconds=30",
+				"alb.ingress.kubernetes.io/actions.maintenance":          `{"type":"fixed-response","fixedResponseConfig":{"contentType":"text/plain","statusCode":"503","messageBody":"Under maintenance"}}`,
+				"alb.ingress.kubernetes.io/conditions.maintenance":       `[{"field":"source-ip","sourceIpConfig":{"values":["10.0.0.0/8","192.168.0.0/16"]}}]`,
+			},
+		},
+		Spec: networking.IngressSpec{
+			IngressClassName: &ingressClassName,
+			Rules: []networking.IngressRule{
+				{
+					Host: hostApp,
+					IngressRuleValue: networking.IngressRuleValue{
+						HTTP: &networking.HTTPIngressRuleValue{
+							Paths: []networking.HTTPIngressPath{
+								{Path: "/api/v1/resources", PathType: &pathPrefix, Backend: ingressBackend("svc-api")},
+								{Path: "/api/v1", PathType: &pathPrefix, Backend: ingressBackend("svc-static")},
+								{Path: "/maintenance", PathType: &pathPrefix, Backend: actionBackend("maintenance")},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// buildGroupMemberA builds the first member of a cross-namespace group:
+//   - action: fixed-response on /api/maintenance, weighted forward on /api/forward
+//   - Paths are longer than member-b's so Gateway API precedence (path length)
+//     matches Ingress group.order precedence (member-a first).
+func buildGroupMemberA(namespace, groupName, ingressClassName string) *networking.Ingress {
+	pathPrefix := networking.PathTypePrefix
+	return &networking.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "member-a",
+			Namespace: namespace,
+			Annotations: map[string]string{
+				annotationGroupName:   groupName,
+				annotationGroupOrder:  "1",
+				annotationScheme:      "internal",
+				annotationTargetType:  "ip",
+				annotationListenPorts: `[{"HTTP":80}]`,
+				annotationTags:        "ManagedBy=teamA,Feature=api",
+				"alb.ingress.kubernetes.io/actions.maintenance-action": `{"type":"fixed-response","fixedResponseConfig":{"contentType":"text/plain","statusCode":"503","messageBody":"Under maintenance"}}`,
+				"alb.ingress.kubernetes.io/actions.weighted-forward":   `{"type":"forward","forwardConfig":{"targetGroups":[{"serviceName":"svc-blue","servicePort":"80","weight":80},{"serviceName":"svc-green","servicePort":"80","weight":20}]}}`,
+			},
+		},
+		Spec: networking.IngressSpec{
+			IngressClassName: &ingressClassName,
+			Rules: []networking.IngressRule{
+				{
+					Host: hostAPI,
+					IngressRuleValue: networking.IngressRuleValue{
+						HTTP: &networking.HTTPIngressRuleValue{
+							Paths: []networking.HTTPIngressPath{
+								{Path: "/api/maintenance", PathType: &pathPrefix, Backend: actionBackend("maintenance-action")},
+								{Path: "/api/forward", PathType: &pathPrefix, Backend: actionBackend("weighted-forward")},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// buildGroupMemberB builds the second member of a cross-namespace group:
+// - listen-ports HTTP:80
+// - group.order set (trigger warning)
+// - Path is shorter than member-a's paths so Gateway API precedence matches group.order
+func buildGroupMemberB(namespace, groupName, ingressClassName string) *networking.Ingress {
+	pathPrefix := networking.PathTypePrefix
+	return &networking.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "member-b",
+			Namespace: namespace,
+			Annotations: map[string]string{
+				annotationGroupName:   groupName,
+				annotationGroupOrder:  "2",
+				annotationTargetType:  "ip",
+				annotationListenPorts: `[{"HTTP":80}]`,
+			},
+		},
+		Spec: networking.IngressSpec{
+			IngressClassName: &ingressClassName,
+			Rules: []networking.IngressRule{
+				{
+					Host: hostAPI,
+					IngressRuleValue: networking.IngressRuleValue{
+						HTTP: &networking.HTTPIngressRuleValue{
+							Paths: []networking.HTTPIngressPath{
+								{Path: "/search", PathType: &pathPrefix, Backend: ingressBackend("svc-search")},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// buildPlatformGroupMember builds a simple platform group member.
+// pathSuffix should be longer for member-1 than member-2 to keep priority
+// deterministic across both Ingress (group.order) and Gateway (path length) controllers.
+func buildPlatformGroupMember(namespace, groupName, ingressClassName, svcName, order, pathSuffix string) *networking.Ingress {
+	pathPrefix := networking.PathTypePrefix
+	return &networking.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("platform-%s", svcName),
+			Namespace: namespace,
+			Annotations: map[string]string{
+				annotationScheme:     "internet-facing",
+				annotationTargetType: "ip",
+				annotationGroupName:  groupName,
+				annotationGroupOrder: order,
+			},
+		},
+		Spec: networking.IngressSpec{
+			IngressClassName: &ingressClassName,
+			Rules: []networking.IngressRule{{
+				Host: fmt.Sprintf("%s.platform.example.com", svcName),
+				IngressRuleValue: networking.IngressRuleValue{
+					HTTP: &networking.HTTPIngressRuleValue{
+						Paths: []networking.HTTPIngressPath{
+							{Path: pathSuffix, PathType: &pathPrefix, Backend: ingressBackend(svcName)},
+						},
+					},
+				},
+			}},
+		},
+	}
+}
+
+// buildStandaloneIngress builds an ungrouped Ingress.
+func buildStandaloneIngress(namespace, ingressClassName, svcName string) *networking.Ingress {
+	pathPrefix := networking.PathTypePrefix
+	return &networking.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "standalone",
+			Namespace: namespace,
+			Annotations: map[string]string{
+				annotationScheme:     "internet-facing",
+				annotationTargetType: "ip",
+			},
+		},
+		Spec: networking.IngressSpec{
+			IngressClassName: &ingressClassName,
+			Rules: []networking.IngressRule{{
+				Host: "standalone.example.com",
+				IngressRuleValue: networking.IngressRuleValue{
+					HTTP: &networking.HTTPIngressRuleValue{
+						Paths: []networking.HTTPIngressPath{
+							{Path: "/", PathType: &pathPrefix, Backend: ingressBackend(svcName)},
+						},
+					},
+				},
+			}},
 		},
 	}
 }

--- a/test/e2e/ingress2gateway/constants.go
+++ b/test/e2e/ingress2gateway/constants.go
@@ -14,6 +14,7 @@ const (
 	annotationHealthCheckInterval = "alb.ingress.kubernetes.io/healthcheck-interval-seconds"
 	annotationIPAddressType       = "alb.ingress.kubernetes.io/ip-address-type"
 	annotationDryRunPlan          = "alb.ingress.kubernetes.io/dry-run-plan"
+	annotationListenPorts         = "alb.ingress.kubernetes.io/listen-ports"
 
 	gwDryRunAnnotation = "gateway.k8s.aws/dry-run"
 	gwDryRunPlan       = "gateway.k8s.aws/dry-run-plan"
@@ -21,6 +22,7 @@ const (
 
 	hostAdmin = "admin.example.com"
 	hostApp   = "app.example.com"
+	hostAPI   = "api.example.com"
 
 	pathRoot   = "/"
 	pathAPI    = "/api"

--- a/test/e2e/ingress2gateway/migration_test.go
+++ b/test/e2e/ingress2gateway/migration_test.go
@@ -5,201 +5,502 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/ingress2gateway/console"
+	i2gutils "sigs.k8s.io/aws-load-balancer-controller/pkg/ingress2gateway/utils"
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework"
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework/manifest"
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework/utils"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("ingress to gateway migration", func() {
-	var (
-		ctx       context.Context
-		sandboxNS *corev1.Namespace
-		ingClass  *networking.IngressClass
-	)
+var _ = Describe("Ingress to Gateway Migration Tests", func() {
+	var ctx context.Context
 
 	BeforeEach(func() {
 		if !tf.Options.EnableMigrationTests {
 			Skip("Skipping migration tests")
 		}
 		ctx = context.Background()
-		By("setup sandbox namespace")
-		ns, err := tf.NSManager.AllocateNamespace(ctx, "i2g-e2e")
-		Expect(err).NotTo(HaveOccurred())
-		sandboxNS = ns
 	})
 
-	AfterEach(func() {
-		if sandboxNS != nil {
-			By("teardown sandbox namespace")
-			ingList := &networking.IngressList{}
-			_ = tf.K8sClient.List(ctx, ingList, client.InNamespace(sandboxNS.Name))
-			for i := range ingList.Items {
-				_ = tf.K8sClient.Delete(ctx, &ingList.Items[i])
+	// Context: dry-run plan comparison tests.
+	// These tests apply Ingress and Gateway with dry-run, then compare the dry-run plan
+	// annotations from both controllers to verify the migration tool produces equivalent
+	// resources. Faster than full cutover (no need to verify real ALB traffic).
+	Context("dry-run plan comparison", func() {
+		var (
+			sandboxNS    *corev1.Namespace
+			sandboxNS2   *corev1.Namespace
+			ingClasses   []*networking.IngressClass
+			icpResources []client.Object
+		)
+
+		AfterEach(func() {
+			// Delete all namespaces in parallel — cascading deletion handles all
+			// namespaced resources (Ingresses, Services, etc.) and the controller
+			// removes finalizers as part of group reconciliation. Matches the pattern
+			// in test/e2e/ingress/multi_path_backend.go.
+			var nsWG sync.WaitGroup
+			for _, ns := range []*corev1.Namespace{sandboxNS, sandboxNS2} {
+				if ns == nil {
+					continue
+				}
+				nsWG.Add(1)
+				go func(ns *corev1.Namespace) {
+					defer nsWG.Done()
+					_ = tf.K8sClient.Delete(ctx, ns)
+					_ = tf.NSManager.WaitUntilNamespaceDeleted(ctx, ns)
+				}(ns)
 			}
-			for i := range ingList.Items {
-				_ = tf.INGManager.WaitUntilIngressDeleted(ctx, &ingList.Items[i])
+			nsWG.Wait()
+
+			for _, ic := range ingClasses {
+				_ = tf.K8sClient.Delete(ctx, ic)
 			}
-			deleteGatewayResources(ctx, tf, sandboxNS.Name)
-			if ingClass != nil {
-				_ = tf.K8sClient.Delete(ctx, ingClass)
+			for _, obj := range icpResources {
+				_ = tf.K8sClient.Delete(ctx, obj)
 			}
-			err := tf.K8sClient.Delete(ctx, sandboxNS)
-			Expect(err).Should(SatisfyAny(BeNil(), Satisfy(apierrs.IsNotFound)))
-			err = tf.NSManager.WaitUntilNamespaceDeleted(ctx, sandboxNS)
+
+			ingClasses = nil
+			icpResources = nil
+			sandboxNS = nil
+			sandboxNS2 = nil
+		})
+
+		// Test 1: Complex single Ingress with many annotation categories.
+		// CLI: --from-cluster
+		It("should produce equivalent plan for complex single ingress", func() {
+			By("setting up namespace and services")
+			ns, err := tf.NSManager.AllocateNamespace(ctx, "i2g-e2e-cmp1")
 			Expect(err).NotTo(HaveOccurred())
-		}
-	})
+			sandboxNS = ns
 
-	It("should migrate an IngressGroup with multiple paths, tags, and health checks through dry-run and full cutover", func() {
-		groupName := fmt.Sprintf("e2e-mig-%s", sandboxNS.Name)
+			createServicesAndWait(ctx, tf, []serviceSpec{
+				{Namespace: ns.Name, Name: "svc-api", Annotations: map[string]string{annotationHealthCheckPath: "/api-health"}},
+				{Namespace: ns.Name, Name: "svc-static"},
+			})
 
-		// --- Phase 1: Create Ingress baseline ---
-		By("creating backend services")
-		appBuilder := manifest.NewFixedResponseServiceBuilder()
+			By("creating IngressClass and Ingress")
+			ingressClassName := fmt.Sprintf("alb-%s", ns.Name)
+			ingClass := &networking.IngressClass{
+				ObjectMeta: metav1.ObjectMeta{Name: ingressClassName},
+				Spec:       networking.IngressClassSpec{Controller: ingressController},
+			}
+			Expect(tf.K8sClient.Create(ctx, ingClass)).To(Succeed())
+			ingClasses = append(ingClasses, ingClass)
 
-		dpA, svcA := appBuilder.WithHTTPBody(bodyServiceA).Build(sandboxNS.Name, "svc-a", tf.Options.TestImageRegistry)
-		dpB, svcB := appBuilder.WithHTTPBody(bodyServiceB).Build(sandboxNS.Name, "svc-b", tf.Options.TestImageRegistry)
-		dpC, svcC := appBuilder.WithHTTPBody(bodyServiceC).Build(sandboxNS.Name, "svc-c", tf.Options.TestImageRegistry)
-
-		for _, obj := range []client.Object{dpA, svcA, dpB, svcB, dpC, svcC} {
-			Expect(tf.K8sClient.Create(ctx, obj)).To(Succeed())
-		}
-		_, err := tf.DPManager.WaitUntilDeploymentReady(ctx, dpA)
-		Expect(err).NotTo(HaveOccurred())
-		_, err = tf.DPManager.WaitUntilDeploymentReady(ctx, dpB)
-		Expect(err).NotTo(HaveOccurred())
-		_, err = tf.DPManager.WaitUntilDeploymentReady(ctx, dpC)
-		Expect(err).NotTo(HaveOccurred())
-
-		By("creating IngressGroup (2 members)")
-		ipFamily := ""
-		if tf.Options.IPFamily == framework.IPv6 {
-			ipFamily = "IPv6"
-		}
-		group := buildBasicIngressGroup(sandboxNS.Name, groupName, ipFamily, svcA.Name, svcB.Name, svcC.Name)
-
-		ingClass = group.IngressClass
-		Expect(tf.K8sClient.Create(ctx, ingClass)).To(Succeed())
-
-		expectedTraffic := []trafficCase{
-			{pathRoot, hostAdmin, bodyServiceC},
-			{pathAPI, hostApp, bodyServiceA},
-			{pathHealth, hostApp, bodyServiceB},
-		}
-
-		for _, ing := range group.Ingresses {
+			ing := buildComplexSingleIngress(ns.Name, ingressClassName)
 			Expect(tf.K8sClient.Create(ctx, ing)).To(Succeed())
-		}
 
-		By("waiting for Ingress ALB to be provisioned")
-		primaryIng := group.Ingresses[0]
-		var ingressLBDNS string
-		Eventually(func(g Gomega) {
-			err := tf.K8sClient.Get(ctx, client.ObjectKeyFromObject(primaryIng), primaryIng)
-			g.Expect(err).NotTo(HaveOccurred())
-			ingressLBDNS = findIngressDNS(primaryIng)
-			g.Expect(ingressLBDNS).NotTo(BeEmpty())
-		}, utils.CertReconcileTimeout, utils.PollIntervalShort).Should(Succeed())
-		tf.Logger.Info("ingress DNS populated", "dns", ingressLBDNS)
+			By("waiting for Ingress dry-run plan")
+			ingressPlan := expectDryRunPlan(ctx, tf, ing)
+			Expect(ingressPlan).NotTo(BeEmpty())
 
-		ingressLBARN, err := tf.LBManager.FindLoadBalancerByDNSName(ctx, ingressLBDNS)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ingressLBARN).NotTo(BeEmpty())
-
-		tf.Logger.Info("waiting for ingress ALB to be available")
-		err = tf.LBManager.WaitUntilLoadBalancerAvailable(ctx, ingressLBARN)
-		Expect(err).NotTo(HaveOccurred())
-
-		By("verifying traffic to ingress ALB", func() {
-			ExpectLBDNSResolvable(ctx, tf, ingressLBDNS)
-			verifyTraffic(tf, ingressLBDNS, expectedTraffic)
-		})
-
-		By("verifying dry-run-plan annotation on primary member only", func() {
-			expectDryRunPlan(ctx, tf, group.Ingresses[0], group.Ingresses[1:]...)
-		})
-
-		// --- Phase 2: Run migration tool ---
-		outputDir, err := os.MkdirTemp("", "i2g-e2e-*")
-		Expect(err).NotTo(HaveOccurred())
-		defer os.RemoveAll(outputDir)
-
-		By("running lbc-migrate tool", func() {
-			err = runMigrateTool(sandboxNS.Name, outputDir, "--dry-run")
+			By("running lbc-migrate --from-cluster")
+			outputDir, err := os.MkdirTemp("", "i2g-e2e-cmp1-*")
 			Expect(err).NotTo(HaveOccurred())
-		})
+			defer os.RemoveAll(outputDir)
 
-		By("verifying migration output files exist", func() {
-			outputFiles, err := filepath.Glob(filepath.Join(outputDir, "*.yaml"))
+			err = runMigrateTool(ns.Name, outputDir, "--dry-run")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(outputFiles).NotTo(BeEmpty())
-		})
 
-		// --- Phase 3: Apply in dry-run mode and verify ---
-		By("applying generated Gateway manifests (dry-run mode)", func() {
+			By("applying generated Gateway manifests")
 			err = applyYAMLDir(outputDir)
 			Expect(err).NotTo(HaveOccurred())
+
+			By("waiting for Gateway dry-run plan")
+			gw := findGatewayInNamespace(ctx, tf, ns.Name)
+			Expect(gw).NotTo(BeNil())
+			gatewayPlan := expectGatewayDryRunPlan(ctx, tf, gw)
+			Expect(gatewayPlan).NotTo(BeEmpty())
+
+			By("comparing plans")
+			userSpecified := console.BuildUserSpecifiedFields(ing.Annotations)
+			assertPlansEquivalent(ingressPlan, gatewayPlan, userSpecified)
 		})
 
-		By("verifying generated resource counts", func() {
-			verifyResourceCounts(ctx, tf, sandboxNS.Name, expectedResourceCounts{
-				gateways:                   1,
-				httpRoutes:                 2,
-				loadBalancerConfigurations: 1,
-				targetGroupConfigurations:  3,
-				listenerRuleConfigurations: 3,
+		// Test 2: Cross-namespace IngressGroup with ICP + actions.
+		// CLI: -f (file mode)
+		It("should produce equivalent plan for cross-namespace group via file mode", func() {
+			By("setting up namespaces and services")
+			nsA, err := tf.NSManager.AllocateNamespace(ctx, "i2g-e2e-cmp2a")
+			Expect(err).NotTo(HaveOccurred())
+			sandboxNS = nsA
+
+			nsB, err := tf.NSManager.AllocateNamespace(ctx, "i2g-e2e-cmp2b")
+			Expect(err).NotTo(HaveOccurred())
+			sandboxNS2 = nsB
+
+			createServicesAndWait(ctx, tf, []serviceSpec{
+				{Namespace: nsA.Name, Name: "svc-blue"},
+				{Namespace: nsA.Name, Name: "svc-green"},
+				{Namespace: nsB.Name, Name: "svc-search"},
 			})
+
+			By("creating IngressClass with IngressClassParams")
+			ingressClassName := fmt.Sprintf("alb-%s", nsA.Name)
+			icpScheme := elbv2api.LoadBalancerSchemeInternetFacing
+			icp := &elbv2api.IngressClassParams{
+				ObjectMeta: metav1.ObjectMeta{Name: ingressClassName},
+				Spec: elbv2api.IngressClassParamsSpec{
+					Scheme: &icpScheme,
+					Tags:   []elbv2api.Tag{{Key: "ManagedBy", Value: "platform"}},
+				},
+			}
+			Expect(tf.K8sClient.Create(ctx, icp)).To(Succeed())
+			icpResources = append(icpResources, icp)
+
+			elbv2Group := "elbv2.k8s.aws"
+			ingClass := &networking.IngressClass{
+				ObjectMeta: metav1.ObjectMeta{Name: ingressClassName},
+				Spec: networking.IngressClassSpec{
+					Controller: ingressController,
+					Parameters: &networking.IngressClassParametersReference{
+						APIGroup: &elbv2Group,
+						Kind:     "IngressClassParams",
+						Name:     ingressClassName,
+					},
+				},
+			}
+			Expect(tf.K8sClient.Create(ctx, ingClass)).To(Succeed())
+			ingClasses = append(ingClasses, ingClass)
+
+			By("creating grouped Ingresses")
+			groupName := fmt.Sprintf("cross-ns-%s", nsA.Name)
+			ingA := buildGroupMemberA(nsA.Name, groupName, ingressClassName)
+			ingB := buildGroupMemberB(nsB.Name, groupName, ingressClassName)
+
+			Expect(tf.K8sClient.Create(ctx, ingA)).To(Succeed())
+			Expect(tf.K8sClient.Create(ctx, ingB)).To(Succeed())
+
+			By("waiting for Ingress dry-run plan")
+			ingressPlan := expectDryRunPlan(ctx, tf, ingA, ingB)
+			Expect(ingressPlan).NotTo(BeEmpty())
+
+			By("running lbc-migrate via -f (file mode)")
+			outputDir, err := os.MkdirTemp("", "i2g-e2e-cmp2-*")
+			Expect(err).NotTo(HaveOccurred())
+			defer os.RemoveAll(outputDir)
+
+			inputFile := writeResourcesToTempFile(ingClass, icp, ingA, ingB,
+				findServiceInNamespace(ctx, tf, nsA.Name, "svc-blue"),
+				findServiceInNamespace(ctx, tf, nsA.Name, "svc-green"),
+				findServiceInNamespace(ctx, tf, nsB.Name, "svc-search"),
+			)
+			defer os.Remove(inputFile)
+
+			err = runMigrateToolWithFile(inputFile, outputDir, "--dry-run")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("applying generated Gateway manifests")
+			err = applyYAMLDir(outputDir)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("waiting for Gateway dry-run plan")
+			gw := findGatewayInNamespace(ctx, tf, nsA.Name)
+			Expect(gw).NotTo(BeNil())
+			gatewayPlan := expectGatewayDryRunPlan(ctx, tf, gw)
+			Expect(gatewayPlan).NotTo(BeEmpty())
+
+			By("comparing plans")
+			userSpecified := console.BuildUserSpecifiedFields(ingA.Annotations)
+			assertPlansEquivalent(ingressPlan, gatewayPlan, userSpecified)
 		})
 
-		gw := findGatewayInNamespace(ctx, tf, sandboxNS.Name)
-		Expect(gw).NotTo(BeNil(), "no Gateway found in namespace %s", sandboxNS.Name)
+		// Test 3: Multi-group cluster with mixed ingresses.
+		// CLI: --input-dir + --split=namespace
+		It("should correctly partition multiple groups and standalone ingresses", func() {
+			By("setting up namespaces")
+			nsPlatform, err := tf.NSManager.AllocateNamespace(ctx, "i2g-e2e-cmp3-plat")
+			Expect(err).NotTo(HaveOccurred())
+			sandboxNS = nsPlatform
 
-		By("verifying Gateway has dry-run annotation", func() {
-			Expect(gw.Annotations[gwDryRunAnnotation]).To(Equal("true"))
-		})
+			nsTeamA, err := tf.NSManager.AllocateNamespace(ctx, "i2g-e2e-cmp3-a")
+			Expect(err).NotTo(HaveOccurred())
+			sandboxNS2 = nsTeamA
 
-		By("waiting for Gateway dry-run-plan annotation", func() {
-			expectGatewayDryRunPlan(ctx, tf, gw)
-		})
-
-		By("verifying NO ALB is created for dry-run Gateway", func() {
-			expectNoALBForGateway(ctx, tf, gw)
-		})
-
-		// --- Phase 4: Full cutover ---
-		By("removing dry-run annotation to trigger real reconciliation", func() {
-			removeDryRunAnnotation(ctx, tf, gw)
-		})
-
-		By("waiting for Gateway ALB to be provisioned")
-		gatewayLBARN, gatewayLBDNS := expectGatewayALBProvisioned(ctx, tf, gw)
-
-		tf.Logger.Info("waiting for gateway ALB to be available")
-		err = tf.LBManager.WaitUntilLoadBalancerAvailable(ctx, gatewayLBARN)
-		Expect(err).NotTo(HaveOccurred())
-
-		By("comparing ALB configurations: listeners, rules, and target groups", func() {
-			compareALBConfigurations(ctx, tf, ingressLBARN, gatewayLBARN)
-		})
-
-		By("comparing ALB configurations: tags", func() {
-			migrationTagLBValue := fmt.Sprintf("ingress-group/%s", groupName)
-			compareTags(ctx, tf, ingressLBARN, gatewayLBARN, migrationTagLBValue, map[string]string{
-				"Team":      "e2e",
-				"Component": "migration",
+			By("creating services with running pods")
+			createServicesAndWait(ctx, tf, []serviceSpec{
+				{Namespace: nsPlatform.Name, Name: "svc-platform-1"},
+				{Namespace: nsPlatform.Name, Name: "svc-platform-2"},
+				{Namespace: nsTeamA.Name, Name: "svc-standalone"},
 			})
+
+			By("creating IngressClasses")
+			albClassName := fmt.Sprintf("alb-%s", nsPlatform.Name)
+			albClass := &networking.IngressClass{
+				ObjectMeta: metav1.ObjectMeta{Name: albClassName},
+				Spec:       networking.IngressClassSpec{Controller: ingressController},
+			}
+			Expect(tf.K8sClient.Create(ctx, albClass)).To(Succeed())
+			ingClasses = append(ingClasses, albClass)
+
+			By("creating platform group (2 members in ns-platform)")
+			platformGroup := fmt.Sprintf("platform-%s", nsPlatform.Name)
+			// Path length determines Gateway API priority; we make member-1's path longer
+			// so its rule gets higher priority on both Ingress (group.order=1) and Gateway sides.
+			platformIng1 := buildPlatformGroupMember(nsPlatform.Name, platformGroup, albClassName, "svc-platform-1", "1", "/api/v1")
+			platformIng2 := buildPlatformGroupMember(nsPlatform.Name, platformGroup, albClassName, "svc-platform-2", "2", "/api")
+			Expect(tf.K8sClient.Create(ctx, platformIng1)).To(Succeed())
+			Expect(tf.K8sClient.Create(ctx, platformIng2)).To(Succeed())
+
+			By("creating standalone ingress in ns-team-a (no group)")
+			standaloneIng := buildStandaloneIngress(nsTeamA.Name, albClassName, "svc-standalone")
+			Expect(tf.K8sClient.Create(ctx, standaloneIng)).To(Succeed())
+
+			By("waiting for Ingress dry-run plans")
+			platformPlan := expectDryRunPlan(ctx, tf, platformIng1, platformIng2)
+			Expect(platformPlan).NotTo(BeEmpty())
+			standalonePlan := expectDryRunPlan(ctx, tf, standaloneIng)
+			Expect(standalonePlan).NotTo(BeEmpty())
+
+			By("running lbc-migrate --input-dir with --split=namespace")
+			inputDir, err := os.MkdirTemp("", "i2g-e2e-cmp3-input-*")
+			Expect(err).NotTo(HaveOccurred())
+			defer os.RemoveAll(inputDir)
+
+			writeResourcesToDir(inputDir,
+				albClass,
+				platformIng1, platformIng2,
+				standaloneIng,
+				findServiceInNamespace(ctx, tf, nsPlatform.Name, "svc-platform-1"),
+				findServiceInNamespace(ctx, tf, nsPlatform.Name, "svc-platform-2"),
+				findServiceInNamespace(ctx, tf, nsTeamA.Name, "svc-standalone"),
+			)
+
+			outputDir, err := os.MkdirTemp("", "i2g-e2e-cmp3-*")
+			Expect(err).NotTo(HaveOccurred())
+			defer os.RemoveAll(outputDir)
+
+			err = runMigrateToolWithInputDir(inputDir, outputDir, "--dry-run", "--split=namespace")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying split-by-namespace output layout")
+			_, err = os.Stat(filepath.Join(outputDir, "gatewayclass.yaml"))
+			Expect(err).NotTo(HaveOccurred(), "gatewayclass.yaml should exist at top level")
+			_, err = os.Stat(filepath.Join(outputDir, nsPlatform.Name, "gateway-resources.yaml"))
+			Expect(err).NotTo(HaveOccurred(), "namespace subdirectory for ns-platform should exist")
+			_, err = os.Stat(filepath.Join(outputDir, nsTeamA.Name, "gateway-resources.yaml"))
+			Expect(err).NotTo(HaveOccurred(), "namespace subdirectory for ns-team-a should exist")
+
+			By("applying generated Gateway manifests recursively")
+			err = applyYAMLDirRecursive(outputDir)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying correct number of Gateways produced")
+			platformGWName := i2gutils.GetGroupGatewayName(platformGroup)
+			platformGW := findGatewayByName(ctx, tf, nsPlatform.Name, platformGWName)
+			Expect(platformGW).NotTo(BeNil(), "platform group Gateway %s/%s not found", nsPlatform.Name, platformGWName)
+
+			standaloneGWName := i2gutils.GetGatewayName(nsTeamA.Name, "standalone")
+			standaloneGW := findGatewayByName(ctx, tf, nsTeamA.Name, standaloneGWName)
+			Expect(standaloneGW).NotTo(BeNil(), "standalone Gateway %s/%s not found", nsTeamA.Name, standaloneGWName)
+
+			By("comparing platform group plans")
+			platformGWPlan := expectGatewayDryRunPlan(ctx, tf, platformGW)
+			userSpecifiedPlatform := console.BuildUserSpecifiedFields(platformIng1.Annotations)
+			assertPlansEquivalent(platformPlan, platformGWPlan, userSpecifiedPlatform)
+
+			By("comparing standalone plans")
+			standaloneGWPlan := expectGatewayDryRunPlan(ctx, tf, standaloneGW)
+			userSpecifiedStandalone := console.BuildUserSpecifiedFields(standaloneIng.Annotations)
+			assertPlansEquivalent(standalonePlan, standaloneGWPlan, userSpecifiedStandalone)
+		})
+	})
+
+	// Context: full cutover workflow test.
+	// This test creates a real ALB from an Ingress, runs the migration tool, applies
+	// the Gateway manifests in dry-run mode, then triggers a real cutover and verifies
+	// the Gateway-side ALB matches the Ingress-side ALB (listeners, rules, target groups,
+	// tags, and traffic).
+	Context("full cutover workflow", func() {
+		var (
+			sandboxNS *corev1.Namespace
+			ingClass  *networking.IngressClass
+		)
+
+		BeforeEach(func() {
+			By("setup sandbox namespace")
+			ns, err := tf.NSManager.AllocateNamespace(ctx, "i2g-e2e")
+			Expect(err).NotTo(HaveOccurred())
+			sandboxNS = ns
 		})
 
-		By("verifying traffic to Gateway ALB", func() {
-			ExpectLBDNSResolvable(ctx, tf, gatewayLBDNS)
-			verifyTraffic(tf, gatewayLBDNS, expectedTraffic)
+		AfterEach(func() {
+			if sandboxNS != nil {
+				By("teardown sandbox namespace")
+				ingList := &networking.IngressList{}
+				_ = tf.K8sClient.List(ctx, ingList, client.InNamespace(sandboxNS.Name))
+				for i := range ingList.Items {
+					_ = tf.K8sClient.Delete(ctx, &ingList.Items[i])
+				}
+				for i := range ingList.Items {
+					_ = tf.INGManager.WaitUntilIngressDeleted(ctx, &ingList.Items[i])
+				}
+				deleteGatewayResources(ctx, tf, sandboxNS.Name)
+				if ingClass != nil {
+					_ = tf.K8sClient.Delete(ctx, ingClass)
+				}
+				err := tf.K8sClient.Delete(ctx, sandboxNS)
+				Expect(err).Should(SatisfyAny(BeNil(), Satisfy(apierrs.IsNotFound)))
+				err = tf.NSManager.WaitUntilNamespaceDeleted(ctx, sandboxNS)
+				Expect(err).NotTo(HaveOccurred())
+			}
+		})
+
+		It("should migrate an IngressGroup with multiple paths, tags, and health checks through dry-run and full cutover", func() {
+			groupName := fmt.Sprintf("e2e-mig-%s", sandboxNS.Name)
+
+			// --- Phase 1: Create Ingress baseline ---
+			By("creating backend services")
+			appBuilder := manifest.NewFixedResponseServiceBuilder()
+
+			dpA, svcA := appBuilder.WithHTTPBody(bodyServiceA).Build(sandboxNS.Name, "svc-a", tf.Options.TestImageRegistry)
+			dpB, svcB := appBuilder.WithHTTPBody(bodyServiceB).Build(sandboxNS.Name, "svc-b", tf.Options.TestImageRegistry)
+			dpC, svcC := appBuilder.WithHTTPBody(bodyServiceC).Build(sandboxNS.Name, "svc-c", tf.Options.TestImageRegistry)
+
+			for _, obj := range []client.Object{dpA, svcA, dpB, svcB, dpC, svcC} {
+				Expect(tf.K8sClient.Create(ctx, obj)).To(Succeed())
+			}
+			_, err := tf.DPManager.WaitUntilDeploymentReady(ctx, dpA)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = tf.DPManager.WaitUntilDeploymentReady(ctx, dpB)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = tf.DPManager.WaitUntilDeploymentReady(ctx, dpC)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("creating IngressGroup (2 members)")
+			ipFamily := ""
+			if tf.Options.IPFamily == framework.IPv6 {
+				ipFamily = "IPv6"
+			}
+			group := buildBasicIngressGroup(sandboxNS.Name, groupName, ipFamily, svcA.Name, svcB.Name, svcC.Name)
+
+			ingClass = group.IngressClass
+			Expect(tf.K8sClient.Create(ctx, ingClass)).To(Succeed())
+
+			expectedTraffic := []trafficCase{
+				{pathRoot, hostAdmin, bodyServiceC},
+				{pathAPI, hostApp, bodyServiceA},
+				{pathHealth, hostApp, bodyServiceB},
+			}
+
+			for _, ing := range group.Ingresses {
+				Expect(tf.K8sClient.Create(ctx, ing)).To(Succeed())
+			}
+
+			By("waiting for Ingress ALB to be provisioned")
+			primaryIng := group.Ingresses[0]
+			var ingressLBDNS string
+			Eventually(func(g Gomega) {
+				err := tf.K8sClient.Get(ctx, client.ObjectKeyFromObject(primaryIng), primaryIng)
+				g.Expect(err).NotTo(HaveOccurred())
+				ingressLBDNS = findIngressDNS(primaryIng)
+				g.Expect(ingressLBDNS).NotTo(BeEmpty())
+			}, utils.CertReconcileTimeout, utils.PollIntervalShort).Should(Succeed())
+			tf.Logger.Info("ingress DNS populated", "dns", ingressLBDNS)
+
+			ingressLBARN, err := tf.LBManager.FindLoadBalancerByDNSName(ctx, ingressLBDNS)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ingressLBARN).NotTo(BeEmpty())
+
+			tf.Logger.Info("waiting for ingress ALB to be available")
+			err = tf.LBManager.WaitUntilLoadBalancerAvailable(ctx, ingressLBARN)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying traffic to ingress ALB", func() {
+				ExpectLBDNSResolvable(ctx, tf, ingressLBDNS)
+				verifyTraffic(tf, ingressLBDNS, expectedTraffic)
+			})
+
+			By("verifying dry-run-plan annotation on primary member only", func() {
+				expectDryRunPlan(ctx, tf, group.Ingresses[0], group.Ingresses[1:]...)
+			})
+
+			// --- Phase 2: Run migration tool ---
+			outputDir, err := os.MkdirTemp("", "i2g-e2e-*")
+			Expect(err).NotTo(HaveOccurred())
+			defer os.RemoveAll(outputDir)
+
+			By("running lbc-migrate tool", func() {
+				err = runMigrateTool(sandboxNS.Name, outputDir, "--dry-run")
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("verifying migration output files exist", func() {
+				outputFiles, err := filepath.Glob(filepath.Join(outputDir, "*.yaml"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(outputFiles).NotTo(BeEmpty())
+			})
+
+			// --- Phase 3: Apply in dry-run mode and verify ---
+			By("applying generated Gateway manifests (dry-run mode)", func() {
+				err = applyYAMLDir(outputDir)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("verifying generated resource counts", func() {
+				verifyResourceCounts(ctx, tf, sandboxNS.Name, expectedResourceCounts{
+					gateways:                   1,
+					httpRoutes:                 2,
+					loadBalancerConfigurations: 1,
+					targetGroupConfigurations:  3,
+					listenerRuleConfigurations: 3,
+				})
+			})
+
+			gw := findGatewayInNamespace(ctx, tf, sandboxNS.Name)
+			Expect(gw).NotTo(BeNil(), "no Gateway found in namespace %s", sandboxNS.Name)
+
+			By("verifying Gateway has dry-run annotation", func() {
+				Expect(gw.Annotations[gwDryRunAnnotation]).To(Equal("true"))
+			})
+
+			By("waiting for Gateway dry-run-plan annotation", func() {
+				expectGatewayDryRunPlan(ctx, tf, gw)
+			})
+
+			By("verifying NO ALB is created for dry-run Gateway", func() {
+				expectNoALBForGateway(ctx, tf, gw)
+			})
+
+			// --- Phase 4: Full cutover ---
+			By("removing dry-run annotation to trigger real reconciliation", func() {
+				removeDryRunAnnotation(ctx, tf, gw)
+			})
+
+			By("waiting for Gateway ALB to be provisioned")
+			gatewayLBARN, gatewayLBDNS := expectGatewayALBProvisioned(ctx, tf, gw)
+
+			tf.Logger.Info("waiting for gateway ALB to be available")
+			err = tf.LBManager.WaitUntilLoadBalancerAvailable(ctx, gatewayLBARN)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("comparing ALB configurations: listeners, rules, and target groups", func() {
+				compareALBConfigurations(ctx, tf, ingressLBARN, gatewayLBARN)
+			})
+
+			By("comparing ALB configurations: tags", func() {
+				migrationTagLBValue := fmt.Sprintf("ingress-group/%s", groupName)
+				compareTags(ctx, tf, ingressLBARN, gatewayLBARN, migrationTagLBValue, map[string]string{
+					"Team":      "e2e",
+					"Component": "migration",
+				})
+			})
+
+			By("verifying traffic to Gateway ALB", func() {
+				ExpectLBDNSResolvable(ctx, tf, gatewayLBDNS)
+				verifyTraffic(tf, gatewayLBDNS, expectedTraffic)
+			})
 		})
 	})
 })

--- a/test/e2e/ingress2gateway/utils.go
+++ b/test/e2e/ingress2gateway/utils.go
@@ -1,18 +1,33 @@
 package ingress2gateway
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
+	"time"
 
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	elbv2api "sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1"
 	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework"
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework/utils"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+	sigsyaml "sigs.k8s.io/yaml"
+)
+
+const (
+	planStabilizeTimeout = 3 * time.Minute
+	// shellCommandTimeout caps how long any kubectl/lbc-migrate invocation may
+	// run before the test gives up. Without it, a hung subprocess would stall
+	// the entire suite indefinitely.
+	shellCommandTimeout = 2 * time.Minute
 )
 
 // runMigrateTool runs lbc-migrate as a subprocess with the given extra flags.
@@ -23,42 +38,72 @@ func runMigrateTool(namespace, outputDir string, extraArgs ...string) error {
 		args = append(args, "--from-cluster", "--namespaces", namespace)
 	}
 	args = append(args, extraArgs...)
-	cmd := exec.Command("lbc-migrate", args...)
-	out, err := cmd.CombinedOutput()
+	return runLBCMigrate(args)
+}
+
+// runLBCMigrate executes lbc-migrate with the given args and wraps the output on failure.
+func runLBCMigrate(args []string) error {
+	out, err := runShell("lbc-migrate", args...)
 	if err != nil {
 		return fmt.Errorf("lbc-migrate failed: %v\noutput: %s", err, string(out))
 	}
 	return nil
 }
 
-// expectDryRunPlan waits for the dry-run-plan annotation to appear on the primary ingress
-// and verifies it is absent on all secondary members, using a single polling loop.
+// runShell runs name with args under shellCommandTimeout and returns combined output.
+func runShell(name string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), shellCommandTimeout)
+	defer cancel()
+	return exec.CommandContext(ctx, name, args...).CombinedOutput()
+}
+
+// expectDryRunPlan waits for the Ingress ALB to be fully provisioned (LB DNS populated
+// in status), then reads the dry-run-plan annotation. Since the controller writes the
+// annotation during model building (before deployment), DNS appearing in status means
+// the full reconcile is complete and the annotation is finalized.
+// Verifies the annotation is absent on all secondary group members.
 func expectDryRunPlan(ctx context.Context, tf *framework.Framework, primary *networking.Ingress, secondaries ...*networking.Ingress) string {
-	var plan string
 	Eventually(func(g Gomega) {
 		err := tf.K8sClient.Get(ctx, client.ObjectKeyFromObject(primary), primary)
 		g.Expect(err).NotTo(HaveOccurred())
-		plan = primary.Annotations[annotationDryRunPlan]
-		g.Expect(plan).ShouldNot(BeEmpty())
+		g.Expect(findIngressDNS(primary)).NotTo(BeEmpty(),
+			"primary ingress ALB DNS not yet populated (reconcile in progress)")
+	}, utils.CertReconcileTimeout, utils.PollIntervalShort).Should(Succeed())
 
-		for _, sec := range secondaries {
-			err = tf.K8sClient.Get(ctx, client.ObjectKeyFromObject(sec), sec)
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(sec.Annotations[annotationDryRunPlan]).To(BeEmpty())
-		}
-	}, utils.IngressReconcileTimeout, utils.PollIntervalShort).Should(Succeed())
+	plan := primary.Annotations[annotationDryRunPlan]
+	Expect(plan).NotTo(BeEmpty(), "dry-run-plan annotation missing on primary ingress")
+
+	for _, sec := range secondaries {
+		err := tf.K8sClient.Get(ctx, client.ObjectKeyFromObject(sec), sec)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sec.Annotations[annotationDryRunPlan]).To(BeEmpty(),
+			"dry-run-plan annotation should be absent on secondary member %s/%s",
+			sec.Namespace, sec.Name)
+	}
 	return plan
 }
 
-// expectGatewayDryRunPlan waits for the gateway controller to write the dry-run-plan annotation.
+// expectGatewayDryRunPlan waits for the gateway controller to write a stable dry-run-plan
+// annotation. The controller may reconcile multiple times as routes attach, so we poll
+// until the plan stops changing (same value across 2 consecutive reads).
 func expectGatewayDryRunPlan(ctx context.Context, tf *framework.Framework, gw *gwv1.Gateway) string {
 	var plan string
+	var lastPlan string
+	stableCount := 0
 	Eventually(func(g Gomega) {
 		err := tf.K8sClient.Get(ctx, client.ObjectKeyFromObject(gw), gw)
 		g.Expect(err).NotTo(HaveOccurred())
 		plan = gw.Annotations[gwDryRunPlan]
 		g.Expect(plan).ShouldNot(BeEmpty())
-	}, utils.CertReconcileTimeout, utils.PollIntervalShort).Should(Succeed())
+		if plan == lastPlan {
+			stableCount++
+		} else {
+			stableCount = 0
+		}
+		lastPlan = plan
+		g.Expect(stableCount).To(BeNumerically(">=", 2),
+			"dry-run plan not yet stable (controller still reconciling)")
+	}, planStabilizeTimeout, utils.PollIntervalShort).Should(Succeed())
 	return plan
 }
 
@@ -123,7 +168,7 @@ func applyYAMLDir(dir string) error {
 		return err
 	}
 	for _, f := range files {
-		out, err := exec.Command("kubectl", "apply", "-f", f).CombinedOutput()
+		out, err := runShell("kubectl", "apply", "-f", f)
 		if err != nil {
 			return fmt.Errorf("kubectl apply failed for %s: %v\noutput: %s", f, err, out)
 		}
@@ -148,4 +193,85 @@ func findIngressDNS(ing *networking.Ingress) string {
 		}
 	}
 	return ""
+}
+
+// applyYAMLDirRecursive applies all YAML files in a directory tree using kubectl apply -R.
+func applyYAMLDirRecursive(dir string) error {
+	out, err := runShell("kubectl", "apply", "-R", "-f", dir)
+	if err != nil {
+		return fmt.Errorf("kubectl apply -R failed for %s: %v\noutput: %s", dir, err, out)
+	}
+	return nil
+}
+
+// runMigrateToolWithInputDir runs lbc-migrate with --input-dir.
+func runMigrateToolWithInputDir(inputDir, outputDir string, extraArgs ...string) error {
+	args := append([]string{"--output-dir", outputDir, "--input-dir", inputDir}, extraArgs...)
+	return runLBCMigrate(args)
+}
+
+// runMigrateToolWithFile runs lbc-migrate with -f (file input mode).
+func runMigrateToolWithFile(inputFile, outputDir string, extraArgs ...string) error {
+	args := append([]string{"--output-dir", outputDir, "-f", inputFile}, extraArgs...)
+	return runLBCMigrate(args)
+}
+
+// writeResourcesToTempFile serializes multiple k8s objects to a temp YAML file
+// joined by "---\n" so the migration tool's -f mode can consume them.
+func writeResourcesToTempFile(objects ...client.Object) string {
+	docs := make([][]byte, 0, len(objects))
+	for _, obj := range objects {
+		docs = append(docs, marshalObjectToYAML(obj))
+	}
+
+	f, err := os.CreateTemp("", "i2g-input-*.yaml")
+	Expect(err).NotTo(HaveOccurred())
+	_, err = f.Write(bytes.Join(docs, []byte("---\n")))
+	Expect(err).NotTo(HaveOccurred())
+	Expect(f.Close()).To(Succeed())
+	return f.Name()
+}
+
+// writeResourcesToDir writes each k8s object as a separate YAML file in the given directory.
+func writeResourcesToDir(dir string, objects ...client.Object) {
+	for i, obj := range objects {
+		filename := fmt.Sprintf("%03d-%s-%s.yaml", i, obj.GetNamespace(), obj.GetName())
+		Expect(os.WriteFile(filepath.Join(dir, filename), marshalObjectToYAML(obj), 0644)).To(Succeed())
+	}
+}
+
+// marshalObjectToYAML serializes obj as a YAML document with apiVersion/kind
+// populated. controller-runtime clients leave TypeMeta empty when round-tripping
+// objects, so we set it explicitly before marshaling.
+func marshalObjectToYAML(obj client.Object) []byte {
+	groupVersionKind := groupVersionKindForObject(obj)
+	obj.GetObjectKind().SetGroupVersionKind(groupVersionKind)
+	data, err := sigsyaml.Marshal(obj)
+	Expect(err).NotTo(HaveOccurred(), "marshal %T: %v", obj, err)
+	return data
+}
+
+// groupVersionKindForObject returns the GroupVersionKind for the supported test types.
+func groupVersionKindForObject(obj client.Object) schema.GroupVersionKind {
+	switch obj.(type) {
+	case *networking.Ingress:
+		return networking.SchemeGroupVersion.WithKind("Ingress")
+	case *networking.IngressClass:
+		return networking.SchemeGroupVersion.WithKind("IngressClass")
+	case *corev1.Service:
+		return corev1.SchemeGroupVersion.WithKind("Service")
+	case *elbv2api.IngressClassParams:
+		return elbv2api.GroupVersion.WithKind("IngressClassParams")
+	default:
+		Expect(obj).To(BeNil(), "unsupported object type %T for YAML marshaling", obj)
+		return schema.GroupVersionKind{}
+	}
+}
+
+// findServiceInNamespace fetches a Service object from the cluster.
+func findServiceInNamespace(ctx context.Context, tf *framework.Framework, namespace, name string) *corev1.Service {
+	svc := &corev1.Service{}
+	err := tf.K8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, svc)
+	Expect(err).NotTo(HaveOccurred())
+	return svc
 }

--- a/test/e2e/ingress2gateway/verifiers.go
+++ b/test/e2e/ingress2gateway/verifiers.go
@@ -9,11 +9,45 @@ import (
 	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 	. "github.com/onsi/gomega"
 	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/apis/gateway/v1beta1"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/ingress2gateway/console"
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework"
 	frameworkhttp "sigs.k8s.io/aws-load-balancer-controller/test/framework/http"
+	"sigs.k8s.io/aws-load-balancer-controller/test/framework/manifest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
+
+// serviceSpec describes a backend service to create for an e2e test.
+type serviceSpec struct {
+	Namespace   string
+	Name        string
+	Annotations map[string]string
+}
+
+// createServicesAndWait creates a Deployment+Service for each spec and blocks
+// until every Deployment is ready.
+func createServicesAndWait(ctx context.Context, tf *framework.Framework, specs []serviceSpec) {
+	appBuilder := manifest.NewFixedResponseServiceBuilder()
+	for _, s := range specs {
+		dp, svc := appBuilder.WithHTTPBody(s.Name).Build(s.Namespace, s.Name, tf.Options.TestImageRegistry)
+		if len(s.Annotations) > 0 {
+			svc.Annotations = s.Annotations
+		}
+		Expect(tf.K8sClient.Create(ctx, dp)).To(Succeed())
+		Expect(tf.K8sClient.Create(ctx, svc)).To(Succeed())
+		_, err := tf.DPManager.WaitUntilDeploymentReady(ctx, dp)
+		Expect(err).NotTo(HaveOccurred())
+	}
+}
+
+// findGatewayByName fetches a Gateway by name. Returns nil if not found.
+func findGatewayByName(ctx context.Context, tf *framework.Framework, namespace, name string) *gwv1.Gateway {
+	gw := &gwv1.Gateway{}
+	if err := tf.K8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gw); err != nil {
+		return nil
+	}
+	return gw
+}
 
 // compareALBConfigurations fetches listeners once for both ALBs and compares listeners, rules, target groups.
 func compareALBConfigurations(ctx context.Context, tf *framework.Framework, ingressLBARN, gatewayLBARN string) {
@@ -305,4 +339,37 @@ func verifyResourceCounts(ctx context.Context, tf *framework.Framework, namespac
 	lrcList := &elbv2gw.ListenerRuleConfigurationList{}
 	Expect(tf.K8sClient.List(ctx, lrcList, client.InNamespace(namespace))).To(Succeed())
 	Expect(lrcList.Items).To(HaveLen(expected.listenerRuleConfigurations), "ListenerRuleConfiguration count mismatch")
+}
+
+// assertPlansEquivalent parses both plans, runs the console differ, and asserts
+// that all non-"Known" entries are StatusSame.
+func assertPlansEquivalent(ingressPlanJSON, gatewayPlanJSON string, userSpecified console.UserSpecifiedFields) {
+	ingressTree, err := console.ParseStack(ingressPlanJSON)
+	Expect(err).NotTo(HaveOccurred(), "failed to parse ingress plan")
+
+	gatewayTree, err := console.ParseStack(gatewayPlanJSON)
+	Expect(err).NotTo(HaveOccurred(), "failed to parse gateway plan")
+
+	result := console.Diff(ingressTree, gatewayTree, userSpecified)
+
+	var unexpected []console.DiffEntry
+	for _, e := range result.Entries {
+		if e.Status == console.StatusSame || e.Known {
+			continue
+		}
+		unexpected = append(unexpected, e)
+	}
+
+	Expect(unexpected).To(BeEmpty(),
+		"unexpected differences between ingress and gateway plans:\n%s",
+		formatUnexpectedDiffs(unexpected))
+}
+
+func formatUnexpectedDiffs(entries []console.DiffEntry) string {
+	var result string
+	for _, e := range entries {
+		result += fmt.Sprintf("[%s] %s/%s field=%s ingress=%v gateway=%v\n",
+			e.Status, e.ResourceType, e.CorrelationID, e.Field, e.Ingress, e.Gateway)
+	}
+	return result
 }


### PR DESCRIPTION
### Description

Adds e2e tests that verify the `lbc-migrate` tool produces Gateway resources whose model matches what the Ingress controller would build for the same Ingress. The verification compares the dry-run-plan annotations from both controllers and asserts there are no unexpected diffs (the existing `pkg/ingress2gateway/console` classifier marks expected migration artifacts — added migration tag, controller-generated names, default health-check drift, etc. — as `Known`).

#### New tests (under `test/e2e/ingress2gateway`, gated by `--enable-migration-tests`)

All three live in a new `Context("dry-run plan comparison")` inside the existing `Describe("Ingress to Gateway Migration Tests")`. They sit alongside the pre-existing full-cutover test, which is now in its own `Context("full cutover workflow")`.

**Test 1 — complex single Ingress (`--from-cluster`)**
- One Ingress with: scheme, target-type=ip, listen-ports HTTP:80, load-balancer-attributes, tags, full health-check overrides, target-group-attributes, a fixed-response action with a `source-ip` condition, plus a per-Service health-check-path override.
- Three paths (longest first to match Gateway-API path-length precedence): `/api/v1/resources` → svc-api, `/api/v1` → svc-static, `/maintenance` → fixed-response action.
- Runs `lbc-migrate --from-cluster --namespaces <ns> --dry-run`, applies the generated YAML, then diffs the two plans.

**Test 2 — cross-namespace IngressGroup with IngressClassParams (`-f` file mode)**
- Two Ingresses in two different namespaces sharing a `group.name`. Member A carries two action annotations (fixed-response + weighted forward to two services) and Member B is a simple member.
- Adds an IngressClassParams that overrides scheme to `internet-facing` (overriding Member A's `internal`) and adds an extra tag — exercises the ICP-priority chain.
- Runs `lbc-migrate -f <temp-file> --dry-run` against a serialized YAML doc containing the IngressClass, ICP, both Ingresses, and three Services.

**Test 3 — multi-group cluster (`--input-dir` + `--split=namespace`)**
- A platform group (2 members in `nsPlatform`) and a standalone Ingress in `nsTeamA`. Member-1's path is longer so Gateway-API path-length precedence aligns with `group.order`.
- Runs `lbc-migrate --input-dir ... --output-dir ... --split=namespace --dry-run`, verifies the per-namespace output layout (`gatewayclass.yaml` at top level + per-namespace subdirs), applies recursively, then compares both plans (platform vs standalone).

#### Other changes

- `pkg/ingress2gateway/translate/httproute.go`: when assembling the route for `spec.defaultBackend`, also call `t.buildLRCForTags` — symmetric with non-default rules at line 154. Without this, user-tag annotations would not be emitted onto the catch-all rule.
- `test/e2e/ingress2gateway/utils.go`: subprocess invocations (`lbc-migrate`, `kubectl apply`) now run through `runShell` which wraps them with a 2-minute `context.WithTimeout`; prevents an unresponsive subprocess from stalling the suite. 

 Dry-run plan annotation cleanup on feature disable

 - When the IngressPlanAnnotation feature gate is disabled (e.g. after migration is complete), the ingress controller now cleans up stale alb.ingress.kubernetes.io/dry-run-plan annotations from all group members on next reconcile. 

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
```
Ran 4 of 4 Specs in 730.793 seconds
SUCCESS! -- 4 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 12m28.47794825s
Test Suite Passed
```
- [x] Made sure the title of the PR is a good description that can go into the release notes