### PR TITLE
fix: use "/" separator in getCacheKey to avoid TGB cache collisions

### DIFF
--- a/pkg/targetgroupbinding/multicluster_manager.go
+++ b/pkg/targetgroupbinding/multicluster_manager.go
@@ -246,9 +246,12 @@ func (m *multiClusterManagerImpl) updateCache(tgb *elbv2api.TargetGroupBinding, 
 	m.configMapCache[cacheKey] = endpointMap
 }
 
-// getCacheKey generates a key to use with the k8s api
+// getCacheKey generates a key to use with the in-memory config map cache.
+// The "/" separator cannot appear in a namespace or name, so the key is unambiguous. Using a
+// separator that is legal within those values (e.g. "-") would let distinct TGBs collide, for
+// example namespace "a" + name "b-c" and namespace "a-b" + name "c".
 func getCacheKey(tgb *elbv2api.TargetGroupBinding) string {
-	return fmt.Sprintf("%s-%s", tgb.Namespace, tgb.Name)
+	return fmt.Sprintf("%s/%s", tgb.Namespace, tgb.Name)
 }
 
 // getConfigMapName generates a config map name to use with the k8s api.

--- a/pkg/targetgroupbinding/multicluster_manager_test.go
+++ b/pkg/targetgroupbinding/multicluster_manager_test.go
@@ -676,8 +676,68 @@ func TestCleanUp(t *testing.T) {
 	}
 }
 
+func TestGetCacheKey(t *testing.T) {
+	testCases := []struct {
+		name        string
+		namespace   string
+		tgbName     string
+		expectedKey string
+	}{
+		{
+			name:        "namespace and name without hyphens",
+			namespace:   "a",
+			tgbName:     "c",
+			expectedKey: "a/c",
+		},
+		{
+			name:        "hyphen in name",
+			namespace:   "a",
+			tgbName:     "b-c",
+			expectedKey: "a/b-c",
+		},
+		{
+			name:        "hyphen in namespace",
+			namespace:   "a-b",
+			tgbName:     "c",
+			expectedKey: "a-b/c",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tgb := &elbv2api.TargetGroupBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: tc.namespace,
+					Name:      tc.tgbName,
+				},
+			}
+			assert.Equal(t, tc.expectedKey, getCacheKey(tgb))
+		})
+	}
+}
+
+// TestGetCacheKeyNoCollisionWithHyphens ensures that TGBs whose namespace / name differ only in
+// where a hyphen falls do not share a cache key. Sharing a key would let one TGB's tracked target
+// set drive another TGB's deregistration decisions.
+func TestGetCacheKeyNoCollisionWithHyphens(t *testing.T) {
+	first := &elbv2api.TargetGroupBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "a",
+			Name:      "b-c",
+		},
+	}
+	second := &elbv2api.TargetGroupBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "a-b",
+			Name:      "c",
+		},
+	}
+
+	assert.NotEqual(t, getCacheKey(first), getCacheKey(second))
+}
+
 func getCachedValue(mc *multiClusterManagerImpl, namespace, name string) sets.Set[string] {
-	key := fmt.Sprintf("%s-%s", namespace, name)
+	key := fmt.Sprintf("%s/%s", namespace, name)
 
 	if v, ok := mc.configMapCache[key]; !ok {
 		return nil
@@ -687,6 +747,6 @@ func getCachedValue(mc *multiClusterManagerImpl, namespace, name string) sets.Se
 }
 
 func setCachedValue(mc *multiClusterManagerImpl, v sets.Set[string], namespace, name string) {
-	key := fmt.Sprintf("%s-%s", namespace, name)
+	key := fmt.Sprintf("%s/%s", namespace, name)
 	mc.configMapCache[key] = v
 }


### PR DESCRIPTION

### Issue

<!-- Please link the GitHub issues related to this PR, if available -->
Bug: getCacheKey uses a hyphen separator (<namespace>-<name>), which can produce collisions when namespaces or names themselves contain hyphens. For example, namespace "a" + name "b-c" produces the same key as namespace "a-b" + name "c". This could cause one TGB's cached target set to be incorrectly used for a different TGB's deregistration decisions.

### Description

<!--
Please explain the changes you made here.

Help your reviewers by guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

Hyphens are legal in namespaces and names, so joining them with "-" was ambiguous: namespace "a" + name "b-c" and namespace "a-b" + name "c" both produced "a-b-c". Colliding TGBs shared one configMapCache entry, letting one TGB's tracked targets drive the other's deregistration.

"/" cannot appear in either field. The key is in-memory only and never persisted, so no migration is needed.

ran e2e test/e2e/service/nlb_ip_target_test.go successfully with the fix in PR

```
Will run 1 of 15 specs
------------------------------
[BeforeSuite] 
/home/kaposmee/albc-cachekey-fix/test/e2e/service/service_suite_test.go:19
[BeforeSuite] PASSED [0.028 seconds]
------------------------------
SSS
------------------------------
k8s service using ip target reconciled by the aws load balancer NLB with IP target configuration Should create and verify internet-facing NLB with IP targets
/home/kaposmee/albc-cachekey-fix/test/e2e/service/nlb_ip_target_test.go:110
  STEP: deploying stack @ 07/29/26 01:24:05.274
  {"level":"info","ts":1785288245.2746434,"msg":"allocating namespace"}
  {"level":"info","ts":1785288245.3516278,"msg":"allocated namespace","nsName":"service-ip-e2e-a207ab"}
  {"level":"info","ts":1785288245.3517172,"msg":"labeling namespace","nsName":"service-ip-e2e-a207ab","labels":{}}
  {"level":"info","ts":1785288245.3635318,"msg":"labeled namespace with podReadinessGate injection","nsName":"service-ip-e2e-a207ab"}
  {"level":"info","ts":1785288245.3635993,"msg":"creating deployment","dp":{"name":"ip-e2e","namespace":"service-ip-e2e-a207ab"}}
  {"level":"info","ts":1785288245.3799527,"msg":"created deployment","dp":{"name":"ip-e2e","namespace":"service-ip-e2e-a207ab"}}
  {"level":"info","ts":1785288245.3800225,"msg":"creating base service","svc":{"name":"ip-e2e","namespace":"service-ip-e2e-a207ab"}}
  {"level":"info","ts":1785288245.418587,"msg":"created base service","svc":{"name":"ip-e2e","namespace":"service-ip-e2e-a207ab"}}
  {"level":"info","ts":1785288245.418699,"msg":"waiting until deployment becomes ready","dp":{"name":"ip-e2e","namespace":"service-ip-e2e-a207ab"}}
  {"level":"info","ts":1785288249.4311783,"msg":"deployment is ready","dp":{"name":"ip-e2e","namespace":"service-ip-e2e-a207ab"}}
  {"level":"info","ts":1785288249.4312499,"msg":"waiting until service becomes ready","svc":{"name":"ip-e2e","namespace":"service-ip-e2e-a207ab"}}
  STEP: checking service status for lb dns name @ 07/29/26 01:24:09.436
  STEP: querying AWS loadbalancer from the dns name @ 07/29/26 01:24:09.436
  STEP: Verify Service with AWS @ 07/29/26 01:24:09.561
  STEP: waiting for target group targets to be healthy @ 07/29/26 01:24:19.71
  STEP: Send traffic to LB @ 07/29/26 01:27:20.064
  STEP: Specifying Healthcheck annotations @ 07/29/26 01:27:20.079
  {"level":"info","ts":1785288440.0795965,"msg":"updating service annotations","svc":{"name":"ip-e2e","namespace":"service-ip-e2e-a207ab"}}
  {"level":"info","ts":1785288440.0796864,"msg":"updating service","svc":{"name":"ip-e2e","namespace":"service-ip-e2e-a207ab"}}
  {"level":"info","ts":1785288440.159082,"msg":"waiting until service becomes ready","svc":{"name":"ip-e2e","namespace":"service-ip-e2e-a207ab"}}
  STEP: Enabling Multi-cluster mode @ 07/29/26 01:27:30.354
  {"level":"info","ts":1785288450.354399,"msg":"updating service annotations","svc":{"name":"ip-e2e","namespace":"service-ip-e2e-a207ab"}}
  {"level":"info","ts":1785288450.3545592,"msg":"updating service","svc":{"name":"ip-e2e","namespace":"service-ip-e2e-a207ab"}}
  {"level":"info","ts":1785288450.3662674,"msg":"waiting until service becomes ready","svc":{"name":"ip-e2e","namespace":"service-ip-e2e-a207ab"}}
  {"level":"info","ts":1785288510.746017,"msg":"updating service annotations","svc":{"name":"ip-e2e","namespace":"service-ip-e2e-a207ab"}}
  {"level":"info","ts":1785288510.7461555,"msg":"updating service","svc":{"name":"ip-e2e","namespace":"service-ip-e2e-a207ab"}}
  {"level":"info","ts":1785288510.7571297,"msg":"waiting until service becomes ready","svc":{"name":"ip-e2e","namespace":"service-ip-e2e-a207ab"}}
  {"level":"info","ts":1785288630.9103968,"msg":"updating service annotations","svc":{"name":"ip-e2e","namespace":"service-ip-e2e-a207ab"}}
  {"level":"info","ts":1785288630.9105175,"msg":"updating service","svc":{"name":"ip-e2e","namespace":"service-ip-e2e-a207ab"}}
  {"level":"info","ts":1785288630.9334693,"msg":"waiting until service becomes ready","svc":{"name":"ip-e2e","namespace":"service-ip-e2e-a207ab"}}
  {"level":"info","ts":1785288751.0729957,"msg":"deleting deployment","dp":{"name":"ip-e2e","namespace":"service-ip-e2e-a207ab"}}
  {"level":"info","ts":1785288751.11529,"msg":"deleted deployment","dp":{"name":"ip-e2e","namespace":"service-ip-e2e-a207ab"}}
  {"level":"info","ts":1785288751.115375,"msg":"deleting service","svc":{"name":"ip-e2e","namespace":"service-ip-e2e-a207ab"}}
  {"level":"info","ts":1785288773.1491327,"msg":"deleted service","svc":{"name":"ip-e2e","namespace":"service-ip-e2e-a207ab"}}
  {"level":"info","ts":1785288773.1492176,"msg":"deleting namespace","ns":{"name":"service-ip-e2e-a207ab"}}
  {"level":"info","ts":1785288781.1790054,"msg":"deleted namespace","ns":{"name":"service-ip-e2e-a207ab"}}
• [535.905 seconds]
------------------------------
SSSSSSSSSSS

Ran 1 of 15 Specs in 535.934 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 14 Skipped
PASS

Ginkgo ran 1 suite in 9m14.83819291s
Test Suite Passed

```

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
