### PR TITLE
docs: clarify scheme change replacement

### DIFF
--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -697,6 +697,9 @@ Access control for LoadBalancer can be controlled with following annotations:
         alb.ingress.kubernetes.io/scheme: internal
         ```
 
+    !!!warning
+        Changing the scheme from `internet-facing` to `internal`, or vice versa, creates a replacement Application Load Balancer. Plan a traffic migration to avoid downtime.
+
 - <a name="inbound-cidrs">`alb.ingress.kubernetes.io/inbound-cidrs`</a> specifies the CIDRs that are allowed to access LoadBalancer.
 
     !!!note "Merge Behavior"


### PR DESCRIPTION
Clarify that changing `alb.ingress.kubernetes.io/scheme` replaces the Application Load Balancer and requires traffic-migration planning.