### PR TITLE
refactor ipv6 testing

### DIFF
--- a/test/e2e/gateway/alb_tests/alb_test_helper.go
+++ b/test/e2e/gateway/alb_tests/alb_test_helper.go
@@ -33,11 +33,6 @@ func (s *ALBTestStack) DeployHTTP(ctx context.Context, auxiliaryStack *test_reso
 		httprs = append(httprs, test_resources.BuildOtherNsRefHttpRoute("other-ns", auxiliaryStack.Ns))
 	}
 
-	if f.Options.IPFamily == framework.IPv6 {
-		v6 := elbv2gw.LoadBalancerIpAddressTypeDualstack
-		lbConfSpec.IpAddressType = &v6
-	}
-
 	svc := test_resources.BuildServiceSpec(map[string]string{})
 	tgc := test_resources.BuildTargetGroupConfig(test_resources.DefaultTgConfigName, tgConfSpec, svc)
 	return s.deploy(ctx, f, gwListeners, httprs, []*gwv1.GRPCRoute{}, []*appsv1.Deployment{test_resources.BuildDeploymentSpec(f.Options.TestImageRegistry)}, []*corev1.Service{svc}, lbConfSpec, []*elbv2gw.TargetGroupConfiguration{tgc}, lrConfSpec, secret, readinessGateEnabled)
@@ -66,11 +61,6 @@ func (s *ALBTestStack) DeployGRPC(ctx context.Context, f *framework.Framework, g
 // DeployHTTPWithDefaultTGC deploys an ALB stack with a gateway-level default TGC referenced by the LBC,
 // plus two services: svc1 inherits defaults, svc2 has a service-level TGC override.
 func (s *ALBTestStack) DeployHTTPWithDefaultTGC(ctx context.Context, f *framework.Framework, lbConfSpec elbv2gw.LoadBalancerConfigurationSpec, defaultTGC *elbv2gw.TargetGroupConfiguration, svcTgSpec elbv2gw.TargetGroupConfigurationSpec, readinessGateEnabled bool) error {
-	if f.Options.IPFamily == framework.IPv6 {
-		v6 := elbv2gw.LoadBalancerIpAddressTypeDualstack
-		lbConfSpec.IpAddressType = &v6
-	}
-
 	gwListeners := []gwv1.Listener{
 		{
 			Name:     "http80",
@@ -120,7 +110,7 @@ func (s *ALBTestStack) DeployHTTPWithDefaultTGC(ctx context.Context, f *framewor
 func (s *ALBTestStack) deploy(ctx context.Context, f *framework.Framework, gwListeners []gwv1.Listener, httprs []*gwv1.HTTPRoute, grpcrs []*gwv1.GRPCRoute, dps []*appsv1.Deployment, svcs []*corev1.Service, lbConfSpec elbv2gw.LoadBalancerConfigurationSpec, tgcs []*elbv2gw.TargetGroupConfiguration, lrConfSpec elbv2gw.ListenerRuleConfigurationSpec, secret *testOIDCSecret, readinessGateEnabled bool) error {
 	gwc := test_resources.BuildGatewayClassSpec("gateway.k8s.aws/alb")
 	gw := test_resources.BuildBasicGatewaySpec(gwc, gwListeners)
-	lbc := test_resources.BuildLoadBalancerConfig(lbConfSpec)
+	lbc := test_resources.BuildLoadBalancerConfig(f, lbConfSpec)
 	lrc := test_resources.BuildListenerRuleConfig(test_resources.DefaultLRConfigName, lrConfSpec)
 
 	namespaceLabels := test_resources.GetNamespaceLabels(readinessGateEnabled)

--- a/test/e2e/gateway/listenerset_tests/listenerset_test.go
+++ b/test/e2e/gateway/listenerset_tests/listenerset_test.go
@@ -94,7 +94,7 @@ var _ = Describe("test k8s alb gateway with ListenerSet", func() {
 			})
 
 			By("creating LB config and TG config", func() {
-				lbc := test_resources.BuildLoadBalancerConfig(lbcSpec)
+				lbc := test_resources.BuildLoadBalancerConfig(tf, lbcSpec)
 				lbc.Namespace = ns.Name
 				err := test_resources.CreateLoadBalancerConfig(ctx, tf, lbc)
 				Expect(err).NotTo(HaveOccurred())
@@ -304,7 +304,7 @@ var _ = Describe("test k8s alb gateway with ListenerSet", func() {
 			})
 
 			By("creating LB config and TG config", func() {
-				lbc := test_resources.BuildLoadBalancerConfig(lbcSpec)
+				lbc := test_resources.BuildLoadBalancerConfig(tf, lbcSpec)
 				lbc.Namespace = ns.Name
 				err := test_resources.CreateLoadBalancerConfig(ctx, tf, lbc)
 				Expect(err).NotTo(HaveOccurred())
@@ -486,7 +486,7 @@ var _ = Describe("test k8s alb gateway with ListenerSet", func() {
 			})
 
 			By("creating LB config and TG config", func() {
-				lbc := test_resources.BuildLoadBalancerConfig(lbcSpec)
+				lbc := test_resources.BuildLoadBalancerConfig(tf, lbcSpec)
 				lbc.Namespace = ns.Name
 				err := test_resources.CreateLoadBalancerConfig(ctx, tf, lbc)
 				Expect(err).NotTo(HaveOccurred())
@@ -687,7 +687,7 @@ var _ = Describe("test k8s alb gateway with ListenerSet", func() {
 				err = test_resources.CreateServices(ctx, tf, []*corev1.Service{svc})
 				Expect(err).NotTo(HaveOccurred())
 
-				lbc := test_resources.BuildLoadBalancerConfig(lbcSpec)
+				lbc := test_resources.BuildLoadBalancerConfig(tf, lbcSpec)
 				lbc.Namespace = ns.Name
 				err = test_resources.CreateLoadBalancerConfig(ctx, tf, lbc)
 				Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/gateway/nlb_tests/nlb_test_helper.go
+++ b/test/e2e/gateway/nlb_tests/nlb_test_helper.go
@@ -32,11 +32,6 @@ func (s *NLBTestStack) Deploy(ctx context.Context, f *framework.Framework, auxil
 	svcUDP := test_resources.BuildUDPServiceSpec()
 	gwc := test_resources.BuildGatewayClassSpec("gateway.k8s.aws/nlb")
 
-	if f.Options.IPFamily == framework.IPv6 {
-		v6 := elbv2gw.LoadBalancerIpAddressTypeDualstack
-		lbConfSpec.IpAddressType = &v6
-	}
-
 	listeners := []gwv1.Listener{
 		{
 			Name:     "port80",
@@ -79,7 +74,7 @@ func (s *NLBTestStack) Deploy(ctx context.Context, f *framework.Framework, auxil
 
 	gw := test_resources.BuildBasicGatewaySpec(gwc, listeners)
 
-	lbc := test_resources.BuildLoadBalancerConfig(lbConfSpec)
+	lbc := test_resources.BuildLoadBalancerConfig(f, lbConfSpec)
 	tgcTCP := test_resources.BuildTargetGroupConfig(test_resources.DefaultTgConfigName, tgConfSpec, svcTCP)
 	tgcUDP := test_resources.BuildTargetGroupConfig(test_resources.UDPDefaultTgConfigName, tgConfSpec, svcUDP)
 	udpr := test_resources.BuildUDPRoute("port8080")
@@ -97,11 +92,6 @@ func (s *NLBTestStack) DeployTCPWeightedStack(ctx context.Context, f *framework.
 	svcTCP2.Name = svcTCP2.Name + "-2"
 
 	gwc := test_resources.BuildGatewayClassSpec("gateway.k8s.aws/nlb")
-
-	if f.Options.IPFamily == framework.IPv6 {
-		v6 := elbv2gw.LoadBalancerIpAddressTypeDualstack
-		lbConfSpec.IpAddressType = &v6
-	}
 
 	listeners := []gwv1.Listener{
 		{
@@ -154,7 +144,7 @@ func (s *NLBTestStack) DeployTCPWeightedStack(ctx context.Context, f *framework.
 
 	gw := test_resources.BuildBasicGatewaySpec(gwc, listeners)
 
-	lbc := test_resources.BuildLoadBalancerConfig(lbConfSpec)
+	lbc := test_resources.BuildLoadBalancerConfig(f, lbConfSpec)
 	tgcTCP1 := test_resources.BuildTargetGroupConfig(svcTCP1.Name, tgConfSpec, svcTCP1)
 	tgcTCP2 := test_resources.BuildTargetGroupConfig(svcTCP2.Name, tgConfSpec, svcTCP2)
 
@@ -167,11 +157,6 @@ func (s *NLBTestStack) DeployTCP_UDP(ctx context.Context, f *framework.Framework
 	dpUDP := test_resources.BuildUDPDeploymentSpec()
 	svcUDP := test_resources.BuildUDPServiceSpec()
 	gwc := test_resources.BuildGatewayClassSpec("gateway.k8s.aws/nlb")
-
-	if f.Options.IPFamily == framework.IPv6 {
-		v6 := elbv2gw.LoadBalancerIpAddressTypeDualstack
-		lbConfSpec.IpAddressType = &v6
-	}
 
 	listeners := []gwv1.Listener{
 		{
@@ -190,7 +175,7 @@ func (s *NLBTestStack) DeployTCP_UDP(ctx context.Context, f *framework.Framework
 
 	gw := test_resources.BuildBasicGatewaySpec(gwc, listeners)
 
-	lbc := test_resources.BuildLoadBalancerConfig(lbConfSpec)
+	lbc := test_resources.BuildLoadBalancerConfig(f, lbConfSpec)
 	tgcUDP := test_resources.BuildTargetGroupConfig(test_resources.UDPDefaultTgConfigName, tgConfSpec, svcUDP)
 	udpr := test_resources.BuildUDPRoute("port80udp")
 
@@ -207,11 +192,6 @@ func (s *NLBTestStack) DeployQUIC(ctx context.Context, f *framework.Framework, l
 	dpUDP.Spec.Template.Annotations["service.beta.kubernetes.io/aws-load-balancer-quic-enabled-containers"] = "app"
 	gwc := test_resources.BuildGatewayClassSpec("gateway.k8s.aws/nlb")
 
-	if f.Options.IPFamily == framework.IPv6 {
-		v6 := elbv2gw.LoadBalancerIpAddressTypeDualstack
-		lbConfSpec.IpAddressType = &v6
-	}
-
 	gw := test_resources.BuildBasicGatewaySpec(gwc, []gwv1.Listener{
 		{
 			Name:     "udp-listener",
@@ -220,7 +200,7 @@ func (s *NLBTestStack) DeployQUIC(ctx context.Context, f *framework.Framework, l
 		},
 	})
 
-	lbc := test_resources.BuildLoadBalancerConfig(lbConfSpec)
+	lbc := test_resources.BuildLoadBalancerConfig(f, lbConfSpec)
 	tgcUDP := test_resources.BuildTargetGroupConfig(svcUDP.Name, tgConfSpec, svcUDP)
 
 	udpr := test_resources.BuildUDPRoute("udp-listener")
@@ -253,7 +233,7 @@ func (s *NLBTestStack) DeployTCP_QUIC(ctx context.Context, f *framework.Framewor
 		},
 	})
 
-	lbc := test_resources.BuildLoadBalancerConfig(lbConfSpec)
+	lbc := test_resources.BuildLoadBalancerConfig(f, lbConfSpec)
 	tgcUDP := test_resources.BuildTargetGroupConfig(svcUDP.Name, tgConfSpec, svcUDP)
 
 	udpr := test_resources.BuildUDPRoute("udp-listener")
@@ -267,10 +247,6 @@ func (s *NLBTestStack) DeployTCP_QUIC(ctx context.Context, f *framework.Framewor
 // DeployWithDefaultTGC deploys an NLB stack with a gateway-level default TGC referenced by the LBC,
 // plus two services: svc1 inherits defaults, svc2 has a service-level TGC override.
 func (s *NLBTestStack) DeployWithDefaultTGC(ctx context.Context, f *framework.Framework, lbConfSpec elbv2gw.LoadBalancerConfigurationSpec, defaultTGC *elbv2gw.TargetGroupConfiguration, svcTgSpec elbv2gw.TargetGroupConfigurationSpec, readinessGateEnabled bool) error {
-	if f.Options.IPFamily == framework.IPv6 {
-		v6 := elbv2gw.LoadBalancerIpAddressTypeDualstack
-		lbConfSpec.IpAddressType = &v6
-	}
 
 	listeners := []gwv1.Listener{
 		{
@@ -304,7 +280,7 @@ func (s *NLBTestStack) DeployWithDefaultTGC(ctx context.Context, f *framework.Fr
 
 	gwc := test_resources.BuildGatewayClassSpec("gateway.k8s.aws/nlb")
 	gw := test_resources.BuildBasicGatewaySpec(gwc, listeners)
-	lbc := test_resources.BuildLoadBalancerConfig(lbConfSpec)
+	lbc := test_resources.BuildLoadBalancerConfig(f, lbConfSpec)
 
 	s.Resources = newNLBResourceStack(
 		[]*appsv1.Deployment{dpTCP},
@@ -319,11 +295,6 @@ func (s *NLBTestStack) DeployWithDefaultTGC(ctx context.Context, f *framework.Fr
 
 func (s *NLBTestStack) DeployFrontendNLB(ctx context.Context, albStack alb_tests.ALBTestStack, f *framework.Framework, lbConfSpec elbv2gw.LoadBalancerConfigurationSpec, hasTLS bool, readinessGateEnabled bool) error {
 	gwc := test_resources.BuildGatewayClassSpec("gateway.k8s.aws/nlb")
-
-	if f.Options.IPFamily == framework.IPv6 {
-		v6 := elbv2gw.LoadBalancerIpAddressTypeDualstack
-		lbConfSpec.IpAddressType = &v6
-	}
 
 	listeners := []gwv1.Listener{
 		{
@@ -348,7 +319,7 @@ func (s *NLBTestStack) DeployFrontendNLB(ctx context.Context, albStack alb_tests
 
 	gw := test_resources.BuildBasicGatewaySpec(gwc, listeners)
 
-	lbc := test_resources.BuildLoadBalancerConfig(lbConfSpec)
+	lbc := test_resources.BuildLoadBalancerConfig(f, lbConfSpec)
 
 	s.Resources = newNLBResourceStack([]*appsv1.Deployment{}, []*corev1.Service{}, gwc, gw, lbc, []*elbv2gw.TargetGroupConfiguration{}, tcprs, []*gwalpha2.UDPRoute{}, nil, "nlb-gateway-e2e", test_resources.GetNamespaceLabels(readinessGateEnabled))
 
@@ -640,11 +611,6 @@ func (s *NLBTestStack) DeployListenerMismatch(ctx context.Context, f *framework.
 	svcTCP := test_resources.BuildServiceSpec(map[string]string{})
 	gwc := test_resources.BuildGatewayClassSpec("gateway.k8s.aws/nlb")
 
-	if f.Options.IPFamily == framework.IPv6 {
-		v6 := elbv2gw.LoadBalancerIpAddressTypeDualstack
-		lbConfSpec.IpAddressType = &v6
-	}
-
 	listeners := []gwv1.Listener{
 		{
 			Name:     "listener-exists",
@@ -660,7 +626,7 @@ func (s *NLBTestStack) DeployListenerMismatch(ctx context.Context, f *framework.
 
 	tcprs := []*gwalpha2.TCPRoute{test_resources.BuildTCPRouteWithMismatchedParentRefs()}
 	gw := test_resources.BuildBasicGatewaySpec(gwc, listeners)
-	lbc := test_resources.BuildLoadBalancerConfig(lbConfSpec)
+	lbc := test_resources.BuildLoadBalancerConfig(f, lbConfSpec)
 	tgcTCP := test_resources.BuildTargetGroupConfig(test_resources.DefaultTgConfigName, tgConfSpec, svcTCP)
 
 	s.Resources = newNLBResourceStack([]*appsv1.Deployment{dpTCP}, []*corev1.Service{svcTCP}, gwc, gw, lbc, []*elbv2gw.TargetGroupConfiguration{tgcTCP}, tcprs, []*gwalpha2.UDPRoute{}, nil, "nlb-gateway-e2e", test_resources.GetNamespaceLabels(readinessGateEnabled))

--- a/test/e2e/gateway/test_resources/shared_resource_definitions.go
+++ b/test/e2e/gateway/test_resources/shared_resource_definitions.go
@@ -278,7 +278,12 @@ func BuildGatewayClassSpec(controllerName string) *gwv1.GatewayClass {
 	return gwc
 }
 
-func BuildLoadBalancerConfig(spec elbv2gw.LoadBalancerConfigurationSpec) *elbv2gw.LoadBalancerConfiguration {
+func BuildLoadBalancerConfig(f *framework.Framework, spec elbv2gw.LoadBalancerConfigurationSpec) *elbv2gw.LoadBalancerConfiguration {
+
+	if f.Options.IPFamily == framework.IPv6 {
+		spec.IpAddressType = new(elbv2gw.LoadBalancerIpAddressTypeDualstack)
+	}
+
 	lbc := &elbv2gw.LoadBalancerConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: DefaultLbConfigName,


### PR DESCRIPTION
### Description

Our tests were manually specifying ipv6 lb types when the framework was set to ipv6. I moved this logic into the lb conf creation we no longer have to remember to set this property for gateway tests.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
