### PR TITLE
Fix Markdown formatting of blue/green guide

### DIFF
--- a/docs/guide/use_cases/blue_green/index.md
+++ b/docs/guide/use_cases/blue_green/index.md
@@ -4,10 +4,10 @@ You can configure an Application Load Balancer (ALB) to split traffic from the s
 
 More specifically, the ALB supports weighted target groups and advanced request routing. 
 
-**Weighted target group**
+**Weighted target group**  
 Multiple target groups can be attached to the same forward action of a listener rule and specify a weight for each group. It allows developers to control how to distribute traffic to multiple versions of their application. For example, when you define a rule having two target groups with weights of 8 and 2, the load balancer will route 80 percent of the traffic to the first target group and 20 percent to the other.
 
-**Advanced request routing**
+**Advanced request routing**  
 In addition to the weighted target group, AWS announced the advanced request routing feature in 2019. Advanced request routing gives developers the ability to write rules (and route traffic) based on standard and custom HTTP headers and methods, the request path, the query string, and the source IP address. This new feature simplifies the application architecture by eliminating the need for a proxy fleet for routing, blocks unwanted traffic at the load balancer, and enables the implementation of A/B testing.
 
 ## Overview
@@ -17,7 +17,8 @@ The body of the annotation is a JSON document that identifies an action type, an
 
 With forward action, multiple target groups with different weights can be defined in the annotation. The LBC provisions the target groups and configures the listener rules as per the annotation to direct the traffic. 
 
-Importantly: 
+Importantly:
+
 * The `action-name` in the annotation must match the service name in the Ingress rules. For example, the annotation `alb.ingress.kubernetes.io/actions.blue-green` matches the service name `blue-green` referenced in the Ingress rules. 
 * The `servicePort` of the service in the Ingress rules must be `use-annotation`.
 
@@ -70,6 +71,7 @@ spec:
                 name: blue-green
                 port:
                   name: use-annotation
+```
 
 ## Migrating between services without downtime
 
@@ -82,7 +84,3 @@ To migrate without dropping connections, use the weighted target group pattern d
 3. Once traffic is fully shifted to the new service, remove the old service from the annotation.
 
 Since both target groups stay registered with the ALB throughout the migration, connections drain naturally and no traffic is dropped.
-```
-
-
-


### PR DESCRIPTION
### Issue

Follow up to: https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4819
Original issue: https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4810

### Description

While reading through the [recent changes](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4819) to the document, I noticed there was some incorrect Markdown formatting, which was making the reading experience more difficult. This fixes them.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
