### PR TITLE
Fix incorrect enableEndpointSlices default in Helm values.yaml comment

### DIFF
--- a/helm/aws-load-balancer-controller/values.yaml
+++ b/helm/aws-load-balancer-controller/values.yaml
@@ -388,7 +388,7 @@ podDisruptionBudget: {}
 # externalManagedTags is the list of tag keys on AWS resources that will be managed externally
 externalManagedTags: []
 
-# enableEndpointSlices enables k8s EndpointSlices for IP targets instead of Endpoints (default false)
+# enableEndpointSlices enables k8s EndpointSlices for IP targets instead of Endpoints (default true)
 enableEndpointSlices:
 
 # enableBackendSecurityGroup enables shared security group for backend traffic (default true)


### PR DESCRIPTION
### Issue

N/A — no existing issue; small self-contained fix for an internal inconsistency in the chart's `values.yaml` comment.

### Description

The `enableEndpointSlices` comment in the Helm chart `values.yaml` says `(default false)`, but the controller's binary default has been `true` since v2.14.0, when #4353 flipped `defaultEnableEndpointSlices` to `true` in `pkg/config/controller_config.go`.

The chart only passes the flag when the value is an explicit bool:

    {{- if kindIs "bool" .Values.enableEndpointSlices }}
    - --enable-endpoint-slices={{ .Values.enableEndpointSlices }}
    {{- end }}

Since the value is unset (`null`) by default, the flag is not rendered and the controller falls through to its binary default (`true`). So a default install actually enables EndpointSlices, contradicting the `(default false)` comment. `docs/deploy/configurations.md` already documents `--enable-endpoint-slices` default as `true`, so this is an internal inconsistency within the chart comment. This PR aligns the comment with the actual default.

### Checklist
- [ ] Added tests that cover your change (if possible) — N/A, comment-only change
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested — `helm template` renders no `--enable-endpoint-slices` flag when the value is unset, confirming the binary default (`true`) applies
- [x] Made sure the title of the PR is a good description that can go into the release notes
