### PR TITLE
feat(metrics): add per-resource reconcile condition gauge

### DIFF
--- a/controllers/aga/globalaccelerator_controller.go
+++ b/controllers/aga/globalaccelerator_controller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ktypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
@@ -191,8 +192,7 @@ type globalAcceleratorReconciler struct {
 func (r *globalAcceleratorReconciler) Reconcile(ctx context.Context, req reconcile.Request) (ctrl.Result, error) {
 	r.reconcileTracker(req.NamespacedName)
 	r.logger.V(1).Info("Reconcile request", "name", req.Name)
-	err := r.reconcile(ctx, req)
-	return runtime.HandleReconcileError(err, r.logger)
+	return runtime.HandleReconcileErrorWithCondition(r.reconcile(ctx, req), controllerName, req, r.metricsCollector, r.logger)
 }
 
 func (r *globalAcceleratorReconciler) reconcile(ctx context.Context, req reconcile.Request) error {
@@ -203,11 +203,19 @@ func (r *globalAcceleratorReconciler) reconcile(ctx context.Context, req reconci
 	}
 	r.metricsCollector.ObserveControllerReconcileLatency(controllerName, MetricStageFetchGlobalAccelerator, fetchGlobalAcceleratorFn)
 	if err != nil {
-		return client.IgnoreNotFound(err)
+		if apierrors.IsNotFound(err) {
+			r.metricsCollector.DeleteControllerReconcileCondition(controllerName, req.Namespace, req.Name)
+			return nil
+		}
+		return err
 	}
 
 	if ga.DeletionTimestamp != nil && !ga.DeletionTimestamp.IsZero() {
-		return r.cleanupGlobalAccelerator(ctx, ga)
+		if err := r.cleanupGlobalAccelerator(ctx, ga); err != nil {
+			return err
+		}
+		r.metricsCollector.DeleteControllerReconcileCondition(controllerName, ga.Namespace, ga.Name)
+		return nil
 	}
 	return r.reconcileGlobalAccelerator(ctx, ga)
 }
@@ -368,6 +376,7 @@ func (r *globalAcceleratorReconciler) reconcileGlobalAcceleratorResources(ctx co
 	}
 
 	r.eventRecorder.Event(ga, corev1.EventTypeNormal, k8s.GlobalAcceleratorEventReasonSuccessfullyReconciled, "Successfully reconciled")
+	r.metricsCollector.ObserveControllerReconcileCondition(controllerName, ga.Namespace, ga.Name, true)
 
 	return nil
 }

--- a/controllers/aga/globalaccelerator_controller_test.go
+++ b/controllers/aga/globalaccelerator_controller_test.go
@@ -1,0 +1,74 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	agaapi "sigs.k8s.io/aws-load-balancer-controller/v3/apis/aga/v1beta1"
+	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// recordedCondition captures the arguments of a reconcile-condition observation/deletion.
+type recordedCondition struct {
+	controller string
+	namespace  string
+	name       string
+	reconciled bool
+}
+
+// recordingMetricCollector records the reconcile-condition calls so tests can assert on the
+// per-resource condition metric. ObserveControllerReconcileLatency invokes the passed fn so the
+// wrapped reconcile stages actually run.
+type recordingMetricCollector struct {
+	conditions []recordedCondition
+	deletes    []recordedCondition
+}
+
+func (m *recordingMetricCollector) ObservePodReadinessGateReady(_ string, _ string, _ time.Duration) {
+}
+func (m *recordingMetricCollector) ObserveQUICTargetMissingServerId(_ string, _ string) {}
+func (m *recordingMetricCollector) ObserveControllerReconcileError(_ string, _ string)  {}
+func (m *recordingMetricCollector) ObserveControllerReconcileCondition(controller string, namespace string, name string, reconciled bool) {
+	m.conditions = append(m.conditions, recordedCondition{controller, namespace, name, reconciled})
+}
+func (m *recordingMetricCollector) DeleteControllerReconcileCondition(controller string, namespace string, name string) {
+	m.deletes = append(m.deletes, recordedCondition{controller: controller, namespace: namespace, name: name})
+}
+func (m *recordingMetricCollector) ObserveControllerReconcileLatency(_ string, _ string, fn func()) {
+	fn()
+}
+func (m *recordingMetricCollector) ObserveWebhookValidationError(_ string, _ string) {}
+func (m *recordingMetricCollector) ObserveWebhookMutationError(_ string, _ string)   {}
+func (m *recordingMetricCollector) StartCollectTopTalkers(_ context.Context)         {}
+func (m *recordingMetricCollector) StartCollectCacheSize(_ context.Context)          {}
+
+// TestGlobalAcceleratorReconciler_Reconcile_NotFound covers the branch where the GlobalAccelerator
+// has already been deleted: the fetch returns NotFound and the reconcile drops the condition series.
+func TestGlobalAcceleratorReconciler_Reconcile_NotFound(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = agaapi.AddToScheme(scheme)
+
+	// no object seeded into the fake client, so the Get returns NotFound
+	k8sClient := testclient.NewClientBuilder().WithScheme(scheme).Build()
+
+	metricsCollector := &recordingMetricCollector{}
+	r := &globalAcceleratorReconciler{
+		k8sClient:        k8sClient,
+		logger:           logr.Discard(),
+		metricsCollector: metricsCollector,
+	}
+
+	err := r.reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: "default", Name: "gone-aga"},
+	})
+
+	assert.NoError(t, err)
+	assert.Empty(t, metricsCollector.conditions)
+	assert.Equal(t, []recordedCondition{{controller: "globalAccelerator", namespace: "default", name: "gone-aga"}}, metricsCollector.deletes)
+}

--- a/controllers/elbv2/targetgroupbinding_controller.go
+++ b/controllers/elbv2/targetgroupbinding_controller.go
@@ -29,6 +29,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -107,7 +108,7 @@ type targetGroupBindingReconciler struct {
 func (r *targetGroupBindingReconciler) Reconcile(ctx context.Context, req reconcile.Request) (ctrl.Result, error) {
 	r.reconcileCounters.IncrementTGB(req.NamespacedName)
 	r.logger.V(1).Info("Reconcile request", "name", req.Name)
-	return runtime.HandleReconcileError(r.reconcile(ctx, req), r.logger)
+	return runtime.HandleReconcileErrorWithCondition(r.reconcile(ctx, req), controllerName, req, r.metricsCollector, r.logger)
 }
 
 func (r *targetGroupBindingReconciler) reconcile(ctx context.Context, req reconcile.Request) error {
@@ -118,11 +119,19 @@ func (r *targetGroupBindingReconciler) reconcile(ctx context.Context, req reconc
 	}
 	r.metricsCollector.ObserveControllerReconcileLatency(controllerName, "fetch_targetGroupBinding", fetchTargetGroupBindingFn)
 	if err != nil {
-		return client.IgnoreNotFound(err)
+		if apierrors.IsNotFound(err) {
+			r.metricsCollector.DeleteControllerReconcileCondition(controllerName, req.Namespace, req.Name)
+			return nil
+		}
+		return err
 	}
 
 	if !tgb.DeletionTimestamp.IsZero() {
-		return r.cleanupTargetGroupBinding(ctx, tgb)
+		if err := r.cleanupTargetGroupBinding(ctx, tgb); err != nil {
+			return err
+		}
+		r.metricsCollector.DeleteControllerReconcileCondition(controllerName, tgb.Namespace, tgb.Name)
+		return nil
 	}
 	return r.reconcileTargetGroupBinding(ctx, tgb)
 }
@@ -152,6 +161,9 @@ func (r *targetGroupBindingReconciler) reconcileTargetGroupBinding(ctx context.C
 
 	if deferred {
 		r.deferredTargetGroupBindingReconciler.Enqueue(tgb)
+		// the reconcile pass itself did not fail, so a previously failing TGB must not stay
+		// reported as failing for the whole deferral window
+		r.metricsCollector.ObserveControllerReconcileCondition(controllerName, tgb.Namespace, tgb.Name, true)
 		return nil
 	} else {
 		r.deferredTargetGroupBindingReconciler.MarkProcessed(tgb)
@@ -167,6 +179,7 @@ func (r *targetGroupBindingReconciler) reconcileTargetGroupBinding(ctx context.C
 	}
 
 	r.eventRecorder.Event(tgb, corev1.EventTypeNormal, k8s.TargetGroupBindingEventReasonSuccessfullyReconciled, "Successfully reconciled")
+	r.metricsCollector.ObserveControllerReconcileCondition(controllerName, tgb.Namespace, tgb.Name, true)
 	return nil
 }
 

--- a/controllers/elbv2/targetgroupbinding_controller_test.go
+++ b/controllers/elbv2/targetgroupbinding_controller_test.go
@@ -52,6 +52,10 @@ func (m *mockMetricCollector) ObservePodReadinessGateReady(namespace string, tgb
 func (m *mockMetricCollector) ObserveQUICTargetMissingServerId(namespace string, tgbName string) {}
 func (m *mockMetricCollector) ObserveControllerReconcileError(controller string, errorType string) {
 }
+func (m *mockMetricCollector) ObserveControllerReconcileCondition(controller string, namespace string, name string, reconciled bool) {
+}
+func (m *mockMetricCollector) DeleteControllerReconcileCondition(controller string, namespace string, name string) {
+}
 func (m *mockMetricCollector) ObserveControllerReconcileLatency(controller string, stage string, fn func()) {
 	fn()
 }

--- a/controllers/elbv2/targetgroupbinding_controller_test.go
+++ b/controllers/elbv2/targetgroupbinding_controller_test.go
@@ -64,6 +64,30 @@ func (m *mockMetricCollector) ObserveWebhookMutationError(webhookName string, er
 func (m *mockMetricCollector) StartCollectTopTalkers(ctx context.Context)                         {}
 func (m *mockMetricCollector) StartCollectCacheSize(ctx context.Context)                          {}
 
+// recordedCondition captures the arguments of a reconcile-condition observation/deletion.
+type recordedCondition struct {
+	controller string
+	namespace  string
+	name       string
+	reconciled bool
+}
+
+// recordingMetricCollector records the reconcile-condition calls so tests can assert on the
+// per-resource condition metric, delegating every other method to mockMetricCollector.
+type recordingMetricCollector struct {
+	mockMetricCollector
+	conditions []recordedCondition
+	deletes    []recordedCondition
+}
+
+func (m *recordingMetricCollector) ObserveControllerReconcileCondition(controller string, namespace string, name string, reconciled bool) {
+	m.conditions = append(m.conditions, recordedCondition{controller, namespace, name, reconciled})
+}
+
+func (m *recordingMetricCollector) DeleteControllerReconcileCondition(controller string, namespace string, name string) {
+	m.deletes = append(m.deletes, recordedCondition{controller: controller, namespace: namespace, name: name})
+}
+
 // --- Test ---
 
 func TestTargetGroupBindingReconciler_Delete_Stuck(t *testing.T) {
@@ -230,6 +254,7 @@ func TestTargetGroupBindingReconciler_Reconcile_Success(t *testing.T) {
 
 	fakeRecorder := record.NewFakeRecorder(10)
 
+	metricsCollector := &recordingMetricCollector{}
 	reconciler := &targetGroupBindingReconciler{
 		k8sClient:                            k8sClient,
 		eventRecorder:                        fakeRecorder,
@@ -237,7 +262,7 @@ func TestTargetGroupBindingReconciler_Reconcile_Success(t *testing.T) {
 		tgbResourceManager:                   mockResMgr,
 		deferredTargetGroupBindingReconciler: &mockDeferredReconciler{},
 		logger:                               log.Log.WithName("controllers").WithName("TargetGroupBinding"),
-		metricsCollector:                     &mockMetricCollector{},
+		metricsCollector:                     metricsCollector,
 		reconcileCounters:                    metricsutil.NewReconcileCounters(),
 	}
 
@@ -262,4 +287,148 @@ func TestTargetGroupBindingReconciler_Reconcile_Success(t *testing.T) {
 	default:
 		t.Fatal("expected SuccessfullyReconciled event but none was emitted")
 	}
+
+	// a successful reconcile marks the resource's condition as healthy
+	assert.Equal(t, []recordedCondition{{controller: "targetGroupBinding", namespace: "default", name: "test-tgb", reconciled: true}}, metricsCollector.conditions)
+	assert.Empty(t, metricsCollector.deletes)
+}
+
+// TestTargetGroupBindingReconciler_Reconcile_NotFound covers the branch where the TGB has already
+// been deleted: the fetch returns NotFound and the reconcile drops the condition series.
+func TestTargetGroupBindingReconciler_Reconcile_NotFound(t *testing.T) {
+	scheme := runtime.NewScheme()
+	clientgoscheme.AddToScheme(scheme)
+	elbv2api.AddToScheme(scheme)
+
+	// no TGB seeded into the client, so the Get returns NotFound
+	k8sClient := testclient.NewClientBuilder().WithScheme(scheme).Build()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	metricsCollector := &recordingMetricCollector{}
+	reconciler := &targetGroupBindingReconciler{
+		k8sClient:                            k8sClient,
+		eventRecorder:                        record.NewFakeRecorder(10),
+		finalizerManager:                     k8s.NewMockFinalizerManager(ctrl),
+		tgbResourceManager:                   targetgroupbinding.NewMockResourceManager(ctrl),
+		deferredTargetGroupBindingReconciler: &mockDeferredReconciler{},
+		logger:                               log.Log.WithName("controllers").WithName("TargetGroupBinding"),
+		metricsCollector:                     metricsCollector,
+		reconcileCounters:                    metricsutil.NewReconcileCounters(),
+	}
+
+	req := reconcile.Request{
+		NamespacedName: client.ObjectKey{Namespace: "default", Name: "gone-tgb"},
+	}
+
+	_, err := reconciler.Reconcile(context.Background(), req)
+
+	assert.NoError(t, err)
+	assert.Empty(t, metricsCollector.conditions)
+	assert.Equal(t, []recordedCondition{{controller: "targetGroupBinding", namespace: "default", name: "gone-tgb"}}, metricsCollector.deletes)
+}
+
+// TestTargetGroupBindingReconciler_Reconcile_CleanupSuccess covers a successful delete: after
+// cleanup the condition series must be removed.
+func TestTargetGroupBindingReconciler_Reconcile_CleanupSuccess(t *testing.T) {
+	scheme := runtime.NewScheme()
+	clientgoscheme.AddToScheme(scheme)
+	elbv2api.AddToScheme(scheme)
+
+	tgb := &elbv2api.TargetGroupBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-tgb",
+			Namespace:         "default",
+			Finalizers:        []string{"elbv2.k8s.aws/resources"},
+			DeletionTimestamp: &metav1.Time{Time: time.Now()},
+		},
+		Spec: elbv2api.TargetGroupBindingSpec{
+			TargetGroupARN: "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/test/123",
+		},
+	}
+
+	k8sClient := testclient.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(tgb).WithRuntimeObjects(tgb).Build()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockFinalizerManager := k8s.NewMockFinalizerManager(ctrl)
+	mockFinalizerManager.EXPECT().RemoveFinalizers(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+
+	mockResMgr := targetgroupbinding.NewMockResourceManager(ctrl)
+	mockResMgr.EXPECT().Cleanup(gomock.Any(), gomock.Any()).Return(nil)
+
+	metricsCollector := &recordingMetricCollector{}
+	reconciler := &targetGroupBindingReconciler{
+		k8sClient:                            k8sClient,
+		eventRecorder:                        record.NewFakeRecorder(10),
+		finalizerManager:                     mockFinalizerManager,
+		tgbResourceManager:                   mockResMgr,
+		deferredTargetGroupBindingReconciler: &mockDeferredReconciler{},
+		logger:                               log.Log.WithName("controllers").WithName("TargetGroupBinding"),
+		metricsCollector:                     metricsCollector,
+		reconcileCounters:                    metricsutil.NewReconcileCounters(),
+	}
+
+	req := reconcile.Request{
+		NamespacedName: client.ObjectKey{Namespace: "default", Name: "test-tgb"},
+	}
+
+	_, err := reconciler.Reconcile(context.Background(), req)
+
+	assert.NoError(t, err)
+	assert.Empty(t, metricsCollector.conditions)
+	assert.Equal(t, []recordedCondition{{controller: "targetGroupBinding", namespace: "default", name: "test-tgb"}}, metricsCollector.deletes)
+}
+
+// TestTargetGroupBindingReconciler_Reconcile_Deferred covers a deferred reconcile: the pass itself
+// did not fail, so the condition must be marked healthy even though the work is enqueued.
+func TestTargetGroupBindingReconciler_Reconcile_Deferred(t *testing.T) {
+	scheme := runtime.NewScheme()
+	clientgoscheme.AddToScheme(scheme)
+	elbv2api.AddToScheme(scheme)
+
+	tgb := &elbv2api.TargetGroupBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-tgb",
+			Namespace: "default",
+		},
+		Spec: elbv2api.TargetGroupBindingSpec{
+			TargetGroupARN: "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/test/123",
+		},
+	}
+
+	k8sClient := testclient.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(tgb).WithRuntimeObjects(tgb).Build()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockFinalizerManager := k8s.NewMockFinalizerManager(ctrl)
+	mockFinalizerManager.EXPECT().AddFinalizers(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+
+	mockResMgr := targetgroupbinding.NewMockResourceManager(ctrl)
+	mockResMgr.EXPECT().Reconcile(gomock.Any(), gomock.Any()).Return(true, nil)
+
+	metricsCollector := &recordingMetricCollector{}
+	reconciler := &targetGroupBindingReconciler{
+		k8sClient:                            k8sClient,
+		eventRecorder:                        record.NewFakeRecorder(10),
+		finalizerManager:                     mockFinalizerManager,
+		tgbResourceManager:                   mockResMgr,
+		deferredTargetGroupBindingReconciler: &mockDeferredReconciler{},
+		logger:                               log.Log.WithName("controllers").WithName("TargetGroupBinding"),
+		metricsCollector:                     metricsCollector,
+		reconcileCounters:                    metricsutil.NewReconcileCounters(),
+	}
+
+	req := reconcile.Request{
+		NamespacedName: client.ObjectKey{Namespace: "default", Name: "test-tgb"},
+	}
+
+	_, err := reconciler.Reconcile(context.Background(), req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, []recordedCondition{{controller: "targetGroupBinding", namespace: "default", name: "test-tgb", reconciled: true}}, metricsCollector.conditions)
+	assert.Empty(t, metricsCollector.deletes)
 }

--- a/controllers/gateway/gateway_controller.go
+++ b/controllers/gateway/gateway_controller.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -190,15 +191,18 @@ type gatewayReconciler struct {
 
 func (r *gatewayReconciler) Reconcile(ctx context.Context, req reconcile.Request) (ctrl.Result, error) {
 	r.reconcileTracker(req.NamespacedName)
-	err := r.reconcileHelper(ctx, req)
-	return runtime.HandleReconcileError(err, r.logger)
+	return runtime.HandleReconcileErrorWithCondition(r.reconcileHelper(ctx, req), r.controllerName, req, r.metricsCollector, r.logger)
 }
 
 func (r *gatewayReconciler) reconcileHelper(ctx context.Context, req reconcile.Request) error {
 
 	gw := &gwv1.Gateway{}
 	if err := r.k8sClient.Get(ctx, req.NamespacedName, gw); err != nil {
-		return client.IgnoreNotFound(err)
+		if apierrors.IsNotFound(err) {
+			r.metricsCollector.DeleteControllerReconcileCondition(r.controllerName, req.Namespace, req.Name)
+			return nil
+		}
+		return err
 	}
 
 	r.logger.Info("Got request for reconcile", "gw", *gw)
@@ -217,6 +221,9 @@ func (r *gatewayReconciler) reconcileHelper(ctx context.Context, req reconcile.R
 
 	if string(gwClass.Spec.ControllerName) != r.controllerName {
 		// ignore this gateway event as the gateway belongs to a different controller.
+		// drop any condition series this controller recorded for it before ownership was known,
+		// e.g. from a transient fetch error on an earlier reconcile.
+		r.metricsCollector.DeleteControllerReconcileCondition(r.controllerName, gw.Namespace, gw.Name)
 		return nil
 	}
 
@@ -284,7 +291,12 @@ func (r *gatewayReconciler) reconcileHelper(ctx context.Context, req reconcile.R
 		if k8s.HasFinalizer(gw, r.finalizer) {
 			r.logger.Info("Ignoring dry-run annotation on already-provisioned Gateway", "gateway", k8s.NamespacedName(gw))
 		} else {
-			return r.reconcileDryRun(ctx, gw, stack)
+			if err := r.reconcileDryRun(ctx, gw, stack); err != nil {
+				return err
+			}
+			// a successful dry-run pass must clear a previously failing condition
+			r.metricsCollector.ObserveControllerReconcileCondition(r.controllerName, gw.Namespace, gw.Name, true)
+			return nil
 		}
 	}
 
@@ -314,6 +326,7 @@ func (r *gatewayReconciler) reconcileHelper(ctx context.Context, req reconcile.R
 			r.logger.Error(err, "Failed to process gateway delete")
 			return err
 		}
+		r.metricsCollector.DeleteControllerReconcileCondition(r.controllerName, gw.Namespace, gw.Name)
 		return nil
 	}
 	r.serviceReferenceCounter.UpdateRelations(getServicesFromRoutes(allRoutes), k8s.NamespacedName(gw), false)
@@ -376,6 +389,7 @@ func (r *gatewayReconciler) reconcileUpdate(ctx context.Context, gw *gwv1.Gatewa
 		return err
 	}
 	r.eventRecorder.Event(gw, corev1.EventTypeNormal, k8s.GatewayEventReasonSuccessfullyReconciled, "Successfully reconciled")
+	r.metricsCollector.ObserveControllerReconcileCondition(r.controllerName, gw.Namespace, gw.Name, true)
 	return nil
 }
 

--- a/controllers/gateway/gateway_controller_test.go
+++ b/controllers/gateway/gateway_controller_test.go
@@ -10,13 +10,16 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrlerrors "sigs.k8s.io/aws-load-balancer-controller/v3/pkg/error"
 	gateway_constants "sigs.k8s.io/aws-load-balancer-controller/v3/pkg/gateway/constants"
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/gateway/routeutils"
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/k8s"
+	lbcmetrics "sigs.k8s.io/aws-load-balancer-controller/v3/pkg/metrics/lbc"
 	elbv2model "sigs.k8s.io/aws-load-balancer-controller/v3/pkg/model/elbv2"
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/testutils"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -181,4 +184,29 @@ func Test_updateGatewayStatusSuccess_normalizesDNSNameToLowercase(t *testing.T) 
 	assert.Equal(t, "mycamelbalancer-1234567890.eu-west-1.elb.amazonaws.com", updatedGW.Status.Addresses[0].Value)
 	assert.NotNil(t, updatedGW.Status.Addresses[0].Type)
 	assert.Equal(t, gwv1.HostnameAddressType, *updatedGW.Status.Addresses[0].Type)
+}
+
+// Test_reconcileHelper_NotFound covers the branch where the Gateway has already been deleted: the
+// fetch returns NotFound and reconcileHelper drops the condition series without erroring.
+func Test_reconcileHelper_NotFound(t *testing.T) {
+	k8sClient := testutils.GenerateTestClient()
+
+	collector := lbcmetrics.NewMockCollector()
+	reconciler := &gatewayReconciler{
+		k8sClient:        k8sClient,
+		logger:           logr.Discard(),
+		eventRecorder:    record.NewFakeRecorder(10),
+		controllerName:   "gateway.k8s.aws/nlb",
+		metricsCollector: collector,
+	}
+
+	// no Gateway seeded into the client, so the Get returns NotFound
+	err := reconciler.reconcileHelper(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: "test-ns", Name: "gone-gw"},
+	})
+
+	assert.NoError(t, err)
+	// the resource's condition series is removed (a single delete invocation, no set)
+	mc := collector.(*lbcmetrics.MockCollector)
+	assert.Equal(t, 1, len(mc.Invocations[lbcmetrics.MetricControllerReconcileCondition]))
 }

--- a/controllers/ingress/group_controller.go
+++ b/controllers/ingress/group_controller.go
@@ -137,7 +137,7 @@ type groupReconciler struct {
 
 func (r *groupReconciler) Reconcile(ctx context.Context, req reconcile.Request) (ctrl.Result, error) {
 	r.reconcileCounters.IncrementIngress(req.NamespacedName)
-	return runtime.HandleReconcileError(r.reconcile(ctx, req), r.logger)
+	return runtime.HandleReconcileErrorWithCondition(r.reconcile(ctx, req), controllerName, req, r.metricsCollector, r.logger)
 }
 
 func (r *groupReconciler) reconcile(ctx context.Context, req reconcile.Request) error {
@@ -207,6 +207,12 @@ func (r *groupReconciler) reconcile(ctx context.Context, req reconcile.Request) 
 		}
 	}
 
+	if len(ingGroup.Members) > 0 {
+		r.metricsCollector.ObserveControllerReconcileCondition(controllerName, ingGroupID.Namespace, ingGroupID.Name, true)
+	} else {
+		// the group no longer contains any member Ingress, so its series must not linger
+		r.metricsCollector.DeleteControllerReconcileCondition(controllerName, ingGroupID.Namespace, ingGroupID.Name)
+	}
 	r.recordIngressGroupEvent(ctx, ingGroup, corev1.EventTypeNormal, k8s.IngressEventReasonSuccessfullyReconciled, "Successfully reconciled")
 	return nil
 }

--- a/controllers/ingress/group_controller_reconcile_test.go
+++ b/controllers/ingress/group_controller_reconcile_test.go
@@ -1,0 +1,180 @@
+package ingress
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	networking "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/config"
+	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/ingress"
+	lbcmetrics "sigs.k8s.io/aws-load-balancer-controller/v3/pkg/metrics/lbc"
+	metricsutil "sigs.k8s.io/aws-load-balancer-controller/v3/pkg/metrics/util"
+	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/model/core"
+	elbv2model "sigs.k8s.io/aws-load-balancer-controller/v3/pkg/model/elbv2"
+	networkingpkg "sigs.k8s.io/aws-load-balancer-controller/v3/pkg/networking"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// --- mocks ---
+
+type recordedCondition struct {
+	controller string
+	namespace  string
+	name       string
+	reconciled bool
+}
+
+type recordingMetricsCollector struct {
+	conditions []recordedCondition
+	deletes    []recordedCondition
+}
+
+func (m *recordingMetricsCollector) ObservePodReadinessGateReady(_ string, _ string, _ time.Duration) {
+}
+func (m *recordingMetricsCollector) ObserveQUICTargetMissingServerId(_ string, _ string) {}
+func (m *recordingMetricsCollector) ObserveControllerReconcileError(_ string, _ string)  {}
+func (m *recordingMetricsCollector) ObserveControllerReconcileCondition(controller string, namespace string, name string, reconciled bool) {
+	m.conditions = append(m.conditions, recordedCondition{controller, namespace, name, reconciled})
+}
+func (m *recordingMetricsCollector) DeleteControllerReconcileCondition(controller string, namespace string, name string) {
+	m.deletes = append(m.deletes, recordedCondition{controller: controller, namespace: namespace, name: name})
+}
+func (m *recordingMetricsCollector) ObserveControllerReconcileLatency(_ string, _ string, fn func()) {
+	fn()
+}
+func (m *recordingMetricsCollector) ObserveWebhookValidationError(_ string, _ string) {}
+func (m *recordingMetricsCollector) ObserveWebhookMutationError(_ string, _ string)   {}
+func (m *recordingMetricsCollector) StartCollectTopTalkers(_ context.Context)         {}
+func (m *recordingMetricsCollector) StartCollectCacheSize(_ context.Context)          {}
+
+type mockGroupLoader struct {
+	group ingress.Group
+	err   error
+}
+
+func (m *mockGroupLoader) Load(_ context.Context, _ ingress.GroupID) (ingress.Group, error) {
+	return m.group, m.err
+}
+func (m *mockGroupLoader) LoadGroupIDIfAny(_ context.Context, _ *networking.Ingress) (*ingress.GroupID, error) {
+	return nil, nil
+}
+func (m *mockGroupLoader) LoadGroupIDsPendingFinalization(_ context.Context, _ *networking.Ingress) []ingress.GroupID {
+	return nil
+}
+
+type mockGroupFinalizerManager struct{}
+
+func (m *mockGroupFinalizerManager) AddGroupFinalizer(_ context.Context, _ ingress.GroupID, _ []ingress.ClassifiedIngress) error {
+	return nil
+}
+func (m *mockGroupFinalizerManager) RemoveGroupFinalizer(_ context.Context, _ ingress.GroupID, _ []*networking.Ingress) error {
+	return nil
+}
+
+type mockModelBuilder struct {
+	lb *elbv2model.LoadBalancer
+}
+
+func (m *mockModelBuilder) Build(_ context.Context, ingGroup ingress.Group, _ lbcmetrics.MetricCollector) (core.Stack, *elbv2model.LoadBalancer, []types.NamespacedName, bool, *elbv2model.LoadBalancer, []int32, error) {
+	stack := core.NewDefaultStack(core.StackID(types.NamespacedName(ingGroup.ID)))
+	return stack, m.lb, nil, false, nil, nil, nil
+}
+
+type mockStackMarshaller struct{}
+
+func (m *mockStackMarshaller) Marshal(_ core.Stack) (string, error) { return "{}", nil }
+
+type mockStackDeployer struct{}
+
+func (m *mockStackDeployer) Deploy(_ context.Context, _ core.Stack, _ lbcmetrics.MetricCollector, _ string) error {
+	return nil
+}
+
+type mockSecretsManager struct{}
+
+func (m *mockSecretsManager) MonitorSecrets(_ string, _ []types.NamespacedName) {}
+func (m *mockSecretsManager) GetSecret(_ context.Context, _ client.Client, _ types.NamespacedName) (*corev1.Secret, error) {
+	return nil, nil
+}
+func (m *mockSecretsManager) SetEventChannel(_ chan<- event.TypedGenericEvent[*corev1.Secret]) {}
+
+type mockBackendSGProvider struct{}
+
+func (m *mockBackendSGProvider) Get(_ context.Context, _ networkingpkg.ResourceType, _ []types.NamespacedName) (string, error) {
+	return "", nil
+}
+func (m *mockBackendSGProvider) Release(_ context.Context, _ networkingpkg.ResourceType, _ []types.NamespacedName) error {
+	return nil
+}
+
+func buildTestGroupReconciler(loader *mockGroupLoader, mb *mockModelBuilder) *groupReconciler {
+	return &groupReconciler{
+		eventRecorder:         record.NewFakeRecorder(10),
+		modelBuilder:          mb,
+		stackMarshaller:       &mockStackMarshaller{},
+		stackDeployer:         &mockStackDeployer{},
+		secretsManager:        &mockSecretsManager{},
+		backendSGProvider:     &mockBackendSGProvider{},
+		groupLoader:           loader,
+		groupFinalizerManager: &mockGroupFinalizerManager{},
+		featureGates:          config.NewFeatureGates(),
+		logger:                logr.Discard(),
+		metricsCollector:      &recordingMetricsCollector{},
+		reconcileCounters:     metricsutil.NewReconcileCounters(),
+	}
+}
+
+// --- tests ---
+
+// TestGroupReconciler_reconcile_membersPresent covers the branch where the group still has member
+// Ingresses: the reconcile marks the group's condition healthy.
+func TestGroupReconciler_reconcile_membersPresent(t *testing.T) {
+	group := ingress.Group{
+		ID: ingress.GroupID{Namespace: "default", Name: "my-ing"},
+		Members: []ingress.ClassifiedIngress{
+			{
+				Ing: &networking.Ingress{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-ing", Namespace: "default"},
+				},
+			},
+		},
+	}
+	// lb nil so the reconcile skips DNS resolution and status update
+	r := buildTestGroupReconciler(&mockGroupLoader{group: group}, &mockModelBuilder{lb: nil})
+
+	err := r.reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: "default", Name: "my-ing"},
+	})
+
+	assert.NoError(t, err)
+	mc := r.metricsCollector.(*recordingMetricsCollector)
+	assert.Equal(t, []recordedCondition{{controller: "ingress", namespace: "default", name: "my-ing", reconciled: true}}, mc.conditions)
+	assert.Empty(t, mc.deletes)
+}
+
+// TestGroupReconciler_reconcile_noMembers covers the branch where the group no longer contains any
+// member Ingress: its condition series must be removed so it does not linger.
+func TestGroupReconciler_reconcile_noMembers(t *testing.T) {
+	group := ingress.Group{
+		ID: ingress.GroupID{Namespace: "default", Name: "empty-ing"},
+	}
+	r := buildTestGroupReconciler(&mockGroupLoader{group: group}, &mockModelBuilder{lb: nil})
+
+	err := r.reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: "default", Name: "empty-ing"},
+	})
+
+	assert.NoError(t, err)
+	mc := r.metricsCollector.(*recordingMetricsCollector)
+	assert.Empty(t, mc.conditions)
+	assert.Equal(t, []recordedCondition{{controller: "ingress", namespace: "default", name: "empty-ing"}}, mc.deletes)
+}

--- a/controllers/service/service_controller.go
+++ b/controllers/service/service_controller.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/aws-load-balancer-controller/v3/controllers/service/eventhandlers"
@@ -104,7 +105,7 @@ type serviceReconciler struct {
 
 func (r *serviceReconciler) Reconcile(ctx context.Context, req reconcile.Request) (ctrl.Result, error) {
 	r.reconcileCounters.IncrementService(req.NamespacedName)
-	return runtime.HandleReconcileError(r.reconcile(ctx, req), r.logger)
+	return runtime.HandleReconcileErrorWithCondition(r.reconcile(ctx, req), controllerName, req, r.metricsCollector, r.logger)
 }
 
 func (r *serviceReconciler) reconcile(ctx context.Context, req reconcile.Request) error {
@@ -115,7 +116,11 @@ func (r *serviceReconciler) reconcile(ctx context.Context, req reconcile.Request
 	}
 	r.metricsCollector.ObserveControllerReconcileLatency(controllerName, "fetch_service", fetchServiceFn)
 	if err != nil {
-		return client.IgnoreNotFound(err)
+		if apierrors.IsNotFound(err) {
+			r.metricsCollector.DeleteControllerReconcileCondition(controllerName, req.Namespace, req.Name)
+			return nil
+		}
+		return err
 	}
 
 	var stack core.Stack
@@ -137,6 +142,7 @@ func (r *serviceReconciler) reconcile(ctx context.Context, req reconcile.Request
 		if err != nil {
 			return ctrlerrors.NewErrorWithMetrics(controllerName, "cleanup_load_balancer_error", err, r.metricsCollector)
 		}
+		r.metricsCollector.DeleteControllerReconcileCondition(controllerName, svc.Namespace, svc.Name)
 		return nil
 	}
 	return r.reconcileLoadBalancerResources(ctx, svc, stack, lb, backendSGRequired)
@@ -218,6 +224,7 @@ func (r *serviceReconciler) reconcileLoadBalancerResources(ctx context.Context, 
 		return ctrlerrors.NewErrorWithMetrics(controllerName, "update_status_error", err, r.metricsCollector)
 	}
 	r.eventRecorder.Event(svc, corev1.EventTypeNormal, k8s.ServiceEventReasonSuccessfullyReconciled, "Successfully reconciled")
+	r.metricsCollector.ObserveControllerReconcileCondition(controllerName, svc.Namespace, svc.Name, true)
 	return nil
 }
 

--- a/controllers/service/service_controller_test.go
+++ b/controllers/service/service_controller_test.go
@@ -74,12 +74,37 @@ func (m *mockMetricsCollector) ObserveWebhookMutationError(_ string, _ string)  
 func (m *mockMetricsCollector) StartCollectTopTalkers(_ context.Context)                        {}
 func (m *mockMetricsCollector) StartCollectCacheSize(_ context.Context)                         {}
 
+// recordedCondition captures the arguments of a reconcile-condition observation/deletion.
+type recordedCondition struct {
+	controller string
+	namespace  string
+	name       string
+	reconciled bool
+}
+
+// recordingMetricsCollector records the reconcile-condition calls so tests can assert on the
+// per-resource condition metric. It relies on mockMetricsCollector for every other method,
+// including ObserveControllerReconcileLatency which invokes the passed fn.
+type recordingMetricsCollector struct {
+	mockMetricsCollector
+	conditions []recordedCondition
+	deletes    []recordedCondition
+}
+
+func (m *recordingMetricsCollector) ObserveControllerReconcileCondition(controller string, namespace string, name string, reconciled bool) {
+	m.conditions = append(m.conditions, recordedCondition{controller, namespace, name, reconciled})
+}
+
+func (m *recordingMetricsCollector) DeleteControllerReconcileCondition(controller string, namespace string, name string) {
+	m.deletes = append(m.deletes, recordedCondition{controller: controller, namespace: namespace, name: name})
+}
+
 // buildTestReconciler wires up a serviceReconciler with the given mocks and a real fake k8s client
-// pre-populated with svc.
-func buildTestReconciler(svc *corev1.Service, mb *mockModelBuilder, sd *mockStackDeployer) *serviceReconciler {
+// pre-populated with the given objects.
+func buildTestReconciler(mb *mockModelBuilder, sd *mockStackDeployer, objs ...client.Object) *serviceReconciler {
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
-	k8sClient := testclient.NewClientBuilder().WithScheme(scheme).WithObjects(svc).Build()
+	k8sClient := testclient.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
 
 	return &serviceReconciler{
 		k8sClient:        k8sClient,
@@ -89,7 +114,7 @@ func buildTestReconciler(svc *corev1.Service, mb *mockModelBuilder, sd *mockStac
 		stackMarshaller:  &mockStackMarshaller{},
 		stackDeployer:    sd,
 		logger:           logr.Discard(),
-		metricsCollector: &mockMetricsCollector{},
+		metricsCollector: &recordingMetricsCollector{},
 	}
 }
 
@@ -98,24 +123,28 @@ func buildTestReconciler(svc *corev1.Service, mb *mockModelBuilder, sd *mockStac
 func TestReconcile(t *testing.T) {
 	stack := core.NewDefaultStack(core.StackID(types.NamespacedName{Namespace: "default", Name: "my-svc"}))
 	tests := []struct {
-		name         string
-		svc          *corev1.Service
-		lb           *elbv2model.LoadBalancer
-		deployErr    error
-		wantErr      bool
-		wantDeployed int
+		name           string
+		svc            *corev1.Service
+		lb             *elbv2model.LoadBalancer
+		deployErr      error
+		wantErr        bool
+		wantDeployed   int
+		wantConditions []recordedCondition
+		wantDeletes    []recordedCondition
 	}{
 		{
-			name: "lb nil, no finalizer: cleanup is no-op, returns nil",
+			name: "lb nil, no finalizer: cleanup is no-op, condition series is removed",
 			svc: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{Name: "my-svc", Namespace: "default"},
 			},
 			lb:           nil,
 			wantErr:      false,
 			wantDeployed: 0,
+			// no LB means the resource is no longer managed, so its series must be deleted
+			wantDeletes: []recordedCondition{{controller: "service", namespace: "default", name: "my-svc"}},
 		},
 		{
-			name: "lb nil, has finalizer, cleanup deploy fails: returns error",
+			name: "lb nil, has finalizer, cleanup deploy fails: returns error, no condition recorded",
 			svc: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "my-svc",
@@ -127,6 +156,7 @@ func TestReconcile(t *testing.T) {
 			deployErr:    errors.New("deploy failed"),
 			wantErr:      true,
 			wantDeployed: 1,
+			// the failure is surfaced by HandleReconcileErrorWithCondition, not reconcile itself
 		},
 		{
 			name: "lb not nil: reconcileLoadBalancerResources is called",
@@ -147,7 +177,7 @@ func TestReconcile(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mb := &mockModelBuilder{stack: stack, lb: tt.lb}
 			sd := &mockStackDeployer{err: tt.deployErr}
-			r := buildTestReconciler(tt.svc, mb, sd)
+			r := buildTestReconciler(mb, sd, tt.svc)
 
 			err := r.reconcile(context.Background(), reconcile.Request{
 				NamespacedName: types.NamespacedName{Namespace: "default", Name: "my-svc"},
@@ -159,8 +189,32 @@ func TestReconcile(t *testing.T) {
 				assert.NoError(t, err)
 			}
 			assert.Equal(t, tt.wantDeployed, sd.deployedCount)
+
+			mc := r.metricsCollector.(*recordingMetricsCollector)
+			assert.Equal(t, tt.wantConditions, mc.conditions)
+			assert.Equal(t, tt.wantDeletes, mc.deletes)
 		})
 	}
+}
+
+// TestReconcile_NotFound covers the branch where the Service has already been deleted: the fetch
+// returns NotFound and the reconcile must drop the resource's condition series without erroring.
+func TestReconcile_NotFound(t *testing.T) {
+	mb := &mockModelBuilder{}
+	sd := &mockStackDeployer{}
+	// no objects seeded into the fake client, so the Get returns NotFound
+	r := buildTestReconciler(mb, sd)
+
+	err := r.reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: "default", Name: "gone-svc"},
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, 0, sd.deployedCount)
+
+	mc := r.metricsCollector.(*recordingMetricsCollector)
+	assert.Empty(t, mc.conditions)
+	assert.Equal(t, []recordedCondition{{controller: "service", namespace: "default", name: "gone-svc"}}, mc.deletes)
 }
 
 func TestBuildPortsForStatus(t *testing.T) {

--- a/controllers/service/service_controller_test.go
+++ b/controllers/service/service_controller_test.go
@@ -65,11 +65,14 @@ type mockMetricsCollector struct{}
 func (m *mockMetricsCollector) ObservePodReadinessGateReady(_ string, _ string, _ time.Duration) {}
 func (m *mockMetricsCollector) ObserveQUICTargetMissingServerId(_ string, _ string)              {}
 func (m *mockMetricsCollector) ObserveControllerReconcileError(_ string, _ string)               {}
-func (m *mockMetricsCollector) ObserveControllerReconcileLatency(_ string, _ string, fn func())  { fn() }
-func (m *mockMetricsCollector) ObserveWebhookValidationError(_ string, _ string)                 {}
-func (m *mockMetricsCollector) ObserveWebhookMutationError(_ string, _ string)                   {}
-func (m *mockMetricsCollector) StartCollectTopTalkers(_ context.Context)                         {}
-func (m *mockMetricsCollector) StartCollectCacheSize(_ context.Context)                          {}
+func (m *mockMetricsCollector) ObserveControllerReconcileCondition(_ string, _ string, _ string, _ bool) {
+}
+func (m *mockMetricsCollector) DeleteControllerReconcileCondition(_ string, _ string, _ string) {}
+func (m *mockMetricsCollector) ObserveControllerReconcileLatency(_ string, _ string, fn func()) { fn() }
+func (m *mockMetricsCollector) ObserveWebhookValidationError(_ string, _ string)                {}
+func (m *mockMetricsCollector) ObserveWebhookMutationError(_ string, _ string)                  {}
+func (m *mockMetricsCollector) StartCollectTopTalkers(_ context.Context)                        {}
+func (m *mockMetricsCollector) StartCollectCacheSize(_ context.Context)                         {}
 
 // buildTestReconciler wires up a serviceReconciler with the given mocks and a real fake k8s client
 // pre-populated with svc.

--- a/docs/guide/metrics/prometheus/index.md
+++ b/docs/guide/metrics/prometheus/index.md
@@ -55,6 +55,7 @@ Following metrics are added:
 | awslbc_webhook_validation_failures_total | Counter   | Number of validation errors by webhook type |
 | awslbc_webhook_mutation_failures_total | Counter   | Number of mutation errors by webhook type |
 | awslbc_top_talkers | Gauge     | Number of reconciliations by resource |
+| awslbc_controller_reconcile_condition | Gauge     | Per-resource reconcile condition, 1 when the last reconcile of the resource succeeded and 0 when it failed. The series is removed when the resource is deleted |
 
 
 ##  Accessing and Querying the Metrics in Prometheus UI
@@ -72,6 +73,7 @@ Once inside the Prometheus UI, you can use PromQL queries. Here are some example
 * Get the average reconcile duration for stage : `avg(awslbc_controller_reconcile_stage_duration_sum{controller="service", reconcile_stage="DNS_resolve"})`
 * Get the cached object: `sum(awslbc_cache_object_total)`
 * Enrich metrics with information about target group: `aws_target_group_info * on(target_group) group_left last_over_time(aws_applicationelb_healthy_host_count_minimum[20m])`
+* Find the resources that are failing to reconcile: `awslbc_controller_reconcile_condition == 0`
 
 
 ##  Visualizing Metrics

--- a/go.mod
+++ b/go.mod
@@ -122,6 +122,7 @@ require (
 	github.com/jmoiron/sqlx v1.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/lib/pq v1.12.3 // indirect

--- a/pkg/error/error_with_metrics.go
+++ b/pkg/error/error_with_metrics.go
@@ -35,3 +35,8 @@ func NewErrorWithMetrics(resourceType string, errorCategory string, err error, m
 func (e *ErrorWithMetrics) Error() string {
 	return e.Err.Error()
 }
+
+// Unwrap exposes the wrapped error so errors.Is/errors.As can classify it, e.g. requeue detection.
+func (e *ErrorWithMetrics) Unwrap() error {
+	return e.Err
+}

--- a/pkg/error/error_with_metrics_test.go
+++ b/pkg/error/error_with_metrics_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	lbcmetrics "sigs.k8s.io/aws-load-balancer-controller/v3/pkg/metrics/lbc"
 	"testing"
+	"time"
 )
 
 func Test_NewErrorWithMetrics(t *testing.T) {
@@ -41,4 +42,13 @@ func Test_NewErrorWithMetrics(t *testing.T) {
 			assert.Equal(t, tc.expectedInvocations, len(mc.Invocations[lbcmetrics.MetricControllerReconcileErrors]))
 		})
 	}
+}
+
+func Test_ErrorWithMetrics_Unwrap(t *testing.T) {
+	requeueErr := NewRequeueNeededAfter("waiting", time.Second)
+	wrapped := &ErrorWithMetrics{Err: requeueErr}
+
+	var target *RequeueNeededAfter
+	assert.True(t, errors.As(wrapped, &target))
+	assert.Equal(t, requeueErr, target)
 }

--- a/pkg/metrics/lbc/collector.go
+++ b/pkg/metrics/lbc/collector.go
@@ -22,6 +22,12 @@ type MetricCollector interface {
 	ObservePodReadinessGateReady(namespace string, tgbName string, duration time.Duration)
 	ObserveQUICTargetMissingServerId(namespace string, tgbName string)
 	ObserveControllerReconcileError(controller string, errorType string)
+	// ObserveControllerReconcileCondition tracks the per-resource reconcile condition, 1 when the last reconcile
+	// of the resource succeeded and 0 when it failed.
+	ObserveControllerReconcileCondition(controller string, namespace string, name string, reconciled bool)
+	// DeleteControllerReconcileCondition removes the reconcile condition series of a resource, so deleted
+	// resources don't report a frozen state forever and cardinality stays bounded to live resources.
+	DeleteControllerReconcileCondition(controller string, namespace string, name string)
 	ObserveControllerReconcileLatency(controller string, stage string, fn func())
 	ObserveWebhookValidationError(webhookName string, errorType string)
 	ObserveWebhookMutationError(webhookName string, errorType string)
@@ -45,6 +51,12 @@ func (n *noOpCollector) ObservePodReadinessGateReady(_ string, _ string, _ time.
 }
 
 func (n *noOpCollector) ObserveControllerReconcileError(_ string, _ string) {
+}
+
+func (n *noOpCollector) ObserveControllerReconcileCondition(_ string, _ string, _ string, _ bool) {
+}
+
+func (n *noOpCollector) DeleteControllerReconcileCondition(_ string, _ string, _ string) {
 }
 
 func (n *noOpCollector) ObserveWebhookValidationError(_ string, _ string) {
@@ -98,6 +110,26 @@ func (c *collector) ObserveControllerReconcileError(controller string, errorCate
 		labelController:    controller,
 		labelErrorCategory: errorCategory,
 	}).Inc()
+}
+
+func (c *collector) ObserveControllerReconcileCondition(controller string, namespace string, name string, reconciled bool) {
+	value := float64(0)
+	if reconciled {
+		value = 1
+	}
+	c.instruments.controllerReconcileCondition.With(prometheus.Labels{
+		labelController: controller,
+		labelNamespace:  namespace,
+		labelName:       name,
+	}).Set(value)
+}
+
+func (c *collector) DeleteControllerReconcileCondition(controller string, namespace string, name string) {
+	c.instruments.controllerReconcileCondition.Delete(prometheus.Labels{
+		labelController: controller,
+		labelNamespace:  namespace,
+		labelName:       name,
+	})
 }
 
 func (c *collector) ObserveControllerReconcileLatency(controller string, stage string, fn func()) {

--- a/pkg/metrics/lbc/collector_test.go
+++ b/pkg/metrics/lbc/collector_test.go
@@ -1,0 +1,63 @@
+package lbc
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestCollector() *collector {
+	registry := prometheus.NewPedanticRegistry()
+	return NewCollector(registry, nil, nil, logr.Discard()).(*collector)
+}
+
+func TestObserveControllerReconcileCondition(t *testing.T) {
+	c := newTestCollector()
+	gauge := c.instruments.controllerReconcileCondition
+
+	c.ObserveControllerReconcileCondition("ingress", "ns-1", "ing-1", true)
+	c.ObserveControllerReconcileCondition("ingress", "ns-1", "ing-2", false)
+
+	assert.Equal(t, float64(1), testutil.ToFloat64(gauge.WithLabelValues("ingress", "ns-1", "ing-1")))
+	assert.Equal(t, float64(0), testutil.ToFloat64(gauge.WithLabelValues("ingress", "ns-1", "ing-2")))
+	assert.Equal(t, 2, testutil.CollectAndCount(gauge))
+
+	// a state flip updates the existing series in place
+	c.ObserveControllerReconcileCondition("ingress", "ns-1", "ing-2", true)
+	assert.Equal(t, float64(1), testutil.ToFloat64(gauge.WithLabelValues("ingress", "ns-1", "ing-2")))
+	assert.Equal(t, 2, testutil.CollectAndCount(gauge))
+}
+
+func TestObserveControllerReconcileCondition_metricNameAndLabels(t *testing.T) {
+	c := newTestCollector()
+	c.ObserveControllerReconcileCondition("service", "ns-1", "svc-1", true)
+
+	expected := `
+# HELP awslbc_controller_reconcile_condition Whether the last reconcile of the resource succeeded (1) or failed (0). The series is removed when the resource is deleted.
+# TYPE awslbc_controller_reconcile_condition gauge
+awslbc_controller_reconcile_condition{controller="service",name="svc-1",namespace="ns-1"} 1
+`
+	assert.NoError(t, testutil.CollectAndCompare(c.instruments.controllerReconcileCondition, strings.NewReader(expected)))
+}
+
+func TestDeleteControllerReconcileCondition(t *testing.T) {
+	c := newTestCollector()
+	gauge := c.instruments.controllerReconcileCondition
+
+	c.ObserveControllerReconcileCondition("service", "ns-1", "svc-1", true)
+	c.ObserveControllerReconcileCondition("service", "ns-1", "svc-2", false)
+	c.ObserveControllerReconcileCondition("targetGroupBinding", "ns-1", "svc-1", true)
+
+	c.DeleteControllerReconcileCondition("service", "ns-1", "svc-1")
+	assert.Equal(t, 2, testutil.CollectAndCount(gauge))
+	assert.Equal(t, float64(0), testutil.ToFloat64(gauge.WithLabelValues("service", "ns-1", "svc-2")))
+	assert.Equal(t, float64(1), testutil.ToFloat64(gauge.WithLabelValues("targetGroupBinding", "ns-1", "svc-1")))
+
+	// deleting a series that does not exist is a no-op
+	c.DeleteControllerReconcileCondition("service", "ns-1", "does-not-exist")
+	assert.Equal(t, 2, testutil.CollectAndCount(gauge))
+}

--- a/pkg/metrics/lbc/instruments.go
+++ b/pkg/metrics/lbc/instruments.go
@@ -26,6 +26,8 @@ const (
 	MetricControllerTopTalkers = "controller_top_talkers"
 	// MetricQuicTargetMissingServerId tracks the total number of QUIC targets attempted to be registered without a generated server id.
 	MetricQuicTargetMissingServerId = "quic_target_missing_server_id"
+	// MetricControllerReconcileCondition tracks the per-resource reconcile condition, 1 for reconciled and 0 for failing.
+	MetricControllerReconcileCondition = "controller_reconcile_condition"
 )
 
 const (
@@ -47,6 +49,7 @@ type instruments struct {
 	webhookMutationFailure        *prometheus.CounterVec
 	controllerCacheObjectCount    *prometheus.GaugeVec
 	controllerReconcileTopTalkers *prometheus.GaugeVec
+	controllerReconcileCondition  *prometheus.GaugeVec
 }
 
 // newInstruments allocates and register new metrics to registerer
@@ -101,7 +104,13 @@ func newInstruments(registerer prometheus.Registerer) *instruments {
 		Help:      "Counts the number of reconciliations triggered per resource",
 	}, []string{labelController, labelNamespace, labelName})
 
-	registerer.MustRegister(podReadinessFlipSeconds, controllerReconcileErrors, controllerReconcileStageDuration, webhookValidationFailure, webhookMutationFailure, controllerCacheObjectCount, controllerReconcileTopTalkers)
+	controllerReconcileCondition := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: metricSubsystem,
+		Name:      MetricControllerReconcileCondition,
+		Help:      "Whether the last reconcile of the resource succeeded (1) or failed (0). The series is removed when the resource is deleted.",
+	}, []string{labelController, labelNamespace, labelName})
+
+	registerer.MustRegister(podReadinessFlipSeconds, controllerReconcileErrors, controllerReconcileStageDuration, webhookValidationFailure, webhookMutationFailure, controllerCacheObjectCount, controllerReconcileTopTalkers, controllerReconcileCondition)
 	return &instruments{
 		podReadinessFlipSeconds:       podReadinessFlipSeconds,
 		controllerReconcileErrors:     controllerReconcileErrors,
@@ -110,6 +119,7 @@ func newInstruments(registerer prometheus.Registerer) *instruments {
 		webhookMutationFailure:        webhookMutationFailure,
 		controllerCacheObjectCount:    controllerCacheObjectCount,
 		controllerReconcileTopTalkers: controllerReconcileTopTalkers,
+		controllerReconcileCondition:  controllerReconcileCondition,
 		quicTargetsMissingServerId:    controllerQuicTargetMissingServerId,
 	}
 }

--- a/pkg/metrics/lbc/mockcollector.go
+++ b/pkg/metrics/lbc/mockcollector.go
@@ -26,6 +26,14 @@ type MockHistogramMetric struct {
 	duration  time.Duration
 }
 
+type MockGaugeMetric struct {
+	labelController string
+	labelNamespace  string
+	labelName       string
+	value           bool
+	deleted         bool
+}
+
 type MockCounterMetric struct {
 	labelController    string
 	labelErrorCategory string
@@ -51,6 +59,24 @@ func (m *MockCollector) ObserveControllerReconcileError(controller string, error
 	m.Invocations[MetricControllerReconcileErrors] = append(m.Invocations[MetricControllerReconcileErrors], MockCounterMetric{
 		labelController:    controller,
 		labelErrorCategory: errorCategory,
+	})
+}
+
+func (m *MockCollector) ObserveControllerReconcileCondition(controller string, namespace string, name string, reconciled bool) {
+	m.Invocations[MetricControllerReconcileCondition] = append(m.Invocations[MetricControllerReconcileCondition], MockGaugeMetric{
+		labelController: controller,
+		labelNamespace:  namespace,
+		labelName:       name,
+		value:           reconciled,
+	})
+}
+
+func (m *MockCollector) DeleteControllerReconcileCondition(controller string, namespace string, name string) {
+	m.Invocations[MetricControllerReconcileCondition] = append(m.Invocations[MetricControllerReconcileCondition], MockGaugeMetric{
+		labelController: controller,
+		labelNamespace:  namespace,
+		labelName:       name,
+		deleted:         true,
 	})
 }
 
@@ -166,6 +192,7 @@ func NewMockCollector() MetricCollector {
 	mockInvocations[MetricWebhookMutationFailure] = make([]interface{}, 0)
 	mockInvocations[MetricControllerCacheObjectCount] = make([]interface{}, 0)
 	mockInvocations[MetricControllerTopTalkers] = make([]interface{}, 0)
+	mockInvocations[MetricControllerReconcileCondition] = make([]interface{}, 0)
 
 	return &MockCollector{
 		Invocations: mockInvocations,

--- a/pkg/metrics/lbc/mockcollector_test.go
+++ b/pkg/metrics/lbc/mockcollector_test.go
@@ -1,0 +1,43 @@
+package lbc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMockCollector_ReconcileCondition(t *testing.T) {
+	c := NewMockCollector()
+	mc := c.(*MockCollector)
+
+	// the condition series starts empty
+	assert.Empty(t, mc.Invocations[MetricControllerReconcileCondition])
+
+	c.ObserveControllerReconcileCondition("ingress", "ns-1", "ing-1", true)
+	c.ObserveControllerReconcileCondition("service", "ns-2", "svc-1", false)
+	c.DeleteControllerReconcileCondition("service", "ns-2", "svc-1")
+
+	recordings := mc.Invocations[MetricControllerReconcileCondition]
+	assert.Len(t, recordings, 3)
+
+	assert.Equal(t, MockGaugeMetric{
+		labelController: "ingress",
+		labelNamespace:  "ns-1",
+		labelName:       "ing-1",
+		value:           true,
+	}, recordings[0])
+
+	assert.Equal(t, MockGaugeMetric{
+		labelController: "service",
+		labelNamespace:  "ns-2",
+		labelName:       "svc-1",
+		value:           false,
+	}, recordings[1])
+
+	assert.Equal(t, MockGaugeMetric{
+		labelController: "service",
+		labelNamespace:  "ns-2",
+		labelName:       "svc-1",
+		deleted:         true,
+	}, recordings[2])
+}

--- a/pkg/runtime/reconcile.go
+++ b/pkg/runtime/reconcile.go
@@ -4,6 +4,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	ctrlerrors "sigs.k8s.io/aws-load-balancer-controller/v3/pkg/error"
+	lbcmetrics "sigs.k8s.io/aws-load-balancer-controller/v3/pkg/metrics/lbc"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -27,6 +28,16 @@ func HandleReconcileError(inputErr error, log logr.Logger) (ctrl.Result, error) 
 	}
 
 	return ctrl.Result{}, inputErr
+}
+
+// HandleReconcileErrorWithCondition records the reconcile condition of the reconciled resource as
+// failing when inputErr is a genuine failure (requeues are expected retries, not failures), then
+// handles the error like HandleReconcileError.
+func HandleReconcileErrorWithCondition(inputErr error, controller string, req ctrl.Request, metricsCollector lbcmetrics.MetricCollector, log logr.Logger) (ctrl.Result, error) {
+	if inputErr != nil && !IsRequeueError(inputErr) {
+		metricsCollector.ObserveControllerReconcileCondition(controller, req.Namespace, req.Name, false)
+	}
+	return HandleReconcileError(inputErr, log)
 }
 
 // IsRequeueError returns true when err indicates a requeue (expected retry).

--- a/pkg/runtime/reconcile_test.go
+++ b/pkg/runtime/reconcile_test.go
@@ -2,12 +2,14 @@ package runtime
 
 import (
 	ctrlerrors "sigs.k8s.io/aws-load-balancer-controller/v3/pkg/error"
+	lbcmetrics "sigs.k8s.io/aws-load-balancer-controller/v3/pkg/metrics/lbc"
 	"testing"
 	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -115,6 +117,67 @@ func TestHandleReconcileError(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.want, got)
 			}
+		})
+	}
+}
+
+func TestHandleReconcileErrorWithCondition(t *testing.T) {
+	otherErrType := errors.New("some error")
+	tests := []struct {
+		name                    string
+		err                     error
+		want                    ctrl.Result
+		wantErr                 error
+		wantConditionRecordings int
+	}{
+		{
+			name:                    "input err is nil",
+			err:                     nil,
+			want:                    ctrl.Result{},
+			wantConditionRecordings: 0,
+		},
+		{
+			name:                    "input err is other error type",
+			err:                     otherErrType,
+			wantErr:                 otherErrType,
+			wantConditionRecordings: 1,
+		},
+		{
+			name: "input err is ErrorWithMetrics wrapping other error type",
+			err: &ctrlerrors.ErrorWithMetrics{
+				Err: otherErrType,
+			},
+			wantErr:                 otherErrType,
+			wantConditionRecordings: 1,
+		},
+		{
+			name:                    "input err is RequeueNeeded",
+			err:                     ctrlerrors.NewRequeueNeeded("some error"),
+			want:                    ctrl.Result{Requeue: true},
+			wantConditionRecordings: 0,
+		},
+		{
+			name: "input err is ErrorWithMetrics wrapping RequeueNeededAfter",
+			err: &ctrlerrors.ErrorWithMetrics{
+				Err: ctrlerrors.NewRequeueNeededAfter("some error", 3*time.Second),
+			},
+			want:                    ctrl.Result{RequeueAfter: 3 * time.Second},
+			wantConditionRecordings: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			collector := lbcmetrics.NewMockCollector()
+			req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "awesome-ns", Name: "my-res"}}
+			got, err := HandleReconcileErrorWithCondition(tt.err, "service", req, collector, logr.New(&log.NullLogSink{}))
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+			mc := collector.(*lbcmetrics.MockCollector)
+			assert.Equal(t, tt.wantConditionRecordings, len(mc.Invocations[lbcmetrics.MetricControllerReconcileCondition]))
 		})
 	}
 }


### PR DESCRIPTION
### Issue

Fixes #4808

### Description

Adds a per-resource reconciliation-status metric so Prometheus alerts can identify *which* resource is failing to reconcile, not just that some reconcile in a controller is failing:

```
awslbc_controller_reconcile_condition{controller, namespace, name} = 1 | 0
```

- `1` — the last reconcile of the resource succeeded; `0` — the resource is failing to reconcile.
- The series is deleted when the resource is deleted (finalizer cleanup, `NotFound` on fetch, service no longer of LB type, or an ingress group losing its last member), so the metric never reports a frozen state and cardinality stays bounded to live resources.
- Requeue errors (`RequeueNeeded`/`RequeueNeededAfter`) do **not** mark the resource as failing, matching the existing `awslbc_controller_reconcile_errors_total` semantics — an LB mid-provisioning is not a failure.
- Wired into all five reconcilers that share the `lbcmetrics.MetricCollector`: ingress, service, targetGroupBinding, gateway (NLB/ALB), and globalAccelerator.

Implementation notes, following existing patterns in the repo:

- This is the lower-cardinality single-gauge shape discussed in #4808 (one series per resource, no `status` label), mirroring the existing per-resource `Set`/`Delete` lifecycle of `aws_target_group_info` (`pkg/metrics/aws/target_group.go`).
- For the ingress controller the series identity is the **ingress group** (the unit actually reconciled), exactly like `awslbc_controller_top_talkers`: implicit groups map 1:1 to the Ingress's namespace/name; explicit groups are cluster-scoped and emit an empty `namespace` label.
- The failure/requeue classification lives in a new `runtime.HandleReconcileErrorWithCondition` helper next to the existing `HandleReconcileError`, so each reconciler's `Reconcile()` is a one-line change and future controllers get the metric for free.
- `ErrorWithMetrics` gains an `Unwrap()` method so `errors.As`-based requeue detection (`runtime.IsRequeueError`) can see through it. Without this, requeue errors wrapped by `NewErrorWithMetrics` were opaque to `errors.Is`/`errors.As`; `HandleReconcileError` previously compensated with manual unwrapping (`handleNestedError`), which still works unchanged.
- Corner cases covered: gateways owned by a different controller class drop any series recorded before ownership was known; deferred TGB reconciles and successful gateway dry-run passes clear a previously-failing condition; resources deleted before acquiring a finalizer have their series removed on the `NotFound` path.

Example alert query (also added to the docs): `awslbc_controller_reconcile_condition == 0`

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [x] Backfilled missing tests for code in same general area :tada: (first metric-output tests for `pkg/metrics/lbc` using prometheus `testutil`)
- [ ] Refactored something and made the world a better place :star2: