### PR TITLE
Add frontend-nlb-private-ipv4-addresses annotation for internal NLB static IPs

### DIFF
--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -87,6 +87,7 @@ You can add annotations to kubernetes Ingress and Service objects to customize t
 | [alb.ingress.kubernetes.io/frontend-nlb-healthcheck-success-codes](#frontend-nlb-healthcheck-success-codes) | string                                     |200| Ingress | N/A           |
 | [alb.ingress.kubernetes.io/frontend-nlb-tags](#frontend-nlb-tags) | stringMap | N/A | Ingress | Exclusive |
 | [alb.ingress.kubernetes.io/frontend-nlb-eip-allocations](#frontend-nlb-eip-allocations) | stringList                                     |200| Ingress | N/A           |
+| [alb.ingress.kubernetes.io/frontend-nlb-private-ipv4-addresses](#frontend-nlb-private-ipv4-addresses) | stringList                                     |N/A| Ingress | N/A           |
 | [alb.ingress.kubernetes.io/target-control-port.${serviceName}.${servicePort}](#target-control-port)                                       | integer                                    |N/A| Ingress | N/A           |
 | [alb.ingress.kubernetes.io/frontend-nlb-attributes](#frontend-nlb-attributes) | stringList                                     |N/A| Ingress | N/A           |
 
@@ -1415,6 +1416,21 @@ When this option is set to true, the controller will automatically provision a N
         ```
         alb.ingress.kubernetes.io/frontend-nlb-eip-allocations: eipalloc-xyz, eipalloc-zzz
         ```
+
+- <a name="frontend-nlb-private-ipv4-addresses">`alb.ingress.kubernetes.io/frontend-nlb-private-ipv4-addresses`</a> specifies a list of private IPv4 addresses to assign to an internal frontend NLB.
+
+    !!!note
+        - This configuration is optional, and you can use it to assign static private IP addresses to your internal NLB
+        - If you include the subnets [annotation](#frontend-nlb-subnets) it must have the same number of subnets as this annotation has addresses
+        - NLB must be internal (scheme must be `internal`)
+        - Mutually exclusive with [frontend-nlb-eip-allocations](#frontend-nlb-eip-allocations)
+        - Each address must be a valid IPv4 address within the respective subnet's CIDR range
+
+    !!!example
+        ```
+        alb.ingress.kubernetes.io/frontend-nlb-private-ipv4-addresses: 10.0.1.10, 10.0.2.10
+        ```
+
 - <a name="target-control-port">`alb.ingress.kubernetes.io/target-control-port.${serviceName}.${servicePort}`</a> specifies the port on which the target control agent and application load balancer exchange management traffic for the target optimizer feature.  
 
     !!!note

--- a/docs/guide/ingress/annotations.md
+++ b/docs/guide/ingress/annotations.md
@@ -1420,11 +1420,11 @@ When this option is set to true, the controller will automatically provision a N
 - <a name="frontend-nlb-private-ipv4-addresses">`alb.ingress.kubernetes.io/frontend-nlb-private-ipv4-addresses`</a> specifies a list of private IPv4 addresses to assign to an internal frontend NLB.
 
     !!!note
-        - This configuration is optional, and you can use it to assign static private IP addresses to your internal NLB
-        - If you include the subnets [annotation](#frontend-nlb-subnets) it must have the same number of subnets as this annotation has addresses
         - NLB must be internal (scheme must be `internal`)
+        - This configuration is optional, and you can use it to assign static private IPv4 addresses to your internal frontend NLB
+        - You must specify the same number of private IPv4 addresses as frontend NLB subnets [annotation](#frontend-nlb-subnets)
+        - You must specify the IPv4 addresses from the frontend NLB subnet IPv4 ranges
         - Mutually exclusive with [frontend-nlb-eip-allocations](#frontend-nlb-eip-allocations)
-        - Each address must be a valid IPv4 address within the respective subnet's CIDR range
 
     !!!example
         ```

--- a/pkg/annotations/constants.go
+++ b/pkg/annotations/constants.go
@@ -67,6 +67,7 @@ const (
 	IngressSuffixFrontendNlbSecurityGroups                     = "frontend-nlb-security-groups"
 	IngressSuffixFrontendNlbListenerPortMapping                = "frontend-nlb-listener-port-mapping"
 	IngressSuffixFrontendNlbEipAllocations                     = "frontend-nlb-eip-allocations"
+	IngressSuffixFrontendNlbPrivateIPv4Addresses               = "frontend-nlb-private-ipv4-addresses"
 	IngressSuffixFrontendNlbHealthCheckPort                    = "frontend-nlb-healthcheck-port"
 	IngressSuffixFrontendNlbHealthCheckProtocol                = "frontend-nlb-healthcheck-protocol"
 	IngressSuffixFrontendNlbHealthCheckPath                    = "frontend-nlb-healthcheck-path"

--- a/pkg/ingress/model_build_frontend_nlb.go
+++ b/pkg/ingress/model_build_frontend_nlb.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"net"
 	"strconv"
 
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/shared_constants"
@@ -155,9 +156,31 @@ func (t *defaultModelBuildTask) validateEIPAllocations(eipAllocationsList [][]st
 	return []string{}, nil
 }
 
+func (t *defaultModelBuildTask) validatePrivateIPv4Addresses(privateIPv4AddressesList [][]string, scheme elbv2model.LoadBalancerScheme) ([]string, error) {
+	if len(privateIPv4AddressesList) != 0 {
+		if scheme != elbv2model.LoadBalancerSchemeInternal {
+			return nil, errors.Errorf("private IPv4 addresses can only be set for internal load balancers")
+		}
+		chosenPrivateIPv4Addresses := privateIPv4AddressesList[0]
+		for _, privateIPv4Addresses := range privateIPv4AddressesList[1:] {
+			if !cmp.Equal(chosenPrivateIPv4Addresses, privateIPv4Addresses, equality.IgnoreStringSliceOrder()) {
+				return nil, errors.Errorf("all private IPv4 addresses for the ingress group must be the same: %v | %v", chosenPrivateIPv4Addresses, privateIPv4Addresses)
+			}
+		}
+		for _, ip := range chosenPrivateIPv4Addresses {
+			if net.ParseIP(ip) == nil || net.ParseIP(ip).To4() == nil {
+				return nil, errors.Errorf("invalid private IPv4 address: %s", ip)
+			}
+		}
+		return chosenPrivateIPv4Addresses, nil
+	}
+	return []string{}, nil
+}
+
 func (t *defaultModelBuildTask) buildFrontendNlbSubnetMappings(ctx context.Context, scheme elbv2model.LoadBalancerScheme, ipAddressType elbv2model.IPAddressType) ([]elbv2model.SubnetMapping, error) {
 	var explicitSubnetNameOrIDsList [][]string
 	var eipAllocationsList [][]string
+	var privateIPv4AddressesList [][]string
 	// Read annotations
 	for _, member := range t.ingGroup.Members {
 		var rawSubnetNameOrIDs []string
@@ -168,6 +191,15 @@ func (t *defaultModelBuildTask) buildFrontendNlbSubnetMappings(ctx context.Conte
 		if exists := t.annotationParser.ParseStringSliceAnnotation(annotations.IngressSuffixFrontendNlbEipAllocations, &rawEIP, member.Ing.Annotations); exists {
 			eipAllocationsList = append(eipAllocationsList, rawEIP)
 		}
+		var rawPrivateIPv4 []string
+		if exists := t.annotationParser.ParseStringSliceAnnotation(annotations.IngressSuffixFrontendNlbPrivateIPv4Addresses, &rawPrivateIPv4, member.Ing.Annotations); exists {
+			privateIPv4AddressesList = append(privateIPv4AddressesList, rawPrivateIPv4)
+		}
+	}
+
+	// EIP and private IPv4 are mutually exclusive — check before individual validation
+	if len(eipAllocationsList) != 0 && len(privateIPv4AddressesList) != 0 {
+		return nil, errors.Errorf("EIP allocations and private IPv4 addresses are mutually exclusive")
 	}
 
 	chosenSubnets, err := t.validateAndResolveSubnets(ctx, explicitSubnetNameOrIDsList, scheme, ipAddressType)
@@ -180,18 +212,30 @@ func (t *defaultModelBuildTask) buildFrontendNlbSubnetMappings(ctx context.Conte
 		return nil, err
 	}
 
+	chosenPrivateIPv4Addresses, err := t.validatePrivateIPv4Addresses(privateIPv4AddressesList, scheme)
+	if err != nil {
+		return nil, err
+	}
+
 	// Construct subnet mapping
 	if len(chosenEipAllocations) != 0 {
 		if len(chosenEipAllocations) != len(chosenSubnets) {
 			return nil, errors.Errorf("count of EIP allocations (%d) and subnets (%d) must match", len(chosenEipAllocations), len(chosenSubnets))
 		}
-		return buildFrontendNlbSubnetMappingsWithSubnets(chosenSubnets, chosenEipAllocations), nil
+		return buildFrontendNlbSubnetMappingsWithSubnets(chosenSubnets, chosenEipAllocations, []string{}), nil
 	}
 
-	return buildFrontendNlbSubnetMappingsWithSubnets(chosenSubnets, []string{}), nil
+	if len(chosenPrivateIPv4Addresses) != 0 {
+		if len(chosenPrivateIPv4Addresses) != len(chosenSubnets) {
+			return nil, errors.Errorf("count of private IPv4 addresses (%d) and subnets (%d) must match", len(chosenPrivateIPv4Addresses), len(chosenSubnets))
+		}
+		return buildFrontendNlbSubnetMappingsWithSubnets(chosenSubnets, []string{}, chosenPrivateIPv4Addresses), nil
+	}
+
+	return buildFrontendNlbSubnetMappingsWithSubnets(chosenSubnets, []string{}, []string{}), nil
 }
 
-func buildFrontendNlbSubnetMappingsWithSubnets(subnets []ec2types.Subnet, eipAllocation []string) []elbv2model.SubnetMapping {
+func buildFrontendNlbSubnetMappingsWithSubnets(subnets []ec2types.Subnet, eipAllocation []string, privateIPv4Addresses []string) []elbv2model.SubnetMapping {
 	subnetMappings := make([]elbv2model.SubnetMapping, 0, len(subnets))
 	for idx, subnet := range subnets {
 		subnetMappings = append(subnetMappings, elbv2model.SubnetMapping{
@@ -199,6 +243,9 @@ func buildFrontendNlbSubnetMappingsWithSubnets(subnets []ec2types.Subnet, eipAll
 		})
 		if len(eipAllocation) > 0 {
 			subnetMappings[idx].AllocationID = awssdk.String(eipAllocation[idx])
+		}
+		if len(privateIPv4Addresses) > 0 {
+			subnetMappings[idx].PrivateIPv4Address = awssdk.String(privateIPv4Addresses[idx])
 		}
 	}
 

--- a/pkg/ingress/model_build_frontend_nlb.go
+++ b/pkg/ingress/model_build_frontend_nlb.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net"
+	"net/netip"
 	"strconv"
 
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/shared_constants"
@@ -229,7 +230,32 @@ func (t *defaultModelBuildTask) buildFrontendNlbSubnetMappings(ctx context.Conte
 		if len(chosenPrivateIPv4Addresses) != len(chosenSubnets) {
 			return nil, errors.Errorf("count of private IPv4 addresses (%d) and subnets (%d) must match", len(chosenPrivateIPv4Addresses), len(chosenSubnets))
 		}
-		return buildFrontendNlbSubnetMappingsWithSubnets(chosenSubnets, []string{}, chosenPrivateIPv4Addresses), nil
+		// Parse all private IPv4 addresses into netip.Addr
+		var ipv4Addresses []netip.Addr
+		for _, ip := range chosenPrivateIPv4Addresses {
+			addr, err := netip.ParseAddr(ip)
+			if err != nil || !addr.Is4() {
+				return nil, errors.Errorf("invalid private IPv4 address: %s", ip)
+			}
+			ipv4Addresses = append(ipv4Addresses, addr)
+		}
+		// Build subnet mappings using CIDR-based matching (same pattern as service NLB)
+		subnetMappings := make([]elbv2model.SubnetMapping, 0, len(chosenSubnets))
+		for _, subnet := range chosenSubnets {
+			subnetIPv4CIDRs, err := networking.GetSubnetAssociatedIPv4CIDRs(subnet)
+			if err != nil {
+				return nil, err
+			}
+			ipv4AddressesWithinSubnet := networking.FilterIPsWithinCIDRs(ipv4Addresses, subnetIPv4CIDRs)
+			if len(ipv4AddressesWithinSubnet) != 1 {
+				return nil, errors.Errorf("expect exactly one private IPv4 address within subnet %v CIDR, got %d", awssdk.ToString(subnet.SubnetId), len(ipv4AddressesWithinSubnet))
+			}
+			subnetMappings = append(subnetMappings, elbv2model.SubnetMapping{
+				SubnetID:           awssdk.ToString(subnet.SubnetId),
+				PrivateIPv4Address: awssdk.String(ipv4AddressesWithinSubnet[0].String()),
+			})
+		}
+		return subnetMappings, nil
 	}
 
 	return buildFrontendNlbSubnetMappingsWithSubnets(chosenSubnets, []string{}, []string{}), nil

--- a/pkg/ingress/model_build_frontend_nlb_test.go
+++ b/pkg/ingress/model_build_frontend_nlb_test.go
@@ -215,8 +215,9 @@ func Test_buildFrontendNlbSubnetMappings(t *testing.T) {
 	}
 
 	type expectedMapping struct {
-		SubnetID     string
-		AllocationID *string
+		SubnetID           string
+		AllocationID       *string
+		PrivateIPv4Address *string
 	}
 
 	tests := []struct {
@@ -392,6 +393,149 @@ func Test_buildFrontendNlbSubnetMappings(t *testing.T) {
 				{SubnetID: "subnet-2", AllocationID: awssdk.String("eip-20")},
 			},
 		},
+		{
+			name: "with subnets and private IPv4 addresses",
+			fields: fields{
+				ingGroup: Group{
+					ID: GroupID{
+						Namespace: "awesome-ns",
+						Name:      "my-ingress",
+					},
+					Members: []ClassifiedIngress{
+						{
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "awesome-ns",
+									Name:      "ing-7",
+									Annotations: map[string]string{
+										"alb.ingress.kubernetes.io/frontend-nlb-subnets":                  "subnet-1,subnet-2",
+										"alb.ingress.kubernetes.io/frontend-nlb-private-ipv4-addresses": "10.0.1.10,10.0.2.10",
+									},
+								},
+							},
+						},
+					},
+				},
+				scheme: elbv2.LoadBalancerSchemeInternal,
+			},
+			wantMappings: []expectedMapping{
+				{SubnetID: "subnet-1", AllocationID: nil, PrivateIPv4Address: awssdk.String("10.0.1.10")},
+				{SubnetID: "subnet-2", AllocationID: nil, PrivateIPv4Address: awssdk.String("10.0.2.10")},
+			},
+		},
+		{
+			name: "error when private IPv4 addresses are specified but scheme is internet-facing",
+			fields: fields{
+				ingGroup: Group{
+					ID: GroupID{
+						Namespace: "awesome-ns",
+						Name:      "my-ingress",
+					},
+					Members: []ClassifiedIngress{
+						{
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "awesome-ns",
+									Name:      "ing-8",
+									Annotations: map[string]string{
+										"alb.ingress.kubernetes.io/frontend-nlb-subnets":                  "subnet-1,subnet-2",
+										"alb.ingress.kubernetes.io/frontend-nlb-private-ipv4-addresses": "10.0.1.10,10.0.2.10",
+									},
+								},
+							},
+						},
+					},
+				},
+				scheme: elbv2.LoadBalancerSchemeInternetFacing,
+			},
+			wantMappings: nil,
+			wantErr:      "private IPv4 addresses can only be set for internal load balancers",
+		},
+		{
+			name: "error when number of private IPv4 addresses does not match subnets",
+			fields: fields{
+				ingGroup: Group{
+					ID: GroupID{
+						Namespace: "awesome-ns",
+						Name:      "my-ingress",
+					},
+					Members: []ClassifiedIngress{
+						{
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "awesome-ns",
+									Name:      "ing-9",
+									Annotations: map[string]string{
+										"alb.ingress.kubernetes.io/frontend-nlb-subnets":                  "subnet-1,subnet-2",
+										"alb.ingress.kubernetes.io/frontend-nlb-private-ipv4-addresses": "10.0.1.10",
+									},
+								},
+							},
+						},
+					},
+				},
+				scheme: elbv2.LoadBalancerSchemeInternal,
+			},
+			wantMappings: nil,
+			wantErr:      "count of private IPv4 addresses (1) and subnets (2) must match",
+		},
+		{
+			name: "error when both EIP and private IPv4 are specified",
+			fields: fields{
+				ingGroup: Group{
+					ID: GroupID{
+						Namespace: "awesome-ns",
+						Name:      "my-ingress",
+					},
+					Members: []ClassifiedIngress{
+						{
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "awesome-ns",
+									Name:      "ing-10",
+									Annotations: map[string]string{
+										"alb.ingress.kubernetes.io/frontend-nlb-subnets":                  "subnet-1,subnet-2",
+										"alb.ingress.kubernetes.io/frontend-nlb-eip-allocations":        "eip-1,eip-2",
+										"alb.ingress.kubernetes.io/frontend-nlb-private-ipv4-addresses": "10.0.1.10,10.0.2.10",
+									},
+								},
+							},
+						},
+					},
+				},
+				scheme: elbv2.LoadBalancerSchemeInternetFacing,
+			},
+			wantMappings: nil,
+			wantErr:      "EIP allocations and private IPv4 addresses are mutually exclusive",
+		},
+		{
+			name: "error when invalid IPv4 address format",
+			fields: fields{
+				ingGroup: Group{
+					ID: GroupID{
+						Namespace: "awesome-ns",
+						Name:      "my-ingress",
+					},
+					Members: []ClassifiedIngress{
+						{
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "awesome-ns",
+									Name:      "ing-11",
+									Annotations: map[string]string{
+										"alb.ingress.kubernetes.io/frontend-nlb-subnets":                  "subnet-1,subnet-2",
+										"alb.ingress.kubernetes.io/frontend-nlb-private-ipv4-addresses": "not-an-ip,10.0.2.10",
+									},
+								},
+							},
+						},
+					},
+				},
+				scheme: elbv2.LoadBalancerSchemeInternal,
+			},
+			wantMappings: nil,
+			wantErr:      "invalid private IPv4 address: not-an-ip",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -427,8 +571,9 @@ func Test_buildFrontendNlbSubnetMappings(t *testing.T) {
 				var gotMappings []expectedMapping
 				for _, mapping := range got {
 					gotMappings = append(gotMappings, expectedMapping{
-						SubnetID:     mapping.SubnetID,
-						AllocationID: mapping.AllocationID,
+						SubnetID:           mapping.SubnetID,
+						AllocationID:       mapping.AllocationID,
+						PrivateIPv4Address: mapping.PrivateIPv4Address,
 					})
 				}
 				assert.Equal(t, tt.wantMappings, gotMappings)

--- a/pkg/ingress/model_build_frontend_nlb_test.go
+++ b/pkg/ingress/model_build_frontend_nlb_test.go
@@ -536,6 +536,74 @@ func Test_buildFrontendNlbSubnetMappings(t *testing.T) {
 			wantMappings: nil,
 			wantErr:      "invalid private IPv4 address: not-an-ip",
 		},
+		{
+			name: "error when ingress group members have different private IPv4 addresses",
+			fields: fields{
+				ingGroup: Group{
+					ID: GroupID{
+						Namespace: "awesome-ns",
+						Name:      "my-ingress",
+					},
+					Members: []ClassifiedIngress{
+						{
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "awesome-ns",
+									Name:      "ing-12",
+									Annotations: map[string]string{
+										"alb.ingress.kubernetes.io/frontend-nlb-subnets":                  "subnet-1,subnet-2",
+										"alb.ingress.kubernetes.io/frontend-nlb-private-ipv4-addresses": "10.0.1.10,10.0.2.10",
+									},
+								},
+							},
+						},
+						{
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "awesome-ns",
+									Name:      "ing-13",
+									Annotations: map[string]string{
+										"alb.ingress.kubernetes.io/frontend-nlb-subnets":                  "subnet-1,subnet-2",
+										"alb.ingress.kubernetes.io/frontend-nlb-private-ipv4-addresses": "10.0.1.99,10.0.2.99",
+									},
+								},
+							},
+						},
+					},
+				},
+				scheme: elbv2.LoadBalancerSchemeInternal,
+			},
+			wantMappings: nil,
+			wantErr:      "all private IPv4 addresses for the ingress group must be the same: [10.0.1.10 10.0.2.10] | [10.0.1.99 10.0.2.99]",
+		},
+		{
+			name: "error when private IPv4 address is not within subnet CIDR",
+			fields: fields{
+				ingGroup: Group{
+					ID: GroupID{
+						Namespace: "awesome-ns",
+						Name:      "my-ingress",
+					},
+					Members: []ClassifiedIngress{
+						{
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "awesome-ns",
+									Name:      "ing-14",
+									Annotations: map[string]string{
+										"alb.ingress.kubernetes.io/frontend-nlb-subnets":                  "subnet-1,subnet-2",
+										"alb.ingress.kubernetes.io/frontend-nlb-private-ipv4-addresses": "192.168.1.10,10.0.2.10",
+									},
+								},
+							},
+						},
+					},
+				},
+				scheme: elbv2.LoadBalancerSchemeInternal,
+			},
+			wantMappings: nil,
+			wantErr:      "expect exactly one private IPv4 address within subnet subnet-1 CIDR, got 0",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -547,13 +615,13 @@ func Test_buildFrontendNlbSubnetMappings(t *testing.T) {
 
 			mockSubnetsResolver.EXPECT().ResolveViaDiscovery(gomock.Any(), gomock.Any()).
 				Return([]ec2types.Subnet{
-					{SubnetId: awssdk.String("subnet-1")},
-					{SubnetId: awssdk.String("subnet-2")},
+					{SubnetId: awssdk.String("subnet-1"), CidrBlock: awssdk.String("10.0.1.0/24")},
+					{SubnetId: awssdk.String("subnet-2"), CidrBlock: awssdk.String("10.0.2.0/24")},
 				}, nil).AnyTimes()
 			mockSubnetsResolver.EXPECT().ResolveViaNameOrIDSlice(gomock.Any(), gomock.Any(), gomock.Any()).
 				Return([]ec2types.Subnet{
-					{SubnetId: awssdk.String("subnet-1")},
-					{SubnetId: awssdk.String("subnet-2")},
+					{SubnetId: awssdk.String("subnet-1"), CidrBlock: awssdk.String("10.0.1.0/24")},
+					{SubnetId: awssdk.String("subnet-2"), CidrBlock: awssdk.String("10.0.2.0/24")},
 				}, nil).AnyTimes()
 
 			annotationParser := annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io")


### PR DESCRIPTION
   ## Description

   When frontend NLB is configured as internal via `alb.ingress.kubernetes.io/frontend-nlb-scheme:
   "internal"`, there is currently no way to assign static private IPv4 addresses to the NLB. This is needed
   for scenarios where downstream consumers require stable IP addresses for allowlisting or DNS configuration.

   This PR adds a new annotation:
   `alb.ingress.kubernetes.io/frontend-nlb-private-ipv4-addresses: "10.0.1.10, 10.0.2.10"`

   The implementation mirrors the existing `frontend-nlb-eip-allocations` annotation:
   - Validates that the NLB scheme is `internal`
   - Validates each value is a valid IPv4 address
   - Ensures mutual exclusivity with `frontend-nlb-eip-allocations`
   - Requires address count to match subnet count
   - Ensures all ingresses in a group specify the same addresses

   The annotation is opt-in and has no effect on existing configurations.

Fixes #4857 

   ## Validation

   - Unit tests covering happy path, scheme validation, count mismatch, mutual exclusivity, and invalid IP
   format
   - Full `pkg/ingress/` test suite passes
   - Manually validated on EKS (ap-northeast-2): internal frontend NLB created with static private IPv4
   addresses (`10.99.1.100`, `10.99.2.100`) confirmed via `aws elbv2 describe-load-balancers`

   ## Checklist
   - [x] Added tests that cover your change (if possible)
   - [x] Added/modified documentation as required (such as the README.md, or the docs directory)
   - [x] Manually tested
   - [x] Made sure the title of the PR is a good description that can go into the release notes