### PR TITLE
fix(e2e): Use correct gRPC service name in cross-kind precedence test

### DIFF
--- a/test/e2e/gateway/alb_tests/alb_ip_target_test.go
+++ b/test/e2e/gateway/alb_tests/alb_ip_target_test.go
@@ -2140,7 +2140,7 @@ var _ = Describe("test k8s alb gateway using ip targets reconciled by the aws lo
 						{
 							Method: &gwv1.GRPCMethodMatch{
 								Type:    &grpcExact,
-								Service: awssdk.String("grpc.testing.EchoService"),
+								Service: awssdk.String("echo.EchoService"),
 								Method:  awssdk.String("Echo"),
 							},
 						},
@@ -2212,7 +2212,7 @@ var _ = Describe("test k8s alb gateway using ip targets reconciled by the aws lo
 			By("verifying ALB listener rules have correct priority ordering (GRPCRoute rule < HTTPRoute rule)", func() {
 				err := verifier.VerifyListenerRulePrecedence(ctx, tf, lbARN, verifier.RulePrecedenceExpectation{
 					// GRPCRoute's specific path should have lower priority number (evaluated first)
-					MoreSpecificPath: "/grpc.testing.EchoService/Echo",
+					MoreSpecificPath: "/echo.EchoService/Echo",
 					LessSpecificPath: "/*",
 				})
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Summary

Fixes the e2e test added in #4818 which was failing with ALB error 464 (malformed header: missing HTTP content-type).

## Root Cause

The GRPCRoute match in the cross-kind precedence test used `grpc.testing.EchoService` as the service name, but the actual gRPC echo server backend (`public.ecr.aws/u6k2n8q7/nixozach/grpc-echoserver`) implements `echo.EchoService`.

This caused the ALB listener rule to have path-pattern `/grpc.testing.EchoService/Echo`, which never matched the actual gRPC client call to `/echo.EchoService/Echo`. The request fell through to the catch-all HTTPRoute, hit the HTTP backend, and returned a non-gRPC response → 464 error.

## Fix

- Changed GRPCRoute match from `grpc.testing.EchoService/Echo` → `echo.EchoService/Echo`
- Updated `VerifyListenerRulePrecedence` assertion to match

## Testing

E2e test passes locally against a real EKS cluster with the fix image deployed.