### PR TITLE
Reconcile listener rule tags for all matched rules

### DIFF
--- a/pkg/deploy/elbv2/listener_rule_synthesizer.go
+++ b/pkg/deploy/elbv2/listener_rule_synthesizer.go
@@ -14,6 +14,7 @@ import (
 	elbv2equality "sigs.k8s.io/aws-load-balancer-controller/pkg/equality/elbv2"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/model/core"
 	elbv2model "sigs.k8s.io/aws-load-balancer-controller/pkg/model/elbv2"
+	"slices"
 	"strconv"
 )
 
@@ -86,9 +87,10 @@ func (s *listenerRuleSynthesizer) synthesizeListenerRulesOnListener(ctx context.
 
 	// matchedResAndSDKLRsBySettings : A slice of matched resLR and SDKLR rule pairs that have matching settings like actions and conditions. These needs to be only reprioratized to their corresponding priorities
 	// matchedResAndSDKLRsByPriority :  A slice of matched resLR and SDKLR rule pairs that have matching priorities but not settings like actions and conditions. These needs to be modified in place to avoid any 503 errors
+	// matchedResAndSDKLRsFullyMatched : A slice of matched resLR and SDKLR rule pairs that have matching settings AND priority. These rules only need tag reconciliation.
 	// unmatchedResLRs : A slice of resLR that do not have a corresponding match in the sdkLRs. These rules need to be created on the load balancer.
 	// unmatchedSDKLRs : A slice of sdkLRs that do not have a corresponding match in the resLRs. These rules need to be first pushed down in the priority so that the new rules are created/modified at higher priority first and then deleted from the load balancer to avoid any 503 errors.
-	matchedResAndSDKLRsBySettings, matchedResAndSDKLRsByPriority, unmatchedResLRs, unmatchedSDKLRs, err := s.matchResAndSDKListenerRules(resLRs, sdkLRs, resLRDesiredRuleConfigs)
+	matchedResAndSDKLRsBySettings, matchedResAndSDKLRsByPriority, matchedResAndSDKLRsFullyMatched, unmatchedResLRs, unmatchedSDKLRs, err := s.matchResAndSDKListenerRules(resLRs, sdkLRs, resLRDesiredRuleConfigs)
 	if err != nil {
 		return err
 	}
@@ -115,7 +117,7 @@ func (s *listenerRuleSynthesizer) synthesizeListenerRulesOnListener(ctx context.
 	}
 
 	// Update existing listener rules on the load balancer for their tags
-	for _, resAndSDKLR := range matchedResAndSDKLRsBySettings {
+	for _, resAndSDKLR := range slices.Concat(matchedResAndSDKLRsBySettings, matchedResAndSDKLRsFullyMatched, matchedResAndSDKLRsByPriority) {
 		lsStatus, err := s.lrManager.UpdateRulesTags(ctx, resAndSDKLR.resLR, resAndSDKLR.sdkLR)
 		if err != nil {
 			return err
@@ -152,9 +154,10 @@ type resLRDesiredRuleConfig struct {
 	desiredTransforms []types.RuleTransform
 }
 
-func (s *listenerRuleSynthesizer) matchResAndSDKListenerRules(resLRs []*elbv2model.ListenerRule, unmatchedSDKLRs []ListenerRuleWithTags, resLRDesiredRuleConfigs map[*elbv2model.ListenerRule]*resLRDesiredRuleConfig) ([]resAndSDKListenerRulePair, []resAndSDKListenerRulePair, []*elbv2model.ListenerRule, []ListenerRuleWithTags, error) {
+func (s *listenerRuleSynthesizer) matchResAndSDKListenerRules(resLRs []*elbv2model.ListenerRule, unmatchedSDKLRs []ListenerRuleWithTags, resLRDesiredRuleConfigs map[*elbv2model.ListenerRule]*resLRDesiredRuleConfig) ([]resAndSDKListenerRulePair, []resAndSDKListenerRulePair, []resAndSDKListenerRulePair, []*elbv2model.ListenerRule, []ListenerRuleWithTags, error) {
 	var matchedResAndSDKLRsBySettings []resAndSDKListenerRulePair
 	var matchedResAndSDKLRsByPriority []resAndSDKListenerRulePair
+	var matchedResAndSDKLRsFullyMatched []resAndSDKListenerRulePair
 	var unmatchedResLRs []*elbv2model.ListenerRule
 	var resLRsToCreate []*elbv2model.ListenerRule
 	var sdkLRsToDelete []ListenerRuleWithTags
@@ -172,6 +175,11 @@ func (s *listenerRuleSynthesizer) matchResAndSDKListenerRules(resLRs []*elbv2mod
 				sdkLRPriority, _ := strconv.ParseInt(awssdk.ToString(sdkLR.ListenerRule.Priority), 10, 64)
 				if resLR.Spec.Priority != int32(sdkLRPriority) {
 					matchedResAndSDKLRsBySettings = append(matchedResAndSDKLRsBySettings, resAndSDKListenerRulePair{
+						resLR: resLR,
+						sdkLR: sdkLR,
+					})
+				} else {
+					matchedResAndSDKLRsFullyMatched = append(matchedResAndSDKLRsFullyMatched, resAndSDKListenerRulePair{
 						resLR: resLR,
 						sdkLR: sdkLR,
 					})
@@ -205,7 +213,7 @@ func (s *listenerRuleSynthesizer) matchResAndSDKListenerRules(resLRs []*elbv2mod
 	for _, priority := range sdkLRPriorities.Difference(resLRPriorities).List() {
 		sdkLRsToDelete = append(sdkLRsToDelete, sdkLRByPriority[priority])
 	}
-	return matchedResAndSDKLRsBySettings, matchedResAndSDKLRsByPriority, resLRsToCreate, sdkLRsToDelete, nil
+	return matchedResAndSDKLRsBySettings, matchedResAndSDKLRsByPriority, matchedResAndSDKLRsFullyMatched, resLRsToCreate, sdkLRsToDelete, nil
 }
 
 func (s *listenerRuleSynthesizer) createAndDeleteRules(ctx context.Context, initialRuleCount int, resLRDesiredActionsAndConditionsPairs map[*elbv2model.ListenerRule]*resLRDesiredRuleConfig, unmatchedResLRs []*elbv2model.ListenerRule, unmatchedSDKLRs []ListenerRuleWithTags) error {

--- a/pkg/deploy/elbv2/listener_rule_synthesizer_test.go
+++ b/pkg/deploy/elbv2/listener_rule_synthesizer_test.go
@@ -26,8 +26,9 @@ func Test_matchResAndSDKListenerRules(t *testing.T) {
 		args    args
 		want    []resAndSDKListenerRulePair
 		want1   []resAndSDKListenerRulePair
-		want2   []*elbv2model.ListenerRule
-		want3   []ListenerRuleWithTags
+		want2   []resAndSDKListenerRulePair
+		want3   []*elbv2model.ListenerRule
+		want4   []ListenerRuleWithTags
 		wantErr error
 	}{
 		{
@@ -194,10 +195,174 @@ func Test_matchResAndSDKListenerRules(t *testing.T) {
 					},
 				},
 			},
-			want:    nil,
-			want1:   nil,
-			want2:   nil,
+			want:  nil,
+			want1: nil,
+			want2: []resAndSDKListenerRulePair{
+				{
+					resLR: &elbv2model.ListenerRule{
+						ResourceMeta: coremodel.NewResourceMeta(stack, "AWS::ElasticLoadBalancingV2::ListenerRule", "id-1"),
+						Spec: elbv2model.ListenerRuleSpec{
+							Priority: 1,
+							Actions: []elbv2model.Action{
+								{
+									Type: "forward",
+									ForwardConfig: &elbv2model.ForwardActionConfig{
+										TargetGroups: []elbv2model.TargetGroupTuple{
+											{
+												TargetGroupARN: core.LiteralStringToken("foo1-tg"),
+											},
+										},
+									},
+								},
+							},
+							Conditions: []elbv2model.RuleCondition{
+								{
+									Field: "path-pattern",
+									PathPatternConfig: &elbv2model.PathPatternConditionConfig{
+										Values: []string{"/foo1"},
+									},
+								},
+							},
+						},
+					},
+					sdkLR: ListenerRuleWithTags{
+						ListenerRule: &elbv2types.Rule{
+							RuleArn:  awssdk.String("arn-1"),
+							Priority: awssdk.String("1"),
+							Actions: []elbv2types.Action{
+								{
+									Type: elbv2types.ActionTypeEnumForward,
+									ForwardConfig: &elbv2types.ForwardActionConfig{
+										TargetGroups: []elbv2types.TargetGroupTuple{
+											{
+												TargetGroupArn: awssdk.String("foo1-tg"),
+											},
+										},
+									},
+								},
+							},
+							Conditions: []elbv2types.RuleCondition{
+								{
+									Field: awssdk.String("path-pattern"),
+									PathPatternConfig: &elbv2types.PathPatternConditionConfig{
+										Values: []string{"/foo1"},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					resLR: &elbv2model.ListenerRule{
+						ResourceMeta: coremodel.NewResourceMeta(stack, "AWS::ElasticLoadBalancingV2::ListenerRule", "id-1"),
+						Spec: elbv2model.ListenerRuleSpec{
+							Priority: 2,
+							Actions: []elbv2model.Action{
+								{
+									Type: "forward",
+									ForwardConfig: &elbv2model.ForwardActionConfig{
+										TargetGroups: []elbv2model.TargetGroupTuple{
+											{
+												TargetGroupARN: core.LiteralStringToken("foo2-tg"),
+											},
+										},
+									},
+								},
+							},
+							Conditions: []elbv2model.RuleCondition{
+								{
+									Field: "path-pattern",
+									PathPatternConfig: &elbv2model.PathPatternConditionConfig{
+										Values: []string{"/foo2"},
+									},
+								},
+							},
+						},
+					},
+					sdkLR: ListenerRuleWithTags{
+						ListenerRule: &elbv2types.Rule{
+							RuleArn:  awssdk.String("arn-2"),
+							Priority: awssdk.String("2"),
+							Actions: []elbv2types.Action{
+								{
+									Type: elbv2types.ActionTypeEnumForward,
+									ForwardConfig: &elbv2types.ForwardActionConfig{
+										TargetGroups: []elbv2types.TargetGroupTuple{
+											{
+												TargetGroupArn: awssdk.String("foo2-tg"),
+											},
+										},
+									},
+								},
+							},
+							Conditions: []elbv2types.RuleCondition{
+								{
+									Field: awssdk.String("path-pattern"),
+									PathPatternConfig: &elbv2types.PathPatternConditionConfig{
+										Values: []string{"/foo2"},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					resLR: &elbv2model.ListenerRule{
+						ResourceMeta: coremodel.NewResourceMeta(stack, "AWS::ElasticLoadBalancingV2::ListenerRule", "id-1"),
+						Spec: elbv2model.ListenerRuleSpec{
+							Priority: 3,
+							Actions: []elbv2model.Action{
+								{
+									Type: "forward",
+									ForwardConfig: &elbv2model.ForwardActionConfig{
+										TargetGroups: []elbv2model.TargetGroupTuple{
+											{
+												TargetGroupARN: core.LiteralStringToken("foo3-tg"),
+											},
+										},
+									},
+								},
+							},
+							Conditions: []elbv2model.RuleCondition{
+								{
+									Field: "path-pattern",
+									PathPatternConfig: &elbv2model.PathPatternConditionConfig{
+										Values: []string{"/foo3"},
+									},
+								},
+							},
+						},
+					},
+					sdkLR: ListenerRuleWithTags{
+						ListenerRule: &elbv2types.Rule{
+							RuleArn:  awssdk.String("arn-3"),
+							Priority: awssdk.String("3"),
+							Actions: []elbv2types.Action{
+								{
+									Type: elbv2types.ActionTypeEnumForward,
+									ForwardConfig: &elbv2types.ForwardActionConfig{
+										TargetGroups: []elbv2types.TargetGroupTuple{
+											{
+												TargetGroupArn: awssdk.String("foo3-tg"),
+											},
+										},
+									},
+								},
+							},
+							Conditions: []elbv2types.RuleCondition{
+								{
+									Field: awssdk.String("path-pattern"),
+									PathPatternConfig: &elbv2types.PathPatternConditionConfig{
+										Values: []string{"/foo3"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			want3:   nil,
+			want4:   nil,
 			wantErr: nil,
 		},
 		{
@@ -474,10 +639,66 @@ func Test_matchResAndSDKListenerRules(t *testing.T) {
 					},
 				},
 			},
-			want1:   nil,
-			want2:   nil,
-			want3:   nil,
+			want1: nil,
+			want2: []resAndSDKListenerRulePair{
+				{
+					resLR: &elbv2model.ListenerRule{
+						ResourceMeta: coremodel.NewResourceMeta(stack, "AWS::ElasticLoadBalancingV2::ListenerRule", "id-1"),
+						Spec: elbv2model.ListenerRuleSpec{
+							Priority: 2,
+							Actions: []elbv2model.Action{
+								{
+									Type: "forward",
+									ForwardConfig: &elbv2model.ForwardActionConfig{
+										TargetGroups: []elbv2model.TargetGroupTuple{
+											{
+												TargetGroupARN: core.LiteralStringToken("foo2-tg"),
+											},
+										},
+									},
+								},
+							},
+							Conditions: []elbv2model.RuleCondition{
+								{
+									Field: "path-pattern",
+									PathPatternConfig: &elbv2model.PathPatternConditionConfig{
+										Values: []string{"/foo2"},
+									},
+								},
+							},
+						},
+					},
+					sdkLR: ListenerRuleWithTags{
+						ListenerRule: &elbv2types.Rule{
+							RuleArn:  awssdk.String("arn-2"),
+							Priority: awssdk.String("2"),
+							Actions: []elbv2types.Action{
+								{
+									Type: elbv2types.ActionTypeEnumForward,
+									ForwardConfig: &elbv2types.ForwardActionConfig{
+										TargetGroups: []elbv2types.TargetGroupTuple{
+											{
+												TargetGroupArn: awssdk.String("foo2-tg"),
+											},
+										},
+									},
+								},
+							},
+							Conditions: []elbv2types.RuleCondition{
+								{
+									Field: awssdk.String("path-pattern"),
+									PathPatternConfig: &elbv2types.PathPatternConditionConfig{
+										Values: []string{"/foo2"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			wantErr: nil,
+			want3:   nil,
+			want4:   nil,
 		},
 		{
 			name: "all listener rules settings including transforms has match but not priority",
@@ -883,9 +1104,91 @@ func Test_matchResAndSDKListenerRules(t *testing.T) {
 					},
 				},
 			},
-			want1:   nil,
-			want2:   nil,
+			want1: nil,
+			want2: []resAndSDKListenerRulePair{
+				{
+					resLR: &elbv2model.ListenerRule{
+						ResourceMeta: coremodel.NewResourceMeta(stack, "AWS::ElasticLoadBalancingV2::ListenerRule", "id-1"),
+						Spec: elbv2model.ListenerRuleSpec{
+							Priority: 2,
+							Actions: []elbv2model.Action{
+								{
+									Type: "forward",
+									ForwardConfig: &elbv2model.ForwardActionConfig{
+										TargetGroups: []elbv2model.TargetGroupTuple{
+											{
+												TargetGroupARN: core.LiteralStringToken("foo2-tg"),
+											},
+										},
+									},
+								},
+							},
+							Conditions: []elbv2model.RuleCondition{
+								{
+									Field: "path-pattern",
+									PathPatternConfig: &elbv2model.PathPatternConditionConfig{
+										Values: []string{"/foo2"},
+									},
+								},
+							},
+							Transforms: []elbv2model.Transform{
+								{
+									Type: elbv2model.TransformTypeUrlRewrite,
+									UrlRewriteConfig: &elbv2model.RewriteConfigObject{
+										Rewrites: []elbv2model.RewriteConfig{
+											{
+												Regex:   "/path2/(.*)",
+												Replace: "/newpath2/$1",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					sdkLR: ListenerRuleWithTags{
+						ListenerRule: &elbv2types.Rule{
+							RuleArn:  awssdk.String("arn-2"),
+							Priority: awssdk.String("2"),
+							Actions: []elbv2types.Action{
+								{
+									Type: elbv2types.ActionTypeEnumForward,
+									ForwardConfig: &elbv2types.ForwardActionConfig{
+										TargetGroups: []elbv2types.TargetGroupTuple{
+											{
+												TargetGroupArn: awssdk.String("foo2-tg"),
+											},
+										},
+									},
+								},
+							},
+							Conditions: []elbv2types.RuleCondition{
+								{
+									Field: awssdk.String("path-pattern"),
+									PathPatternConfig: &elbv2types.PathPatternConditionConfig{
+										Values: []string{"/foo2"},
+									},
+								},
+							},
+							Transforms: []elbv2types.RuleTransform{
+								{
+									Type: elbv2types.TransformTypeEnumUrlRewrite,
+									UrlRewriteConfig: &elbv2types.UrlRewriteConfig{
+										Rewrites: []elbv2types.RewriteConfig{
+											{
+												Regex:   awssdk.String("/path2/(.*)"),
+												Replace: awssdk.String("/newpath2/$1"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			want3:   nil,
+			want4:   nil,
 			wantErr: nil,
 		},
 		{
@@ -1220,6 +1523,7 @@ func Test_matchResAndSDKListenerRules(t *testing.T) {
 			},
 			want2:   nil,
 			want3:   nil,
+			want4:   nil,
 			wantErr: nil,
 		},
 		{
@@ -1602,7 +1906,117 @@ func Test_matchResAndSDKListenerRules(t *testing.T) {
 					},
 				},
 			},
-			want2: []*elbv2model.ListenerRule{
+			want2: []resAndSDKListenerRulePair{
+				{
+					resLR: &elbv2model.ListenerRule{
+						ResourceMeta: coremodel.NewResourceMeta(stack, "AWS::ElasticLoadBalancingV2::ListenerRule", "id-1"),
+						Spec: elbv2model.ListenerRuleSpec{
+							Priority: 1,
+							Actions: []elbv2model.Action{
+								{
+									Type: "forward",
+									ForwardConfig: &elbv2model.ForwardActionConfig{
+										TargetGroups: []elbv2model.TargetGroupTuple{
+											{
+												TargetGroupARN: core.LiteralStringToken("foo1-tg"),
+											},
+										},
+									},
+								},
+							},
+							Conditions: []elbv2model.RuleCondition{
+								{
+									Field: "path-pattern",
+									PathPatternConfig: &elbv2model.PathPatternConditionConfig{
+										Values: []string{"/foo1"},
+									},
+								},
+							},
+						},
+					},
+					sdkLR: ListenerRuleWithTags{
+						ListenerRule: &elbv2types.Rule{
+							RuleArn:  awssdk.String("arn-1"),
+							Priority: awssdk.String("1"),
+							Actions: []elbv2types.Action{
+								{
+									Type: elbv2types.ActionTypeEnumForward,
+									ForwardConfig: &elbv2types.ForwardActionConfig{
+										TargetGroups: []elbv2types.TargetGroupTuple{
+											{
+												TargetGroupArn: awssdk.String("foo1-tg"),
+											},
+										},
+									},
+								},
+							},
+							Conditions: []elbv2types.RuleCondition{
+								{
+									Field: awssdk.String("path-pattern"),
+									PathPatternConfig: &elbv2types.PathPatternConditionConfig{
+										Values: []string{"/foo1"},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					resLR: &elbv2model.ListenerRule{
+						ResourceMeta: coremodel.NewResourceMeta(stack, "AWS::ElasticLoadBalancingV2::ListenerRule", "id-1"),
+						Spec: elbv2model.ListenerRuleSpec{
+							Priority: 2,
+							Actions: []elbv2model.Action{
+								{
+									Type: "forward",
+									ForwardConfig: &elbv2model.ForwardActionConfig{
+										TargetGroups: []elbv2model.TargetGroupTuple{
+											{
+												TargetGroupARN: core.LiteralStringToken("foo2-tg"),
+											},
+										},
+									},
+								},
+							},
+							Conditions: []elbv2model.RuleCondition{
+								{
+									Field: "path-pattern",
+									PathPatternConfig: &elbv2model.PathPatternConditionConfig{
+										Values: []string{"/foo2"},
+									},
+								},
+							},
+						},
+					},
+					sdkLR: ListenerRuleWithTags{
+						ListenerRule: &elbv2types.Rule{
+							RuleArn:  awssdk.String("arn-2"),
+							Priority: awssdk.String("2"),
+							Actions: []elbv2types.Action{
+								{
+									Type: elbv2types.ActionTypeEnumForward,
+									ForwardConfig: &elbv2types.ForwardActionConfig{
+										TargetGroups: []elbv2types.TargetGroupTuple{
+											{
+												TargetGroupArn: awssdk.String("foo2-tg"),
+											},
+										},
+									},
+								},
+							},
+							Conditions: []elbv2types.RuleCondition{
+								{
+									Field: awssdk.String("path-pattern"),
+									PathPatternConfig: &elbv2types.PathPatternConditionConfig{
+										Values: []string{"/foo2"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want3: []*elbv2model.ListenerRule{
 				{
 					ResourceMeta: coremodel.NewResourceMeta(stack, "AWS::ElasticLoadBalancingV2::ListenerRule", "id-1"),
 					Spec: elbv2model.ListenerRuleSpec{
@@ -1630,7 +2044,7 @@ func Test_matchResAndSDKListenerRules(t *testing.T) {
 					},
 				},
 			},
-			want3: []ListenerRuleWithTags{
+			want4: []ListenerRuleWithTags{
 				{
 					ListenerRule: &elbv2types.Rule{
 						RuleArn:  awssdk.String("arn-5"),
@@ -1676,7 +2090,7 @@ func Test_matchResAndSDKListenerRules(t *testing.T) {
 				resLRDesiredRuleConfig, _ := buildResLRDesiredRuleConfig(resLR, featureGates)
 				resLRDesiredRuleConfigs[resLR] = resLRDesiredRuleConfig
 			}
-			got, got1, got2, got3, err := s.matchResAndSDKListenerRules(tt.args.resLRs, tt.args.sdkLRs, resLRDesiredRuleConfigs)
+			got, got1, got2, got3, got4, err := s.matchResAndSDKListenerRules(tt.args.resLRs, tt.args.sdkLRs, resLRDesiredRuleConfigs)
 			if tt.wantErr != nil {
 				assert.EqualError(t, err, tt.wantErr.Error())
 			} else {
@@ -1685,6 +2099,7 @@ func Test_matchResAndSDKListenerRules(t *testing.T) {
 				assert.Equal(t, tt.want1, got1)
 				assert.Equal(t, tt.want2, got2)
 				assert.Equal(t, tt.want3, got3)
+				assert.Equal(t, tt.want4, got4)
 			}
 		})
 	}
@@ -1695,6 +2110,8 @@ type mockLROperation int
 const (
 	createLR mockLROperation = iota
 	deleteLR
+	updateRulesLR
+	updateRulesTagsLR
 )
 
 type mockLRCall struct {
@@ -2082,16 +2499,183 @@ func (m *mockListenerRuleManager) Delete(ctx context.Context, sdkLR ListenerRule
 }
 
 func (m *mockListenerRuleManager) UpdateRules(ctx context.Context, resLR *elbv2model.ListenerRule, sdkLR ListenerRuleWithTags, desiredActionsAndConditions *resLRDesiredRuleConfig) (elbv2model.ListenerRuleStatus, error) {
-	//TODO implement me
-	panic("implement me")
+	m.calls = append(m.calls, mockLRCall{
+		arn: *sdkLR.ListenerRule.RuleArn,
+		op:  updateRulesLR,
+	})
+	return elbv2model.ListenerRuleStatus{RuleARN: *sdkLR.ListenerRule.RuleArn}, nil
 }
 
 func (m *mockListenerRuleManager) UpdateRulesTags(ctx context.Context, resLR *elbv2model.ListenerRule, sdkLR ListenerRuleWithTags) (elbv2model.ListenerRuleStatus, error) {
-	//TODO implement me
-	panic("implement me")
+	m.calls = append(m.calls, mockLRCall{
+		arn: *sdkLR.ListenerRule.RuleArn,
+		op:  updateRulesTagsLR,
+	})
+	return elbv2model.ListenerRuleStatus{RuleARN: *sdkLR.ListenerRule.RuleArn}, nil
 }
 
 func (m *mockListenerRuleManager) SetRulePriorities(ctx context.Context, matchedResAndSDKLRsBySettings []resAndSDKListenerRulePair, unmatchedSDKLRs []ListenerRuleWithTags) error {
-	//TODO implement me
-	panic("implement me")
+	return nil
+}
+
+func Test_synthesizeListenerRulesOnListener_TagsUpdatedForAllBuckets(t *testing.T) {
+	stack := coremodel.NewDefaultStack(coremodel.StackID{Namespace: "namespace", Name: "name"})
+	featureGates := config.NewFeatureGates()
+
+	testCases := []struct {
+		name          string
+		resLRs        []*elbv2model.ListenerRule
+		sdkLRs        []ListenerRuleWithTags
+		expectedCalls []mockLRCall
+	}{
+		{
+			name: "tags-only change on fully matched rule triggers UpdateRulesTags",
+			resLRs: []*elbv2model.ListenerRule{
+				{
+					ResourceMeta: coremodel.NewResourceMeta(stack, "AWS::ElasticLoadBalancingV2::ListenerRule", "id-1"),
+					Spec: elbv2model.ListenerRuleSpec{
+						Priority: 1,
+						Actions: []elbv2model.Action{
+							{
+								Type: "forward",
+								ForwardConfig: &elbv2model.ForwardActionConfig{
+									TargetGroups: []elbv2model.TargetGroupTuple{
+										{
+											TargetGroupARN: core.LiteralStringToken("tg-1"),
+										},
+									},
+								},
+							},
+						},
+						Conditions: []elbv2model.RuleCondition{
+							{
+								Field: "path-pattern",
+								PathPatternConfig: &elbv2model.PathPatternConditionConfig{
+									Values: []string{"/app"},
+								},
+							},
+						},
+					},
+				},
+			},
+			sdkLRs: []ListenerRuleWithTags{
+				{
+					ListenerRule: &elbv2types.Rule{
+						RuleArn:  awssdk.String("arn:rule-1"),
+						Priority: awssdk.String("1"),
+						Actions: []elbv2types.Action{
+							{
+								Type: elbv2types.ActionTypeEnumForward,
+								ForwardConfig: &elbv2types.ForwardActionConfig{
+									TargetGroups: []elbv2types.TargetGroupTuple{
+										{
+											TargetGroupArn: awssdk.String("tg-1"),
+										},
+									},
+								},
+							},
+						},
+						Conditions: []elbv2types.RuleCondition{
+							{
+								Field: awssdk.String("path-pattern"),
+								PathPatternConfig: &elbv2types.PathPatternConditionConfig{
+									Values: []string{"/app"},
+								},
+							},
+						},
+					},
+					Tags: map[string]string{"env": "old-value"},
+				},
+			},
+			expectedCalls: []mockLRCall{
+				{arn: "arn:rule-1", op: updateRulesTagsLR},
+			},
+		},
+		{
+			name: "priority-matched rule with different actions also gets UpdateRulesTags",
+			resLRs: []*elbv2model.ListenerRule{
+				{
+					ResourceMeta: coremodel.NewResourceMeta(stack, "AWS::ElasticLoadBalancingV2::ListenerRule", "id-1"),
+					Spec: elbv2model.ListenerRuleSpec{
+						Priority: 1,
+						Actions: []elbv2model.Action{
+							{
+								Type: "forward",
+								ForwardConfig: &elbv2model.ForwardActionConfig{
+									TargetGroups: []elbv2model.TargetGroupTuple{
+										{
+											TargetGroupARN: core.LiteralStringToken("tg-new"),
+										},
+									},
+								},
+							},
+						},
+						Conditions: []elbv2model.RuleCondition{
+							{
+								Field: "path-pattern",
+								PathPatternConfig: &elbv2model.PathPatternConditionConfig{
+									Values: []string{"/app"},
+								},
+							},
+						},
+					},
+				},
+			},
+			sdkLRs: []ListenerRuleWithTags{
+				{
+					ListenerRule: &elbv2types.Rule{
+						RuleArn:  awssdk.String("arn:rule-1"),
+						Priority: awssdk.String("1"),
+						Actions: []elbv2types.Action{
+							{
+								Type: elbv2types.ActionTypeEnumForward,
+								ForwardConfig: &elbv2types.ForwardActionConfig{
+									TargetGroups: []elbv2types.TargetGroupTuple{
+										{
+											TargetGroupArn: awssdk.String("tg-old"),
+										},
+									},
+								},
+							},
+						},
+						Conditions: []elbv2types.RuleCondition{
+							{
+								Field: awssdk.String("path-pattern"),
+								PathPatternConfig: &elbv2types.PathPatternConditionConfig{
+									Values: []string{"/app"},
+								},
+							},
+						},
+					},
+					Tags: map[string]string{"env": "old-value"},
+				},
+			},
+			expectedCalls: []mockLRCall{
+				{arn: "arn:rule-1", op: updateRulesLR},
+				{arn: "arn:rule-1", op: updateRulesTagsLR},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockTaggingManager := NewMockTaggingManager(ctrl)
+			mockTaggingManager.EXPECT().ListListenerRules(gomock.Any(), "arn:listener-1").Return(tc.sdkLRs, nil)
+
+			mLRManager := &mockListenerRuleManager{
+				maxRuleCount: 100,
+			}
+			s := &listenerRuleSynthesizer{
+				lrManager:      mLRManager,
+				taggingManager: mockTaggingManager,
+				featureGates:   featureGates,
+			}
+			err := s.synthesizeListenerRulesOnListener(context.Background(), "arn:listener-1", tc.resLRs)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedCalls, mLRManager.calls)
+		})
+	}
 }


### PR DESCRIPTION
Reconcile listener rule tags for all matched rules

### Motivation

In some cases, listener rule tags would not be updated after `alb.ingress.kubernetes.io/tags` is changed.

Specifically:
* The `synthesizeListenerRulesOnListener` function only called `UpdateRulesTags` for listener rules where the settings (condition/action/transform) match but priority differs.
* However, it did not call `UpdateRulesTags` for 1/ listener rules where the settings and priority both match or 2/ listener rules where the settings don't match but the priority does.

### Details

* Update `matchResAndSDKListenerRules` to return `matchedResAndSDKLRsFullyMatched` for fully-matched listener rules that only need tag reconciliation
* Update `synthesizeListenerRulesOnListener` to also reconcile tags for `matchedResAndSDKLRsFullyMatched` and  `matchedResAndSDKLRsByPriority`
* Add and update unit tests

### Testing

Unit tests pass

```
=== RUN   Test_matchResAndSDKListenerRules
=== RUN   Test_matchResAndSDKListenerRules/all_listener_rules_has_match
=== RUN   Test_matchResAndSDKListenerRules/all_listener_rules_settings_has_match_but_not_priority
=== RUN   Test_matchResAndSDKListenerRules/all_listener_rules_settings_including_transforms_has_match_but_not_priority
=== RUN   Test_matchResAndSDKListenerRules/some_listener_rules_settings_has_match_but_not_priority,_some_listener_rules_priority_match_but_not_settings
=== RUN   Test_matchResAndSDKListenerRules/some_listener_rules_settings_has_match_but_not_priority,_some_listener_rules_priority_match_but_not_settings(requires_modification),_some_needs_to_be_created_and_some_sdk_needs_to_be_deleted
--- PASS: Test_matchResAndSDKListenerRules (0.05s)
    --- PASS: Test_matchResAndSDKListenerRules/all_listener_rules_has_match (0.01s)
    --- PASS: Test_matchResAndSDKListenerRules/all_listener_rules_settings_has_match_but_not_priority (0.01s)
    --- PASS: Test_matchResAndSDKListenerRules/all_listener_rules_settings_including_transforms_has_match_but_not_priority (0.01s)
    --- PASS: Test_matchResAndSDKListenerRules/some_listener_rules_settings_has_match_but_not_priority,_some_listener_rules_priority_match_but_not_settings (0.01s)
    --- PASS: Test_matchResAndSDKListenerRules/some_listener_rules_settings_has_match_but_not_priority,_some_listener_rules_priority_match_but_not_settings(requires_modification),_some_needs_to_be_created_and_some_sdk_needs_to_be_deleted (0.02s)
=== RUN   Test_CreateAndDeleteRules
=== RUN   Test_CreateAndDeleteRules/no_rules
=== RUN   Test_CreateAndDeleteRules/just_creation
=== RUN   Test_CreateAndDeleteRules/just_deletes
=== RUN   Test_CreateAndDeleteRules/just_creation_--_at_limit
=== RUN   Test_CreateAndDeleteRules/just_deletes_--_at_max_limit
=== RUN   Test_CreateAndDeleteRules/mix_of_deletes_and_creates
=== RUN   Test_CreateAndDeleteRules/mix_of_deletes_and_creates_--_already_at_limit
=== RUN   Test_CreateAndDeleteRules/mix_of_deletes_and_creates_--_limit_reached_part_way_between_creations
--- PASS: Test_CreateAndDeleteRules (0.00s)
    --- PASS: Test_CreateAndDeleteRules/no_rules (0.00s)
    --- PASS: Test_CreateAndDeleteRules/just_creation (0.00s)
    --- PASS: Test_CreateAndDeleteRules/just_deletes (0.00s)
    --- PASS: Test_CreateAndDeleteRules/just_creation_--_at_limit (0.00s)
    --- PASS: Test_CreateAndDeleteRules/just_deletes_--_at_max_limit (0.00s)
    --- PASS: Test_CreateAndDeleteRules/mix_of_deletes_and_creates (0.00s)
    --- PASS: Test_CreateAndDeleteRules/mix_of_deletes_and_creates_--_already_at_limit (0.00s)
    --- PASS: Test_CreateAndDeleteRules/mix_of_deletes_and_creates_--_limit_reached_part_way_between_creations (0.00s)
=== RUN   Test_synthesizeListenerRulesOnListener_TagsUpdatedForAllBuckets
=== RUN   Test_synthesizeListenerRulesOnListener_TagsUpdatedForAllBuckets/tags-only_change_on_fully_matched_rule_triggers_UpdateRulesTags
=== RUN   Test_synthesizeListenerRulesOnListener_TagsUpdatedForAllBuckets/priority-matched_rule_with_different_actions_also_gets_UpdateRulesTags
--- PASS: Test_synthesizeListenerRulesOnListener_TagsUpdatedForAllBuckets (0.00s)
    --- PASS: Test_synthesizeListenerRulesOnListener_TagsUpdatedForAllBuckets/tags-only_change_on_fully_matched_rule_triggers_UpdateRulesTags (0.00s)
    --- PASS: Test_synthesizeListenerRulesOnListener_TagsUpdatedForAllBuckets/priority-matched_rule_with_different_actions_also_gets_UpdateRulesTags (0.00s)
PASS
ok  	sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/elbv2	1.121s
```

### Checklist
- [yes] Added tests that cover your change (if possible)
- [N/A] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [no] Manually tested
- [yes] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [N/A] Backfilled missing tests for code in same general area :tada:
- [N/A] Refactored something and made the world a better place :star2:
