### PR TITLE
add ipv6 annotations to cert generation tests

### DIFF
--- a/test/e2e/ingress/acm_ingress_test.go
+++ b/test/e2e/ingress/acm_ingress_test.go
@@ -102,6 +102,11 @@ var _ = Describe("certificate management ingress tests", func() {
 				"alb.ingress.kubernetes.io/listen-ports":    `[{"HTTP": 80}, {"HTTPS": 443}]`,
 				"alb.ingress.kubernetes.io/create-acm-cert": "true",
 			}
+
+			if tf.Options.IPFamily == framework.IPv6 {
+				annotation["alb.ingress.kubernetes.io/ip-address-type"] = "dualstack"
+			}
+
 			ing := ingBuilder.
 				AddHTTPRoute(tf.Options.Route53ValidationDomain, networking.HTTPIngressPath{Path: "/path", PathType: &exact, Backend: ingBackend}).
 				WithIngressClassName(ingClass.Name).
@@ -171,6 +176,11 @@ var _ = Describe("certificate management ingress tests", func() {
 				"alb.ingress.kubernetes.io/create-acm-cert": "true",
 				"alb.ingress.kubernetes.io/acm-pca-arn":     tf.Options.PCAARN,
 			}
+
+			if tf.Options.IPFamily == framework.IPv6 {
+				annotation["alb.ingress.kubernetes.io/ip-address-type"] = "dualstack"
+			}
+			
 			ing := ingBuilder.
 				AddHTTPRoute("example.com", networking.HTTPIngressPath{Path: "/path", PathType: &exact, Backend: ingBackend}).
 				WithIngressClassName(ingClass.Name).


### PR DESCRIPTION
These tests currently fail because they manually set annotations, but don't add the dualstack annotation when running against an ipv6 cluster.