### PR TITLE
add source nat setting so udp tests pass on ipv6 cluster

### DIFF
--- a/test/e2e/gateway/nlb_tests/nlb_instance_target_test.go
+++ b/test/e2e/gateway/nlb_tests/nlb_instance_target_test.go
@@ -590,6 +590,7 @@ var _ = Describe("test nlb gateway using instance targets reconciled by the aws 
 						TargetType: &instanceTargetType,
 					},
 				}
+
 				By("deploying stack", func() {
 					err := stack.DeployTCP_UDP(ctx, tf, lbcSpec, tgSpec, false)
 					Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/gateway/nlb_tests/nlb_resource_stack.go
+++ b/test/e2e/gateway/nlb_tests/nlb_resource_stack.go
@@ -33,6 +33,12 @@ type NLBResourceStack struct {
 }
 
 func (s *NLBResourceStack) Deploy(ctx context.Context, f *framework.Framework) error {
+	for _, l := range s.CommonStack.Gw.Spec.Listeners {
+		if l.Protocol == gwv1.UDPProtocolType {
+			configureIPv6SourceNAT(ctx, f, &s.CommonStack.Lbc.Spec)
+			break
+		}
+	}
 	return s.CommonStack.Deploy(ctx, f, func(ctx context.Context, f *framework.Framework, namespace string) error {
 
 		for _, v := range s.Tcprs {

--- a/test/e2e/gateway/nlb_tests/nlb_test_helper.go
+++ b/test/e2e/gateway/nlb_tests/nlb_test_helper.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/test/e2e/gateway/alb_tests"
 	"sigs.k8s.io/aws-load-balancer-controller/test/e2e/gateway/test_resources"
 	"sigs.k8s.io/aws-load-balancer-controller/test/framework"
+	"sigs.k8s.io/aws-load-balancer-controller/test/framework/utils"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwalpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gwbeta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -708,4 +709,19 @@ func validateTCPRouteListenerMismatch(tf *framework.Framework, stack NLBTestStac
 			},
 		},
 	})
+}
+
+func configureIPv6SourceNAT(ctx context.Context, tf *framework.Framework, lbcSpec *elbv2gw.LoadBalancerConfigurationSpec) {
+	// To support UDP over IPv6, we must set the source ipv6 value.
+	// For simplicity, we just let the ELB control plane to assign it.
+	if tf.Options.IPFamily == framework.IPv6 {
+		// We need the # of zones, as we must configure source nat prefix for each lb zone.
+		zones, err := utils.GetClusterZones(ctx, tf.K8sClient)
+		Expect(err).NotTo(HaveOccurred())
+		subnetConfigs := make([]elbv2gw.SubnetConfiguration, len(zones))
+		for i := range subnetConfigs {
+			subnetConfigs[i].SourceNatIPv6Prefix = new("auto_assigned")
+		}
+		lbcSpec.LoadBalancerSubnets = &subnetConfigs
+	}
 }

--- a/test/framework/utils/aws.go
+++ b/test/framework/utils/aws.go
@@ -1,6 +1,13 @@
 package utils
 
-import "strings"
+import (
+	"context"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
 
 // IsCommercialPartition returns true if the region is in the commercial AWS partition
 func IsCommercialPartition(region string) bool {
@@ -11,4 +18,27 @@ func IsCommercialPartition(region string) bool {
 		}
 	}
 	return true
+}
+
+func GetClusterZones(ctx context.Context, k8sClient client.Client) ([]string, error) {
+	nodes := &corev1.NodeList{}
+	err := k8sClient.List(ctx, nodes)
+	if err != nil {
+		return nil, err
+	}
+
+	result := sets.New[string]()
+
+	for _, node := range nodes.Items {
+		if node.Labels == nil {
+			continue
+		}
+		v, ok := node.Labels["topology.kubernetes.io/zone"]
+		if !ok {
+			continue
+		}
+		result.Insert(v)
+	}
+
+	return result.UnsortedList(), nil
 }


### PR DESCRIPTION
### Description

Any test that uses a UDP listener fails on an ipv6 cluster, the root cause is that we need to allow for source nating, otherwise the ELB API rejects the configuration. We have to set this value for all subnets in the LB [this is a crazy API setting]. In order to calculate the number of subnets to set the source nat value for, we calculate the unique AZs in the cluster.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
