### PR TITLE
[Gateway API]remove overlapping check in httpRoute and GRPCRoute

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -41,8 +41,39 @@ jobs:
           show-progress: false
       - name: Setup Go Version
         run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
-      - id: govulncheck
-        uses: golang/govulncheck-action@31f7c5463448f83528bd771c2d978d940080c9fd
+      - name: Setup Go
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5
         with:
-          go-version-input: ${{ env.GO_VERSION }}
-          go-version-file: go.mod
+          go-version: ${{ env.GO_VERSION }}
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      - name: Run govulncheck
+        run: |
+          set -euo pipefail
+          # govulncheck has no native suppression, so we filter its JSON output: fail on
+          # any "called" vuln not in IGNORE.
+          #
+          # IGNORE: containerd CRI checkpoint/restore advisories. Fix exists only in the
+          # containerd v2 module; we get v1.7.x transitively via the Helm SDK (e2e tests
+          # only, not linked into the controller binary), so it shows "Fixed in: N/A" and
+          # can't be bumped until Helm moves to containerd/v2. Remove once that happens.
+          #   GO-2026-5338 https://github.com/containerd/containerd/security/advisories/GHSA-cvxm-645q-p574
+          #   GO-2026-5064 https://github.com/containerd/containerd/security/advisories/GHSA-33vj-92qq-66hc
+          #   GO-2026-5622 https://github.com/containerd/containerd/security/advisories/GHSA-rgh6-rfwx-v388
+          IGNORE="GO-2026-5338 GO-2026-5064 GO-2026-5622"
+          govulncheck -format json ./... > govulncheck.json
+          # "called" vulns are findings whose leading trace frame resolves to a function.
+          called="$(jq -r 'select(.finding != null) | .finding | select(.trace[0].function != null) | .osv' govulncheck.json | sort -u)"
+          unexpected=""
+          for id in ${called}; do
+            case " ${IGNORE} " in
+              *" ${id} "*) ;;
+              *) unexpected="${unexpected} ${id}" ;;
+            esac
+          done
+          if [ -n "${unexpected}" ]; then
+            echo "::error::govulncheck found vulnerabilities not in the ignore list:${unexpected}"
+            govulncheck ./... || true
+            exit 1
+          fi
+          echo "govulncheck OK. Ignored (no fix available) called vulns: ${called:-none}"

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -41,13 +41,8 @@ jobs:
           show-progress: false
       - name: Setup Go Version
         run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
-      - name: Setup Go
-        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5
+      - id: govulncheck
+        uses: golang/govulncheck-action@31f7c5463448f83528bd771c2d978d940080c9fd
         with:
-          go-version: ${{ env.GO_VERSION }}
-      - name: Run govulncheck
-        # Pin to v1.3.0 due to v1.4.0 panic with Go 1.26+
-        # See: https://github.com/golang/go/issues/80059
-        run: |
-          go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
-          govulncheck ./...
+          go-version-input: ${{ env.GO_VERSION }}
+          go-version-file: go.mod

--- a/go.mod
+++ b/go.mod
@@ -77,11 +77,11 @@ require (
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chai2010/gettext-go v1.0.2 // indirect
-	github.com/containerd/containerd v1.7.29 // indirect
+	github.com/containerd/containerd v1.7.33 // indirect
 	github.com/containerd/errdefs v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
-	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
+	github.com/cyphar/filepath-securejoin v0.5.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
@@ -128,7 +128,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
-	github.com/moby/spdystream v0.5.0 // indirect
+	github.com/moby/spdystream v0.5.1 // indirect
 	github.com/moby/term v0.5.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chai2010/gettext-go v1.0.2 h1:1Lwwip6Q2QGsAdl/ZKPCwTe9fe0CjlUbqj5bFNSjIRk=
 github.com/chai2010/gettext-go v1.0.2/go.mod h1:y+wnP2cHYaVj19NZhYKAwEMH2CI1gNHeQQ+5AjwawxA=
-github.com/containerd/containerd v1.7.29 h1:90fWABQsaN9mJhGkoVnuzEY+o1XDPbg9BTC9QTAHnuE=
-github.com/containerd/containerd v1.7.29/go.mod h1:azUkWcOvHrWvaiUjSQH0fjzuHIwSPg1WL5PshGP4Szs=
+github.com/containerd/containerd v1.7.33 h1:iAkYGC/ifR/V+0eR4iXWHNGYUF0DF2PmGV5iz4Irj5M=
+github.com/containerd/containerd v1.7.33/go.mod h1:gSbSCVjPCdkfJCjyrzz7aRC+xFlqVbatNpfHfVCYGUM=
 github.com/containerd/errdefs v0.3.0 h1:FSZgGOeK4yuT/+DnF07/Olde/q4KBoMsaamhXxIMDp4=
 github.com/containerd/errdefs v0.3.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
@@ -102,8 +102,8 @@ github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
-github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
-github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
+github.com/cyphar/filepath-securejoin v0.5.1 h1:eYgfMq5yryL4fbWfkLpFFy2ukSELzaJOTaUTuh+oF48=
+github.com/cyphar/filepath-securejoin v0.5.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
 github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -305,8 +305,8 @@ github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQ
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/moby/spdystream v0.5.0 h1:7r0J1Si3QO/kjRitvSLVVFUjxMEb/YLj6S9FF62JBCU=
-github.com/moby/spdystream v0.5.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
+github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y=
+github.com/moby/spdystream v0.5.1/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
 github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/pkg/gateway/routeutils/listener_attachment_helper.go
+++ b/pkg/gateway/routeutils/listener_attachment_helper.go
@@ -15,7 +15,7 @@ import (
 // listenerAttachmentHelper is an internal utility interface that can be used to determine if a listener will allow
 // a route to attach to it.
 type listenerAttachmentHelper interface {
-	listenerAllowsAttachment(ctx context.Context, parentNamespace string, listener gwv1.Listener, route preLoadRouteDescriptor, matchedParentRef gwv1.ParentReference, hostnamesFromHttpRoutes map[int32]sets.Set[gwv1.Hostname], hostnamesFromGrpcRoutes map[int32]sets.Set[gwv1.Hostname]) ([]gwv1.Hostname, *RouteData, error)
+	listenerAllowsAttachment(ctx context.Context, parentNamespace string, listener gwv1.Listener, route preLoadRouteDescriptor, matchedParentRef gwv1.ParentReference) ([]gwv1.Hostname, *RouteData, error)
 }
 
 var _ listenerAttachmentHelper = &listenerAttachmentHelperImpl{}
@@ -36,7 +36,7 @@ func newListenerAttachmentHelper(k8sClient client.Client, logger logr.Logger) li
 // listenerAllowsAttachment utility method to determine if a listener will allow a route to connect using
 // Gateway API rules to determine compatibility between listener and route.
 // Returns: (compatibleHostnames, allowed, failedRouteData, error)
-func (attachmentHelper *listenerAttachmentHelperImpl) listenerAllowsAttachment(ctx context.Context, parentNamespace string, listener gwv1.Listener, route preLoadRouteDescriptor, matchedParentRef gwv1.ParentReference, hostnamesFromHttpRoutes map[int32]sets.Set[gwv1.Hostname], hostnamesFromGrpcRoutes map[int32]sets.Set[gwv1.Hostname]) ([]gwv1.Hostname, *RouteData, error) {
+func (attachmentHelper *listenerAttachmentHelperImpl) listenerAllowsAttachment(ctx context.Context, parentNamespace string, listener gwv1.Listener, route preLoadRouteDescriptor, matchedParentRef gwv1.ParentReference) ([]gwv1.Hostname, *RouteData, error) {
 	namespaceOK, err := attachmentHelper.namespaceCheck(ctx, parentNamespace, listener, route)
 	if err != nil {
 		return nil, nil, err
@@ -61,15 +61,6 @@ func (attachmentHelper *listenerAttachmentHelperImpl) listenerAllowsAttachment(c
 		}
 		if !hostnameOK {
 			return nil, new(GenerateRouteData(false, true, string(gwv1.RouteReasonNoMatchingListenerHostname), RouteStatusInfoRejectedMessageNoMatchingHostname, route.GetRouteNamespacedName(), route.GetRouteKind(), route.GetRouteGeneration(), matchedParentRef)), nil
-		}
-	}
-
-	// check cross serving hostname uniqueness
-	if route.GetRouteKind() == HTTPRouteKind || route.GetRouteKind() == GRPCRouteKind {
-		hostnameUniquenessOK := attachmentHelper.crossServingHostnameUniquenessCheck(listener.Port, route, hostnamesFromHttpRoutes, hostnamesFromGrpcRoutes)
-		if !hostnameUniquenessOK {
-			message := fmt.Sprintf("HTTPRoute and GRPCRoute have overlap hostname, attachment is rejected.")
-			return nil, new(GenerateRouteData(false, true, string(gwv1.RouteReasonNotAllowedByListeners), message, route.GetRouteNamespacedName(), route.GetRouteKind(), route.GetRouteGeneration(), matchedParentRef)), nil
 		}
 	}
 
@@ -163,45 +154,4 @@ func (attachmentHelper *listenerAttachmentHelperImpl) hostnameCheck(listener gwv
 
 	// Return computed compatible hostnames without storing in route
 	return compatibleHostnames, true, nil
-}
-
-func (attachmentHelper *listenerAttachmentHelperImpl) crossServingHostnameUniquenessCheck(listenerPort int32, route preLoadRouteDescriptor, hostnamesFromHttpRoutes map[int32]sets.Set[gwv1.Hostname], hostnamesFromGrpcRoutes map[int32]sets.Set[gwv1.Hostname]) bool {
-	routeKind := route.GetRouteKind()
-	var other sets.Set[gwv1.Hostname]
-	var hostnameSet sets.Set[gwv1.Hostname]
-	var ok bool
-
-	switch routeKind {
-	case GRPCRouteKind:
-		hostnameSet, ok = hostnamesFromGrpcRoutes[listenerPort]
-		if !ok {
-			hostnameSet = sets.New[gwv1.Hostname]()
-			hostnamesFromGrpcRoutes[listenerPort] = hostnameSet
-		}
-
-		for _, hostname := range route.GetHostnames() {
-			hostnameSet.Insert(hostname)
-		}
-		other = hostnamesFromHttpRoutes[listenerPort]
-	case HTTPRouteKind:
-		hostnameSet, ok = hostnamesFromHttpRoutes[listenerPort]
-		if !ok {
-			hostnameSet = sets.New[gwv1.Hostname]()
-			hostnamesFromHttpRoutes[listenerPort] = hostnameSet
-		}
-
-		for _, hostname := range route.GetHostnames() {
-			hostnameSet.Insert(hostname)
-		}
-		other = hostnamesFromGrpcRoutes[listenerPort]
-	}
-
-	for _, hostname := range hostnameSet.UnsortedList() {
-		for _, otherHostNames := range other.UnsortedList() {
-			if isHostnameCompatible(string(hostname), string(otherHostNames)) {
-				return false
-			}
-		}
-	}
-	return true
 }

--- a/pkg/gateway/routeutils/listener_attachment_helper_test.go
+++ b/pkg/gateway/routeutils/listener_attachment_helper_test.go
@@ -83,11 +83,9 @@ func Test_listenerAllowsAttachment(t *testing.T) {
 			attachmentHelper := listenerAttachmentHelperImpl{
 				logger: logr.Discard(),
 			}
-			hostnameFromHttpRoute := map[int32]sets.Set[gwv1.Hostname]{}
-			hostnameFromGrpcRoute := map[int32]sets.Set[gwv1.Hostname]{}
 			_, statusUpdate, err := attachmentHelper.listenerAllowsAttachment(context.Background(), tc.gwNamespace, gwv1.Listener{
 				Protocol: tc.listenerProtocol,
-			}, route, matchedParentRef, hostnameFromHttpRoute, hostnameFromGrpcRoute)
+			}, route, matchedParentRef)
 			assert.NoError(t, err)
 			if tc.expectedStatusUpdate == nil {
 				assert.Nil(t, statusUpdate)
@@ -650,90 +648,51 @@ func ptr[T any](v T) *T {
 	return &v
 }
 
-func Test_crossServingHostnameUniquenessCheck(t *testing.T) {
-	targetPort := int32(80)
-	hostnames := []gwv1.Hostname{"example.com"}
-	namespace := "test-namespace"
-	httpRouteName := "http-route-name"
-	grpcRouteName := "grpc-route-name"
-	tests := []struct {
-		name                    string
-		route                   preLoadRouteDescriptor
-		hostnamesFromHttpRoutes map[int32]sets.Set[gwv1.Hostname]
-		hostnamesFromGrpcRoutes map[int32]sets.Set[gwv1.Hostname]
-		expected                bool
-	}{
-		{
-			name: "GRPC route only - should pass",
-			route: &mockRoute{
-				routeKind:      GRPCRouteKind,
-				hostnames:      hostnames,
-				namespacedName: types.NamespacedName{Name: grpcRouteName, Namespace: namespace},
-			},
-			hostnamesFromHttpRoutes: map[int32]sets.Set[gwv1.Hostname]{},
-			hostnamesFromGrpcRoutes: map[int32]sets.Set[gwv1.Hostname]{},
-			expected:                true,
-		},
-		{
-			name: "HTTP route only - should pass",
-			route: &mockRoute{
-				routeKind:      HTTPRouteKind,
-				hostnames:      hostnames,
-				namespacedName: types.NamespacedName{Name: httpRouteName, Namespace: namespace},
-			},
-			hostnamesFromHttpRoutes: map[int32]sets.Set[gwv1.Hostname]{},
-			hostnamesFromGrpcRoutes: map[int32]sets.Set[gwv1.Hostname]{},
-			expected:                true,
-		},
-		{
-			name: "GRPC route with overlapping HTTP route hostname - should fail",
-			route: &mockRoute{
-				routeKind:      GRPCRouteKind,
-				hostnames:      hostnames,
-				namespacedName: types.NamespacedName{Name: grpcRouteName, Namespace: namespace},
-			},
-			hostnamesFromHttpRoutes: map[int32]sets.Set[gwv1.Hostname]{
-				targetPort: sets.New[gwv1.Hostname](hostnames...),
-			},
-			hostnamesFromGrpcRoutes: map[int32]sets.Set[gwv1.Hostname]{},
-			expected:                false,
-		},
-		{
-			name: "HTTP route with overlapping GRPC route hostname - should fail",
-			route: &mockRoute{
-				routeKind:      HTTPRouteKind,
-				hostnames:      hostnames,
-				namespacedName: types.NamespacedName{Name: httpRouteName, Namespace: namespace},
-			},
-			hostnamesFromGrpcRoutes: map[int32]sets.Set[gwv1.Hostname]{
-				targetPort: sets.New[gwv1.Hostname](hostnames...),
-			},
-			hostnamesFromHttpRoutes: map[int32]sets.Set[gwv1.Hostname]{},
-			expected:                false,
-		},
-		{
-			name: "GRPC route with non-overlapping HTTP route hostname - should pass",
-			route: &mockRoute{
-				routeKind:      GRPCRouteKind,
-				hostnames:      []gwv1.Hostname{"grpc.example.com"},
-				namespacedName: types.NamespacedName{Name: grpcRouteName, Namespace: namespace},
-			},
-			hostnamesFromHttpRoutes: map[int32]sets.Set[gwv1.Hostname]{
-				targetPort: sets.New[gwv1.Hostname]("http.example.com"),
-			},
-			hostnamesFromGrpcRoutes: map[int32]sets.Set[gwv1.Hostname]{},
-			expected:                true,
-		},
+func Test_listenerAllowsAttachment_OverlappingHttpAndGrpcHostname(t *testing.T) {
+	// Per GEP-1016 the controller no longer rejects an HTTPRoute and a GRPCRoute that share a hostname.
+	// This verifies that both route kinds attach to the same HTTPS listener/hostname without error or rejection.
+	const sharedNamespace = "ns1"
+	sharedHostname := gwv1.Hostname("example.com")
+
+	listener := gwv1.Listener{
+		Name:     "https",
+		Protocol: gwv1.HTTPSProtocolType,
+		Port:     443,
+		Hostname: &sharedHostname,
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			helper := &listenerAttachmentHelperImpl{
-				logger: logr.Discard(),
+	parentRef := gwv1.ParentReference{
+		Name:      "gw1",
+		Port:      new(gwv1.PortNumber(443)),
+		Namespace: (*gwv1.Namespace)(new(sharedNamespace)),
+	}
+
+	routes := []struct {
+		name      string
+		routeKind RouteKind
+	}{
+		{name: "http-route", routeKind: HTTPRouteKind},
+		{name: "grpc-route", routeKind: GRPCRouteKind},
+	}
+
+	attachmentHelper := listenerAttachmentHelperImpl{
+		namespaceSelector: &mockNamespaceSelector{},
+		logger:            logr.Discard(),
+	}
+
+	for _, r := range routes {
+		t.Run(string(r.routeKind), func(t *testing.T) {
+			route := &mockRoute{
+				namespacedName: types.NamespacedName{Name: r.name, Namespace: sharedNamespace},
+				routeKind:      r.routeKind,
+				hostnames:      []gwv1.Hostname{sharedHostname},
 			}
 
-			result := helper.crossServingHostnameUniquenessCheck(targetPort, tt.route, tt.hostnamesFromHttpRoutes, tt.hostnamesFromGrpcRoutes)
-			assert.Equal(t, tt.expected, result)
+			compatibleHostnames, statusUpdate, err := attachmentHelper.listenerAllowsAttachment(context.Background(), sharedNamespace, listener, route, parentRef)
+
+			assert.NoError(t, err)
+			assert.Nil(t, statusUpdate, "overlapping HTTPRoute and GRPCRoute hostname should not be rejected")
+			assert.Equal(t, []gwv1.Hostname{sharedHostname}, compatibleHostnames)
 		})
 	}
 }

--- a/pkg/gateway/routeutils/route_listener_mapper.go
+++ b/pkg/gateway/routeutils/route_listener_mapper.go
@@ -22,8 +22,6 @@ type listenerRouteMapResult struct {
 // attachmentState groups the mutable accumulator maps threaded through the attachment methods.
 type attachmentState struct {
 	compatibleHostnamesByPort map[int32]map[string]sets.Set[gwv1.Hostname]
-	hostnamesFromHttpRoutes   map[int32]sets.Set[gwv1.Hostname]
-	hostnamesFromGrpcRoutes   map[int32]sets.Set[gwv1.Hostname]
 	matchedParentRefs         map[string][]gwv1.ParentReference
 }
 
@@ -114,8 +112,6 @@ func (ltr *listenerToRouteMapperImpl) mapListenersAndRoutes(ctx context.Context,
 
 	state := &attachmentState{
 		compatibleHostnamesByPort: make(map[int32]map[string]sets.Set[gwv1.Hostname]),
-		hostnamesFromHttpRoutes:   make(map[int32]sets.Set[gwv1.Hostname]),
-		hostnamesFromGrpcRoutes:   make(map[int32]sets.Set[gwv1.Hostname]),
 		matchedParentRefs:         make(map[string][]gwv1.ParentReference),
 	}
 
@@ -278,7 +274,7 @@ func (ltr *listenerToRouteMapperImpl) attemptListenerRouteAttachment(ctx context
 }
 
 func (ltr *listenerToRouteMapperImpl) attemptRouteSectionAttachment(ctx context.Context, parentNamespace string, targetListener gwv1.Listener, refTuple routeParentRefTuple, acceptedRouteMap map[gwv1.SectionName][]routeParentRefTuple, state *attachmentState) (*RouteData, error) {
-	compatibleHostnames, failedRouteData, err := ltr.listenerAttachmentHelper.listenerAllowsAttachment(ctx, parentNamespace, targetListener, refTuple.route, refTuple.parentRef, state.hostnamesFromHttpRoutes, state.hostnamesFromGrpcRoutes)
+	compatibleHostnames, failedRouteData, err := ltr.listenerAttachmentHelper.listenerAllowsAttachment(ctx, parentNamespace, targetListener, refTuple.route, refTuple.parentRef)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gateway/routeutils/route_listener_mapper_test.go
+++ b/pkg/gateway/routeutils/route_listener_mapper_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -41,7 +40,7 @@ func mockAttachmentKey(parentRef gwv1.ParentReference, listener gwv1.Listener, r
 	return fmt.Sprintf("%s-%s-%s-%s-%d-%s-%s-%s", kind, parentRef.Name, parentRefNamespace, listener.Name, listener.Port, nsn.Name, nsn.Namespace, route.GetRouteKind())
 }
 
-func (m *mockListenerAttachmentHelper) listenerAllowsAttachment(_ context.Context, _ string, listener gwv1.Listener, route preLoadRouteDescriptor, matchedParentRef gwv1.ParentReference, _ map[int32]sets.Set[gwv1.Hostname], _ map[int32]sets.Set[gwv1.Hostname]) ([]gwv1.Hostname, *RouteData, error) {
+func (m *mockListenerAttachmentHelper) listenerAllowsAttachment(_ context.Context, _ string, listener gwv1.Listener, route preLoadRouteDescriptor, matchedParentRef gwv1.ParentReference) ([]gwv1.Hostname, *RouteData, error) {
 	key := mockAttachmentKey(matchedParentRef, listener, route)
 	if result, ok := m.results[key]; ok {
 		return result.compatibleHostnames, result.failedRouteData, result.err

--- a/test/e2e/gateway/alb_tests/alb_instance_target_test.go
+++ b/test/e2e/gateway/alb_tests/alb_instance_target_test.go
@@ -1947,4 +1947,140 @@ var _ = Describe("test k8s alb gateway using instance targets reconciled by the 
 			})
 		})
 	})
+
+	Context("with ALB instance target configuration with an HTTPRoute and a GRPCRoute sharing a hostname", func() {
+		It("should accept both routes and serve HTTP and gRPC on the same ALB", func() {
+			if len(tf.Options.CertificateARNs) == 0 {
+				Skip("Skipping tests, certificates not specified")
+			}
+
+			interf := elbv2gw.LoadBalancerSchemeInternetFacing
+			lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
+				Scheme: &interf,
+			}
+			cert := strings.Split(tf.Options.CertificateARNs, ",")[0]
+			lbcSpec.ListenerConfigurations = &[]elbv2gw.ListenerConfiguration{
+				{
+					ProtocolPort:       "HTTPS:443",
+					DefaultCertificate: &cert,
+				},
+			}
+			instanceTargetType := elbv2gw.TargetTypeInstance
+			tgSpec := elbv2gw.TargetGroupConfigurationSpec{
+				DefaultConfiguration: elbv2gw.TargetGroupProps{
+					TargetType: &instanceTargetType,
+				},
+			}
+			lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{}
+			// An HTTPS listener allows both HTTPRoute and GRPCRoute by default.
+			gwListeners := []gwv1.Listener{
+				{
+					Name:     "test-listener",
+					Port:     443,
+					Protocol: gwv1.HTTPSProtocolType,
+				},
+			}
+
+			exactPath := gwv1.PathMatchExact
+			httpRouteRules := []gwv1.HTTPRouteRule{
+				{
+					Matches: []gwv1.HTTPRouteMatch{
+						{Path: &gwv1.HTTPPathMatch{Type: &exactPath, Value: awssdk.String("/")}},
+					},
+					BackendRefs: test_resources.DefaultHttpRouteRuleBackendRefs,
+				},
+			}
+			httpr := test_resources.BuildHTTPRoute([]string{test_resources.TestHostname}, httpRouteRules, &gwListeners[0].Name)
+			grpcr := test_resources.BuildGRPCRoute([]string{test_resources.TestHostname}, []gwv1.GRPCRouteRule{}, &gwListeners[0].Name)
+
+			By("deploying stack", func() {
+				err := stack.DeployHTTPAndGRPC(ctx, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, []*gwv1.GRPCRoute{grpcr}, lbcSpec, tgSpec, lrcSpec, true)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("checking gateway status for lb dns name", func() {
+				time.Sleep(2 * time.Minute)
+				dnsName = stack.GetLoadBalancerIngressHostName()
+				Expect(dnsName).ToNot(BeEmpty())
+			})
+
+			By("querying AWS loadbalancer from the dns name", func() {
+				var err error
+				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(lbARN).ToNot(BeEmpty())
+			})
+
+			By("confirming both the HTTPRoute and GRPCRoute are accepted", func() {
+				validateOverlappingRoutesStatus(tf, stack)
+			})
+
+			nodeList, err := stack.GetWorkerNodes(ctx, tf)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("verifying AWS loadbalancer resources", func() {
+				expectedTargetGroups := []verifier.ExpectedTargetGroup{
+					{
+						Protocol:      "HTTP",
+						Port:          stack.Resources.CommonStack.Svcs[0].Spec.Ports[0].NodePort,
+						NumTargets:    len(nodeList),
+						TargetType:    "instance",
+						TargetGroupHC: test_resources.DEFAULT_ALB_TARGET_GROUP_HC,
+					},
+					{
+						Protocol:      "HTTP",
+						Port:          stack.Resources.CommonStack.Svcs[1].Spec.Ports[0].NodePort,
+						NumTargets:    len(nodeList),
+						TargetType:    "instance",
+						TargetGroupHC: test_resources.DEFAULT_ALB_TARGET_GROUP_HC_GRPC,
+					},
+				}
+				err := verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
+					Type:         "application",
+					Scheme:       "internet-facing",
+					Listeners:    stack.Resources.GetListenersPortMap(),
+					TargetGroups: expectedTargetGroups,
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("waiting for target group targets to be healthy", func() {
+				err := verifier.WaitUntilTargetsAreHealthy(ctx, tf, lbARN, len(nodeList))
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("waiting until DNS name is available", func() {
+				err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("sending https request to the HTTP backend on the shared hostname", func() {
+				url := fmt.Sprintf("https://%v/", dnsName)
+				urlOptions := http.URLOptions{
+					InsecureSkipVerify: true,
+					HostHeader:         test_resources.TestHostname,
+				}
+				err := tf.HTTPVerifier.VerifyURLWithOptions(url, urlOptions, http.ResponseCodeMatches(200))
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("sending grpc request to the gRPC backend on the shared hostname", func() {
+				// The gRPC route matches on the shared hostname, so the client's :authority must match it.
+				// TestHostname is a wildcard that never matches the real ALB DNS name, so override :authority
+				// with a concrete host that matches the wildcard (mirrors the HTTP check's HostHeader=TestHostname).
+				grpcAuthority := strings.Replace(test_resources.TestHostname, "*", "grpc", 1)
+				conn, err := grpc.NewClient(
+					fmt.Sprintf("%s:443", dnsName),
+					grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})),
+					grpc.WithAuthority(grpcAuthority),
+				)
+				Expect(err).NotTo(HaveOccurred())
+				c := echo2.NewEchoServiceClient(conn)
+				mdCtx := metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{}))
+				response, err := c.Echo(mdCtx, &echo2.EchoRequest{Message: "Hello from overlap E2E test"})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(response.Message).To(Equal("Hello from overlap E2E test"))
+			})
+		})
+	})
 })

--- a/test/e2e/gateway/alb_tests/alb_ip_target_test.go
+++ b/test/e2e/gateway/alb_tests/alb_ip_target_test.go
@@ -1955,6 +1955,139 @@ var _ = Describe("test k8s alb gateway using ip targets reconciled by the aws lo
 			})
 		})
 	})
+	Context("with ALB ip target configuration with an HTTPRoute and a GRPCRoute sharing a hostname", func() {
+		It("should accept both routes and serve HTTP and gRPC on the same ALB", func() {
+			if len(tf.Options.CertificateARNs) == 0 {
+				Skip("Skipping tests, certificates not specified")
+			}
+
+			interf := elbv2gw.LoadBalancerSchemeInternetFacing
+			lbcSpec := elbv2gw.LoadBalancerConfigurationSpec{
+				Scheme: &interf,
+			}
+			cert := strings.Split(tf.Options.CertificateARNs, ",")[0]
+			lbcSpec.ListenerConfigurations = &[]elbv2gw.ListenerConfiguration{
+				{
+					ProtocolPort:       "HTTPS:443",
+					DefaultCertificate: &cert,
+				},
+			}
+			ipTargetType := elbv2gw.TargetTypeIP
+			tgSpec := elbv2gw.TargetGroupConfigurationSpec{
+				DefaultConfiguration: elbv2gw.TargetGroupProps{
+					TargetType: &ipTargetType,
+				},
+			}
+			lrcSpec := elbv2gw.ListenerRuleConfigurationSpec{}
+			// An HTTPS listener allows both HTTPRoute and GRPCRoute by default.
+			gwListeners := []gwv1.Listener{
+				{
+					Name:     "test-listener",
+					Port:     443,
+					Protocol: gwv1.HTTPSProtocolType,
+				},
+			}
+
+			exactPath := gwv1.PathMatchExact
+			httpRouteRules := []gwv1.HTTPRouteRule{
+				{
+					Matches: []gwv1.HTTPRouteMatch{
+						{Path: &gwv1.HTTPPathMatch{Type: &exactPath, Value: awssdk.String("/")}},
+					},
+					BackendRefs: test_resources.DefaultHttpRouteRuleBackendRefs,
+				},
+			}
+			httpr := test_resources.BuildHTTPRoute([]string{test_resources.TestHostname}, httpRouteRules, &gwListeners[0].Name)
+			grpcr := test_resources.BuildGRPCRoute([]string{test_resources.TestHostname}, []gwv1.GRPCRouteRule{}, &gwListeners[0].Name)
+
+			By("deploying stack", func() {
+				err := stack.DeployHTTPAndGRPC(ctx, tf, gwListeners, []*gwv1.HTTPRoute{httpr}, []*gwv1.GRPCRoute{grpcr}, lbcSpec, tgSpec, lrcSpec, true)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("checking gateway status for lb dns name", func() {
+				time.Sleep(2 * time.Minute)
+				dnsName = stack.GetLoadBalancerIngressHostName()
+				Expect(dnsName).ToNot(BeEmpty())
+			})
+
+			By("querying AWS loadbalancer from the dns name", func() {
+				var err error
+				lbARN, err = tf.LBManager.FindLoadBalancerByDNSName(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(lbARN).ToNot(BeEmpty())
+			})
+
+			By("confirming both the HTTPRoute and GRPCRoute are accepted", func() {
+				validateOverlappingRoutesStatus(tf, stack)
+			})
+
+			By("verifying AWS loadbalancer resources", func() {
+				expectedTargetGroups := []verifier.ExpectedTargetGroup{
+					{
+						Protocol:      "HTTP",
+						Port:          80,
+						NumTargets:    int(*stack.Resources.CommonStack.Dps[0].Spec.Replicas),
+						TargetType:    "ip",
+						TargetGroupHC: test_resources.DEFAULT_ALB_TARGET_GROUP_HC,
+					},
+					{
+						Protocol:      "HTTP",
+						Port:          50051,
+						NumTargets:    int(*stack.Resources.CommonStack.Dps[1].Spec.Replicas),
+						TargetType:    "ip",
+						TargetGroupHC: test_resources.DEFAULT_ALB_TARGET_GROUP_HC_GRPC,
+					},
+				}
+				err := verifier.VerifyAWSLoadBalancerResources(ctx, tf, lbARN, verifier.LoadBalancerExpectation{
+					Type:         "application",
+					Scheme:       "internet-facing",
+					Listeners:    stack.Resources.GetListenersPortMap(),
+					TargetGroups: expectedTargetGroups,
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("waiting for target group targets to be healthy", func() {
+				err := verifier.WaitUntilTargetsAreHealthy(ctx, tf, lbARN, int(*stack.Resources.CommonStack.Dps[0].Spec.Replicas))
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("waiting until DNS name is available", func() {
+				err := utils.WaitUntilDNSNameAvailable(ctx, dnsName)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("sending https request to the HTTP backend on the shared hostname", func() {
+				url := fmt.Sprintf("https://%v/", dnsName)
+				urlOptions := http.URLOptions{
+					InsecureSkipVerify: true,
+					HostHeader:         test_resources.TestHostname,
+				}
+				err := tf.HTTPVerifier.VerifyURLWithOptions(url, urlOptions, http.ResponseCodeMatches(200))
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			By("sending grpc request to the gRPC backend on the shared hostname", func() {
+				// The gRPC route matches on the shared hostname, so the client's :authority must match it.
+				// TestHostname is a wildcard that never matches the real ALB DNS name, so override :authority
+				// with a concrete host that matches the wildcard (mirrors the HTTP check's HostHeader=TestHostname).
+				grpcAuthority := strings.Replace(test_resources.TestHostname, "*", "grpc", 1)
+				conn, err := grpc.NewClient(
+					fmt.Sprintf("%s:443", dnsName),
+					grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})),
+					grpc.WithAuthority(grpcAuthority),
+				)
+				Expect(err).NotTo(HaveOccurred())
+				c := echo2.NewEchoServiceClient(conn)
+				mdCtx := metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{}))
+				response, err := c.Echo(mdCtx, &echo2.EchoRequest{Message: "Hello from overlap E2E test"})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(response.Message).To(Equal("Hello from overlap E2E test"))
+			})
+		})
+	})
+
 	Context("with ALB ip target configuration with HTTPRoute path match types (Exact, Prefix, RegularExpression)", func() {
 		BeforeEach(func() {})
 		It("should create listener rules with correct path-pattern condition types on the ALB", func() {

--- a/test/e2e/gateway/alb_tests/alb_test_helper.go
+++ b/test/e2e/gateway/alb_tests/alb_test_helper.go
@@ -58,6 +58,29 @@ func (s *ALBTestStack) DeployGRPC(ctx context.Context, f *framework.Framework, g
 	return s.deploy(ctx, f, gwListeners, []*gwv1.HTTPRoute{}, grpcrs, []*appsv1.Deployment{dp, dpOther}, []*corev1.Service{svc, svcOther}, lbConfSpec, []*elbv2gw.TargetGroupConfiguration{tgc, tgcOther}, lrConfSpec, nil, readinessGateEnabled)
 }
 
+// DeployHTTPAndGRPC deploys an ALB stack with both an HTTP backend and a gRPC backend so that an
+// HTTPRoute and a GRPCRoute can attach to the same listener/hostname. This exercises the GEP-1016
+// behavior where HTTPRoute and GRPCRoute are allowed to share a hostname on an ALB Gateway.
+func (s *ALBTestStack) DeployHTTPAndGRPC(ctx context.Context, f *framework.Framework, gwListeners []gwv1.Listener, httprs []*gwv1.HTTPRoute, grpcrs []*gwv1.GRPCRoute, lbConfSpec elbv2gw.LoadBalancerConfigurationSpec, tgConfSpec elbv2gw.TargetGroupConfigurationSpec, lrConfSpec elbv2gw.ListenerRuleConfigurationSpec, readinessGateEnabled bool) error {
+	httpSvc := test_resources.BuildServiceSpec(map[string]string{})
+	httpDp := test_resources.BuildDeploymentSpec(f.Options.TestImageRegistry)
+	httpTgc := test_resources.BuildTargetGroupConfig(test_resources.DefaultTgConfigName, tgConfSpec, httpSvc)
+
+	grpcLabels := map[string]string{
+		"app.kubernetes.io/instance": test_resources.GRPCDefaultName,
+	}
+	grpcSvc := test_resources.BuildGRPCServiceSpec(test_resources.GRPCDefaultName, grpcLabels)
+	grpcDp := test_resources.BuildGRPCDeploymentSpec(test_resources.GRPCDefaultName, "Hello World", grpcLabels)
+	grpcTgc := test_resources.BuildTargetGroupConfig(test_resources.DefaultTgConfigName+"-grpc", tgConfSpec, grpcSvc)
+
+	return s.deploy(ctx, f, gwListeners, httprs, grpcrs,
+		[]*appsv1.Deployment{httpDp, grpcDp},
+		[]*corev1.Service{httpSvc, grpcSvc},
+		lbConfSpec,
+		[]*elbv2gw.TargetGroupConfiguration{httpTgc, grpcTgc},
+		lrConfSpec, nil, readinessGateEnabled)
+}
+
 // DeployHTTPWithDefaultTGC deploys an ALB stack with a gateway-level default TGC referenced by the LBC,
 // plus two services: svc1 inherits defaults, svc2 has a service-level TGC override.
 func (s *ALBTestStack) DeployHTTPWithDefaultTGC(ctx context.Context, f *framework.Framework, lbConfSpec elbv2gw.LoadBalancerConfigurationSpec, defaultTGC *elbv2gw.TargetGroupConfiguration, svcTgSpec elbv2gw.TargetGroupConfigurationSpec, readinessGateEnabled bool) error {
@@ -244,6 +267,37 @@ func validateGRPCRouteStatus(tf *framework.Framework, stack ALBTestStack) {
 		},
 	}
 	test_resources.ValidateRouteStatus(tf, stack.Resources.Grpcrs, grpcRouteStatusConverter, validationInfo)
+}
+
+// validateOverlappingRoutesStatus asserts that an HTTPRoute and a GRPCRoute sharing the same listener
+// and hostname are both Accepted.
+func validateOverlappingRoutesStatus(tf *framework.Framework, stack ALBTestStack) {
+	acceptedListenerInfo := []test_resources.ListenerValidationInfo{
+		{
+			ListenerName:       "test-listener",
+			ParentKind:         "Gateway",
+			ResolvedRefReason:  "ResolvedRefs",
+			ResolvedRefsStatus: "True",
+			AcceptedReason:     "Accepted",
+			AcceptedStatus:     "True",
+		},
+	}
+
+	httpInfo := map[string]test_resources.RouteValidationInfo{
+		k8s.NamespacedName(stack.Resources.Httprs[0]).String(): {
+			ParentGatewayName: stack.Resources.CommonStack.Gw.Name,
+			ListenerInfo:      acceptedListenerInfo,
+		},
+	}
+	test_resources.ValidateRouteStatus(tf, stack.Resources.Httprs, httpRouteStatusConverter, httpInfo)
+
+	grpcInfo := map[string]test_resources.RouteValidationInfo{
+		k8s.NamespacedName(stack.Resources.Grpcrs[0]).String(): {
+			ParentGatewayName: stack.Resources.CommonStack.Gw.Name,
+			ListenerInfo:      acceptedListenerInfo,
+		},
+	}
+	test_resources.ValidateRouteStatus(tf, stack.Resources.Grpcrs, grpcRouteStatusConverter, grpcInfo)
 }
 
 func httpRouteStatusConverter(tf *framework.Framework, i interface{}) (gwv1.RouteStatus, types.NamespacedName, error) {


### PR DESCRIPTION
### Issue

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4793

### Description

- remove rejection for httpRoute and grpcRoute sharing same hostname. 
- this is not breaking change for existing customers, since we are loosing the restriction. what's not allowed before is now allowed. 

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
  - before the change, grpc route status update shows 'Accepted=False` for NotAllowedByListeners
  - after the change, grpc route shows `Accepted=true`
  - added e2e test
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
