### PR TITLE
Fix input order dependency in GW rules precedence

### DIFF
--- a/pkg/gateway/routeutils/route_rule_precedence.go
+++ b/pkg/gateway/routeutils/route_rule_precedence.go
@@ -183,11 +183,7 @@ func getHostnameListPrecedenceOrder(hostnameListOne, hostnameListTwo []string) i
 			return precedence
 		}
 	}
-	if len(hostnameListOne) < len(hostnameListTwo) {
-		return -1
-	} else if len(hostnameListOne) > len(hostnameListTwo) {
-		return 1
-	}
+	// can not complete tie breaking at hostname level
 	return 0
 }
 
@@ -216,6 +212,9 @@ func compareHttpRulePrecedence(ruleOne RulePrecedence, ruleTwo RulePrecedence) b
 	// compare query param count
 	if ruleOne.HttpSpecificRulePrecedenceFactor.QueryParamCount != ruleTwo.HttpSpecificRulePrecedenceFactor.QueryParamCount {
 		return ruleOne.HttpSpecificRulePrecedenceFactor.QueryParamCount > ruleTwo.HttpSpecificRulePrecedenceFactor.QueryParamCount
+	}
+	if len(ruleOne.CommonRulePrecedence.Hostnames) != len(ruleTwo.CommonRulePrecedence.Hostnames) {
+		return len(ruleOne.CommonRulePrecedence.Hostnames) > len(ruleTwo.CommonRulePrecedence.Hostnames)
 	}
 	return compareCommonTieBreakers(ruleOne, ruleTwo)
 }

--- a/pkg/gateway/routeutils/route_rule_precedence.go
+++ b/pkg/gateway/routeutils/route_rule_precedence.go
@@ -183,7 +183,11 @@ func getHostnameListPrecedenceOrder(hostnameListOne, hostnameListTwo []string) i
 			return precedence
 		}
 	}
-	// can not complete tie breaking at hostname level
+	if len(hostnameListOne) < len(hostnameListTwo) {
+		return -1
+	} else if len(hostnameListOne) > len(hostnameListTwo) {
+		return 1
+	}
 	return 0
 }
 

--- a/pkg/gateway/routeutils/route_rule_precedence_test.go
+++ b/pkg/gateway/routeutils/route_rule_precedence_test.go
@@ -490,9 +490,9 @@ func Test_SortAllRulesByPrecedence(t *testing.T) {
 				httpRouteThreeDotsHost, // a.b.c.com (3 dots)
 			},
 			output: []RulePrecedence{
-				makeRulePrecedenceForRouteDescription(httpRouteNoHost, nil),        // no hostname
 				makeRulePrecedenceForRouteDescription(httpRouteThreeDotsHost, nil), // a.b.c.com (3 dots)
 				makeRulePrecedenceForRouteDescription(httpRouteOneDotHost, nil),    // zzz.com (1 dot)
+				makeRulePrecedenceForRouteDescription(httpRouteNoHost, nil),        // no hostname
 			},
 		},
 		{
@@ -503,9 +503,9 @@ func Test_SortAllRulesByPrecedence(t *testing.T) {
 				httpRouteOneDotHost,    // zzz.com (1 dot)
 			},
 			output: []RulePrecedence{
-				makeRulePrecedenceForRouteDescription(httpRouteNoHost, nil),        // no hostname
 				makeRulePrecedenceForRouteDescription(httpRouteThreeDotsHost, nil), // a.b.c.com (3 dots)
 				makeRulePrecedenceForRouteDescription(httpRouteOneDotHost, nil),    // zzz.com (1 dot)
+				makeRulePrecedenceForRouteDescription(httpRouteNoHost, nil),        // no hostname
 			},
 		},
 		{

--- a/pkg/gateway/routeutils/route_rule_precedence_test.go
+++ b/pkg/gateway/routeutils/route_rule_precedence_test.go
@@ -151,6 +151,95 @@ func Test_SortAllRulesByPrecedence(t *testing.T) {
 			},
 		},
 	}
+
+	httpRouteOneDotHost := &httpRouteDescription{
+		route: &gwv1.HTTPRoute{
+			ObjectMeta: v1.ObjectMeta{Name: "a-host", Namespace: "ns"},
+			Spec:       gwv1.HTTPRouteSpec{Hostnames: []gwv1.Hostname{"zzz.com"}},
+		},
+		rules: []RouteRule{
+			&convertedHTTPRouteRule{rule: &gwv1.HTTPRouteRule{
+				Matches: []gwv1.HTTPRouteMatch{{
+					Path: &gwv1.HTTPPathMatch{Value: new("/"), Type: new(gwv1.PathMatchPathPrefix)},
+				}},
+			}},
+		},
+	}
+
+	httpRouteNoHost := &httpRouteDescription{
+		route: &gwv1.HTTPRoute{
+			ObjectMeta: v1.ObjectMeta{Name: "b-nohost", Namespace: "ns"},
+		},
+		rules: []RouteRule{
+			&convertedHTTPRouteRule{rule: &gwv1.HTTPRouteRule{
+				Matches: []gwv1.HTTPRouteMatch{{
+					Path: &gwv1.HTTPPathMatch{Value: new("/"), Type: new(gwv1.PathMatchPathPrefix)},
+				}},
+			}},
+		},
+	}
+
+	httpRouteThreeDotsHost := &httpRouteDescription{
+		route: &gwv1.HTTPRoute{
+			ObjectMeta: v1.ObjectMeta{Name: "c-host", Namespace: "ns"},
+			Spec:       gwv1.HTTPRouteSpec{Hostnames: []gwv1.Hostname{"a.b.c.com"}},
+		},
+		rules: []RouteRule{
+			&convertedHTTPRouteRule{rule: &gwv1.HTTPRouteRule{
+				Matches: []gwv1.HTTPRouteMatch{{
+					Path: &gwv1.HTTPPathMatch{Value: new("/"), Type: new(gwv1.PathMatchPathPrefix)},
+				}},
+			}},
+		},
+	}
+
+	httpRouteNoHostWithPost := &httpRouteDescription{
+		route: &gwv1.HTTPRoute{
+			ObjectMeta: v1.ObjectMeta{Name: "b-nohost", Namespace: "ns"},
+		},
+		rules: []RouteRule{
+			&convertedHTTPRouteRule{rule: &gwv1.HTTPRouteRule{
+				Matches: []gwv1.HTTPRouteMatch{
+					{
+						Method: new(gwv1.HTTPMethodPost),
+						Path:   &gwv1.HTTPPathMatch{Value: new("/"), Type: new(gwv1.PathMatchPathPrefix)},
+					},
+				},
+			}},
+		},
+	}
+
+	makeRulePrecedenceForRouteDescription := func(desc *httpRouteDescription, fn func(*RulePrecedence)) RulePrecedence {
+		rule := RulePrecedence{
+			CommonRulePrecedence: CommonRulePrecedence{
+				RouteNamespacedName: desc.route.Namespace + "/" + desc.route.Name,
+				Hostnames: func() []string {
+					hostnames := make([]string, len(desc.route.Spec.Hostnames))
+					for i := range desc.route.Spec.Hostnames {
+						hostnames[i] = string(desc.route.Spec.Hostnames[i])
+					}
+					return hostnames
+				}(),
+				RouteDescriptor:      desc,
+				Rule:                 desc.rules[0],
+				RuleIndexInRoute:     0,
+				MatchIndexInRule:     0,
+				RouteCreateTimestamp: desc.GetRouteCreateTimestamp(),
+			},
+			HttpSpecificRulePrecedenceFactor: &HttpSpecificRulePrecedenceFactor{
+				PathType:   2,
+				PathLength: 1,
+			},
+			HTTPMatch: &gwv1.HTTPRouteMatch{
+				Path: &gwv1.HTTPPathMatch{Value: new("/"), Type: new(gwv1.PathMatchPathPrefix)},
+			},
+		}
+		if fn != nil {
+			fn(&rule)
+		}
+		return rule
+	}
+
 	testCases := []struct {
 		name   string
 		input  []RouteDescriptor
@@ -391,6 +480,64 @@ func Test_SortAllRulesByPrecedence(t *testing.T) {
 						},
 					},
 				},
+			},
+		},
+		{
+			name: "input order independent result for mixed hostname and no-hostname rules - input order A",
+			input: []RouteDescriptor{
+				httpRouteOneDotHost,    // zzz.com (1 dot)
+				httpRouteNoHost,        // no hostname
+				httpRouteThreeDotsHost, // a.b.c.com (3 dots)
+			},
+			output: []RulePrecedence{
+				makeRulePrecedenceForRouteDescription(httpRouteNoHost, nil),        // no hostname
+				makeRulePrecedenceForRouteDescription(httpRouteThreeDotsHost, nil), // a.b.c.com (3 dots)
+				makeRulePrecedenceForRouteDescription(httpRouteOneDotHost, nil),    // zzz.com (1 dot)
+			},
+		},
+		{
+			name: "input order independent result for mixed hostname and no-hostname rules - input order B",
+			input: []RouteDescriptor{
+				httpRouteThreeDotsHost, // a.b.c.com (3 dots)
+				httpRouteNoHost,        // no hostname
+				httpRouteOneDotHost,    // zzz.com (1 dot)
+			},
+			output: []RulePrecedence{
+				makeRulePrecedenceForRouteDescription(httpRouteNoHost, nil),        // no hostname
+				makeRulePrecedenceForRouteDescription(httpRouteThreeDotsHost, nil), // a.b.c.com (3 dots)
+				makeRulePrecedenceForRouteDescription(httpRouteOneDotHost, nil),    // zzz.com (1 dot)
+			},
+		},
+		{
+			name: "input order independent result for mixed hostname and no-hostname rules, with method - input order A",
+			input: []RouteDescriptor{
+				httpRouteOneDotHost,     // zzz.com (1 dot)
+				httpRouteNoHostWithPost, // no hostname with POST
+				httpRouteThreeDotsHost,  // a.b.c.com (3 dots)
+			},
+			output: []RulePrecedence{
+				makeRulePrecedenceForRouteDescription(httpRouteNoHostWithPost, func(r *RulePrecedence) { // no hostname with POST
+					r.HTTPMatch.Method = new(gwv1.HTTPMethodPost)
+					r.HttpSpecificRulePrecedenceFactor.HasMethod = true
+				}),
+				makeRulePrecedenceForRouteDescription(httpRouteThreeDotsHost, nil), // a.b.c.com (3 dots)
+				makeRulePrecedenceForRouteDescription(httpRouteOneDotHost, nil),    // zzz.com (1 dot)
+			},
+		},
+		{
+			name: "input order independent result for mixed hostname and no-hostname rules, with method - input order B",
+			input: []RouteDescriptor{
+				httpRouteThreeDotsHost,  // a.b.c.com (3 dots)
+				httpRouteNoHostWithPost, // no hostname with POST
+				httpRouteOneDotHost,     // zzz.com (1 dot)
+			},
+			output: []RulePrecedence{
+				makeRulePrecedenceForRouteDescription(httpRouteNoHostWithPost, func(r *RulePrecedence) { // no hostname with POST
+					r.HTTPMatch.Method = new(gwv1.HTTPMethodPost)
+					r.HttpSpecificRulePrecedenceFactor.HasMethod = true
+				}),
+				makeRulePrecedenceForRouteDescription(httpRouteThreeDotsHost, nil), // a.b.c.com (3 dots)
+				makeRulePrecedenceForRouteDescription(httpRouteOneDotHost, nil),    // zzz.com (1 dot)
 			},
 		},
 	}


### PR DESCRIPTION
### Description

Currently, the rule precedence is non-deterministic when some rules include no hostname matches. This is demonstrated by the added test cases.

With no code changes, the test results are as follows:
| Test case  | Result |
| ------------- | ------------- |
| `input order independent result for mixed hostname and no-hostname rules - input order A` | FAIL |
| `input order independent result for mixed hostname and no-hostname rules - input order B` | PASS |
| `input order independent result for mixed hostname and no-hostname rules, with method - input order A` | PASS |
| `input order independent result for mixed hostname and no-hostname rules, with method - input order B` | PASS |

The only thing that changes between test cases with `input order A` and `input order B` is really the order of the input rules.

In practice, this makes the rule ordering non-deterministic, since the input order depends on Go map ordering and the order in which resources are read from the k8s cluster. This bug was found in production while investigating why the listener rules order was flapping.

The fix included here is tentative, and I'm not sure if that's the right approach. I'm open to suggestions on different fixes that make the output deterministic.




### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
