### PR TITLE
Added frontend-nlb-status-only annotation to fix ExternalDNS record creation when using a frontend NLB

### DIFF
--- a/controllers/ingress/group_controller.go
+++ b/controllers/ingress/group_controller.go
@@ -314,8 +314,9 @@ func (r *groupReconciler) updateIngressStatus(ctx context.Context, lbDNS string,
 
 	ingOld := ing.DeepCopy()
 	if frontendNlbStatusOnly && frontendNlbDNS != "" {
-		// Only write the NLB hostname so that tools like ExternalDNS create DNS
-		// records pointing at the NLB rather than both the ALB and the NLB.
+		// Only write the NLB hostname to status. When using ExternalDNS on AWS,
+		// only the first status entry gets a DNS record, which would be the ALB,
+		// not the NLB that clients should actually reach.
 		if len(ing.Status.LoadBalancer.Ingress) != 1 ||
 			ing.Status.LoadBalancer.Ingress[0].Hostname != frontendNlbDNS {
 			ing.Status.LoadBalancer.Ingress = []networking.IngressLoadBalancerIngress{

--- a/controllers/ingress/group_controller.go
+++ b/controllers/ingress/group_controller.go
@@ -90,7 +90,9 @@ func NewGroupReconciler(cloud services.Cloud, k8sClient client.Client, eventReco
 		stackMarshaller:   stackMarshaller,
 		stackDeployer:     stackDeployer,
 		backendSGProvider: backendSGProvider,
+
 		secretsManager:    secretsManager,
+		annotationParser:  annotationParser,
 
 		groupLoader:           groupLoader,
 		groupFinalizerManager: groupFinalizerManager,
@@ -114,6 +116,7 @@ type groupReconciler struct {
 	stackDeployer     deploy.StackDeployer
 	backendSGProvider networkingpkg.BackendSGProvider
 	secretsManager    k8s.SecretsManager
+	annotationParser  annotations.Parser
 
 	groupLoader           ingress.GroupLoader
 	groupFinalizerManager ingress.FinalizerManager
@@ -306,25 +309,39 @@ func (r *groupReconciler) updateIngressStatus(ctx context.Context, lbDNS string,
 		}
 	}
 
-	ingOld := ing.DeepCopy()
-	if len(ing.Status.LoadBalancer.Ingress) != 1 ||
-		ing.Status.LoadBalancer.Ingress[0].IP != "" ||
-		ing.Status.LoadBalancer.Ingress[0].Hostname != lbDNS {
-		ing.Status.LoadBalancer.Ingress = []networking.IngressLoadBalancerIngress{
-			{
-				Hostname: lbDNS,
-				Ports:    ingressPorts,
-			},
-		}
-	} else if len(ports) > 0 {
-		ing.Status.LoadBalancer.Ingress[0].Ports = ingressPorts
-	}
+	frontendNlbStatusOnly := false
+	r.annotationParser.ParseBoolAnnotation(annotations.IngressSuffixFrontendNlbStatusOnly, &frontendNlbStatusOnly, ing.Annotations)
 
-	// Ensure frontendNLBDNS is appended if it is not already added
-	if frontendNlbDNS != "" && !hasFrontendNlbHostName(ing.Status.LoadBalancer.Ingress, frontendNlbDNS) {
-		ing.Status.LoadBalancer.Ingress = append(ing.Status.LoadBalancer.Ingress, networking.IngressLoadBalancerIngress{
-			Hostname: frontendNlbDNS,
-		})
+	ingOld := ing.DeepCopy()
+	if frontendNlbStatusOnly && frontendNlbDNS != "" {
+		// Only write the NLB hostname so that tools like ExternalDNS create DNS
+		// records pointing at the NLB rather than both the ALB and the NLB.
+		if len(ing.Status.LoadBalancer.Ingress) != 1 ||
+			ing.Status.LoadBalancer.Ingress[0].Hostname != frontendNlbDNS {
+			ing.Status.LoadBalancer.Ingress = []networking.IngressLoadBalancerIngress{
+				{Hostname: frontendNlbDNS},
+			}
+		}
+	} else {
+		if len(ing.Status.LoadBalancer.Ingress) != 1 ||
+			ing.Status.LoadBalancer.Ingress[0].IP != "" ||
+			ing.Status.LoadBalancer.Ingress[0].Hostname != lbDNS {
+			ing.Status.LoadBalancer.Ingress = []networking.IngressLoadBalancerIngress{
+				{
+					Hostname: lbDNS,
+					Ports:    ingressPorts,
+				},
+			}
+		} else if len(ports) > 0 {
+			ing.Status.LoadBalancer.Ingress[0].Ports = ingressPorts
+		}
+
+		// Ensure frontendNLBDNS is appended if it is not already added
+		if frontendNlbDNS != "" && !hasFrontendNlbHostName(ing.Status.LoadBalancer.Ingress, frontendNlbDNS) {
+			ing.Status.LoadBalancer.Ingress = append(ing.Status.LoadBalancer.Ingress, networking.IngressLoadBalancerIngress{
+				Hostname: frontendNlbDNS,
+			})
+		}
 	}
 
 	if !isIngressStatusEqual(ingOld.Status.LoadBalancer.Ingress, ing.Status.LoadBalancer.Ingress) {

--- a/controllers/ingress/group_controller.go
+++ b/controllers/ingress/group_controller.go
@@ -91,8 +91,8 @@ func NewGroupReconciler(cloud services.Cloud, k8sClient client.Client, eventReco
 		stackDeployer:     stackDeployer,
 		backendSGProvider: backendSGProvider,
 
-		secretsManager:    secretsManager,
-		annotationParser:  annotationParser,
+		secretsManager:   secretsManager,
+		annotationParser: annotationParser,
 
 		groupLoader:           groupLoader,
 		groupFinalizerManager: groupFinalizerManager,
@@ -313,19 +313,18 @@ func (r *groupReconciler) updateIngressStatus(ctx context.Context, lbDNS string,
 	r.annotationParser.ParseBoolAnnotation(annotations.IngressSuffixFrontendNlbStatusOnly, &frontendNlbStatusOnly, ing.Annotations)
 
 	ingOld := ing.DeepCopy()
-	if frontendNlbStatusOnly {
-		if frontendNlbDNS != "" {
-			if len(ing.Status.LoadBalancer.Ingress) != 1 ||
-				ing.Status.LoadBalancer.Ingress[0].Hostname != frontendNlbDNS {
-				ing.Status.LoadBalancer.Ingress = []networking.IngressLoadBalancerIngress{
-					{Hostname: frontendNlbDNS},
-				}
+	if frontendNlbStatusOnly && frontendNlbDNS != "" {
+		// Only write the NLB hostname to status. When using ExternalDNS on AWS,
+		// only the first status entry gets a DNS record. Writing only the NLB hostname
+		// ensures ExternalDNS creates a record pointing at the NLB, not the ALB.
+		if len(ing.Status.LoadBalancer.Ingress) != 1 ||
+			ing.Status.LoadBalancer.Ingress[0].Hostname != frontendNlbDNS {
+			ing.Status.LoadBalancer.Ingress = []networking.IngressLoadBalancerIngress{
+				{Hostname: frontendNlbDNS},
 			}
-		} else {
-			// NLB not yet provisioned or failed to provision. Status is empty to avoid
-			// a transient DNS record pointing at the ALB that will be replaced later anyways.
 		}
-	} else {
+		// In case frontendNlbStatusOnly && frontendNlbDNS == "" nothing gets applied until the NLB is provisioned
+	} else if !frontendNlbStatusOnly {
 		if len(ing.Status.LoadBalancer.Ingress) != 1 ||
 			ing.Status.LoadBalancer.Ingress[0].IP != "" ||
 			ing.Status.LoadBalancer.Ingress[0].Hostname != lbDNS {

--- a/controllers/ingress/group_controller.go
+++ b/controllers/ingress/group_controller.go
@@ -313,15 +313,17 @@ func (r *groupReconciler) updateIngressStatus(ctx context.Context, lbDNS string,
 	r.annotationParser.ParseBoolAnnotation(annotations.IngressSuffixFrontendNlbStatusOnly, &frontendNlbStatusOnly, ing.Annotations)
 
 	ingOld := ing.DeepCopy()
-	if frontendNlbStatusOnly && frontendNlbDNS != "" {
-		// Only write the NLB hostname to status. When using ExternalDNS on AWS,
-		// only the first status entry gets a DNS record, which would be the ALB,
-		// not the NLB that clients should actually reach.
-		if len(ing.Status.LoadBalancer.Ingress) != 1 ||
-			ing.Status.LoadBalancer.Ingress[0].Hostname != frontendNlbDNS {
-			ing.Status.LoadBalancer.Ingress = []networking.IngressLoadBalancerIngress{
-				{Hostname: frontendNlbDNS},
+	if frontendNlbStatusOnly {
+		if frontendNlbDNS != "" {
+			if len(ing.Status.LoadBalancer.Ingress) != 1 ||
+				ing.Status.LoadBalancer.Ingress[0].Hostname != frontendNlbDNS {
+				ing.Status.LoadBalancer.Ingress = []networking.IngressLoadBalancerIngress{
+					{Hostname: frontendNlbDNS},
+				}
 			}
+		} else {
+			// NLB not yet provisioned or failed to provision. Status is empty to avoid
+			// a transient DNS record pointing at the ALB that will be replaced later anyways.
 		}
 	} else {
 		if len(ing.Status.LoadBalancer.Ingress) != 1 ||

--- a/controllers/ingress/group_controller_test.go
+++ b/controllers/ingress/group_controller_test.go
@@ -1,9 +1,18 @@
 package ingress
 
 import (
-	"github.com/stretchr/testify/assert"
-	networking "k8s.io/api/networking/v1"
+	"context"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	networking "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestIsIngressStatusEqual(t *testing.T) {
@@ -285,6 +294,97 @@ func TestIsIngressStatusEqual(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result := isIngressStatusEqual(tc.statusA, tc.statusB)
 			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func Test_updateIngressStatus(t *testing.T) {
+	albDNS := "alb.example.com"
+	nlbDNS := "nlb.example.com"
+
+	tests := []struct {
+		name           string
+		annotations    map[string]string
+		lbDNS          string
+		frontendNlbDNS string
+		wantHostnames  []string
+	}{
+		{
+			name:           "no frontend NLB: only ALB in status",
+			lbDNS:          albDNS,
+			frontendNlbDNS: "",
+			wantHostnames:  []string{albDNS},
+		},
+		{
+			name:           "frontend NLB without annotation: ALB first then NLB",
+			lbDNS:          albDNS,
+			frontendNlbDNS: nlbDNS,
+			wantHostnames:  []string{albDNS, nlbDNS},
+		},
+		{
+			name: "frontend-nlb-status-only=true: only NLB in status",
+			annotations: map[string]string{
+				"alb.ingress.kubernetes.io/frontend-nlb-status-only": "true",
+			},
+			lbDNS:          albDNS,
+			frontendNlbDNS: nlbDNS,
+			wantHostnames:  []string{nlbDNS},
+		},
+		{
+			name: "frontend-nlb-status-only=true but no NLB DNS: falls back to ALB",
+			annotations: map[string]string{
+				"alb.ingress.kubernetes.io/frontend-nlb-status-only": "true",
+			},
+			lbDNS:          albDNS,
+			frontendNlbDNS: "",
+			wantHostnames:  []string{albDNS},
+		},
+		{
+			name: "frontend-nlb-status-only=false: ALB first then NLB",
+			annotations: map[string]string{
+				"alb.ingress.kubernetes.io/frontend-nlb-status-only": "false",
+			},
+			lbDNS:          albDNS,
+			frontendNlbDNS: nlbDNS,
+			wantHostnames:  []string{albDNS, nlbDNS},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ing := &networking.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-ingress",
+					Namespace:   "default",
+					Annotations: tt.annotations,
+				},
+			}
+
+			scheme := runtime.NewScheme()
+			require.NoError(t, clientgoscheme.AddToScheme(scheme))
+
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithStatusSubresource(ing).
+				WithObjects(ing).
+				Build()
+
+			r := &groupReconciler{
+				k8sClient:        k8sClient,
+				annotationParser: annotations.NewSuffixAnnotationParser(annotations.AnnotationPrefixIngress),
+			}
+
+			err := r.updateIngressStatus(context.Background(), tt.lbDNS, tt.frontendNlbDNS, ing, nil)
+			require.NoError(t, err)
+
+			updated := &networking.Ingress{}
+			require.NoError(t, k8sClient.Get(context.Background(), types.NamespacedName{Name: "test-ingress", Namespace: "default"}, updated))
+
+			var gotHostnames []string
+			for _, entry := range updated.Status.LoadBalancer.Ingress {
+				gotHostnames = append(gotHostnames, entry.Hostname)
+			}
+			assert.Equal(t, tt.wantHostnames, gotHostnames)
 		})
 	}
 }

--- a/controllers/ingress/group_controller_test.go
+++ b/controllers/ingress/group_controller_test.go
@@ -331,13 +331,13 @@ func Test_updateIngressStatus(t *testing.T) {
 			wantHostnames:  []string{nlbDNS},
 		},
 		{
-			name: "frontend-nlb-status-only=true but no NLB DNS: falls back to ALB",
+			name: "frontend-nlb-status-only=true but no NLB DNS: status left empty to avoid transient ALB record",
 			annotations: map[string]string{
 				"alb.ingress.kubernetes.io/frontend-nlb-status-only": "true",
 			},
 			lbDNS:          albDNS,
 			frontendNlbDNS: "",
-			wantHostnames:  []string{albDNS},
+			wantHostnames:  nil,
 		},
 		{
 			name: "frontend-nlb-status-only=false: ALB first then NLB",

--- a/controllers/ingress/group_controller_test.go
+++ b/controllers/ingress/group_controller_test.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
+	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/annotations"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 

--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -89,6 +89,7 @@ You can add annotations to kubernetes Ingress and Service objects to customize t
 | [alb.ingress.kubernetes.io/frontend-nlb-eip-allocations](#frontend-nlb-eip-allocations) | stringList                                     |200| Ingress | N/A           |
 | [alb.ingress.kubernetes.io/target-control-port.${serviceName}.${servicePort}](#target-control-port)                                       | integer                                    |N/A| Ingress | N/A           |
 | [alb.ingress.kubernetes.io/frontend-nlb-attributes](#frontend-nlb-attributes) | stringList                                     |N/A| Ingress | N/A           |
+| [alb.ingress.kubernetes.io/frontend-nlb-status-only](#frontend-nlb-status-only) | boolean                                    |false| Ingress | N/A           |
 
 ## IngressGroup
 IngressGroup feature enables you to group multiple Ingress resources together.
@@ -1449,4 +1450,37 @@ When this option is set to true, the controller will automatically provision a N
         - enable client availability zone affinity
         ```
         alb.ingress.kubernetes.io/frontend-nlb-attributes: dns_record.client_routing_policy=availability_zone_affinity
+        ```
+
+- <a name="frontend-nlb-status-only">`alb.ingress.kubernetes.io/frontend-nlb-status-only`</a> controls whether only the frontend NLB hostname is written to `status.loadBalancer.ingress` instead of both the ALB and NLB hostnames.
+
+    By default, when a frontend NLB is enabled, both the ALB and NLB hostnames appear in the ingress status. Tools like [ExternalDNS](https://github.com/kubernetes-sigs/external-dns) create DNS records for every hostname in the status, which means traffic would be split between the ALB and the NLB. Setting this annotation to `"true"` restricts the status to only the NLB hostname, so ExternalDNS and similar tools create records pointing exclusively at the NLB.
+
+    !!!note
+        This annotation has no effect if `alb.ingress.kubernetes.io/enable-frontend-nlb` is not set, or if the NLB has not yet been provisioned. In those cases the ALB hostname is written to status as normal.
+
+    === "NLB only"
+        ```yaml
+        alb.ingress.kubernetes.io/enable-frontend-nlb: "true"
+        alb.ingress.kubernetes.io/frontend-nlb-status-only: "true"
+        ```
+        Resulting ingress status:
+        ```yaml
+        status:
+          loadBalancer:
+            ingress:
+              - hostname: nlb-xxxx.elb.amazonaws.com
+        ```
+
+    === "Both hostnames (default)"
+        ```yaml
+        alb.ingress.kubernetes.io/enable-frontend-nlb: "true"
+        ```
+        Resulting ingress status:
+        ```yaml
+        status:
+          loadBalancer:
+            ingress:
+              - hostname: alb-xxxx.elb.amazonaws.com
+              - hostname: nlb-xxxx.elb.amazonaws.com
         ```

--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -1454,7 +1454,7 @@ When this option is set to true, the controller will automatically provision a N
 
 - <a name="frontend-nlb-status-only">`alb.ingress.kubernetes.io/frontend-nlb-status-only`</a> controls whether only the frontend NLB hostname is written to `status.loadBalancer.ingress` instead of both the ALB and NLB hostnames.
 
-    By default, when a frontend NLB is enabled, both the ALB and NLB hostnames appear in the ingress status. Tools like [ExternalDNS](https://github.com/kubernetes-sigs/external-dns) create DNS records for every hostname in the status, which means traffic would be split between the ALB and the NLB. Setting this annotation to `"true"` restricts the status to only the NLB hostname, so ExternalDNS and similar tools create records pointing exclusively at the NLB.
+    By default, when a frontend NLB is enabled, both the ALB and NLB hostnames appear in the ingress status. When using [ExternalDNS](https://github.com/kubernetes-sigs/external-dns) on AWS, only a DNS record for the first entry is created (see [external-dns#5661](https://github.com/kubernetes-sigs/external-dns/issues/5661)), which means the NLB does not get a DNS record. Setting this annotation to `"true"` restricts the status to only the NLB hostname, so ExternalDNS creates a DNS record pointing at the NLB.
 
     !!!note
         This annotation has no effect if `alb.ingress.kubernetes.io/enable-frontend-nlb` is not set, or if the NLB has not yet been provisioned. In those cases the ALB hostname is written to status as normal.

--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -1457,7 +1457,7 @@ When this option is set to true, the controller will automatically provision a N
     By default, when a frontend NLB is enabled, both the ALB and NLB hostnames appear in the ingress status. When using [ExternalDNS](https://github.com/kubernetes-sigs/external-dns) on AWS, only a DNS record for the first entry is created (see [external-dns#5661](https://github.com/kubernetes-sigs/external-dns/issues/5661)), which means the NLB does not get a DNS record. Setting this annotation to `"true"` restricts the status to only the NLB hostname, so ExternalDNS creates a DNS record pointing at the NLB.
 
     !!!note
-        This annotation has no effect if `alb.ingress.kubernetes.io/enable-frontend-nlb` is not set, or if the NLB has not yet been provisioned. In those cases the ALB hostname is written to status as normal.
+        If `alb.ingress.kubernetes.io/enable-frontend-nlb` is not set, this annotation has no effect. If the NLB has not yet been provisioned or fails to provision, the ingress status is left empty until the NLB is ready, avoiding a transient DNS record pointing at the ALB.
 
     === "NLB only"
         ```yaml

--- a/pkg/annotations/constants.go
+++ b/pkg/annotations/constants.go
@@ -77,6 +77,7 @@ const (
 	IngressSuffixFrontendNlbHealthCheckSuccessCodes            = "frontend-nlb-healthcheck-success-codes"
 	IngressSuffixFrontendNlbAttributes                         = "frontend-nlb-attributes"
 	IngressSuffixFrontendNlbTags                               = "frontend-nlb-tags"
+	IngressSuffixFrontendNlbStatusOnly                         = "frontend-nlb-status-only"
 	IngressSuffixUseRegexPathMatch                             = "use-regex-path-match"
 	IngressSuffixTargetControlPort                             = "target-control-port"
 	IngressSuffixCreateCertificate                             = "create-acm-cert"


### PR DESCRIPTION
### Issue

#4805 

The original issue was surfaced in [external-dns#5661](https://github.com/kubernetes-sigs/external-dns/issues/5661), where it was decided that the fix belongs in the AWS Load Balancer Controller rather than ExternalDNS

### Description

When frontend NLB is configured via `alb.ingress.kubernetes.io/enable-frontend-nlb: "true"`, the controller writes both the ALB and NLB hostnames to status.loadBalancer.ingress. When using ExternalDNS on AWS, only a DNS record for the first entry is created, meaning the NLB, which is the actual external-facing endpoint, may not get a DNS record at all.

The existing workaround (external-dns.alpha.kubernetes.io/target) requires a two-step deploy because the NLB hostname isn't known until after provisioning, which makes it impractical for automated workflows.

This PR adds a new boolean annotation:
`alb.ingress.kubernetes.io/frontend-nlb-status-only: "true"`

When set, only the NLB hostname is written to status.loadBalancer.ingress, so ExternalDNS creates a record for the NLB only. The annotation is opt-in to avoid a breaking change. If the NLB DNS is not yet available, the controller falls back to the ALB hostname to avoid leaving status empty.

**Validation:**

Manually validated on EKS: ingress with the annotation shows 1 status entry (NLB only) and a control ingress without it shows 2 entries (ALB + NLB).

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
