### PR TITLE
Add label for accessing secrets - to support restricted access for EKS Auto LBC

### DIFF
--- a/controllers/gateway/gateway_controller.go
+++ b/controllers/gateway/gateway_controller.go
@@ -110,6 +110,7 @@ func newGatewayReconciler(controllerName string, lbType elbv2model.LoadBalancerT
 		targetGroupNameToArnMapper: targetGroupNameToArnMapper,
 		listenerSetStatusSubmitter: listenerSetStatusSubmitter,
 		listenerSetEnabled:         controllerConfig.FeatureGates.Enabled(config.GatewayListenerSet),
+		controllerConfig:           controllerConfig,
 	}
 }
 
@@ -130,6 +131,7 @@ type gatewayReconciler struct {
 	finalizerManager           k8s.FinalizerManager
 	eventRecorder              record.EventRecorder
 	targetGroupNameToArnMapper shared_utils.TargetGroupARNMapper
+	controllerConfig           config.ControllerConfig
 	logger                     logr.Logger
 	metricsCollector           lbcmetrics.MetricCollector
 	reconcileTracker           func(namespaceName types.NamespacedName)
@@ -670,7 +672,8 @@ func (r *gatewayReconciler) setupALBGatewayControllerWatches(ctrl controller.Con
 		}
 	}
 
-	r.secretsManager = k8s.NewSecretsManager(clientSet, secretEventsChan, r.logger.WithName("secrets-manager"))
+	requiredLabelKey, requiredLabelValue := config.ParseRequiredSecretsLabel(r.controllerConfig.RequiredSecretsLabel)
+	r.secretsManager = k8s.NewSecretsManager(clientSet, secretEventsChan, r.logger.WithName("secrets-manager"), requiredLabelKey, requiredLabelValue)
 	return nil
 }
 

--- a/controllers/gateway/gateway_controller.go
+++ b/controllers/gateway/gateway_controller.go
@@ -110,7 +110,6 @@ func newGatewayReconciler(controllerName string, lbType elbv2model.LoadBalancerT
 		targetGroupNameToArnMapper: targetGroupNameToArnMapper,
 		listenerSetStatusSubmitter: listenerSetStatusSubmitter,
 		listenerSetEnabled:         controllerConfig.FeatureGates.Enabled(config.GatewayListenerSet),
-		controllerConfig:           controllerConfig,
 	}
 }
 
@@ -131,7 +130,6 @@ type gatewayReconciler struct {
 	finalizerManager           k8s.FinalizerManager
 	eventRecorder              record.EventRecorder
 	targetGroupNameToArnMapper shared_utils.TargetGroupARNMapper
-	controllerConfig           config.ControllerConfig
 	logger                     logr.Logger
 	metricsCollector           lbcmetrics.MetricCollector
 	reconcileTracker           func(namespaceName types.NamespacedName)
@@ -672,8 +670,7 @@ func (r *gatewayReconciler) setupALBGatewayControllerWatches(ctrl controller.Con
 		}
 	}
 
-	requiredLabelKey, requiredLabelValue := config.ParseRequiredSecretsLabel(r.controllerConfig.RequiredSecretsLabel)
-	r.secretsManager = k8s.NewSecretsManager(clientSet, secretEventsChan, r.logger.WithName("secrets-manager"), requiredLabelKey, requiredLabelValue)
+	r.secretsManager = k8s.NewSecretsManager(clientSet, secretEventsChan, r.logger.WithName("secrets-manager"), "", "")
 	return nil
 }
 

--- a/controllers/gateway/listenerrule_configuration_controller.go
+++ b/controllers/gateway/listenerrule_configuration_controller.go
@@ -39,7 +39,6 @@ func NewListenerRuleConfigurationReconciler(k8sClient client.Client, eventRecord
 		eventRecorder:    eventRecorder,
 		logger:           logger,
 		finalizerManager: finalizerManager,
-		controllerConfig: controllerConfig,
 		workers:          controllerConfig.GatewayClassMaxConcurrentReconciles,
 	}
 }
@@ -51,7 +50,6 @@ type listenerRuleConfigurationReconciler struct {
 	eventRecorder    record.EventRecorder
 	secretsManager   k8s.SecretsManager
 	finalizerManager k8s.FinalizerManager
-	controllerConfig config.ControllerConfig
 	workers          int
 }
 
@@ -68,8 +66,7 @@ func (r *listenerRuleConfigurationReconciler) SetupWatches(_ context.Context, ct
 	if err := ctrl.Watch(source.Channel(secretEventsChan, secretToLRCHandler)); err != nil {
 		return err
 	}
-	requiredLabelKey, requiredLabelValue := config.ParseRequiredSecretsLabel(r.controllerConfig.RequiredSecretsLabel)
-	r.secretsManager = k8s.NewSecretsManager(clientSet, secretEventsChan, r.logger.WithName("secrets-manager"), requiredLabelKey, requiredLabelValue)
+	r.secretsManager = k8s.NewSecretsManager(clientSet, secretEventsChan, r.logger.WithName("secrets-manager"), "", "")
 	return nil
 }
 

--- a/controllers/gateway/listenerrule_configuration_controller.go
+++ b/controllers/gateway/listenerrule_configuration_controller.go
@@ -39,6 +39,7 @@ func NewListenerRuleConfigurationReconciler(k8sClient client.Client, eventRecord
 		eventRecorder:    eventRecorder,
 		logger:           logger,
 		finalizerManager: finalizerManager,
+		controllerConfig: controllerConfig,
 		workers:          controllerConfig.GatewayClassMaxConcurrentReconciles,
 	}
 }
@@ -50,6 +51,7 @@ type listenerRuleConfigurationReconciler struct {
 	eventRecorder    record.EventRecorder
 	secretsManager   k8s.SecretsManager
 	finalizerManager k8s.FinalizerManager
+	controllerConfig config.ControllerConfig
 	workers          int
 }
 
@@ -66,7 +68,8 @@ func (r *listenerRuleConfigurationReconciler) SetupWatches(_ context.Context, ct
 	if err := ctrl.Watch(source.Channel(secretEventsChan, secretToLRCHandler)); err != nil {
 		return err
 	}
-	r.secretsManager = k8s.NewSecretsManager(clientSet, secretEventsChan, r.logger.WithName("secrets-manager"))
+	requiredLabelKey, requiredLabelValue := config.ParseRequiredSecretsLabel(r.controllerConfig.RequiredSecretsLabel)
+	r.secretsManager = k8s.NewSecretsManager(clientSet, secretEventsChan, r.logger.WithName("secrets-manager"), requiredLabelKey, requiredLabelValue)
 	return nil
 }
 

--- a/controllers/ingress/group_controller.go
+++ b/controllers/ingress/group_controller.go
@@ -65,13 +65,6 @@ func NewGroupReconciler(cloud services.Cloud, k8sClient client.Client, eventReco
 	referenceIndexer := ingress.NewDefaultReferenceIndexer(enhancedBackendBuilder, authConfigBuilder, logger)
 	trackingProvider := tracking.NewDefaultProvider(ingressTagPrefix, controllerConfig.ClusterName)
 	certDiscovery := certs.NewACMCertDiscovery(cloud.ACM(), controllerConfig.IngressConfig.AllowedCertificateAuthorityARNs, controllerConfig.FeatureGates.Enabled(config.EnableCertificateManagement), logger)
-	modelBuilder := ingress.NewDefaultModelBuilder(k8sClient, eventRecorder,
-		cloud.EC2(), cloud.ELBV2(), cloud.WAFv2(), cloud.ACM(),
-		annotationParser, subnetsResolver,
-		authConfigBuilder, enhancedBackendBuilder, trackingProvider, elbv2TaggingManager, controllerConfig.FeatureGates,
-		cloud.VpcID(), controllerConfig.ClusterName, controllerConfig.DefaultTags, controllerConfig.ExternalManagedTags,
-		controllerConfig.DefaultSSLPolicy, controllerConfig.DefaultTargetType, controllerConfig.DefaultLoadBalancerScheme, backendSGProvider, sgResolver,
-		controllerConfig.EnableBackendSecurityGroup, controllerConfig.EnableManageBackendSecurityGroupRules, controllerConfig.DisableRestrictedSGRules, controllerConfig.IngressConfig.AllowedCertificateAuthorityARNs, controllerConfig.FeatureGates.Enabled(config.EnableIPTargetType), controllerConfig.FeatureGates.Enabled(config.EnableCertificateManagement), controllerConfig.IngressConfig.DefaultPCAArn, targetGroupNameToArnMapper, logger, metricsCollector, certDiscovery)
 	stackMarshaller := deploy.NewDefaultStackMarshaller()
 	stackDeployer := deploy.NewDefaultStackDeployer(cloud, k8sClient, networkingManager, networkingSGManager, networkingSGReconciler, elbv2TaggingManager,
 		controllerConfig, ingressTagPrefix, logger, metricsCollector, controllerName, controllerConfig.FeatureGates.Enabled(config.EnhancedDefaultBehavior), targetGroupCollector, true)
@@ -84,11 +77,22 @@ func NewGroupReconciler(cloud services.Cloud, k8sClient client.Client, eventReco
 	return &groupReconciler{
 		k8sClient:         k8sClient,
 		eventRecorder:     eventRecorder,
+		cloud:             cloud,
 		referenceIndexer:  referenceIndexer,
-		modelBuilder:      modelBuilder,
 		stackMarshaller:   stackMarshaller,
 		stackDeployer:     stackDeployer,
 		backendSGProvider: backendSGProvider,
+
+		annotationParser:           annotationParser,
+		authConfigBuilder:          authConfigBuilder,
+		enhancedBackendBuilder:     enhancedBackendBuilder,
+		trackingProvider:           trackingProvider,
+		elbv2TaggingManager:        elbv2TaggingManager,
+		subnetsResolver:            subnetsResolver,
+		sgResolver:                 sgResolver,
+		controllerConfig:           controllerConfig,
+		targetGroupNameToArnMapper: targetGroupNameToArnMapper,
+		certDiscovery:              certDiscovery,
 
 		groupLoader:           groupLoader,
 		groupFinalizerManager: groupFinalizerManager,
@@ -106,12 +110,24 @@ func NewGroupReconciler(cloud services.Cloud, k8sClient client.Client, eventReco
 type groupReconciler struct {
 	k8sClient         client.Client
 	eventRecorder     record.EventRecorder
+	cloud             services.Cloud
 	referenceIndexer  ingress.ReferenceIndexer
 	modelBuilder      ingress.ModelBuilder
 	stackMarshaller   deploy.StackMarshaller
 	stackDeployer     deploy.StackDeployer
 	backendSGProvider networkingpkg.BackendSGProvider
 	secretsManager    k8s.SecretsManager
+
+	annotationParser           annotations.Parser
+	authConfigBuilder          ingress.AuthConfigBuilder
+	enhancedBackendBuilder     ingress.EnhancedBackendBuilder
+	trackingProvider           tracking.Provider
+	elbv2TaggingManager        elbv2deploy.TaggingManager
+	subnetsResolver            networkingpkg.SubnetsResolver
+	sgResolver                 networkingpkg.SecurityGroupResolver
+	controllerConfig           config.ControllerConfig
+	targetGroupNameToArnMapper shared_utils.TargetGroupARNMapper
+	certDiscovery              certs.CertDiscovery
 
 	groupLoader           ingress.GroupLoader
 	groupFinalizerManager ingress.FinalizerManager
@@ -439,7 +455,16 @@ func (r *groupReconciler) setupWatches(_ context.Context, c controller.Controlle
 			return err
 		}
 	}
-	r.secretsManager = k8s.NewSecretsManager(clientSet, secretEventsChan, ctrl.Log.WithName("secrets-manager"))
+	requiredLabelKey, requiredLabelValue := config.ParseRequiredSecretsLabel(r.controllerConfig.RequiredSecretsLabel)
+	r.secretsManager = k8s.NewSecretsManager(clientSet, secretEventsChan, ctrl.Log.WithName("secrets-manager"), requiredLabelKey, requiredLabelValue)
+	r.modelBuilder = ingress.NewDefaultModelBuilder(r.k8sClient, r.eventRecorder,
+		r.cloud.EC2(), r.cloud.ELBV2(), r.cloud.WAFv2(), r.cloud.ACM(),
+		r.annotationParser, r.subnetsResolver,
+		r.authConfigBuilder, r.enhancedBackendBuilder, r.trackingProvider, r.elbv2TaggingManager, r.controllerConfig.FeatureGates,
+		r.cloud.VpcID(), r.controllerConfig.ClusterName, r.controllerConfig.DefaultTags, r.controllerConfig.ExternalManagedTags,
+		r.controllerConfig.DefaultSSLPolicy, r.controllerConfig.DefaultTargetType, r.controllerConfig.DefaultLoadBalancerScheme, r.backendSGProvider, r.sgResolver,
+		r.controllerConfig.EnableBackendSecurityGroup, r.controllerConfig.EnableManageBackendSecurityGroupRules, r.controllerConfig.DisableRestrictedSGRules, r.controllerConfig.IngressConfig.AllowedCertificateAuthorityARNs, r.controllerConfig.FeatureGates.Enabled(config.EnableIPTargetType), r.controllerConfig.FeatureGates.Enabled(config.EnableCertificateManagement), r.controllerConfig.IngressConfig.DefaultPCAArn, r.targetGroupNameToArnMapper, r.secretsManager, r.logger, r.metricsCollector,
+		r.certDiscovery)
 	return nil
 }
 

--- a/controllers/ingress/group_controller.go
+++ b/controllers/ingress/group_controller.go
@@ -56,7 +56,7 @@ func NewGroupReconciler(cloud services.Cloud, k8sClient client.Client, eventReco
 	finalizerManager k8s.FinalizerManager, networkingSGManager networkingpkg.SecurityGroupManager,
 	networkingManager networkingpkg.NetworkingManager, networkingSGReconciler networkingpkg.SecurityGroupReconciler, subnetsResolver networkingpkg.SubnetsResolver,
 	elbv2TaggingManager elbv2deploy.TaggingManager, controllerConfig config.ControllerConfig, backendSGProvider networkingpkg.BackendSGProvider,
-	sgResolver networkingpkg.SecurityGroupResolver, logger logr.Logger, metricsCollector lbcmetrics.MetricCollector, reconcileCounters *metricsutil.ReconcileCounters,
+	sgResolver networkingpkg.SecurityGroupResolver, secretsManager k8s.SecretsManager, logger logr.Logger, metricsCollector lbcmetrics.MetricCollector, reconcileCounters *metricsutil.ReconcileCounters,
 	targetGroupCollector awsmetrics.TargetGroupCollector, targetGroupNameToArnMapper shared_utils.TargetGroupARNMapper,
 ) *groupReconciler {
 	annotationParser := annotations.NewSuffixAnnotationParser(annotations.AnnotationPrefixIngress)
@@ -65,6 +65,14 @@ func NewGroupReconciler(cloud services.Cloud, k8sClient client.Client, eventReco
 	referenceIndexer := ingress.NewDefaultReferenceIndexer(enhancedBackendBuilder, authConfigBuilder, logger)
 	trackingProvider := tracking.NewDefaultProvider(ingressTagPrefix, controllerConfig.ClusterName)
 	certDiscovery := certs.NewACMCertDiscovery(cloud.ACM(), controllerConfig.IngressConfig.AllowedCertificateAuthorityARNs, controllerConfig.FeatureGates.Enabled(config.EnableCertificateManagement), logger)
+	modelBuilder := ingress.NewDefaultModelBuilder(k8sClient, eventRecorder,
+		cloud.EC2(), cloud.ELBV2(), cloud.WAFv2(), cloud.ACM(),
+		annotationParser, subnetsResolver,
+		authConfigBuilder, enhancedBackendBuilder, trackingProvider, elbv2TaggingManager, controllerConfig.FeatureGates,
+		cloud.VpcID(), controllerConfig.ClusterName, controllerConfig.DefaultTags, controllerConfig.ExternalManagedTags,
+		controllerConfig.DefaultSSLPolicy, controllerConfig.DefaultTargetType, controllerConfig.DefaultLoadBalancerScheme, backendSGProvider, sgResolver,
+		controllerConfig.EnableBackendSecurityGroup, controllerConfig.EnableManageBackendSecurityGroupRules, controllerConfig.DisableRestrictedSGRules, controllerConfig.IngressConfig.AllowedCertificateAuthorityARNs, controllerConfig.FeatureGates.Enabled(config.EnableIPTargetType), controllerConfig.FeatureGates.Enabled(config.EnableCertificateManagement), controllerConfig.IngressConfig.DefaultPCAArn, targetGroupNameToArnMapper, secretsManager, logger, metricsCollector,
+		certDiscovery)
 	stackMarshaller := deploy.NewDefaultStackMarshaller()
 	stackDeployer := deploy.NewDefaultStackDeployer(cloud, k8sClient, networkingManager, networkingSGManager, networkingSGReconciler, elbv2TaggingManager,
 		controllerConfig, ingressTagPrefix, logger, metricsCollector, controllerName, controllerConfig.FeatureGates.Enabled(config.EnhancedDefaultBehavior), targetGroupCollector, true)
@@ -77,22 +85,12 @@ func NewGroupReconciler(cloud services.Cloud, k8sClient client.Client, eventReco
 	return &groupReconciler{
 		k8sClient:         k8sClient,
 		eventRecorder:     eventRecorder,
-		cloud:             cloud,
 		referenceIndexer:  referenceIndexer,
+		modelBuilder:      modelBuilder,
 		stackMarshaller:   stackMarshaller,
 		stackDeployer:     stackDeployer,
 		backendSGProvider: backendSGProvider,
-
-		annotationParser:           annotationParser,
-		authConfigBuilder:          authConfigBuilder,
-		enhancedBackendBuilder:     enhancedBackendBuilder,
-		trackingProvider:           trackingProvider,
-		elbv2TaggingManager:        elbv2TaggingManager,
-		subnetsResolver:            subnetsResolver,
-		sgResolver:                 sgResolver,
-		controllerConfig:           controllerConfig,
-		targetGroupNameToArnMapper: targetGroupNameToArnMapper,
-		certDiscovery:              certDiscovery,
+		secretsManager:    secretsManager,
 
 		groupLoader:           groupLoader,
 		groupFinalizerManager: groupFinalizerManager,
@@ -110,24 +108,12 @@ func NewGroupReconciler(cloud services.Cloud, k8sClient client.Client, eventReco
 type groupReconciler struct {
 	k8sClient         client.Client
 	eventRecorder     record.EventRecorder
-	cloud             services.Cloud
 	referenceIndexer  ingress.ReferenceIndexer
 	modelBuilder      ingress.ModelBuilder
 	stackMarshaller   deploy.StackMarshaller
 	stackDeployer     deploy.StackDeployer
 	backendSGProvider networkingpkg.BackendSGProvider
 	secretsManager    k8s.SecretsManager
-
-	annotationParser           annotations.Parser
-	authConfigBuilder          ingress.AuthConfigBuilder
-	enhancedBackendBuilder     ingress.EnhancedBackendBuilder
-	trackingProvider           tracking.Provider
-	elbv2TaggingManager        elbv2deploy.TaggingManager
-	subnetsResolver            networkingpkg.SubnetsResolver
-	sgResolver                 networkingpkg.SecurityGroupResolver
-	controllerConfig           config.ControllerConfig
-	targetGroupNameToArnMapper shared_utils.TargetGroupARNMapper
-	certDiscovery              certs.CertDiscovery
 
 	groupLoader           ingress.GroupLoader
 	groupFinalizerManager ingress.FinalizerManager
@@ -418,6 +404,7 @@ func (r *groupReconciler) setupWatches(_ context.Context, c controller.Controlle
 	ingEventChan := make(chan event.TypedGenericEvent[*networking.Ingress])
 	svcEventChan := make(chan event.TypedGenericEvent[*corev1.Service])
 	secretEventsChan := make(chan event.TypedGenericEvent[*corev1.Secret])
+	r.secretsManager.SetEventChannel(secretEventsChan)
 	ingEventHandler := eventhandlers.NewEnqueueRequestsForIngressEvent(r.groupLoader, r.eventRecorder,
 		r.logger.WithName("eventHandlers").WithName("ingress"))
 	svcEventHandler := eventhandlers.NewEnqueueRequestsForServiceEvent(ingEventChan, r.k8sClient, r.eventRecorder,
@@ -455,16 +442,6 @@ func (r *groupReconciler) setupWatches(_ context.Context, c controller.Controlle
 			return err
 		}
 	}
-	requiredLabelKey, requiredLabelValue := config.ParseRequiredSecretsLabel(r.controllerConfig.RequiredSecretsLabel)
-	r.secretsManager = k8s.NewSecretsManager(clientSet, secretEventsChan, ctrl.Log.WithName("secrets-manager"), requiredLabelKey, requiredLabelValue)
-	r.modelBuilder = ingress.NewDefaultModelBuilder(r.k8sClient, r.eventRecorder,
-		r.cloud.EC2(), r.cloud.ELBV2(), r.cloud.WAFv2(), r.cloud.ACM(),
-		r.annotationParser, r.subnetsResolver,
-		r.authConfigBuilder, r.enhancedBackendBuilder, r.trackingProvider, r.elbv2TaggingManager, r.controllerConfig.FeatureGates,
-		r.cloud.VpcID(), r.controllerConfig.ClusterName, r.controllerConfig.DefaultTags, r.controllerConfig.ExternalManagedTags,
-		r.controllerConfig.DefaultSSLPolicy, r.controllerConfig.DefaultTargetType, r.controllerConfig.DefaultLoadBalancerScheme, r.backendSGProvider, r.sgResolver,
-		r.controllerConfig.EnableBackendSecurityGroup, r.controllerConfig.EnableManageBackendSecurityGroupRules, r.controllerConfig.DisableRestrictedSGRules, r.controllerConfig.IngressConfig.AllowedCertificateAuthorityARNs, r.controllerConfig.FeatureGates.Enabled(config.EnableIPTargetType), r.controllerConfig.FeatureGates.Enabled(config.EnableCertificateManagement), r.controllerConfig.IngressConfig.DefaultPCAArn, r.targetGroupNameToArnMapper, r.secretsManager, r.logger, r.metricsCollector,
-		r.certDiscovery)
 	return nil
 }
 

--- a/docs/deploy/configurations.md
+++ b/docs/deploy/configurations.md
@@ -122,6 +122,35 @@ The --cluster-name flag is mandatory and the value must match the name of the ku
 | alb-gateway-max-concurrent-reconciles                                           | int                       | 3                                          | Maximum number of concurrently running reconcile loops for ALB gateways, if enabled                                                                                           |
 | nlb-gateway-max-concurrent-reconciles                                           | int                       | 3                                          | Maximum number of concurrently running reconcile loops for NLB gateways, if enabled                                                                                           |
 | max-targets-per-target-group                                                        | int                       | 0                                          | Maximum number of targets that will be added to a given Target Group. The default value of zero will leave the number of targets unlimited                                    |
+| [required-secrets-label](#required-secrets-label)                                   | string                    |                                            | Required label (key=value) that Secrets must have to be read by the controller. If unset, the controller can read all Secrets it has RBAC access to                           |
+
+### required-secrets-label
+`--required-secrets-label` restricts which Kubernetes Secrets the controller is allowed to read. The value must be a single `key=value` pair (e.g. `allow-read-access=eks-lbc`). When set, the controller will only read Secrets that carry a matching label; Secrets without the label will be rejected during model building.
+
+This is useful for environments where the controller should not have blanket read access to all Secrets in a namespace. Only one label pair is supported.
+
+Example:
+```yaml
+spec:
+  containers:
+  - args:
+    - --required-secrets-label=allow-read-access=eks-lbc
+```
+
+The corresponding Secret must have the matching label:
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-oidc-secret
+  namespace: my-namespace
+  labels:
+    allow-read-access: eks-lbc
+type: Opaque
+data:
+  clientID: ...
+  clientSecret: ...
+```
 
 ### disable-ingress-class-annotation
 `--disable-ingress-class-annotation` controls whether to disable new usage of the `kubernetes.io/ingress.class` annotation.

--- a/docs/deploy/configurations.md
+++ b/docs/deploy/configurations.md
@@ -122,35 +122,6 @@ The --cluster-name flag is mandatory and the value must match the name of the ku
 | alb-gateway-max-concurrent-reconciles                                           | int                       | 3                                          | Maximum number of concurrently running reconcile loops for ALB gateways, if enabled                                                                                           |
 | nlb-gateway-max-concurrent-reconciles                                           | int                       | 3                                          | Maximum number of concurrently running reconcile loops for NLB gateways, if enabled                                                                                           |
 | max-targets-per-target-group                                                        | int                       | 0                                          | Maximum number of targets that will be added to a given Target Group. The default value of zero will leave the number of targets unlimited                                    |
-| [required-secrets-label](#required-secrets-label)                                   | string                    |                                            | Required label (key=value) that Secrets must have to be read by the controller. If unset, the controller can read all Secrets it has RBAC access to                           |
-
-### required-secrets-label
-`--required-secrets-label` restricts which Kubernetes Secrets the controller is allowed to read. The value must be a single `key=value` pair (e.g. `allow-read-access=eks-lbc`). When set, the controller will only read Secrets that carry a matching label; Secrets without the label will be rejected during model building.
-
-This is useful for environments where the controller should not have blanket read access to all Secrets in a namespace. Only one label pair is supported.
-
-Example:
-```yaml
-spec:
-  containers:
-  - args:
-    - --required-secrets-label=allow-read-access=eks-lbc
-```
-
-The corresponding Secret must have the matching label:
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: my-oidc-secret
-  namespace: my-namespace
-  labels:
-    allow-read-access: eks-lbc
-type: Opaque
-data:
-  clientID: ...
-  clientSecret: ...
-```
 
 ### disable-ingress-class-annotation
 `--disable-ingress-class-annotation` controls whether to disable new usage of the `kubernetes.io/ingress.class` annotation.

--- a/main.go
+++ b/main.go
@@ -214,9 +214,11 @@ func main() {
 		cloud.VpcID(), cloud.EC2(), mgr.GetClient(), controllerCFG.DefaultTags, nlbGatewayEnabled || albGatewayEnabled, ctrl.Log.WithName("backend-sg-provider"))
 	sgResolver := networking.NewDefaultSecurityGroupResolver(cloud.EC2(), cloud.VpcID())
 	elbv2TaggingManager := elbv2deploy.NewDefaultTaggingManager(cloud.ELBV2(), cloud.VpcID(), controllerCFG.FeatureGates, cloud.RGT(), ctrl.Log)
+	requiredLabelKey, requiredLabelValue := config.ParseRequiredSecretsLabel(controllerCFG.RequiredSecretsLabel)
+	secretsManager := k8s.NewSecretsManager(clientSet, nil, ctrl.Log.WithName("secrets-manager"), requiredLabelKey, requiredLabelValue)
 	ingGroupReconciler := ingress.NewGroupReconciler(cloud, mgr.GetClient(), mgr.GetEventRecorderFor("ingress"),
 		finalizerManager, sgManager, networkingManager, sgReconciler, subnetResolver, elbv2TaggingManager,
-		controllerCFG, backendSGProvider, sgResolver, ctrl.Log.WithName("controllers").WithName("ingress"), lbcMetricsCollector, reconcileCounters,
+		controllerCFG, backendSGProvider, sgResolver, secretsManager, ctrl.Log.WithName("controllers").WithName("ingress"), lbcMetricsCollector, reconcileCounters,
 		targetGroupCollector, tgArnMapper)
 	svcReconciler := service.NewServiceReconciler(cloud, mgr.GetClient(), mgr.GetEventRecorderFor("service"),
 		finalizerManager, networkingManager, sgManager, sgReconciler, subnetResolver, vpcInfoProvider, elbv2TaggingManager,

--- a/pkg/config/controller_config.go
+++ b/pkg/config/controller_config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -40,6 +41,7 @@ const (
 	flagDisableRestrictedSGRules                     = "disable-restricted-sg-rules"
 	flagMaxTargetsPerTargetGroup                     = "max-targets-per-target-group"
 	flagTargetGroupBindingRequeueDuration            = "targetgroupbinding-requeue-duration"
+	flagRequiredSecretsLabel                         = "required-secrets-label"
 	defaultLogLevel                                  = "info"
 	defaultGlobalAcceleratorMaxConcurrentReconciles  = 1
 	defaultMaxConcurrentReconciles                   = 3
@@ -158,6 +160,9 @@ type ControllerConfig struct {
 	// for AWS resources to update.
 	TargetGroupBindingRequeueDuration time.Duration
 
+	// RequiredSecretsLabel specifies a required label (key=value) that Secrets must have to be read by the controller
+	RequiredSecretsLabel string
+
 	FeatureGates FeatureGates
 }
 
@@ -210,6 +215,8 @@ func (cfg *ControllerConfig) BindFlags(fs *pflag.FlagSet) {
 		"Maximum number of targets that can be added to an ELB instance. Use this to prevent TargetGroup quotas being exceeded from blocking reconciliation.")
 	fs.DurationVar(&cfg.TargetGroupBindingRequeueDuration, flagTargetGroupBindingRequeueDuration, defaultTargetGroupBindingRequeuDuration,
 		"Duration after which TargetGroupBinding will be requeued for reconciliation when it's waiting for AWS resources to update.")
+	fs.StringVar(&cfg.RequiredSecretsLabel, flagRequiredSecretsLabel, "",
+		"Required label (key=value) that Secrets must have to be read by the controller")
 	cfg.FeatureGates.BindFlags(fs)
 	cfg.AWSConfig.BindFlags(fs)
 	cfg.RuntimeConfig.BindFlags(fs)
@@ -246,6 +253,9 @@ func (cfg *ControllerConfig) Validate() error {
 		return err
 	}
 	if err := cfg.validateManageBackendSecurityGroupRulesConfiguration(); err != nil {
+		return err
+	}
+	if err := cfg.validateRequiredSecretsLabel(); err != nil {
 		return err
 	}
 	return nil
@@ -312,4 +322,29 @@ func (cfg *ControllerConfig) validateManageBackendSecurityGroupRulesConfiguratio
 		return errors.Errorf("backend security group must be enabled when manage backend security group rule is enabled")
 	}
 	return nil
+}
+
+func (cfg *ControllerConfig) validateRequiredSecretsLabel() error {
+	if cfg.RequiredSecretsLabel == "" {
+		return nil
+	}
+	parts := strings.SplitN(cfg.RequiredSecretsLabel, "=", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return fmt.Errorf("invalid value %q for --%s: must be in key=value format",
+			cfg.RequiredSecretsLabel, flagRequiredSecretsLabel)
+	}
+	return nil
+}
+
+// ParseRequiredSecretsLabel splits a "key=value" string into its key and value parts.
+// Returns empty strings when input is empty.
+func ParseRequiredSecretsLabel(label string) (string, string) {
+	if label == "" {
+		return "", ""
+	}
+	parts := strings.SplitN(label, "=", 2)
+	if len(parts) != 2 {
+		return "", ""
+	}
+	return parts[0], parts[1]
 }

--- a/pkg/config/controller_config.go
+++ b/pkg/config/controller_config.go
@@ -160,7 +160,8 @@ type ControllerConfig struct {
 	// for AWS resources to update.
 	TargetGroupBindingRequeueDuration time.Duration
 
-	// RequiredSecretsLabel specifies a required label (key=value) that Secrets must have to be read by the controller
+	// RequiredSecretsLabel specifies a required label (key=value) that Secrets must have to be read by the controller.
+	// By default, no label is required and the controller can read all Secrets.
 	RequiredSecretsLabel string
 
 	FeatureGates FeatureGates

--- a/pkg/gateway/routeutils/route_rule_action_test.go
+++ b/pkg/gateway/routeutils/route_rule_action_test.go
@@ -14,6 +14,7 @@ import (
 	elbv2model "sigs.k8s.io/aws-load-balancer-controller/v3/pkg/model/elbv2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -755,6 +756,9 @@ func (m *mockSecretsManager) GetSecret(ctx context.Context, k8sClient client.Cli
 		return nil, err
 	}
 	return secret, nil
+}
+
+func (m *mockSecretsManager) SetEventChannel(secretsEventChan chan<- event.TypedGenericEvent[*corev1.Secret]) {
 }
 
 func Test_buildJwtValidationAction(t *testing.T) {

--- a/pkg/gateway/routeutils/route_rule_action_test.go
+++ b/pkg/gateway/routeutils/route_rule_action_test.go
@@ -14,7 +14,6 @@ import (
 	elbv2model "sigs.k8s.io/aws-load-balancer-controller/v3/pkg/model/elbv2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -756,9 +755,6 @@ func (m *mockSecretsManager) GetSecret(ctx context.Context, k8sClient client.Cli
 		return nil, err
 	}
 	return secret, nil
-}
-
-func (m *mockSecretsManager) SetEventChannel(secretsEventChan chan<- event.TypedGenericEvent[*corev1.Secret]) {
 }
 
 func Test_buildJwtValidationAction(t *testing.T) {

--- a/pkg/ingress/model_build_actions.go
+++ b/pkg/ingress/model_build_actions.go
@@ -8,7 +8,6 @@ import (
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/model/core"
 	elbv2model "sigs.k8s.io/aws-load-balancer-controller/v3/pkg/model/elbv2"
@@ -189,8 +188,8 @@ func (t *defaultModelBuildTask) buildAuthenticateOIDCAction(ctx context.Context,
 		Namespace: namespace,
 		Name:      authCfg.IDPConfigOIDC.SecretName,
 	}
-	secret := &corev1.Secret{}
-	if err := t.k8sClient.Get(ctx, secretKey, secret); err != nil {
+	secret, err := t.secretsManager.GetSecret(ctx, t.k8sClient, secretKey)
+	if err != nil {
 		return elbv2model.Action{}, err
 	}
 	rawClientID, ok := secret.Data[shared_constants.OIDCSecretKeyClientID]

--- a/pkg/ingress/model_build_actions_test.go
+++ b/pkg/ingress/model_build_actions_test.go
@@ -15,13 +15,31 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/aws/services"
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/model/core"
 	elbv2model "sigs.k8s.io/aws-load-balancer-controller/v3/pkg/model/elbv2"
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/shared_utils"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 )
+
+type mockSecretsManager struct{}
+
+func (m *mockSecretsManager) MonitorSecrets(consumerID string, secrets []types.NamespacedName) {}
+
+func (m *mockSecretsManager) GetSecret(ctx context.Context, k8sClient client.Client, secretKey types.NamespacedName) (*corev1.Secret, error) {
+	secret := &corev1.Secret{}
+	if err := k8sClient.Get(ctx, secretKey, secret); err != nil {
+		return nil, err
+	}
+	return secret, nil
+}
+
+func (m *mockSecretsManager) SetEventChannel(secretsEventChan chan<- event.TypedGenericEvent[*corev1.Secret]) {
+}
 
 func Test_defaultModelBuildTask_buildAuthenticateOIDCAction(t *testing.T) {
 	type env struct {
@@ -300,7 +318,8 @@ func Test_defaultModelBuildTask_buildAuthenticateOIDCAction(t *testing.T) {
 			}
 
 			task := &defaultModelBuildTask{
-				k8sClient: k8sClient,
+				k8sClient:      k8sClient,
+				secretsManager: &mockSecretsManager{},
 			}
 			got, err := task.buildAuthenticateOIDCAction(context.Background(), tt.args.namespace, tt.args.authCfg)
 			if tt.wantErr != nil {

--- a/pkg/ingress/model_builder.go
+++ b/pkg/ingress/model_builder.go
@@ -61,7 +61,7 @@ func NewDefaultModelBuilder(k8sClient client.Client, eventRecorder record.EventR
 	trackingProvider tracking.Provider, elbv2TaggingManager elbv2deploy.TaggingManager, featureGates config.FeatureGates,
 	vpcID string, clusterName string, defaultTags map[string]string, externalManagedTags []string, defaultSSLPolicy string, defaultTargetType string, defaultLoadBalancerScheme string,
 	backendSGProvider networkingpkg.BackendSGProvider, sgResolver networkingpkg.SecurityGroupResolver,
-	enableBackendSG bool, defaultEnableManageBackendSGRules bool, disableRestrictedSGRules bool, allowedCAARNs []string, enableIPTargetType bool, enableACMCertificates bool, defaultCAArn string, targetGroupNameToArnMapper shared_utils.TargetGroupARNMapper, logger logr.Logger, metricsCollector lbcmetrics.MetricCollector,
+	enableBackendSG bool, defaultEnableManageBackendSGRules bool, disableRestrictedSGRules bool, allowedCAARNs []string, enableIPTargetType bool, enableACMCertificates bool, defaultCAArn string, targetGroupNameToArnMapper shared_utils.TargetGroupARNMapper, secretsManager k8s.SecretsManager, logger logr.Logger, metricsCollector lbcmetrics.MetricCollector,
 	certDiscovery certs.CertDiscovery,
 ) *defaultModelBuilder {
 	ruleOptimizer := NewDefaultRuleOptimizer(logger)
@@ -69,6 +69,7 @@ func NewDefaultModelBuilder(k8sClient client.Client, eventRecorder record.EventR
 		k8sClient:                  k8sClient,
 		eventRecorder:              eventRecorder,
 		acmClient:                  acmClient,
+		secretsManager:             secretsManager,
 		ec2Client:                  ec2Client,
 		elbv2Client:                elbv2Client,
 		vpcID:                      vpcID,
@@ -106,12 +107,13 @@ var _ ModelBuilder = &defaultModelBuilder{}
 
 // default implementation for ModelBuilder
 type defaultModelBuilder struct {
-	k8sClient     client.Client
-	eventRecorder record.EventRecorder
-	acmClient     services.ACM
-	ec2Client     services.EC2
-	elbv2Client   services.ELBV2
-	wafv2Client   services.WAFv2
+	k8sClient      client.Client
+	eventRecorder  record.EventRecorder
+	acmClient      services.ACM
+	secretsManager k8s.SecretsManager
+	ec2Client      services.EC2
+	elbv2Client    services.ELBV2
+	wafv2Client    services.WAFv2
 
 	vpcID       string
 	clusterName string
@@ -153,6 +155,7 @@ func (b *defaultModelBuilder) Build(ctx context.Context, ingGroup Group, metrics
 		k8sClient:                  b.k8sClient,
 		eventRecorder:              b.eventRecorder,
 		acmClient:                  b.acmClient,
+		secretsManager:             b.secretsManager,
 		ec2Client:                  b.ec2Client,
 		elbv2Client:                b.elbv2Client,
 		wafv2Client:                b.wafv2Client,
@@ -230,6 +233,7 @@ type defaultModelBuildTask struct {
 	k8sClient              client.Client
 	eventRecorder          record.EventRecorder
 	acmClient              services.ACM
+	secretsManager         k8s.SecretsManager
 	ec2Client              services.EC2
 	elbv2Client            services.ELBV2
 	wafv2Client            services.WAFv2

--- a/pkg/k8s/secrets_manager.go
+++ b/pkg/k8s/secrets_manager.go
@@ -30,24 +30,28 @@ type SecretsManager interface {
 	GetSecret(ctx context.Context, k8sClient client.Client, secretKey types.NamespacedName) (*corev1.Secret, error)
 }
 
-func NewSecretsManager(clientSet kubernetes.Interface, secretsEventChan chan<- event.TypedGenericEvent[*corev1.Secret], logger logr.Logger) *defaultSecretsManager {
+func NewSecretsManager(clientSet kubernetes.Interface, secretsEventChan chan<- event.TypedGenericEvent[*corev1.Secret], logger logr.Logger, requiredLabelKey string, requiredLabelValue string) *defaultSecretsManager {
 	return &defaultSecretsManager{
-		mutex:            sync.Mutex{},
-		secretMap:        make(map[types.NamespacedName]*secretItem),
-		secretsEventChan: secretsEventChan,
-		clientSet:        clientSet,
-		logger:           logger,
+		mutex:              sync.Mutex{},
+		secretMap:          make(map[types.NamespacedName]*secretItem),
+		secretsEventChan:   secretsEventChan,
+		clientSet:          clientSet,
+		logger:             logger,
+		requiredLabelKey:   requiredLabelKey,
+		requiredLabelValue: requiredLabelValue,
 	}
 }
 
 var _ SecretsManager = &defaultSecretsManager{}
 
 type defaultSecretsManager struct {
-	mutex            sync.Mutex
-	secretMap        map[types.NamespacedName]*secretItem
-	secretsEventChan chan<- event.TypedGenericEvent[*corev1.Secret]
-	clientSet        kubernetes.Interface
-	logger           logr.Logger
+	mutex              sync.Mutex
+	secretMap          map[types.NamespacedName]*secretItem
+	secretsEventChan   chan<- event.TypedGenericEvent[*corev1.Secret]
+	clientSet          kubernetes.Interface
+	logger             logr.Logger
+	requiredLabelKey   string
+	requiredLabelValue string
 }
 
 type secretItem struct {
@@ -108,7 +112,11 @@ func (m *defaultSecretsManager) GetSecret(ctx context.Context, k8sClient client.
 		if exists {
 			if secret, ok := obj.(*corev1.Secret); ok {
 				m.logger.V(1).Info("Secret retrieved from cache", "secret", secretKey)
-				return secret.DeepCopy(), nil // Return copy to prevent mutations
+				secretCopy := secret.DeepCopy()
+				if err := m.validateSecretLabel(secretCopy); err != nil {
+					return nil, err
+				}
+				return secretCopy, nil
 			}
 		}
 		// Cache miss - secret might be deleted, fall through to API call
@@ -120,18 +128,39 @@ func (m *defaultSecretsManager) GetSecret(ctx context.Context, k8sClient client.
 	if err := k8sClient.Get(ctx, secretKey, secret); err != nil {
 		return nil, err
 	}
+	if err := m.validateSecretLabel(secret); err != nil {
+		return nil, err
+	}
 
 	return secret, nil
 }
 
+func (m *defaultSecretsManager) validateSecretLabel(secret *corev1.Secret) error {
+	if m.requiredLabelKey == "" {
+		return nil
+	}
+	val, ok := secret.Labels[m.requiredLabelKey]
+	if !ok || val != m.requiredLabelValue {
+		return fmt.Errorf("secret %s/%s is missing required label %s=%s; actual labels: %v",
+			secret.Namespace, secret.Name, m.requiredLabelKey, m.requiredLabelValue, secret.Labels)
+	}
+	return nil
+}
+
 func (m *defaultSecretsManager) newReflector(namespace, name string) *secretItem {
 	fieldSelector := fields.Set{"metadata.name": name}.AsSelector().String()
+	labelSelector := ""
+	if m.requiredLabelKey != "" {
+		labelSelector = fmt.Sprintf("%s=%s", m.requiredLabelKey, m.requiredLabelValue)
+	}
 	listFunc := func(options metav1.ListOptions) (runtime.Object, error) {
 		options.FieldSelector = fieldSelector
+		options.LabelSelector = labelSelector
 		return m.clientSet.CoreV1().Secrets(namespace).List(context.TODO(), options)
 	}
 	watchFunc := func(options metav1.ListOptions) (watch.Interface, error) {
 		options.FieldSelector = fieldSelector
+		options.LabelSelector = labelSelector
 		return m.clientSet.CoreV1().Secrets(namespace).Watch(context.TODO(), options)
 	}
 	store := m.newStore()

--- a/pkg/k8s/secrets_manager.go
+++ b/pkg/k8s/secrets_manager.go
@@ -28,6 +28,9 @@ type SecretsManager interface {
 
 	// GetSecret retrieves from cache (if monitoring) or falls back to API
 	GetSecret(ctx context.Context, k8sClient client.Client, secretKey types.NamespacedName) (*corev1.Secret, error)
+
+	// SetEventChannel sets the event channel for secret updates
+	SetEventChannel(secretsEventChan chan<- event.TypedGenericEvent[*corev1.Secret])
 }
 
 func NewSecretsManager(clientSet kubernetes.Interface, secretsEventChan chan<- event.TypedGenericEvent[*corev1.Secret], logger logr.Logger, requiredLabelKey string, requiredLabelValue string) *defaultSecretsManager {
@@ -40,6 +43,12 @@ func NewSecretsManager(clientSet kubernetes.Interface, secretsEventChan chan<- e
 		requiredLabelKey:   requiredLabelKey,
 		requiredLabelValue: requiredLabelValue,
 	}
+}
+
+func (m *defaultSecretsManager) SetEventChannel(secretsEventChan chan<- event.TypedGenericEvent[*corev1.Secret]) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.secretsEventChan = secretsEventChan
 }
 
 var _ SecretsManager = &defaultSecretsManager{}

--- a/pkg/k8s/secrets_manager.go
+++ b/pkg/k8s/secrets_manager.go
@@ -121,11 +121,7 @@ func (m *defaultSecretsManager) GetSecret(ctx context.Context, k8sClient client.
 		if exists {
 			if secret, ok := obj.(*corev1.Secret); ok {
 				m.logger.V(1).Info("Secret retrieved from cache", "secret", secretKey)
-				secretCopy := secret.DeepCopy()
-				if err := m.validateSecretLabel(secretCopy); err != nil {
-					return nil, err
-				}
-				return secretCopy, nil
+				return secret.DeepCopy(), nil
 			}
 		}
 		// Cache miss - secret might be deleted, fall through to API call

--- a/pkg/k8s/secrets_manager_test.go
+++ b/pkg/k8s/secrets_manager_test.go
@@ -488,6 +488,107 @@ func Test_defaultSecretsManager_GetSecret(t *testing.T) {
 	}
 }
 
+func Test_defaultSecretsManager_GetSecret_RequiredLabel(t *testing.T) {
+	secretNamespace := "test-namespace"
+	secretName := "test-secret"
+	secretKey := types.NamespacedName{
+		Namespace: secretNamespace,
+		Name:      secretName,
+	}
+
+	tests := []struct {
+		name               string
+		requiredLabelKey   string
+		requiredLabelValue string
+		secretLabels       map[string]string
+		useCache           bool
+		wantErr            bool
+		errContains        string
+	}{
+		{
+			name:               "fallback path - secret has required label",
+			requiredLabelKey:   "app.kubernetes.io/managed-by",
+			requiredLabelValue: "eks",
+			secretLabels:       map[string]string{"app.kubernetes.io/managed-by": "eks"},
+			wantErr:            false,
+		},
+		{
+			name:               "fallback path - secret missing required label",
+			requiredLabelKey:   "app.kubernetes.io/managed-by",
+			requiredLabelValue: "eks",
+			secretLabels:       map[string]string{},
+			wantErr:            true,
+			errContains:        "missing required label",
+		},
+		{
+			name:               "fallback path - secret has wrong label value",
+			requiredLabelKey:   "app.kubernetes.io/managed-by",
+			requiredLabelValue: "eks",
+			secretLabels:       map[string]string{"app.kubernetes.io/managed-by": "helm"},
+			wantErr:            true,
+			errContains:        "missing required label",
+		},
+		{
+			name:               "cache path - secret has required label",
+			requiredLabelKey:   "app.kubernetes.io/managed-by",
+			requiredLabelValue: "eks",
+			secretLabels:       map[string]string{"app.kubernetes.io/managed-by": "eks"},
+			useCache:           true,
+			wantErr:            false,
+		},
+		{
+			name:               "no label required - secret without labels accessible",
+			requiredLabelKey:   "",
+			requiredLabelValue: "",
+			secretLabels:       map[string]string{},
+			wantErr:            false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			k8sClient := testutils.GenerateTestClient()
+
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: secretNamespace,
+					Labels:    tt.secretLabels,
+				},
+				Data: map[string][]byte{"key": []byte("value")},
+			}
+			err := k8sClient.Create(ctx, secret.DeepCopy())
+			assert.NoError(t, err)
+
+			secretsEventChan := make(chan event.TypedGenericEvent[*corev1.Secret], 100)
+			fakeClientset := fake.NewSimpleClientset()
+			sm := NewSecretsManager(fakeClientset, secretsEventChan, logr.New(&log.NullLogSink{}), tt.requiredLabelKey, tt.requiredLabelValue)
+
+			if tt.useCache {
+				sm.MonitorSecrets("test-consumer", []types.NamespacedName{secretKey})
+				if item, exists := sm.secretMap[secretKey]; exists {
+					err := item.store.Add(secret.DeepCopy())
+					assert.NoError(t, err)
+				}
+			}
+
+			got, err := sm.GetSecret(ctx, k8sClient, secretKey)
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				assert.Nil(t, got)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, got)
+				assert.Equal(t, secretName, got.Name)
+			}
+		})
+	}
+}
+
 func Test_defaultSecretsManager_GetSecret_CacheInvalidation(t *testing.T) {
 	secretNamespace := "test-namespace"
 	secretName := "test-secret"

--- a/pkg/k8s/secrets_manager_test.go
+++ b/pkg/k8s/secrets_manager_test.go
@@ -297,7 +297,7 @@ func Test_defaultSecretsManager_MonitorSecrets(t *testing.T) {
 		t.Run(tt.testName, func(t *testing.T) {
 			secretsEventChan := make(chan event.TypedGenericEvent[*corev1.Secret], 100)
 			fakeClient := fake.NewSimpleClientset()
-			secretsManager := NewSecretsManager(fakeClient, secretsEventChan, logr.New(&log.NullLogSink{}))
+			secretsManager := NewSecretsManager(fakeClient, secretsEventChan, logr.New(&log.NullLogSink{}), "", "")
 
 			for _, call := range tt.monitorSecretsCall {
 				secretsManager.MonitorSecrets(call.consumerID, call.secrets)
@@ -433,7 +433,7 @@ func Test_defaultSecretsManager_GetSecret(t *testing.T) {
 			// Create SecretsManager
 			secretsEventChan := make(chan event.TypedGenericEvent[*corev1.Secret], 100)
 			fakeClientset := fake.NewSimpleClientset()
-			secretsManager := NewSecretsManager(fakeClientset, secretsEventChan, logr.New(&log.NullLogSink{}))
+			secretsManager := NewSecretsManager(fakeClientset, secretsEventChan, logr.New(&log.NullLogSink{}), "", "")
 
 			// Monitor secrets if specified
 			if len(tt.monitorSecrets) > 0 {
@@ -637,7 +637,7 @@ func Test_defaultSecretsManager_GetSecret_CacheInvalidation(t *testing.T) {
 			k8sClient := testutils.GenerateTestClient()
 			secretsEventChan := make(chan event.TypedGenericEvent[*corev1.Secret], 100)
 			fakeClientset := fake.NewSimpleClientset()
-			secretsManager := NewSecretsManager(fakeClientset, secretsEventChan, logr.New(&log.NullLogSink{}))
+			secretsManager := NewSecretsManager(fakeClientset, secretsEventChan, logr.New(&log.NullLogSink{}), "", "")
 
 			// Run test phases
 			tt.setupPhase(t, secretsManager, k8sClient)


### PR DESCRIPTION
Add label for accessing secrets

### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

Adding `--required-secrets-label ` flag to access secrets 

### Description

<!--
Please explain the changes you made here.

Help your reviewers by guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->
This feature is added to so that it can be used by EKS Auto controller to restrict access to resources with certain labels to address security concerns with support the customer ask https://github.com/aws/containers-roadmap/issues/2542#issuecomment-2657623966

Testing details 

- ran make test successfully 
- ran make deploy against dev cluster successfully 
- manual testing against my local cluster `arn:aws:eks:us-west-2:711387134148:cluster/plugins-test` - to verify that access secrets still works when labels are not set 

**Case 1: Verifying that label restriction on secrets is optional — provisioned a new ALB associated with a secret that has no label, with 
  `--required-secrets-label` flag NOT set**

  1. Set my local cluster in current context `arn:aws:eks:us-west-2:711387134148:cluster/lb-test103`

  2. Built ELB image locally

  ```
  docker build -t aws-load-balancer-controller:local \
  --target bin \
  --build-arg BUILD_IMAGE=public.ecr.aws/docker/library/golang:1.26 \
  --build-arg BASE_IMAGE=public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot:2026-04-02-1775113300.2023 \
  .
  ```

  711387134148.dkr.ecr.us-west-2.amazonaws.com/aws-load-balancer-controller:local

  3. Set my cluster in current context and patched it

  ```
  helm upgrade -i aws-load-balancer-controller ./helm/aws-load-balancer-controller \
    -n kube-system \
    --set image.repository=711387134148.dkr.ecr.us-west-2.amazonaws.com/aws-load-balancer-controller \
    --set image.tag=local \
    --set clusterName=lb-test103 \
    --set region=us-west-2 \
    --set vpcId=vpc-0b737d50a20d7acfd \
    --set serviceAccount.create=false \
    --set serviceAccount.name=aws-load-balancer-controller
  ```

  Verified that my image was updated:
  ```
  kubectl get deployment -n kube-system aws-load-balancer-controller -o jsonpath='{.spec.template.spec.containers[0].image}'

  711387134148.dkr.ecr.us-west-2.amazonaws.com/aws-load-balancer-controller:local
  ```

  4. Added necessary permissions for the controller and applied ingress with config when HTTPS + OIDC is configured, the controller attempts to
  read the Kubernetes secret to extract clientId and clientSecret

  5. ALB created successfully

  ```
  kubectl logs -n kube-system -l app.kubernetes.io/name=aws-load-balancer-controller --tail=20 --since=60s | grep -E
  "(error|successfully|created)"

  {"level":"info","ts":"2026-07-14T21:17:17Z","logger":"controllers.ingress","msg":"successfully built
  model","model":"{\"id\":\"oidc-test/oidc-https-ingress\",...\"clientID\":\"[REDACTED]\",\"clientSecret\":\"[REDACTED]\"...}"}
  {"level":"info","ts":"2026-07-14T21:18:19Z","logger":"controllers.ingress","msg":"created 
  listener","stackID":"oidc-test/oidc-https-ingress","resourceID":"443","arn":"arn:aws:elasticloadbalancing:us-west-2:711387134148:listener/app/k
  8s-oidctest-oidchttp-7a72e53c1c/eb3296a9490cc29e/1d22250192b60b09"}
  {"level":"info","ts":"2026-07-14T21:18:19Z","logger":"controllers.ingress","msg":"created listener 
  rule","stackID":"oidc-test/oidc-https-ingress","resourceID":"443:1","arn":"arn:aws:elasticloadbalancing:us-west-2:711387134148:listener-rule/ap
  p/k8s-oidctest-oidchttp-7a72e53c1c/eb3296a9490cc29e/1d22250192b60b09/b491f5d502065e55"}
  {"level":"info","ts":"2026-07-14T21:18:19Z","logger":"controllers.ingress","msg":"created 
  targetGroupBinding","stackID":"oidc-test/oidc-https-ingress","resourceID":"oidc-test/oidc-https-ingress-test-app:80","targetGroupBinding":{"nam
  e":"k8s-oidctest-testapp-e7bcc7fe29","namespace":"oidc-test"}}
  ```

  **Case 2: Backward compatibility — upgrade to the new image without setting `--required-secrets-label`, verify an ALB with an unlabeled secret 
  continues to reconcile successfully**

  1. Deployed the new image (built with this PR's changes) **without** the `--required-secrets-label` flag

  2. Verified the secret has no label:
  ```
  kubectl get secret oidc-secret -n oidc-test --show-labels

  NAME          TYPE     DATA   AGE     LABELS
  oidc-secret   Opaque   2      4m55s   <none>
  ```

  3. Verified the controller args do NOT include the flag:
  ```
  kubectl get deployment aws-load-balancer-controller -n kube-system -o jsonpath='{.spec.template.spec.containers[0].args}'

  ["--cluster-name=lb-test103","--ingress-class=alb","--aws-region=us-west-2","--aws-vpc-id=vpc-0b737d50a20d7acfd"]
  ```

  4. Ingress reconciled successfully — unlabeled secrets still work when the flag is not set:
  ```
  kubectl describe ingress oidc-https-ingress -n oidc-test | grep -E "(Normal|Warning)"

    Normal   SuccessfullyReconciled  78s (x2 over 3m9s)  ingress  Successfully reconciled
  ```

  **Case 3: Verifying that secrets can be restricted with labels — provisioned ALB successfully by restricting access with label 
  `allow-read-access=eks-lbc`**

  1. Labeled the secret:
  ```
  kubectl label secret oidc-secret -n oidc-test allow-read-access=eks-lbc

  kubectl get secret oidc-secret -n oidc-test --show-labels

  NAME          TYPE     DATA   AGE     LABELS
  oidc-secret   Opaque   2      6m38s   allow-read-access=eks-lbc
  ```

  2. Added the `--required-secrets-label` flag to the controller:
  ```
  kubectl patch deployment aws-load-balancer-controller -n kube-system --type='json' \
    -p='[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--required-secrets-label=allow-read-access=eks-lbc"}]'
  ```

  3. Verified the controller args now include the flag:
  ```
  kubectl get deployment aws-load-balancer-controller -n kube-system -o jsonpath='{.spec.template.spec.containers[0].args}'

  ["--cluster-name=lb-test103","--ingress-class=alb","--aws-region=us-west-2","--aws-vpc-id=vpc-0b737d50a20d7acfd","--required-secrets-label=allo
  w-read-access=eks-lbc"]
  ```

  4. Ingress reconciled successfully:
  ```
  kubectl logs -n kube-system -l app.kubernetes.io/name=aws-load-balancer-controller --tail=20 --since=60s | grep -E
  "(error|successfully|created|modified|deployed)"

  {"level":"info","ts":"2026-07-14T21:22:50Z","logger":"controllers.ingress","msg":"successfully built
  model","model":"{\"id\":\"oidc-test/oidc-https-ingress\",...\"clientID\":\"[REDACTED]\",\"clientSecret\":\"[REDACTED]\"...}"}
  {"level":"info","ts":"2026-07-14T21:22:50Z","logger":"controllers.ingress","msg":"modifying listener 
  rule","stackID":"oidc-test/oidc-https-ingress","resourceID":"443:1","arn":"arn:aws:elasticloadbalancing:us-west-2:711387134148:listener-rule/ap
  p/k8s-oidctest-oidchttp-7a72e53c1c/eb3296a9490cc29e/1d22250192b60b09/b491f5d502065e55"}
  {"level":"info","ts":"2026-07-14T21:22:51Z","logger":"controllers.ingress","msg":"modified listener 
  rule","stackID":"oidc-test/oidc-https-ingress","resourceID":"443:1","arn":"arn:aws:elasticloadbalancing:us-west-2:711387134148:listener-rule/ap
  p/k8s-oidctest-oidchttp-7a72e53c1c/eb3296a9490cc29e/1d22250192b60b09/b491f5d502065e55"}
  {"level":"info","ts":"2026-07-14T21:22:51Z","logger":"controllers.ingress","msg":"successfully deployed
  model","ingressGroup":"oidc-test/oidc-https-ingress"}
  ```



### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:


