### PR TITLE
ci: Add GO-2026-5932 to govulncheck ignore list

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -60,7 +60,13 @@ jobs:
           #   GO-2026-5338 https://github.com/containerd/containerd/security/advisories/GHSA-cvxm-645q-p574
           #   GO-2026-5064 https://github.com/containerd/containerd/security/advisories/GHSA-33vj-92qq-66hc
           #   GO-2026-5622 https://github.com/containerd/containerd/security/advisories/GHSA-rgh6-rfwx-v388
-          IGNORE="GO-2026-5338 GO-2026-5064 GO-2026-5622"
+          #
+          # GO-2026-5932: golang.org/x/crypto/openpgp is deprecated with no fixed version.
+          # Pulled transitively via helm.sh/helm/v3 (pkg/provenance). Helm v4 migrated to
+          # github.com/ProtonMail/go-crypto but no v3 release includes it. Remove once we
+          # upgrade to Helm v4.
+          #   GO-2026-5932 https://pkg.go.dev/vuln/GO-2026-5932
+          IGNORE="GO-2026-5338 GO-2026-5064 GO-2026-5622 GO-2026-5932"
           govulncheck -format json ./... > govulncheck.json
           # "called" vulns are findings whose leading trace frame resolves to a function.
           called="$(jq -r 'select(.finding != null) | .finding | select(.trace[0].function != null) | .osv' govulncheck.json | sort -u)"


### PR DESCRIPTION
## Issue

The `govulncheck` CI job fails on all PRs due to GO-2026-5932, a vulnerability advisory for the permanently deprecated `golang.org/x/crypto/openpgp` package.

## Root Cause

`golang.org/x/crypto/openpgp` is pulled transitively via `helm.sh/helm/v3` (`pkg/provenance` - chart signing). The advisory has **no fixed version** because the package is frozen forever. The recommended migration is to `github.com/ProtonMail/go-crypto/openpgp`, which Helm v4 has adopted but no released Helm v3 version includes.

This is a **test-only** transitive dependency (used in `test/framework/helm/`) and is not linked into the controller binary.

## Fix

Add `GO-2026-5932` to the govulncheck ignore list in `.github/workflows/deps.yml`, following the same pattern as the existing containerd suppressions.

## Testing

Ran govulncheck locally and verified:
- **Without fix**: `FAIL: govulncheck found vulnerabilities not in the ignore list: GO-2026-5932`
- **With fix**: `PASS: govulncheck OK. Ignored (no fix available) called vulns: GO-2026-5064 GO-2026-5338 GO-2026-5622 GO-2026-5932`

## Follow-up

A future PR should upgrade to Helm v4 (which uses `github.com/ProtonMail/go-crypto`), at which point this ignore entry can be removed. That upgrade also requires bumping k8s dependencies from v0.35 to v0.36.