### PR TITLE
docs: clarify scheme change replacement

### DIFF
--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -698,7 +698,7 @@ Access control for LoadBalancer can be controlled with following annotations:
         ```
 
     !!!warning
-        Amazon ELB cannot change a load balancer's scheme in place; updating its [`Scheme` property](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-elasticloadbalancingv2-loadbalancer.html#cfn-elasticloadbalancingv2-loadbalancer-scheme) requires replacement. Therefore, changing the scheme from `internet-facing` to `internal`, or vice versa, causes the controller to create a replacement Application Load Balancer. Plan a traffic migration to avoid downtime.
+        Amazon ELB cannot change a load balancer's scheme in place; updating its `Scheme` property requires replacement. Therefore, changing the scheme from `internet-facing` to `internal`, or vice versa, causes the controller to create a replacement Application Load Balancer. Plan a traffic migration to avoid downtime.
 
 - <a name="inbound-cidrs">`alb.ingress.kubernetes.io/inbound-cidrs`</a> specifies the CIDRs that are allowed to access LoadBalancer.
 

--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -698,7 +698,7 @@ Access control for LoadBalancer can be controlled with following annotations:
         ```
 
     !!!warning
-        Changing the scheme from `internet-facing` to `internal`, or vice versa, creates a replacement Application Load Balancer. Plan a traffic migration to avoid downtime.
+        Amazon ELB cannot change a load balancer's scheme in place; updating its [`Scheme` property](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-elasticloadbalancingv2-loadbalancer.html#cfn-elasticloadbalancingv2-loadbalancer-scheme) requires replacement. Therefore, changing the scheme from `internet-facing` to `internal`, or vice versa, causes the controller to create a replacement Application Load Balancer. Plan a traffic migration to avoid downtime.
 
 - <a name="inbound-cidrs">`alb.ingress.kubernetes.io/inbound-cidrs`</a> specifies the CIDRs that are allowed to access LoadBalancer.
 

--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -697,6 +697,9 @@ Access control for LoadBalancer can be controlled with following annotations:
         alb.ingress.kubernetes.io/scheme: internal
         ```
 
+    !!!warning
+        Changing the scheme from `internet-facing` to `internal`, or vice versa, creates a replacement Application Load Balancer. Plan a traffic migration to avoid downtime.
+
 - <a name="inbound-cidrs">`alb.ingress.kubernetes.io/inbound-cidrs`</a> specifies the CIDRs that are allowed to access LoadBalancer.
 
     !!!note "Merge Behavior"


### PR DESCRIPTION
Clarify that changing `alb.ingress.kubernetes.io/scheme` replaces the Application Load Balancer and requires traffic-migration planning.