### PR TITLE
Fix non-transitive rule precedence for routes without hostnames

### DIFF
--- a/pkg/gateway/routeutils/route_rule_precedence.go
+++ b/pkg/gateway/routeutils/route_rule_precedence.go
@@ -183,7 +183,19 @@ func getHostnameListPrecedenceOrder(hostnameListOne, hostnameListTwo []string) i
 			return precedence
 		}
 	}
-	// can not complete tie breaking at hostname level
+	// All compared hostnames tie up to the shorter list's length. A shorter list
+	// (in the extreme, an empty list as used by a catch-all route) constrains
+	// fewer hostnames and is therefore less specific, so it must have lower
+	// precedence. Without this, an empty hostname list returns 0 ("equal") and
+	// precedence falls through to path length / creation timestamp, mixing
+	// incompatible criteria and making the comparator non-transitive.
+	if len(hostnameListOne) != len(hostnameListTwo) {
+		if len(hostnameListOne) > len(hostnameListTwo) {
+			return -1 // one is more specific (more hostnames)
+		}
+		return 1 // two is more specific
+	}
+	// genuinely equal at hostname level
 	return 0
 }
 

--- a/pkg/gateway/routeutils/route_rule_precedence_test.go
+++ b/pkg/gateway/routeutils/route_rule_precedence_test.go
@@ -496,6 +496,79 @@ func Test_compareHttpRulePrecedence(t *testing.T) {
 			want:   true,
 			reason: "rule with method has higher precedence",
 		},
+		{
+			name: "host-specific vs catch-all (empty hostname) - equal path, catch-all older",
+			ruleOne: RulePrecedence{
+				CommonRulePrecedence: CommonRulePrecedence{
+					Hostnames:            defaultHostname,
+					RouteCreateTimestamp: time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC),
+				},
+				HttpSpecificRulePrecedenceFactor: &HttpSpecificRulePrecedenceFactor{
+					PathType:   2,
+					PathLength: 1,
+				},
+			},
+			ruleTwo: RulePrecedence{
+				CommonRulePrecedence: CommonRulePrecedence{
+					Hostnames:            []string{},
+					RouteCreateTimestamp: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				},
+				HttpSpecificRulePrecedenceFactor: &HttpSpecificRulePrecedenceFactor{
+					PathType:   2,
+					PathLength: 1,
+				},
+			},
+			want:   true,
+			reason: "host-specific rule outranks catch-all even when the catch-all is older and paths are equal",
+		},
+		{
+			name: "catch-all (empty hostname) vs host-specific - equal path, catch-all older",
+			ruleOne: RulePrecedence{
+				CommonRulePrecedence: CommonRulePrecedence{
+					Hostnames:            []string{},
+					RouteCreateTimestamp: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				},
+				HttpSpecificRulePrecedenceFactor: &HttpSpecificRulePrecedenceFactor{
+					PathType:   2,
+					PathLength: 1,
+				},
+			},
+			ruleTwo: RulePrecedence{
+				CommonRulePrecedence: CommonRulePrecedence{
+					Hostnames:            defaultHostname,
+					RouteCreateTimestamp: time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC),
+				},
+				HttpSpecificRulePrecedenceFactor: &HttpSpecificRulePrecedenceFactor{
+					PathType:   2,
+					PathLength: 1,
+				},
+			},
+			want:   false,
+			reason: "catch-all with an empty hostname list is least specific and must not outrank a host-specific rule",
+		},
+		{
+			name: "host-specific (short path) vs catch-all (empty hostname, long path)",
+			ruleOne: RulePrecedence{
+				CommonRulePrecedence: CommonRulePrecedence{
+					Hostnames: defaultHostname,
+				},
+				HttpSpecificRulePrecedenceFactor: &HttpSpecificRulePrecedenceFactor{
+					PathType:   2,
+					PathLength: 1,
+				},
+			},
+			ruleTwo: RulePrecedence{
+				CommonRulePrecedence: CommonRulePrecedence{
+					Hostnames: []string{},
+				},
+				HttpSpecificRulePrecedenceFactor: &HttpSpecificRulePrecedenceFactor{
+					PathType:   2,
+					PathLength: 20,
+				},
+			},
+			want:   true,
+			reason: "host-specific rule outranks catch-all even when the catch-all has a longer path",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### Issue

Related to #4807 and #4792.

### Description

`getHostnameListPrecedenceOrder` compares two hostname lists positionally, but only up to `min(len(a), len(b))`:

```go
length := min(len(hostnameListOne), len(hostnameListTwo))
for i := range length {
    precedence := getHostnamePrecedenceOrder(hostnameListOne[i], hostnameListTwo[i])
    if precedence != 0 {
        return precedence
    }
}
return 0
```

When a route has **no hostnames** (a catch-all `/*` HTTPRoute), its list is empty, so `min(0, N) = 0`, the loop never executes, and the function returns `0` ("equal") instead of treating the empty list as the least specific.

**Why this is a problem:** a catch-all becomes hostname-equal to *every* route, so its precedence falls through to path length / creation timestamp. Meanwhile host-specific routes are ordered against each other by hostname specificity (path is never consulted). Mixing these two criteria makes `compareHttpRulePrecedence` **non-transitive** — it contains comparison cycles, e.g.:

```
catch-all  >  console  (equal path -> older creation timestamp wins)
console    >  login    (more specific hostname wins, path ignored)
login      >  catch-all (longer path wins)
```

`sort.Slice` requires the `less` function to be a strict weak ordering; given a non-transitive comparator its output is **undefined** and depends on the input order (which varies between reconciles). In practice this let the catch-all rule intermittently sort **above** host-specific rules, so requests that should match host-scoped rules were served by the catch-all.

**Fix:** after all compared hostnames tie, break by hostname-list length — a shorter (in the extreme, empty) list constrains fewer hostnames and is therefore less specific, so it gets lower precedence. This makes an empty hostname list always lose to any route that has hostnames and restores a strict weak ordering, so the sort result no longer depends on input order.

The same `getHostnameListPrecedenceOrder` is used by both `compareHttpRulePrecedence` and `compareGrpcRulePrecedence`, so the fix covers HTTP and GRPC routes.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [x] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2: