### PR TITLE
docs: fix stale contributor setup and invalid IAM role ARN examples

### DIFF
--- a/docs/controller-devel.md
+++ b/docs/controller-devel.md
@@ -19,7 +19,7 @@ Please ensure that you have [properly installed Go][install-go].
 [install-go]: https://golang.org/doc/install
 
 !!! note "Go version"
-    We recommend to use a Go version of `1.14` or above for development.
+    Use the Go version declared by the repository (see `.go-version` / `go.mod`).
 
 ## Fork upstream repository
 
@@ -34,7 +34,7 @@ Make sure in your `$GOPATH/src` that you have directories for the
 `sigs.k8s.io` organization:
 
 ```bash
-mkdir -p $GOPATH/src/github.com/sigs.k8s.io
+mkdir -p $GOPATH/src/sigs.k8s.io
 ```
 
 
@@ -50,10 +50,10 @@ You can use this script to do this for you:
 ```bash
 GITHUB_ID="your GH username"
 
-cd $GOPATH/src/github.com/sigs.k8s.io
-git clone git@github.com:$GITHUB_ID/aws-load-balancer-controller
+cd $GOPATH/src/sigs.k8s.io
+git clone git@github.com:$GITHUB_ID/aws-load-balancer-controller.git
 cd aws-load-balancer-controller/
-git remote add upstream git@github.com:kubernetes-sigs/aws-load-balancer-controller
+git remote add upstream git@github.com:kubernetes-sigs/aws-load-balancer-controller.git
 git fetch --all
 
 ```

--- a/docs/examples/echo_server.md
+++ b/docs/examples/echo_server.md
@@ -338,7 +338,7 @@ follow below steps if you want to use kube2iam to provide the AWS credentials
     The new role will have a similar arn:
 
     ```
-    arn:aws:iam:::XXXXXXXXXXXX:role/k8s-lb-controller
+    arn:aws:iam::XXXXXXXXXXXX:role/k8s-lb-controller
     ```
 
 1.  update the alb-load-balancer-controller deployment
@@ -360,5 +360,5 @@ follow below steps if you want to use kube2iam to provide the AWS credentials
     template:
       metadata:
         annotations:
-          iam.amazonaws.com/role: arn:aws:iam:::XXXXXXXXXXXX:role/k8s-lb-controller
+          iam.amazonaws.com/role: arn:aws:iam::XXXXXXXXXXXX:role/k8s-lb-controller
     ```


### PR DESCRIPTION
### Issue
Related: #3776

### Description
A couple docs bits are stale and can trip people up.

- `docs/controller-devel.md` still says Go `1.14+` and uses `$GOPATH/src/github.com/sigs.k8s.io`, but this repo now declares Go `1.26.4` and the module path is `sigs.k8s.io/...`
- `docs/examples/echo_server.md` shows `arn:aws:iam:::...` for the kube2iam role ARN. That extra `:` makes the example invalid

Repro:
1. Follow `docs/controller-devel.md` on `main`. You get stale Go guidance and a checkout path that does not match the module path, kind of a footgun.
2. Copy the kube2iam ARN example from `docs/examples/echo_server.md`. The IAM role ARN has an extra `:` so the sample is wrong as-is.

Fix:
- point the dev guide at `.go-version` and `go.mod`, and use the correct `sigs.k8s.io` GOPATH path
- fix the IAM role ARN examples

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
