### PR TITLE
Fix ACM certificate creation for Ingresses with wildcard hosts

### DIFF
--- a/pkg/ingress/model_build_certificates.go
+++ b/pkg/ingress/model_build_certificates.go
@@ -43,7 +43,9 @@ func (t *defaultModelBuildTask) buildACMCertificates(ctx context.Context, ing *C
 func (t *defaultModelBuildTask) buildCertificateResourceID(spec *acmModel.CertificateSpec, ing *ClassifiedIngress) string {
 	ingKey := fmt.Sprintf("%s/%s", ing.Ing.Namespace, ing.Ing.Name)
 	ingHash := fmt.Sprintf("%x", sha256.Sum256([]byte(ingKey)))[:8]
-	return fmt.Sprintf("%s/%s-%s", strings.ToLower(string(spec.Type)), spec.DomainName, ingHash)
+	// The resourceID becomes a tag value, which rejects '*' (ACM pattern [\p{L}\p{Z}\p{N}_.:/=+\-@]*).
+	domainName := strings.ReplaceAll(spec.DomainName, "*", "wildcard")
+	return fmt.Sprintf("%s/%s-%s", strings.ToLower(string(spec.Type)), domainName, ingHash)
 }
 
 func (t *defaultModelBuildTask) buildCertificateSpec(ctx context.Context, ing *ClassifiedIngress) (*acmModel.CertificateSpec, error) {
@@ -67,19 +69,10 @@ func (t *defaultModelBuildTask) buildCertificateSpec(ctx context.Context, ing *C
 		certType = acmtypes.CertificateTypeAmazonIssued
 	}
 
-	// DomainName feeds the resourceID tag, which rejects '*'; prefer a non-wildcard host.
-	domainName := hosts[0]
-	for _, h := range hosts {
-		if !strings.HasPrefix(h, "*.") {
-			domainName = h
-			break
-		}
-	}
-
 	return &acmModel.CertificateSpec{
 		Type:                    certType,
 		CertificateAuthorityARN: caArn,
-		DomainName:              domainName,
+		DomainName:              hosts[0],
 		SubjectAlternativeNames: hosts,
 		ValidationMethod:        acmtypes.ValidationMethodDns, // currently we only support DNS based validation for AMAZON_ISSUED certificates
 		Tags:                    tags,

--- a/pkg/ingress/model_build_certificates.go
+++ b/pkg/ingress/model_build_certificates.go
@@ -67,10 +67,19 @@ func (t *defaultModelBuildTask) buildCertificateSpec(ctx context.Context, ing *C
 		certType = acmtypes.CertificateTypeAmazonIssued
 	}
 
+	// DomainName feeds the resourceID tag, which rejects '*'; prefer a non-wildcard host.
+	domainName := hosts[0]
+	for _, h := range hosts {
+		if !strings.HasPrefix(h, "*.") {
+			domainName = h
+			break
+		}
+	}
+
 	return &acmModel.CertificateSpec{
 		Type:                    certType,
 		CertificateAuthorityARN: caArn,
-		DomainName:              hosts[0],
+		DomainName:              domainName,
 		SubjectAlternativeNames: hosts,
 		ValidationMethod:        acmtypes.ValidationMethodDns, // currently we only support DNS based validation for AMAZON_ISSUED certificates
 		Tags:                    tags,

--- a/pkg/ingress/model_build_certificates_test.go
+++ b/pkg/ingress/model_build_certificates_test.go
@@ -108,6 +108,35 @@ func Test_buildACMCertificates(t *testing.T) {
 			wantCertSpec: acmModel.CertificateSpec{Type: acmtypes.CertificateTypeAmazonIssued, DomainName: "example.com", SubjectAlternativeNames: []string{"example.com", "otherexample.com", "yetanotherexample.com"}, ValidationMethod: acmtypes.ValidationMethodDns, Tags: map[string]string{}},
 		},
 		{
+			name: "Build certificate prefers a non-wildcard DomainName",
+			fields: fields{
+				ingGroup: Group{
+					ID: GroupID{Name: "explicit-group"},
+					Members: []ClassifiedIngress{
+						{
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "awesome-ns",
+									Name:      "ing-wild",
+									Annotations: map[string]string{
+										"alb.ingress.kubernetes.io/listen-ports":    `[{"HTTP": 80}, {"HTTPS": 443}]`,
+										"alb.ingress.kubernetes.io/create-acm-cert": `true`,
+									},
+								},
+								Spec: networking.IngressSpec{
+									Rules: []networking.IngressRule{
+										{Host: "*.app.example.com"},
+										{Host: "app.example.com"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantCertSpec: acmModel.CertificateSpec{Type: acmtypes.CertificateTypeAmazonIssued, DomainName: "app.example.com", SubjectAlternativeNames: []string{"*.app.example.com", "app.example.com"}, ValidationMethod: acmtypes.ValidationMethodDns, Tags: map[string]string{}},
+		},
+		{
 			name: "Build certificate for certificate-arn pinned ingress",
 			fields: fields{
 				ingGroup: Group{

--- a/pkg/ingress/model_build_certificates_test.go
+++ b/pkg/ingress/model_build_certificates_test.go
@@ -108,7 +108,7 @@ func Test_buildACMCertificates(t *testing.T) {
 			wantCertSpec: acmModel.CertificateSpec{Type: acmtypes.CertificateTypeAmazonIssued, DomainName: "example.com", SubjectAlternativeNames: []string{"example.com", "otherexample.com", "yetanotherexample.com"}, ValidationMethod: acmtypes.ValidationMethodDns, Tags: map[string]string{}},
 		},
 		{
-			name: "Build certificate prefers a non-wildcard DomainName",
+			name: "Build certificate for an all-wildcard ingress keeps the wildcard DomainName",
 			fields: fields{
 				ingGroup: Group{
 					ID: GroupID{Name: "explicit-group"},
@@ -117,7 +117,7 @@ func Test_buildACMCertificates(t *testing.T) {
 							Ing: &networking.Ingress{
 								ObjectMeta: metav1.ObjectMeta{
 									Namespace: "awesome-ns",
-									Name:      "ing-wild",
+									Name:      "ing-all-wild",
 									Annotations: map[string]string{
 										"alb.ingress.kubernetes.io/listen-ports":    `[{"HTTP": 80}, {"HTTPS": 443}]`,
 										"alb.ingress.kubernetes.io/create-acm-cert": `true`,
@@ -126,7 +126,7 @@ func Test_buildACMCertificates(t *testing.T) {
 								Spec: networking.IngressSpec{
 									Rules: []networking.IngressRule{
 										{Host: "*.app.example.com"},
-										{Host: "app.example.com"},
+										{Host: "*.other.example.com"},
 									},
 								},
 							},
@@ -134,7 +134,7 @@ func Test_buildACMCertificates(t *testing.T) {
 					},
 				},
 			},
-			wantCertSpec: acmModel.CertificateSpec{Type: acmtypes.CertificateTypeAmazonIssued, DomainName: "app.example.com", SubjectAlternativeNames: []string{"*.app.example.com", "app.example.com"}, ValidationMethod: acmtypes.ValidationMethodDns, Tags: map[string]string{}},
+			wantCertSpec: acmModel.CertificateSpec{Type: acmtypes.CertificateTypeAmazonIssued, DomainName: "*.app.example.com", SubjectAlternativeNames: []string{"*.app.example.com", "*.other.example.com"}, ValidationMethod: acmtypes.ValidationMethodDns, Tags: map[string]string{}},
 		},
 		{
 			name: "Build certificate for certificate-arn pinned ingress",
@@ -276,4 +276,20 @@ func Test_buildACMCertificates(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_buildCertificateResourceID(t *testing.T) {
+	task := &defaultModelBuildTask{}
+	ing := &ClassifiedIngress{
+		Ing: &networking.Ingress{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "awesome-ns", Name: "ing-wild"},
+		},
+	}
+	got := task.buildCertificateResourceID(&acmModel.CertificateSpec{
+		Type:       acmtypes.CertificateTypeAmazonIssued,
+		DomainName: "*.app.example.com",
+	}, ing)
+
+	assert.NotContains(t, got, "*")
+	assert.Contains(t, got, "wildcard.app.example.com")
 }

--- a/test/e2e/ingress/acm_ingress_test.go
+++ b/test/e2e/ingress/acm_ingress_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/acm/types"
 	. "github.com/onsi/ginkgo/v2"
 
@@ -119,6 +120,72 @@ var _ = Describe("certificate management ingress tests", func() {
 			ExpectCertToBeInUse(ctx, certARN)
 
 			// test traffic (http)
+			ExpectLBDNSBeAvailable(ctx, tf, lbARN, lbDNS)
+			httpsExp := httpexpect.WithConfig(httpexpect.Config{
+				Reporter: tf.LoggerReporter,
+				Client: &http.Client{
+					Transport: &http.Transport{
+						TLSClientConfig: &tls.Config{
+							// accept any certificate; for testing only! (the dns name of the LB doesn't match the domain we issued a cert for)
+							InsecureSkipVerify: true,
+						},
+					},
+				},
+				BaseURL: fmt.Sprintf("https://%s", lbDNS),
+			})
+			httpsExp.GET("/path").WithHeader("Host", tf.Options.Route53ValidationDomain).Expect().
+				Status(http.StatusOK).Body().Equal("Hello World!")
+		})
+
+		It("ingress fronted by a wildcard host", func() {
+			// The cert's DomainName is used in resourceID tag, and ACM rejects '*' in tag values,
+			// so the non-wildcard host must be the DomainName and the wildcard a SAN
+			wildcardHost := fmt.Sprintf("*.%s", tf.Options.Route53ValidationDomain)
+
+			appBuilder := manifest.NewFixedResponseServiceBuilder()
+			ingBuilder := manifest.NewIngressBuilder()
+			dp, svc := appBuilder.Build(sandboxNS.Name, "app", tf.Options.TestImageRegistry)
+			ingBackend := networking.IngressBackend{
+				Service: &networking.IngressServiceBackend{
+					Name: svc.Name,
+					Port: networking.ServiceBackendPort{
+						Number: 80,
+					},
+				},
+			}
+			ingClass := &networking.IngressClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: sandboxNS.Name,
+				},
+				Spec: networking.IngressClassSpec{
+					Controller: "ingress.k8s.aws/alb",
+				},
+			}
+			annotation := map[string]string{
+				"alb.ingress.kubernetes.io/scheme":          "internet-facing",
+				"alb.ingress.kubernetes.io/target-type":     "ip",
+				"alb.ingress.kubernetes.io/listen-ports":    `[{"HTTP": 80}, {"HTTPS": 443}]`,
+				"alb.ingress.kubernetes.io/create-acm-cert": "true",
+			}
+			ing := ingBuilder.
+				AddHTTPRoute(wildcardHost, networking.HTTPIngressPath{Path: "/path", PathType: &exact, Backend: ingBackend}).
+				AddHTTPRoute(tf.Options.Route53ValidationDomain, networking.HTTPIngressPath{Path: "/path", PathType: &exact, Backend: ingBackend}).
+				WithIngressClassName(ingClass.Name).
+				WithAnnotations(annotation).Build(sandboxNS.Name, "ing")
+			resStack := fixture.NewK8SResourceStack(tf, dp, svc, ingClass, ing)
+			err := resStack.Setup(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			defer resStack.TearDown(ctx)
+
+			certARN, _ := ExpectOneCertProvisionedForIngress(ctx, tf, ing)
+			ExpectCertTypeToBe(ctx, certARN, types.CertificateTypeAmazonIssued)
+			ExpectCertDomainNameToBe(ctx, certARN, tf.Options.Route53ValidationDomain)
+			lbARN, lbDNS := ExpectOneLBProvisionedForIngress(ctx, tf, ing)
+			ExpectCertToBeInStatus(ctx, certARN, types.CertificateStatusIssued)
+			ExpectCertToBeInUse(ctx, certARN)
+
+			// test traffic (https)
 			ExpectLBDNSBeAvailable(ctx, tf, lbARN, lbDNS)
 			httpsExp := httpexpect.WithConfig(httpexpect.Config{
 				Reporter: tf.LoggerReporter,
@@ -251,4 +318,12 @@ func ExpectCertTypeToBe(ctx context.Context, certARN string, t types.Certificate
 	Expect(len(detail.Type)).ToNot(Equal(t))
 
 	tf.Logger.Info("Cert of expected type", "arn", certARN, "type", detail.Type)
+}
+
+func ExpectCertDomainNameToBe(ctx context.Context, certARN string, domainName string) {
+	detail, err := tf.CertManager.GetCertificateDetail(ctx, certARN)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(awssdk.ToString(detail.DomainName)).To(Equal(domainName))
+
+	tf.Logger.Info("Cert of expected domain name", "arn", certARN, "domainName", awssdk.ToString(detail.DomainName))
 }

--- a/test/e2e/ingress/acm_ingress_test.go
+++ b/test/e2e/ingress/acm_ingress_test.go
@@ -138,8 +138,10 @@ var _ = Describe("certificate management ingress tests", func() {
 		})
 
 		It("ingress fronted by a wildcard host", func() {
-			// The cert's DomainName is used in resourceID tag, and ACM rejects '*' in tag values,
-			// so the non-wildcard host must be the DomainName and the wildcard a SAN
+			// Hosts are a sorted set and '*' sorts ahead of alphanumerics, so the wildcard
+			// host becomes the cert DomainName. The DomainName feeds the resourceID tag value,
+			// which ACM rejects '*' in, so the '*' must be sanitized out of the resourceID
+			// (not the DomainName) for provisioning to succeed.
 			wildcardHost := fmt.Sprintf("*.%s", tf.Options.Route53ValidationDomain)
 
 			appBuilder := manifest.NewFixedResponseServiceBuilder()
@@ -180,7 +182,7 @@ var _ = Describe("certificate management ingress tests", func() {
 
 			certARN, _ := ExpectOneCertProvisionedForIngress(ctx, tf, ing)
 			ExpectCertTypeToBe(ctx, certARN, types.CertificateTypeAmazonIssued)
-			ExpectCertDomainNameToBe(ctx, certARN, tf.Options.Route53ValidationDomain)
+			ExpectCertDomainNameToBe(ctx, certARN, wildcardHost)
 			lbARN, lbDNS := ExpectOneLBProvisionedForIngress(ctx, tf, ing)
 			ExpectCertToBeInStatus(ctx, certARN, types.CertificateStatusIssued)
 			ExpectCertToBeInUse(ctx, certARN)


### PR DESCRIPTION
### Description

The [`create-acm-cert` annotation](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/ingress/annotations/#create-acm-cert) requests one certificate per ingress, using every host as a SAN and the first host as the Domain Name ([`buildCertificateSpec`](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/3f1e9707ac4ce65504d72b425e82be5245b38e0e/pkg/ingress/model_build_certificates.go#L49)).

- Hosts are a sorted set, so a wildcard like `*.app.example.com` sorts first and becomes the Domain Name.
- The Domain Name is baked into the certificate's resource ID and written as an ACM tag ([`buildCertificateResourceID`](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/3f1e9707ac4ce65504d72b425e82be5245b38e0e/pkg/ingress/model_build_certificates.go#L43), surfaced by [`ResourceTags`](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/3f1e9707ac4ce65504d72b425e82be5245b38e0e/pkg/deploy/tracking/provider.go#L125)).
- ACM rejects `*` in tag values (`[\p{L}\p{Z}\p{N}_.:/=+\-@]*`), so `RequestCertificate` fails for any ingress with a wildcard host:

> ValidationException: Value of the input at 'tags' failed to satisfy constraint: Member must satisfy regular expression pattern: ...

Note this is only the tag value. ACM accepts a wildcard Domain Name on the certificate itself.

#### Fix

- Replace `*` with `wildcard` in the resource ID before it's used as a tag value.
- The Domain Name and SANs sent to ACM are unchanged, so the certificate covers the same names and the resource ID stays unique per ingress.
- Also handles ingresses whose hosts are all wildcards.

#### Tests

- `model_build_certificates_test.go`: an all-wildcard ingress case, plus a test asserting the resource ID contains no `*`.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
