### PR TITLE
docs: fix admonition indentation for ipam-ipv4-pool-id annotation

### DIFF
--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -279,17 +279,17 @@ Traffic Routing can be controlled with following annotations:
 
 - <a name="ipam-ipv4-pool-id">`alb.ingress.kubernetes.io/ipam-ipv4-pool-id`</a> Specifies the [IPv4 IPAM Pool ID](https://docs.aws.amazon.com/vpc/latest/ipam/tutorials-byoip-ipam-console-ipv4.html) which will be used by your load balancer to assign IP addresses.
 
-  !!!note ""
-  The chosen IPAM pool is always the prioritized source when assigning public IPv4 addresses.
-  If there are no more assignable IP addresses in the IPAM pool, AWS managed IPv4 addresses are assigned.
+    !!!note ""
+        The chosen IPAM pool is always the prioritized source when assigning public IPv4 addresses.
+        If there are no more assignable IP addresses in the IPAM pool, AWS managed IPv4 addresses are assigned.
 
-  !!!tip
-  To remove an IPAM pool associated to your ALB, remove the annotation from your ingress.
+    !!!tip
+        To remove an IPAM pool associated to your ALB, remove the annotation from your ingress.
 
-  !!!example
-  ```
-  alb.ingress.kubernetes.io/ipam-ipv4-pool-id: ipam-pool-0f995c17c00375b48
-  ```
+    !!!example
+        ```
+        alb.ingress.kubernetes.io/ipam-ipv4-pool-id: ipam-pool-0f995c17c00375b48
+        ```
 
 - <a name="actions">`alb.ingress.kubernetes.io/actions.${action-name}`</a> Provides a method for configuring custom actions on a listener, such as Redirect Actions.
 


### PR DESCRIPTION
### Issue

N/A — documentation rendering bug (no tracking issue).

### Description

The `!!!note`, `!!!tip`, and `!!!example` admonitions under the
`alb.ingress.kubernetes.io/ipam-ipv4-pool-id` annotation in
`docs/guide/ingress/annotations.md` were rendering as literal
`!!!note` / `!!!tip` / `!!!example` text instead of styled MkDocs
Material admonition boxes.

**Root cause:** the admonitions are nested inside a `-` list item, so
MkDocs Material requires the `!!!` marker to be indented to the list
item's content column (4 spaces) and the admonition body indented a
further 4 spaces (8 total). The original markup placed the marker at 2
spaces with the body at the *same* level as the marker, so the parser
treated the whole block as plain text.

The fix aligns the indentation with the pattern already used by every
other annotation in this document (e.g. `group.order`).

```diff
-  !!!note ""
-  The chosen IPAM pool is always the prioritized source when assigning public IPv4 addresses.
-  If there are no more assignable IP addresses in the IPAM pool, AWS managed IPv4 addresses are assigned.
+    !!!note ""
+        The chosen IPAM pool is always the prioritized source when assigning public IPv4 addresses.
+        If there are no more assignable IP addresses in the IPAM pool, AWS managed IPv4 addresses are assigned.
