### PR TITLE
fix(helm): Bump chart version to 3.4.1 to match appVersion

### DIFF
--- a/helm/aws-load-balancer-controller/Chart.yaml
+++ b/helm/aws-load-balancer-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: aws-load-balancer-controller
 description: AWS Load Balancer Controller Helm chart for Kubernetes
-version: 3.4.0
+version: 3.4.1
 appVersion: v3.4.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png


### PR DESCRIPTION
The chart version was not updated alongside the appVersion for the v3.4.1 release, causing a mismatch that blocked the Helm release pipeline.


### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
