### PR TITLE
fix(hack): Update chart version in set-version script

### DIFF
--- a/hack/set-version
+++ b/hack/set-version
@@ -55,6 +55,7 @@ if [[ -z "$PRERELEASE" ]]; then
 
   sed -i.bak -e "s@newTag: v${PREV_STABLE_VERSION}@newTag: v${NEW_RELEASE_VERSION}@g" config/controller/kustomization.yaml
   sed -i.bak -e "s@appVersion: v${PREV_STABLE_VERSION}@appVersion: v${NEW_RELEASE_VERSION}@g" helm/aws-load-balancer-controller/Chart.yaml
+  sed -i.bak -e "s@version: ${PREV_STABLE_VERSION}@version: ${NEW_RELEASE_VERSION}@g" helm/aws-load-balancer-controller/Chart.yaml
   sed -i.bak -e "s@tag: v${PREV_STABLE_VERSION}@tag: v${NEW_RELEASE_VERSION}@g" helm/aws-load-balancer-controller/test.yaml
   sed -i.bak -e "s@tag: v${PREV_STABLE_VERSION}@tag: v${NEW_RELEASE_VERSION}@g" helm/aws-load-balancer-controller/values.yaml
   sed -i.bak -e "s@/v${PREV_STABLE_VERSION}/v${PREV_STABLE_VERSION//./_}_@/v${NEW_RELEASE_VERSION}/v${NEW_RELEASE_VERSION//./_}_@g" docs/deploy/installation.md


### PR DESCRIPTION
### Issue

The set-version script updated appVersion in Chart.yaml but not the version field, causing a mismatch during the v3.4.1 release that blocked the Helm release.


### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
