### PR TITLE
Match Route53 hosted zones by longest suffix in GetHostedZoneID

### DIFF
--- a/pkg/aws/services/route53.go
+++ b/pkg/aws/services/route53.go
@@ -59,20 +59,21 @@ func (c *route53Client) GetHostedZoneID(ctx context.Context, domain string) (*st
 
 	recParts := strings.Split(domain, ".")
 
-	// try first if we have an apex record
+	var bestID *string
+	bestLen := -1
 	for _, zone := range zones {
 		zoneParts := strings.Split(strings.TrimRight(*zone.Name, "."), ".")
-		if slices.Equal(recParts, zoneParts) {
-			return zone.Id, nil
+		if len(zoneParts) > len(recParts) {
+			continue
+		}
+		if slices.Equal(recParts[len(recParts)-len(zoneParts):], zoneParts) && len(zoneParts) > bestLen {
+			bestLen = len(zoneParts)
+			bestID = zone.Id
 		}
 	}
 
-	// otherwise trim the leftmost part of the domain
-	for _, zone := range zones {
-		zoneParts := strings.Split(strings.TrimRight(*zone.Name, "."), ".")
-		if slices.Equal(recParts[1:], zoneParts) {
-			return zone.Id, nil
-		}
+	if bestID != nil {
+		return bestID, nil
 	}
 
 	return nil, fmt.Errorf("no hosted zone found for validation records")

--- a/pkg/aws/services/route53_test.go
+++ b/pkg/aws/services/route53_test.go
@@ -1,0 +1,65 @@
+package services
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/route53/types"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/cache"
+)
+
+func newCachedRoute53Client(zones []types.HostedZone) *route53Client {
+	c := &route53Client{
+		hostedZonesCache:    cache.NewExpiring(),
+		hostedZonesCacheTTL: defaultHostedZonesCacheTTL,
+	}
+	c.hostedZonesCache.Set(hostedZonesCacheKey, zones, time.Hour)
+	return c
+}
+
+func hostedZone(id, name string) types.HostedZone {
+	return types.HostedZone{Id: awssdk.String(id), Name: awssdk.String(name)}
+}
+
+func TestGetHostedZoneID(t *testing.T) {
+	tests := []struct {
+		name   string
+		domain string
+		zones  []types.HostedZone
+		want   string
+	}{
+		{
+			name:   "exact apex match",
+			domain: "example.com",
+			zones:  []types.HostedZone{hostedZone("Z_EXAMPLE", "example.com.")},
+			want:   "Z_EXAMPLE",
+		},
+		{
+			name:   "wildcard SAN two labels below the zone",
+			domain: "*.app.sub.example.com",
+			zones:  []types.HostedZone{hostedZone("Z_SUB", "sub.example.com.")},
+			want:   "Z_SUB",
+		},
+		{
+			name:   "longest suffix wins over parent zone",
+			domain: "*.app.sub.example.com",
+			zones: []types.HostedZone{
+				hostedZone("Z_PARENT", "example.com."),
+				hostedZone("Z_SUB", "sub.example.com."),
+			},
+			want: "Z_SUB",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newCachedRoute53Client(tt.zones)
+			got, err := c.GetHostedZoneID(context.Background(), tt.domain)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, awssdk.ToString(got))
+		})
+	}
+}


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description

The [ACM certificate management feature](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/ingress/certificate_management/) validates the certificates it requests using DNS records in Route 53. For each name on a certificate, `GetHostedZoneID` (`pkg/aws/services/route53.go`) finds the hosted zone that should hold the validation record.

The lookup only matched a zone whose name was exactly the certificate name, or the certificate name with its first label dropped. A name two or more labels below the zone apex never matched, and validation failed with:

> no hosted zone found for validation records

With a single `env.example.com` hosted zone, for example, the SAN `*.app.pr-1.env.example.com` gets trimmed once to `app.pr-1.env.example.com`. That still isn't `env.example.com`, so no zone is returned, the validation record is never written, and the certificate stays in `PENDING_VALIDATION`.

This replaces the two checks with a single pass that selects the zone whose labels are the longest suffix of the certificate name. That matches how external-dns resolves a zone: [`ZoneIDName.FindZone`](https://github.com/kubernetes-sigs/external-dns/blob/1f6b9f106a50b29eb573cf1c409cbcb0d6bc4875/provider/zonefinder.go#L50-L75) keeps the matching zone with the longest name (`len(zoneName) > len(suitableZoneName)`), and the AWS provider's [`suitableZones`](https://github.com/kubernetes-sigs/external-dns/blob/1f6b9f106a50b29eb573cf1c409cbcb0d6bc4875/provider/aws/aws.go#L1336) does the same when picking a hosted zone. Apex and one-label-below names resolve to the same zone as before. Names nested deeper now resolve, wildcards match on their non-wildcard labels, and when both a parent and a child zone could match, the more specific child zone is used.

`route53_test.go` covers the apex, nested-wildcard, and parent/child cases.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
