### PR TITLE
fix: subnet auto-discovery to IPv6-capable subnets for dualstack ip address type

### DIFF
--- a/pkg/gateway/model/model_build_subnet.go
+++ b/pkg/gateway/model/model_build_subnet.go
@@ -63,7 +63,7 @@ func (subnetBuilder *subnetModelBuilderImpl) buildLoadBalancerSubnets(ctx contex
 		return buildLoadBalancerSubnetsOutput{}, err
 	}
 
-	resolvedEC2Subnets, err := subnetBuilder.resolveEC2Subnets(ctx, stack, gwSubnetConfig, gwSubnetTagSelectors, scheme)
+	resolvedEC2Subnets, err := subnetBuilder.resolveEC2Subnets(ctx, stack, gwSubnetConfig, gwSubnetTagSelectors, scheme, ipAddressType)
 
 	if err != nil {
 		return buildLoadBalancerSubnetsOutput{}, err
@@ -176,7 +176,7 @@ func (subnetBuilder *subnetModelBuilderImpl) validateSubnetsInput(subnetConfigsP
 	return sourceNATSpecified, nil
 }
 
-func (subnetBuilder *subnetModelBuilderImpl) resolveEC2Subnets(ctx context.Context, stack core.Stack, subnetConfigsPtr *[]elbv2gw.SubnetConfiguration, subnetTagSelector *map[string][]string, scheme elbv2model.LoadBalancerScheme) ([]ec2types.Subnet, error) {
+func (subnetBuilder *subnetModelBuilderImpl) resolveEC2Subnets(ctx context.Context, stack core.Stack, subnetConfigsPtr *[]elbv2gw.SubnetConfiguration, subnetTagSelector *map[string][]string, scheme elbv2model.LoadBalancerScheme, ipAddressType elbv2model.IPAddressType) ([]ec2types.Subnet, error) {
 	// if we have identifiers, query directly by them.
 	// this assumes that validateSubnetsInput() was already ran on the input.
 	if subnetConfigsPtr != nil && len(*subnetConfigsPtr) != 0 && (*subnetConfigsPtr)[0].Identifier != "" {
@@ -189,6 +189,7 @@ func (subnetBuilder *subnetModelBuilderImpl) resolveEC2Subnets(ctx context.Conte
 		return subnetBuilder.subnetsResolver.ResolveViaNameOrIDSlice(ctx, nameOrIds,
 			networking.WithSubnetsResolveLBType(subnetBuilder.loadBalancerType),
 			networking.WithSubnetsResolveLBScheme(scheme),
+			networking.WithSubnetsResolveLBIPAddressType(ipAddressType),
 		)
 	}
 
@@ -201,6 +202,7 @@ func (subnetBuilder *subnetModelBuilderImpl) resolveEC2Subnets(ctx context.Conte
 		return subnetBuilder.subnetsResolver.ResolveViaSelector(ctx, selector,
 			networking.WithSubnetsResolveLBType(subnetBuilder.loadBalancerType),
 			networking.WithSubnetsResolveLBScheme(scheme),
+			networking.WithSubnetsResolveLBIPAddressType(ipAddressType),
 		)
 	}
 
@@ -215,6 +217,7 @@ func (subnetBuilder *subnetModelBuilderImpl) resolveEC2Subnets(ctx context.Conte
 		return subnetBuilder.subnetsResolver.ResolveViaDiscovery(ctx,
 			networking.WithSubnetsResolveLBType(subnetBuilder.loadBalancerType),
 			networking.WithSubnetsResolveLBScheme(scheme),
+			networking.WithSubnetsResolveLBIPAddressType(ipAddressType),
 		)
 	}
 
@@ -226,6 +229,7 @@ func (subnetBuilder *subnetModelBuilderImpl) resolveEC2Subnets(ctx context.Conte
 	return subnetBuilder.subnetsResolver.ResolveViaNameOrIDSlice(ctx, storedSubnetIds,
 		networking.WithSubnetsResolveLBType(subnetBuilder.loadBalancerType),
 		networking.WithSubnetsResolveLBScheme(scheme),
+		networking.WithSubnetsResolveLBIPAddressType(ipAddressType),
 	)
 
 }

--- a/pkg/gateway/model/model_build_subnet_test.go
+++ b/pkg/gateway/model/model_build_subnet_test.go
@@ -626,15 +626,15 @@ func Test_ResolveEC2Subnets(t *testing.T) {
 			subnetsResolver := networking.NewMockSubnetsResolver(ctrl)
 
 			if tc.idOrNameResolutionCall != nil {
-				subnetsResolver.EXPECT().ResolveViaNameOrIDSlice(gomock.Any(), gomock.Any(), gomock.Any()).Return(tc.idOrNameResolutionCall.subnets, tc.idOrNameResolutionCall.err)
+				subnetsResolver.EXPECT().ResolveViaNameOrIDSlice(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(tc.idOrNameResolutionCall.subnets, tc.idOrNameResolutionCall.err)
 			}
 
 			if tc.discoveryCall != nil {
-				subnetsResolver.EXPECT().ResolveViaDiscovery(gomock.Any(), gomock.Any(), gomock.Any()).Return(tc.discoveryCall.subnets, tc.discoveryCall.err)
+				subnetsResolver.EXPECT().ResolveViaDiscovery(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(tc.discoveryCall.subnets, tc.discoveryCall.err)
 			}
 
 			if tc.selectorCall != nil {
-				subnetsResolver.EXPECT().ResolveViaSelector(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(tc.selectorCall.subnets, tc.selectorCall.err)
+				subnetsResolver.EXPECT().ResolveViaSelector(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(tc.selectorCall.subnets, tc.selectorCall.err)
 			}
 
 			elbv2TaggingManager := elbv2deploy.NewMockTaggingManager(ctrl)
@@ -649,7 +649,7 @@ func Test_ResolveEC2Subnets(t *testing.T) {
 				elbv2TaggingManager: elbv2TaggingManager,
 			}
 
-			subnets, err := builder.resolveEC2Subnets(context.Background(), nil, tc.subnetConfig, tc.selector, elbv2model.LoadBalancerSchemeInternal)
+			subnets, err := builder.resolveEC2Subnets(context.Background(), nil, tc.subnetConfig, tc.selector, elbv2model.LoadBalancerSchemeInternal, elbv2model.IPAddressTypeIPV4)
 
 			if tc.expectErr {
 				assert.Error(t, err)

--- a/pkg/ingress/model_build_frontend_nlb.go
+++ b/pkg/ingress/model_build_frontend_nlb.go
@@ -106,7 +106,7 @@ func (t *defaultModelBuildTask) buildFrontendNlbScheme(ctx context.Context, alb 
 	return t.defaultScheme, nil
 }
 
-func (t *defaultModelBuildTask) validateAndResolveSubnets(ctx context.Context, explicitSubnetNameOrIDsList [][]string, scheme elbv2model.LoadBalancerScheme) ([]ec2types.Subnet, error) {
+func (t *defaultModelBuildTask) validateAndResolveSubnets(ctx context.Context, explicitSubnetNameOrIDsList [][]string, scheme elbv2model.LoadBalancerScheme, ipAddressType elbv2model.IPAddressType) ([]ec2types.Subnet, error) {
 	if len(explicitSubnetNameOrIDsList) != 0 {
 		// Check all ingresses have the same subnets
 		chosenSubnetNameOrIDs := explicitSubnetNameOrIDsList[0]
@@ -119,6 +119,7 @@ func (t *defaultModelBuildTask) validateAndResolveSubnets(ctx context.Context, e
 		chosenSubnets, err := t.subnetsResolver.ResolveViaNameOrIDSlice(ctx, chosenSubnetNameOrIDs,
 			networking.WithSubnetsResolveLBType(elbv2model.LoadBalancerTypeNetwork),
 			networking.WithSubnetsResolveLBScheme(scheme),
+			networking.WithSubnetsResolveLBIPAddressType(ipAddressType),
 		)
 		if err != nil {
 			return nil, err
@@ -128,7 +129,9 @@ func (t *defaultModelBuildTask) validateAndResolveSubnets(ctx context.Context, e
 
 	// If no explicit subnets, discover public or private subnets based on scheme
 	chosenSubnets, err := t.subnetsResolver.ResolveViaDiscovery(ctx,
+		networking.WithSubnetsResolveLBType(elbv2model.LoadBalancerTypeNetwork),
 		networking.WithSubnetsResolveLBScheme(scheme),
+		networking.WithSubnetsResolveLBIPAddressType(ipAddressType),
 	)
 	if err != nil {
 		return nil, err
@@ -152,7 +155,7 @@ func (t *defaultModelBuildTask) validateEIPAllocations(eipAllocationsList [][]st
 	return []string{}, nil
 }
 
-func (t *defaultModelBuildTask) buildFrontendNlbSubnetMappings(ctx context.Context, scheme elbv2model.LoadBalancerScheme) ([]elbv2model.SubnetMapping, error) {
+func (t *defaultModelBuildTask) buildFrontendNlbSubnetMappings(ctx context.Context, scheme elbv2model.LoadBalancerScheme, ipAddressType elbv2model.IPAddressType) ([]elbv2model.SubnetMapping, error) {
 	var explicitSubnetNameOrIDsList [][]string
 	var eipAllocationsList [][]string
 	// Read annotations
@@ -167,7 +170,7 @@ func (t *defaultModelBuildTask) buildFrontendNlbSubnetMappings(ctx context.Conte
 		}
 	}
 
-	chosenSubnets, err := t.validateAndResolveSubnets(ctx, explicitSubnetNameOrIDsList, scheme)
+	chosenSubnets, err := t.validateAndResolveSubnets(ctx, explicitSubnetNameOrIDsList, scheme, ipAddressType)
 	if err != nil {
 		return nil, err
 	}
@@ -263,7 +266,7 @@ func (t *defaultModelBuildTask) buildFrontendNlbSpec(ctx context.Context, scheme
 		securityGroups = alb.Spec.SecurityGroups
 	}
 
-	subnetMappings, err := t.buildFrontendNlbSubnetMappings(ctx, scheme)
+	subnetMappings, err := t.buildFrontendNlbSubnetMappings(ctx, scheme, alb.Spec.IPAddressType)
 	if err != nil {
 		return elbv2model.LoadBalancerSpec{}, err
 	}

--- a/pkg/ingress/model_build_frontend_nlb_test.go
+++ b/pkg/ingress/model_build_frontend_nlb_test.go
@@ -418,7 +418,7 @@ func Test_buildFrontendNlbSubnetMappings(t *testing.T) {
 				annotationParser: annotationParser,
 				subnetsResolver:  mockSubnetsResolver,
 			}
-			got, err := task.buildFrontendNlbSubnetMappings(context.Background(), tt.fields.scheme)
+			got, err := task.buildFrontendNlbSubnetMappings(context.Background(), tt.fields.scheme, elbv2.IPAddressTypeIPV4)
 
 			if err != nil {
 				assert.EqualError(t, err, tt.wantErr)

--- a/pkg/ingress/model_build_load_balancer.go
+++ b/pkg/ingress/model_build_load_balancer.go
@@ -44,7 +44,7 @@ func (t *defaultModelBuildTask) buildLoadBalancerSpec(ctx context.Context, liste
 	if err != nil {
 		return elbv2model.LoadBalancerSpec{}, err
 	}
-	subnetMappings, err := t.buildLoadBalancerSubnetMappings(ctx, scheme)
+	subnetMappings, err := t.buildLoadBalancerSubnetMappings(ctx, scheme, ipAddressType)
 	if err != nil {
 		return elbv2model.LoadBalancerSpec{}, err
 	}
@@ -200,7 +200,7 @@ func (t *defaultModelBuildTask) buildLoadBalancerIPAddressType(_ context.Context
 	}
 }
 
-func (t *defaultModelBuildTask) buildLoadBalancerSubnetMappings(ctx context.Context, scheme elbv2model.LoadBalancerScheme) ([]elbv2model.SubnetMapping, error) {
+func (t *defaultModelBuildTask) buildLoadBalancerSubnetMappings(ctx context.Context, scheme elbv2model.LoadBalancerScheme, ipAddressType elbv2model.IPAddressType) ([]elbv2model.SubnetMapping, error) {
 	var explicitSubnetSelectorList []v1beta1.SubnetSelector
 	var explicitSubnetNameOrIDsList [][]string
 	for _, member := range t.ingGroup.Members {
@@ -228,6 +228,7 @@ func (t *defaultModelBuildTask) buildLoadBalancerSubnetMappings(ctx context.Cont
 		chosenSubnets, err := t.subnetsResolver.ResolveViaSelector(ctx, chosenSubnetSelector,
 			networking.WithSubnetsResolveLBType(elbv2model.LoadBalancerTypeApplication),
 			networking.WithSubnetsResolveLBScheme(scheme),
+			networking.WithSubnetsResolveLBIPAddressType(ipAddressType),
 		)
 		if err != nil {
 			return nil, err
@@ -246,6 +247,7 @@ func (t *defaultModelBuildTask) buildLoadBalancerSubnetMappings(ctx context.Cont
 		chosenSubnets, err := t.subnetsResolver.ResolveViaNameOrIDSlice(ctx, chosenSubnetNameOrIDs,
 			networking.WithSubnetsResolveLBType(elbv2model.LoadBalancerTypeApplication),
 			networking.WithSubnetsResolveLBScheme(scheme),
+			networking.WithSubnetsResolveLBIPAddressType(ipAddressType),
 		)
 		if err != nil {
 			return nil, err
@@ -263,6 +265,7 @@ func (t *defaultModelBuildTask) buildLoadBalancerSubnetMappings(ctx context.Cont
 		chosenSubnets, err := t.subnetsResolver.ResolveViaDiscovery(ctx,
 			networking.WithSubnetsResolveLBType(elbv2model.LoadBalancerTypeApplication),
 			networking.WithSubnetsResolveLBScheme(scheme),
+			networking.WithSubnetsResolveLBIPAddressType(ipAddressType),
 		)
 		if err != nil {
 			return nil, errors.Wrap(err, "couldn't auto-discover subnets")

--- a/pkg/ingress/model_build_load_balancer_test.go
+++ b/pkg/ingress/model_build_load_balancer_test.go
@@ -1432,7 +1432,7 @@ func Test_defaultModelBuildTask_buildLoadBalancerSubnets(t *testing.T) {
 				subnetsResolver:     subnetsResolver,
 				trackingProvider:    tracking.NewDefaultProvider("ingress.k8s.aws", "test-cluster"),
 			}
-			got, err := task.buildLoadBalancerSubnetMappings(context.Background(), elbv2.LoadBalancerSchemeInternetFacing)
+			got, err := task.buildLoadBalancerSubnetMappings(context.Background(), elbv2.LoadBalancerSchemeInternetFacing, elbv2.IPAddressTypeIPV4)
 			if err != nil {
 				assert.EqualError(t, err, tt.wantErr)
 			} else {

--- a/pkg/networking/subnet_resolver.go
+++ b/pkg/networking/subnet_resolver.go
@@ -53,6 +53,11 @@ type SubnetsResolveOptions struct {
 	// The Load Balancer Scheme.
 	// By default, it's internet-facing.
 	LBScheme elbv2model.LoadBalancerScheme
+	// The Load Balancer IPAddressType.
+	// By default, it's ipv4.
+	// When it requires IPv6 (dualstack/dualstack-without-public-ipv4), only subnets with an
+	// associated IPv6 CIDR block are eligible, matching the ELBv2 CreateLoadBalancer requirement.
+	LBIPAddressType elbv2model.IPAddressType
 }
 
 // ApplyOptions applies slice of SubnetsResolveOption.
@@ -65,8 +70,9 @@ func (opts *SubnetsResolveOptions) ApplyOptions(options []SubnetsResolveOption) 
 // defaultSubnetsResolveOptions generates the default SubnetsResolveOptions
 func defaultSubnetsResolveOptions() SubnetsResolveOptions {
 	return SubnetsResolveOptions{
-		LBType:   elbv2model.LoadBalancerTypeApplication,
-		LBScheme: elbv2model.LoadBalancerSchemeInternetFacing,
+		LBType:          elbv2model.LoadBalancerTypeApplication,
+		LBScheme:        elbv2model.LoadBalancerSchemeInternetFacing,
+		LBIPAddressType: elbv2model.IPAddressTypeIPV4,
 	}
 }
 
@@ -83,6 +89,13 @@ func WithSubnetsResolveLBType(lbType elbv2model.LoadBalancerType) SubnetsResolve
 func WithSubnetsResolveLBScheme(lbScheme elbv2model.LoadBalancerScheme) SubnetsResolveOption {
 	return func(opts *SubnetsResolveOptions) {
 		opts.LBScheme = lbScheme
+	}
+}
+
+// WithSubnetsResolveLBIPAddressType generates an option that configures LBIPAddressType.
+func WithSubnetsResolveLBIPAddressType(ipAddressType elbv2model.IPAddressType) SubnetsResolveOption {
+	return func(opts *SubnetsResolveOptions) {
+		opts.LBIPAddressType = ipAddressType
 	}
 }
 
@@ -489,14 +502,41 @@ func (r *defaultSubnetsResolver) validateSpecifiedSubnets(ctx context.Context, s
 	if err := r.validateSubnetsMinimalCount(subnets, subnetLocale, resolveOpts); err != nil {
 		return err
 	}
+	if err := r.validateSubnetsIPv6CIDR(subnets, resolveOpts); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateSubnetsIPv6CIDR validates that all explicitly specified subnets have an associated IPv6 CIDR block
+// when the load balancer requires IPv6 (dualstack). This surfaces a clear error instead of the opaque
+// ELBv2 "You must specify subnets with an associated IPv6 CIDR block" CreateLoadBalancer failure.
+func (r *defaultSubnetsResolver) validateSubnetsIPv6CIDR(subnets []ec2types.Subnet, resolveOpts SubnetsResolveOptions) error {
+	if !isIPv6CIDRRequired(resolveOpts.LBIPAddressType) {
+		return nil
+	}
+	var subnetsWithoutIPv6CIDR []string
+	for _, subnet := range subnets {
+		if !isSubnetContainsIPv6CIDR(subnet) {
+			subnetsWithoutIPv6CIDR = append(subnetsWithoutIPv6CIDR, awssdk.ToString(subnet.SubnetId))
+		}
+	}
+	if len(subnetsWithoutIPv6CIDR) > 0 {
+		return fmt.Errorf("subnets %v do not have an associated IPv6 CIDR block, which is required for %v load balancers", subnetsWithoutIPv6CIDR, resolveOpts.LBIPAddressType)
+	}
 	return nil
 }
 
 // chooseAndValidateSubnetsPerAZ will choose one subnet per AZ from eligible subnets and then validate against chosen subnets.
 func (r *defaultSubnetsResolver) chooseAndValidateSubnetsPerAZ(ctx context.Context, subnets []ec2types.Subnet, resolveOpts SubnetsResolveOptions) ([]ec2types.Subnet, error) {
-	categorizedSubnets := r.categorizeSubnetsByEligibility(subnets)
+	categorizedSubnets := r.categorizeSubnetsByEligibility(subnets, resolveOpts)
 	chosenSubnets := r.chooseSubnetsPerAZ(categorizedSubnets.eligible)
 	if len(chosenSubnets) == 0 {
+		// only mention the IPv6 criterion when it actually applied, to keep the IPv4 message unchanged.
+		if isIPv6CIDRRequired(resolveOpts.LBIPAddressType) {
+			return nil, fmt.Errorf("unable to resolve at least one subnet. Evaluated %d subnets: %d are tagged for other clusters, %d have insufficient available IP addresses, and %d don't have an associated IPv6 CIDR block, which is required for %v load balancers",
+				len(subnets), len(categorizedSubnets.ineligibleClusterTag), len(categorizedSubnets.insufficientIPs), len(categorizedSubnets.missingIPv6CIDR), resolveOpts.LBIPAddressType)
+		}
 		return nil, fmt.Errorf("unable to resolve at least one subnet. Evaluated %d subnets: %d are tagged for other clusters, and %d have insufficient available IP addresses",
 			len(subnets), len(categorizedSubnets.ineligibleClusterTag), len(categorizedSubnets.insufficientIPs))
 	}
@@ -514,10 +554,12 @@ type categorizeSubnetsByEligibilityResult struct {
 	eligible             []ec2types.Subnet
 	ineligibleClusterTag []ec2types.Subnet
 	insufficientIPs      []ec2types.Subnet
+	missingIPv6CIDR      []ec2types.Subnet
 }
 
 // categorizeSubnetsByEligibility will categorize subnets based it's eligibility of ELB subnet
-func (r *defaultSubnetsResolver) categorizeSubnetsByEligibility(subnets []ec2types.Subnet) categorizeSubnetsByEligibilityResult {
+func (r *defaultSubnetsResolver) categorizeSubnetsByEligibility(subnets []ec2types.Subnet, resolveOpts SubnetsResolveOptions) categorizeSubnetsByEligibilityResult {
+	requiresIPv6 := isIPv6CIDRRequired(resolveOpts.LBIPAddressType)
 	var ret categorizeSubnetsByEligibilityResult
 	for _, subnet := range subnets {
 		if !r.isSubnetContainsEligibleClusterTag(subnet) {
@@ -526,6 +568,13 @@ func (r *defaultSubnetsResolver) categorizeSubnetsByEligibility(subnets []ec2typ
 		}
 		if !r.isSubnetContainsSufficientIPAddresses(subnet) {
 			ret.insufficientIPs = append(ret.insufficientIPs, subnet)
+			continue
+		}
+		// dualstack load balancers require every subnet to have an associated IPv6 CIDR block,
+		// otherwise ELBv2 CreateLoadBalancer fails with "You must specify subnets with an
+		// associated IPv6 CIDR block". Discovery has no other IPv6 awareness, so filter here.
+		if requiresIPv6 && !isSubnetContainsIPv6CIDR(subnet) {
+			ret.missingIPv6CIDR = append(ret.missingIPv6CIDR, subnet)
 			continue
 		}
 		ret.eligible = append(ret.eligible, subnet)
@@ -605,6 +654,30 @@ func (r *defaultSubnetsResolver) isSubnetContainsEligibleClusterTag(subnet ec2ty
 // isSubnetContainsSufficientIPAddresses checks whether subnet has minimal AvailableIPAddressAcount needed.
 func (r *defaultSubnetsResolver) isSubnetContainsSufficientIPAddresses(subnet ec2types.Subnet) bool {
 	return awssdk.ToInt32(subnet.AvailableIpAddressCount) >= r.minimalAvailableIPAddressCount
+}
+
+// isIPv6CIDRRequired returns whether the given load balancer IPAddressType requires subnets to have
+// an associated IPv6 CIDR block.
+func isIPv6CIDRRequired(ipAddressType elbv2model.IPAddressType) bool {
+	switch ipAddressType {
+	case elbv2model.IPAddressTypeDualStack, elbv2model.IPAddressTypeDualStackWithoutPublicIPV4:
+		return true
+	default:
+		return false
+	}
+}
+
+// isSubnetContainsIPv6CIDR checks whether a subnet has at least one associated IPv6 CIDR block.
+func isSubnetContainsIPv6CIDR(subnet ec2types.Subnet) bool {
+	for _, cidrAssociation := range subnet.Ipv6CidrBlockAssociationSet {
+		if cidrAssociation.Ipv6CidrBlockState == nil {
+			continue
+		}
+		if cidrAssociation.Ipv6CidrBlockState.State == ec2types.SubnetCidrBlockStateCodeAssociated {
+			return true
+		}
+	}
+	return false
 }
 
 // validateSDKSubnetsAZExclusivity validates subnets belong to different AZs.

--- a/pkg/networking/subnet_resolver_test.go
+++ b/pkg/networking/subnet_resolver_test.go
@@ -1313,6 +1313,94 @@ func Test_defaultSubnetsResolver_ResolveViaDiscovery(t *testing.T) {
 			},
 			wantErr: errors.New("failed to list subnets by reachability: some error"),
 		},
+		{
+			// Regression test for kubernetes-sigs/aws-load-balancer-controller#4852: a dualstack LB
+			// must only be given subnets with an associated IPv6 CIDR block, otherwise ELBv2
+			// CreateLoadBalancer fails with "You must specify subnets with an associated IPv6 CIDR block".
+			name: "alb/internet-facing/dualstack, skips subnets without an IPv6 CIDR",
+			fields: fields{
+				clusterTagCheckEnabled:         true,
+				albSingleSubnetEnabled:         true,
+				discoveryByReachabilityEnabled: true,
+				describeSubnetsAsListCalls: []describeSubnetsAsListCall{
+					{
+						input: &ec2sdk.DescribeSubnetsInput{
+							Filters: []ec2types.Filter{
+								{
+									Name:   awssdk.String("vpc-id"),
+									Values: []string{"vpc-dummy"},
+								},
+								{
+									Name:   awssdk.String("tag:kubernetes.io/role/elb"),
+									Values: []string{"", "1"},
+								},
+							},
+						},
+						output: []ec2types.Subnet{
+							subnetWithIPv6("subnet-no-ipv6", "us-west-2a", "usw2-az1", false),
+							subnetWithIPv6("subnet-with-ipv6", "us-west-2b", "usw2-az2", true),
+						},
+					},
+				},
+				fetchAZInfosCalls: []fetchAZInfosCall{
+					{
+						availabilityZoneIDs: []string{"usw2-az2"},
+						azInfoByAZID: map[string]ec2types.AvailabilityZone{
+							"usw2-az2": {
+								ZoneId:   awssdk.String("usw2-az2"),
+								ZoneType: awssdk.String("availability-zone"),
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				opts: []SubnetsResolveOption{
+					WithSubnetsResolveLBType(elbv2model.LoadBalancerTypeApplication),
+					WithSubnetsResolveLBScheme(elbv2model.LoadBalancerSchemeInternetFacing),
+					WithSubnetsResolveLBIPAddressType(elbv2model.IPAddressTypeDualStack),
+				},
+			},
+			want: []ec2types.Subnet{
+				subnetWithIPv6("subnet-with-ipv6", "us-west-2b", "usw2-az2", true),
+			},
+		},
+		{
+			name: "alb/internet-facing/dualstack, no subnet has an IPv6 CIDR",
+			fields: fields{
+				clusterTagCheckEnabled:         true,
+				albSingleSubnetEnabled:         true,
+				discoveryByReachabilityEnabled: true,
+				describeSubnetsAsListCalls: []describeSubnetsAsListCall{
+					{
+						input: &ec2sdk.DescribeSubnetsInput{
+							Filters: []ec2types.Filter{
+								{
+									Name:   awssdk.String("vpc-id"),
+									Values: []string{"vpc-dummy"},
+								},
+								{
+									Name:   awssdk.String("tag:kubernetes.io/role/elb"),
+									Values: []string{"", "1"},
+								},
+							},
+						},
+						output: []ec2types.Subnet{
+							subnetWithIPv6("subnet-no-ipv6-a", "us-west-2a", "usw2-az1", false),
+							subnetWithIPv6("subnet-no-ipv6-b", "us-west-2b", "usw2-az2", false),
+						},
+					},
+				},
+			},
+			args: args{
+				opts: []SubnetsResolveOption{
+					WithSubnetsResolveLBType(elbv2model.LoadBalancerTypeApplication),
+					WithSubnetsResolveLBScheme(elbv2model.LoadBalancerSchemeInternetFacing),
+					WithSubnetsResolveLBIPAddressType(elbv2model.IPAddressTypeDualStack),
+				},
+			},
+			wantErr: errors.New("unable to resolve at least one subnet. Evaluated 2 subnets: 0 are tagged for other clusters, 0 have insufficient available IP addresses, and 2 don't have an associated IPv6 CIDR block, which is required for dualstack load balancers"),
+		},
 	}
 
 	for _, tt := range tests {
@@ -1342,6 +1430,8 @@ func Test_defaultSubnetsResolver_ResolveViaDiscovery(t *testing.T) {
 				opts := cmp.Options{
 					cmpopts.IgnoreUnexported(ec2types.Subnet{}),
 					cmpopts.IgnoreUnexported(ec2types.Tag{}),
+					cmpopts.IgnoreUnexported(ec2types.SubnetIpv6CidrBlockAssociation{}),
+					cmpopts.IgnoreUnexported(ec2types.SubnetCidrBlockState{}),
 				}
 				assert.True(t, cmp.Equal(tt.want, got, opts), "diff", cmp.Diff(tt.want, got, opts))
 			}
@@ -3739,6 +3829,203 @@ func Test_IsSubnetInLocalZoneOrOutpost(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func Test_isSubnetContainsIPv6CIDR(t *testing.T) {
+	tests := []struct {
+		name   string
+		subnet ec2types.Subnet
+		want   bool
+	}{
+		{
+			name:   "no IPv6 CIDR association",
+			subnet: ec2types.Subnet{SubnetId: awssdk.String("subnet-1")},
+			want:   false,
+		},
+		{
+			name: "associated IPv6 CIDR",
+			subnet: ec2types.Subnet{
+				SubnetId: awssdk.String("subnet-1"),
+				Ipv6CidrBlockAssociationSet: []ec2types.SubnetIpv6CidrBlockAssociation{
+					{
+						Ipv6CidrBlock:      awssdk.String("2600:1f13::/64"),
+						Ipv6CidrBlockState: &ec2types.SubnetCidrBlockState{State: ec2types.SubnetCidrBlockStateCodeAssociated},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "IPv6 CIDR still associating is not eligible",
+			subnet: ec2types.Subnet{
+				SubnetId: awssdk.String("subnet-1"),
+				Ipv6CidrBlockAssociationSet: []ec2types.SubnetIpv6CidrBlockAssociation{
+					{
+						Ipv6CidrBlock:      awssdk.String("2600:1f13::/64"),
+						Ipv6CidrBlockState: &ec2types.SubnetCidrBlockState{State: ec2types.SubnetCidrBlockStateCodeAssociating},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "nil CIDR block state doesn't panic",
+			subnet: ec2types.Subnet{
+				SubnetId: awssdk.String("subnet-1"),
+				Ipv6CidrBlockAssociationSet: []ec2types.SubnetIpv6CidrBlockAssociation{
+					{Ipv6CidrBlock: awssdk.String("2600:1f13::/64")},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isSubnetContainsIPv6CIDR(tt.subnet))
+		})
+	}
+}
+
+func Test_isIPv6CIDRRequired(t *testing.T) {
+	tests := []struct {
+		name          string
+		ipAddressType elbv2model.IPAddressType
+		want          bool
+	}{
+		{name: "ipv4", ipAddressType: elbv2model.IPAddressTypeIPV4, want: false},
+		{name: "dualstack", ipAddressType: elbv2model.IPAddressTypeDualStack, want: true},
+		{name: "dualstack-without-public-ipv4", ipAddressType: elbv2model.IPAddressTypeDualStackWithoutPublicIPV4, want: true},
+		{name: "empty defaults to not required", ipAddressType: elbv2model.IPAddressType(""), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isIPv6CIDRRequired(tt.ipAddressType))
+		})
+	}
+}
+
+// subnetWithIPv6 returns a discovery-eligible subnet, optionally with an associated IPv6 CIDR.
+func subnetWithIPv6(subnetID string, az string, azID string, hasIPv6 bool) ec2types.Subnet {
+	subnet := ec2types.Subnet{
+		SubnetId:                awssdk.String(subnetID),
+		AvailabilityZone:        awssdk.String(az),
+		AvailabilityZoneId:      awssdk.String(azID),
+		AvailableIpAddressCount: awssdk.Int32(8),
+		VpcId:                   awssdk.String("vpc-dummy"),
+	}
+	if hasIPv6 {
+		subnet.Ipv6CidrBlockAssociationSet = []ec2types.SubnetIpv6CidrBlockAssociation{
+			{
+				Ipv6CidrBlock:      awssdk.String("2600:1f13::/64"),
+				Ipv6CidrBlockState: &ec2types.SubnetCidrBlockState{State: ec2types.SubnetCidrBlockStateCodeAssociated},
+			},
+		}
+	}
+	return subnet
+}
+
+// Test_categorizeSubnetsByEligibility_IPv6CIDR asserts that for dualstack load balancers, subnets
+// lacking an associated IPv6 CIDR block are filtered out of discovery instead of being handed to
+// ELBv2 CreateLoadBalancer, which rejects them with "You must specify subnets with an associated
+// IPv6 CIDR block". See kubernetes-sigs/aws-load-balancer-controller#4852.
+func Test_categorizeSubnetsByEligibility_IPv6CIDR(t *testing.T) {
+	subnetNoIPv6 := subnetWithIPv6("subnet-no-ipv6", "us-west-2a", "usw2-az1", false)
+	subnetWithIPv6A := subnetWithIPv6("subnet-with-ipv6", "us-west-2b", "usw2-az2", true)
+
+	tests := []struct {
+		name                string
+		ipAddressType       elbv2model.IPAddressType
+		subnets             []ec2types.Subnet
+		wantEligible        []string
+		wantMissingIPv6CIDR []string
+	}{
+		{
+			name:                "ipv4 LB accepts subnets without an IPv6 CIDR",
+			ipAddressType:       elbv2model.IPAddressTypeIPV4,
+			subnets:             []ec2types.Subnet{subnetNoIPv6, subnetWithIPv6A},
+			wantEligible:        []string{"subnet-no-ipv6", "subnet-with-ipv6"},
+			wantMissingIPv6CIDR: []string{},
+		},
+		{
+			name:                "dualstack LB filters out subnets without an IPv6 CIDR",
+			ipAddressType:       elbv2model.IPAddressTypeDualStack,
+			subnets:             []ec2types.Subnet{subnetNoIPv6, subnetWithIPv6A},
+			wantEligible:        []string{"subnet-with-ipv6"},
+			wantMissingIPv6CIDR: []string{"subnet-no-ipv6"},
+		},
+		{
+			name:                "dualstack-without-public-ipv4 LB filters out subnets without an IPv6 CIDR",
+			ipAddressType:       elbv2model.IPAddressTypeDualStackWithoutPublicIPV4,
+			subnets:             []ec2types.Subnet{subnetNoIPv6, subnetWithIPv6A},
+			wantEligible:        []string{"subnet-with-ipv6"},
+			wantMissingIPv6CIDR: []string{"subnet-no-ipv6"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &defaultSubnetsResolver{
+				vpcID:                          "vpc-dummy",
+				clusterName:                    "cluster-dummy",
+				minimalAvailableIPAddressCount: 8,
+				logger:                         logr.New(&log.NullLogSink{}),
+			}
+			resolveOpts := defaultSubnetsResolveOptions()
+			resolveOpts.ApplyOptions([]SubnetsResolveOption{WithSubnetsResolveLBIPAddressType(tt.ipAddressType)})
+
+			got := r.categorizeSubnetsByEligibility(tt.subnets, resolveOpts)
+			assert.Equal(t, tt.wantEligible, extractSubnetIDs(got.eligible))
+			assert.Equal(t, tt.wantMissingIPv6CIDR, extractSubnetIDs(got.missingIPv6CIDR))
+		})
+	}
+}
+
+// Test_validateSubnetsIPv6CIDR asserts that explicitly pinned subnets lacking an IPv6 CIDR fail
+// fast with an actionable error rather than the opaque ELBv2 ValidationError.
+func Test_validateSubnetsIPv6CIDR(t *testing.T) {
+	subnetNoIPv6 := subnetWithIPv6("subnet-no-ipv6", "us-west-2a", "usw2-az1", false)
+	subnetWithIPv6A := subnetWithIPv6("subnet-with-ipv6", "us-west-2b", "usw2-az2", true)
+
+	tests := []struct {
+		name          string
+		ipAddressType elbv2model.IPAddressType
+		subnets       []ec2types.Subnet
+		wantErr       string
+	}{
+		{
+			name:          "ipv4 LB tolerates subnets without an IPv6 CIDR",
+			ipAddressType: elbv2model.IPAddressTypeIPV4,
+			subnets:       []ec2types.Subnet{subnetNoIPv6},
+		},
+		{
+			name:          "dualstack LB accepts subnets with an IPv6 CIDR",
+			ipAddressType: elbv2model.IPAddressTypeDualStack,
+			subnets:       []ec2types.Subnet{subnetWithIPv6A},
+		},
+		{
+			name:          "dualstack LB rejects subnets without an IPv6 CIDR",
+			ipAddressType: elbv2model.IPAddressTypeDualStack,
+			subnets:       []ec2types.Subnet{subnetNoIPv6, subnetWithIPv6A},
+			wantErr:       "subnets [subnet-no-ipv6] do not have an associated IPv6 CIDR block, which is required for dualstack load balancers",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &defaultSubnetsResolver{
+				vpcID:       "vpc-dummy",
+				clusterName: "cluster-dummy",
+				logger:      logr.New(&log.NullLogSink{}),
+			}
+			resolveOpts := defaultSubnetsResolveOptions()
+			resolveOpts.ApplyOptions([]SubnetsResolveOption{WithSubnetsResolveLBIPAddressType(tt.ipAddressType)})
+
+			err := r.validateSubnetsIPv6CIDR(tt.subnets, resolveOpts)
+			if tt.wantErr != "" {
+				assert.EqualError(t, err, tt.wantErr)
+			} else {
+				assert.NoError(t, err)
 			}
 		})
 	}

--- a/pkg/service/model_build_load_balancer.go
+++ b/pkg/service/model_build_load_balancer.go
@@ -433,12 +433,13 @@ func (t *defaultModelBuildTask) buildLoadBalancerSubnetMappings(_ context.Contex
 	return subnetMappings, nil
 }
 
-func (t *defaultModelBuildTask) buildLoadBalancerSubnets(ctx context.Context, scheme elbv2model.LoadBalancerScheme) ([]ec2types.Subnet, error) {
+func (t *defaultModelBuildTask) buildLoadBalancerSubnets(ctx context.Context, scheme elbv2model.LoadBalancerScheme, ipAddressType elbv2model.IPAddressType) ([]ec2types.Subnet, error) {
 	var rawSubnetNameOrIDs []string
 	if exists := t.annotationParser.ParseStringSliceAnnotation(annotations.SvcLBSuffixSubnets, &rawSubnetNameOrIDs, t.service.Annotations); exists {
 		return t.subnetsResolver.ResolveViaNameOrIDSlice(ctx, rawSubnetNameOrIDs,
 			networking.WithSubnetsResolveLBType(elbv2model.LoadBalancerTypeNetwork),
 			networking.WithSubnetsResolveLBScheme(scheme),
+			networking.WithSubnetsResolveLBIPAddressType(ipAddressType),
 		)
 	}
 
@@ -456,6 +457,7 @@ func (t *defaultModelBuildTask) buildLoadBalancerSubnets(ctx context.Context, sc
 		return t.subnetsResolver.ResolveViaNameOrIDSlice(ctx, subnetIDs,
 			networking.WithSubnetsResolveLBType(elbv2model.LoadBalancerTypeNetwork),
 			networking.WithSubnetsResolveLBScheme(scheme),
+			networking.WithSubnetsResolveLBIPAddressType(ipAddressType),
 		)
 	}
 
@@ -468,11 +470,13 @@ func (t *defaultModelBuildTask) buildLoadBalancerSubnets(ctx context.Context, sc
 		return t.subnetsResolver.ResolveViaDiscovery(ctx,
 			networking.WithSubnetsResolveLBType(elbv2model.LoadBalancerTypeNetwork),
 			networking.WithSubnetsResolveLBScheme(scheme),
+			networking.WithSubnetsResolveLBIPAddressType(ipAddressType),
 		)
 	}
 	return t.subnetsResolver.ResolveViaDiscovery(ctx,
 		networking.WithSubnetsResolveLBType(elbv2model.LoadBalancerTypeNetwork),
 		networking.WithSubnetsResolveLBScheme(scheme),
+		networking.WithSubnetsResolveLBIPAddressType(ipAddressType),
 	)
 }
 

--- a/pkg/service/model_build_load_balancer_test.go
+++ b/pkg/service/model_build_load_balancer_test.go
@@ -1385,7 +1385,7 @@ func Test_defaultModelBuilderTask_buildLoadBalancerSubnets(t *testing.T) {
 				elbv2TaggingManager: elbv2TaggingManager,
 				featureGates:        featureGates,
 			}
-			got, err := builder.buildLoadBalancerSubnets(context.Background(), tt.scheme)
+			got, err := builder.buildLoadBalancerSubnets(context.Background(), tt.scheme, elbv2.IPAddressTypeIPV4)
 			if tt.wantErr != nil {
 				assert.EqualError(t, err, tt.wantErr.Error())
 			} else {

--- a/pkg/service/model_builder.go
+++ b/pkg/service/model_builder.go
@@ -265,7 +265,11 @@ func (t *defaultModelBuildTask) buildModel(ctx context.Context) error {
 	if err != nil {
 		return ctrlerrors.NewErrorWithMetrics(controllerName, "build_load_balancer_scheme_error", err, t.metricsCollector)
 	}
-	t.ec2Subnets, err = t.buildLoadBalancerSubnets(ctx, scheme)
+	ipAddressType, err := t.buildLoadBalancerIPAddressType(ctx)
+	if err != nil {
+		return ctrlerrors.NewErrorWithMetrics(controllerName, "build_load_balancer_ip_address_type_error", err, t.metricsCollector)
+	}
+	t.ec2Subnets, err = t.buildLoadBalancerSubnets(ctx, scheme, ipAddressType)
 	if err != nil {
 		return ctrlerrors.NewErrorWithMetrics(controllerName, "build_load_balancer_subnets_error", err, t.metricsCollector)
 	}


### PR DESCRIPTION
### Issue

Fixes #4852

<!-- Please link the GitHub issues related to this PR, if available -->

### Description

<!--
Please explain the changes you made here.

Help your reviewers by guiding them through your key changes,
implementation decisions etc.
You can even include snippets of output or screenshots.

A good, clear description == a faster review :)
-->

Subnet auto-discovery never received the load balancer's ipAddressType, so nothing checked Ipv6CidrBlockAssociationSet. A dualstack LB relying on discovery could be handed subnets with no IPv6 CIDR, and ELBv2 rejected the create call with:

```
    ValidationError: You must specify subnets with an associated IPv6 CIDR block.
```
Being a shared resolver defect, this affected ALB Ingress, NLB Services, the Ingress frontend-NLB feature and Gateway alike.

Thread ipAddressType to the resolver via a new WithSubnetsResolveLBIPAddressType option and apply the missing criterion:

- discovery skips subnets without an associated IPv6 CIDR, and reports how many were skipped when none remain eligible.
- explicitly specified subnets fail up front with an error naming the offending subnets, instead of the opaque ELBv2 error.

IPv4 load balancers are unaffected and their failure message is unchanged. An IPv6 CIDR must be in the "associated" state to count.

Case1: When VPC has subnets with Ipv6 CIDRs, if ALB/NLB ip address type is dualstack auto subnet discovery resolves successfully

```
Normal  SuccessfullyReconciled  23s  ingress  Successfully reconciled

  NAME                     CLASS               ADDRESS                                                                   PORTS
  verify-happy-discovery   repro-subnet-disc   k8s-reprosub-verifyha-b7c819922a-1258703918.us-west-2.elb.amazonaws.com   80

  Confirmed in ELBv2 that the LB was created dualstack on the three IPv6-enabled subnets:

  {
    "Name": "k8s-reprosub-verifyha-b7c819922a",
    "IpType": "dualstack",
    "Scheme": "internet-facing",
    "Subnets": ["subnet-00a488ef08f1a058e", "subnet-0e4fb36588a3fc481", "subnet-0fde0bb80a7b0b487"]
  }

```

Case2: When no subnets have any Ipv6 CIDRs available, error logging bubbles up this message 

  - Before: FailedDeployModel — an ValidationError from a wasted ELBv2 CreateLoadBalancer API call.
  - After: FailedBuildModel — the controller stops at model-build time, never calls AWS, and explains exactly why: 
```
Warning  FailedBuildModel  11s (x13 over 33s)  ingress  Failed build model due to couldn't auto-discover subnets: unable to resolve at least one subnet. Evaluated 3 subnets: 0 are tagged for
  other clusters, 0 have insufficient available IP addresses, and 3 don't have an associated IPv6 CIDR block, which is required for dualstack load balancers
```  
Case3: When subnets are explicitly specified and none have Ipv6 CIDRs, validation fails early naming the offending subnets
 - Before: FailedDeployModel — an ValidationError from a wasted ELBv2 CreateLoadBalancer API call.
  - After: FailedBuildModel — the controller stops at model-build time, never calls AWS, and explains exactly why: 
```
  Warning  FailedBuildModel  13s (x13 over 34s)  ingress  Failed build model due to subnets [subnet-0c5ac0d06bdcd265f subnet-0af082802adb73f72 subnet-0a1282ceff5e63623] do not have an associated
  IPv6 CIDR block, which is required for dualstack load balancers
```

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
