### PR TITLE
fix(gateway): use TCP target group protocol for TLSRoute on passthrough NLB listeners

### DIFF
--- a/pkg/gateway/model/model_build_target_group.go
+++ b/pkg/gateway/model/model_build_target_group.go
@@ -355,15 +355,15 @@ func (builder *targetGroupBuilderImpl) buildTargetGroupIPAddressType(backendConf
 func (builder *targetGroupBuilderImpl) buildTargetGroupProtocol(targetGroupProps *elbv2gw.TargetGroupProps, route routeutils.RouteDescriptor, listenerProtocol elbv2model.Protocol) (elbv2model.Protocol, error) {
 	// TODO - Not convinced that this is good, maybe auto detect certs == HTTPS / TLS.
 	if builder.loadBalancerType == elbv2model.LoadBalancerTypeApplication {
-		return builder.buildL7TargetGroupProtocol(targetGroupProps, route)
+		return builder.buildL7TargetGroupProtocol(targetGroupProps, route, listenerProtocol)
 	}
 
 	return builder.buildL4TargetGroupProtocol(targetGroupProps, route, listenerProtocol)
 }
 
-func (builder *targetGroupBuilderImpl) buildL7TargetGroupProtocol(targetGroupProps *elbv2gw.TargetGroupProps, route routeutils.RouteDescriptor) (elbv2model.Protocol, error) {
+func (builder *targetGroupBuilderImpl) buildL7TargetGroupProtocol(targetGroupProps *elbv2gw.TargetGroupProps, route routeutils.RouteDescriptor, listenerProtocol elbv2model.Protocol) (elbv2model.Protocol, error) {
 	if targetGroupProps == nil || targetGroupProps.Protocol == nil {
-		return builder.inferTargetGroupProtocolFromRoute(route), nil
+		return builder.inferTargetGroupProtocolFromRoute(route, listenerProtocol), nil
 	}
 	switch string(*targetGroupProps.Protocol) {
 	case string(elbv2model.ProtocolHTTP):
@@ -381,7 +381,7 @@ func (builder *targetGroupBuilderImpl) buildL4TargetGroupProtocol(targetGroupPro
 	}
 
 	if targetGroupProps == nil || targetGroupProps.Protocol == nil {
-		return builder.inferTargetGroupProtocolFromRoute(route), nil
+		return builder.inferTargetGroupProtocolFromRoute(route, listenerProtocol), nil
 	}
 
 	switch string(*targetGroupProps.Protocol) {
@@ -398,7 +398,7 @@ func (builder *targetGroupBuilderImpl) buildL4TargetGroupProtocol(targetGroupPro
 	}
 }
 
-func (builder *targetGroupBuilderImpl) inferTargetGroupProtocolFromRoute(route routeutils.RouteDescriptor) elbv2model.Protocol {
+func (builder *targetGroupBuilderImpl) inferTargetGroupProtocolFromRoute(route routeutils.RouteDescriptor, listenerProtocol elbv2model.Protocol) elbv2model.Protocol {
 	switch route.GetRouteKind() {
 	case routeutils.TCPRouteKind:
 		return elbv2model.ProtocolTCP
@@ -410,6 +410,12 @@ func (builder *targetGroupBuilderImpl) inferTargetGroupProtocolFromRoute(route r
 		return elbv2model.ProtocolHTTP
 	case routeutils.TLSRouteKind:
 		if builder.loadBalancerType == elbv2model.LoadBalancerTypeNetwork {
+			// A TLS listener with tls.mode: Passthrough is provisioned as a TCP listener
+			// (see mapGatewayListenerConfigsByPort), so the target group protocol must be
+			// TCP as well, otherwise the listener and target group protocols mismatch.
+			if listenerProtocol == elbv2model.ProtocolTCP {
+				return elbv2model.ProtocolTCP
+			}
 			return elbv2model.ProtocolTLS
 		}
 		return elbv2model.ProtocolHTTPS

--- a/pkg/gateway/model/model_build_target_group_test.go
+++ b/pkg/gateway/model/model_build_target_group_test.go
@@ -980,7 +980,7 @@ func Test_buildTargetGroupProtocol(t *testing.T) {
 			expected: elbv2model.ProtocolUDP,
 		},
 		{
-			name:             "nlb - auto detect - tls",
+			name:             "nlb - auto detect - tls passthrough listener downgraded to tcp",
 			listenerProtocol: elbv2model.ProtocolTCP,
 			lbType:           elbv2model.LoadBalancerTypeNetwork,
 			route: &routeutils.MockRoute{
@@ -988,7 +988,7 @@ func Test_buildTargetGroupProtocol(t *testing.T) {
 				Name:      "r1",
 				Namespace: "ns",
 			},
-			expected: elbv2model.ProtocolTLS,
+			expected: elbv2model.ProtocolTCP,
 		},
 		{
 			name:             "alb - specified - http",


### PR DESCRIPTION
Motivation:
Issue #4556 reported that a Gateway API NLB listener with `protocol: TLS`
and `tls.mode: Passthrough` incorrectly built a TLS listener. That part
was already fixed in v3.1.0 by downgrading the listener protocol to TCP
for passthrough mode.

However, follow-up reports on the same issue (from 2026-03-04 and
2026-03-10) show the fix was incomplete: when a `TLSRoute` is bound to
such a passthrough listener, the controller still infers the *target
group* protocol as TLS. This produces a real AWS API error when
reconciling the load balancer:

  IncompatibleProtocols: The listener and the following target groups
  have incompatible protocols

because the (now TCP) listener cannot be attached to a TLS target group.
This is a functional failure, not cosmetic: the Gateway never reaches a
working state and reconciliation errors repeatedly.

Approach:
`inferTargetGroupProtocolFromRoute` in
pkg/gateway/model/model_build_target_group.go always returned
`ProtocolTLS` for `TLSRouteKind` on an NLB, regardless of the actual
listener protocol. It now takes the (already passthrough-downgraded)
listener protocol and returns `ProtocolTCP` when the listener protocol
is TCP, keeping `ProtocolTLS` for the `tls.mode: Terminate` case. Users
who explicitly set `targetGroupProps.Protocol` are unaffected, since
that explicit-override path is checked before the inference path.

This only changes NLB behavior for TLSRoute; ALB target group protocol
inference (which cannot take this NLB-only branch) is unaffected.

Validation:
go build ./...
go test -count=1 ./pkg/gateway/model/...
Both pass, including a corrected unit test case in
Test_buildTargetGroupProtocol that had been asserting the buggy
(mismatched) behavior.

Fixes #4556

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>