### PR TITLE
fix(gateway): avoid DuplicateTargetGroupName for Services with multiple named targetPorts

### DIFF
--- a/pkg/gateway/model/model_build_target_group.go
+++ b/pkg/gateway/model/model_build_target_group.go
@@ -283,11 +283,12 @@ func (builder *targetGroupBuilderImpl) buildTargetGroupSpec(gw *gwv1.Gateway, ro
 		return elbv2model.TargetGroupSpec{}, err
 	}
 	tgPort := backendConfig.GetTargetGroupPort(targetType)
+	identifierPort := backendConfig.GetIdentifierPort()
 	targetControlPort, err := builder.buildTargetControlPort(targetGroupProps, tgProtocol, targetType)
 	if err != nil {
 		return elbv2model.TargetGroupSpec{}, err
 	}
-	name := builder.buildTargetGroupName(targetGroupProps, k8s.NamespacedName(gw), route.GetRouteNamespacedName(), route.GetRouteKind(), backendConfig.GetBackendNamespacedName(), tgPort, targetType, tgProtocol, tgProtocolVersion, targetControlPort)
+	name := builder.buildTargetGroupName(targetGroupProps, k8s.NamespacedName(gw), route.GetRouteNamespacedName(), route.GetRouteKind(), backendConfig.GetBackendNamespacedName(), tgPort, identifierPort, targetType, tgProtocol, tgProtocolVersion, targetControlPort)
 
 	if tgPort == 0 {
 		if targetType == elbv2model.TargetTypeIP {
@@ -313,10 +314,18 @@ var invalidTargetGroupNamePattern = regexp.MustCompile("[[:^alnum:]]")
 // buildTargetGroupName will calculate the targetGroup's name.
 func (builder *targetGroupBuilderImpl) buildTargetGroupName(targetGroupProps *elbv2gw.TargetGroupProps,
 	gwKey types.NamespacedName, routeKey types.NamespacedName, routeKind routeutils.RouteKind, svcKey types.NamespacedName, tgPort int32,
-	targetType elbv2model.TargetType, tgProtocol elbv2model.Protocol, tgProtocolVersion *elbv2model.ProtocolVersion, targetControlPort *int32) string {
+	identifierPort intstr.IntOrString, targetType elbv2model.TargetType, tgProtocol elbv2model.Protocol, tgProtocolVersion *elbv2model.ProtocolVersion, targetControlPort *int32) string {
 
 	if targetGroupProps != nil && targetGroupProps.TargetGroupName != nil {
 		return *targetGroupProps.TargetGroupName
+	}
+
+	// Named targetPorts collapse to a constant tgPort for IP targets, so hash the
+	// per-backend identifier port to keep sibling names unique. Numeric ports stay
+	// stable (String() == itoa(tgPort)); Instance targets keep hashing the NodePort.
+	portHashInput := strconv.Itoa(int(tgPort))
+	if targetType != elbv2model.TargetTypeInstance {
+		portHashInput = identifierPort.String()
 	}
 
 	uuidHash := sha256.New()
@@ -328,7 +337,7 @@ func (builder *targetGroupBuilderImpl) buildTargetGroupName(targetGroupProps *el
 	_, _ = uuidHash.Write([]byte(routeKind))
 	_, _ = uuidHash.Write([]byte(svcKey.Namespace))
 	_, _ = uuidHash.Write([]byte(svcKey.Name))
-	_, _ = uuidHash.Write([]byte(strconv.Itoa(int(tgPort))))
+	_, _ = uuidHash.Write([]byte(portHashInput))
 	_, _ = uuidHash.Write([]byte(targetType))
 	_, _ = uuidHash.Write([]byte(tgProtocol))
 	if tgProtocolVersion != nil {

--- a/pkg/gateway/model/model_build_target_group_test.go
+++ b/pkg/gateway/model/model_build_target_group_test.go
@@ -2,6 +2,8 @@ package model
 
 import (
 	"context"
+	"testing"
+
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -20,7 +22,6 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/shared_constants"
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/shared_utils"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
-	"testing"
 )
 
 func Test_buildTargetGroupSpec(t *testing.T) {
@@ -849,9 +850,16 @@ func Test_buildTargetGroupName_namedPortUniqueness(t *testing.T) {
 	}
 
 	// Named ports both collapse to tgPort 1 for IP targets, but must stay unique.
-	first := nameFor(1, intstr.FromString("web"), elbv2model.TargetTypeIP)
-	second := nameFor(1, intstr.FromString("metrics"), elbv2model.TargetTypeIP)
-	assert.NotEqual(t, first, second, "named targetPorts must produce distinct target group names")
+	assert.NotEqual(t,
+		nameFor(1, intstr.FromString("web"), elbv2model.TargetTypeIP),
+		nameFor(1, intstr.FromString("metrics"), elbv2model.TargetTypeIP),
+		"named targetPorts must produce distinct target group names")
+
+	// Non-Instance names hash the identifier port, not the resolved tgPort.
+	assert.Equal(t,
+		nameFor(1, intstr.FromString("web"), elbv2model.TargetTypeIP),
+		nameFor(999, intstr.FromString("web"), elbv2model.TargetTypeIP),
+		"non-instance target names must ignore the resolved tgPort")
 
 	// Numeric IP targets keep their historical name.
 	assert.Equal(t, "k8s-myns-myroute-27d98b9190", nameFor(80, intstr.FromInt32(80), elbv2model.TargetTypeIP))

--- a/pkg/gateway/model/model_build_target_group_test.go
+++ b/pkg/gateway/model/model_build_target_group_test.go
@@ -829,10 +829,38 @@ func Test_buildTargetGroupName(t *testing.T) {
 				targetControlPort = tc.targetGroupProps.TargetControlPort
 			}
 
-			result := builder.buildTargetGroupName(tc.targetGroupProps, gwKey, routeKey, routeutils.HTTPRouteKind, svcKey, 80, elbv2model.TargetTypeIP, elbv2model.ProtocolTCP, tc.protocolVersion, targetControlPort)
+			result := builder.buildTargetGroupName(tc.targetGroupProps, gwKey, routeKey, routeutils.HTTPRouteKind, svcKey, 80, intstr.FromInt32(80), elbv2model.TargetTypeIP, elbv2model.ProtocolTCP, tc.protocolVersion, targetControlPort)
 			assert.Equal(t, tc.expected, result)
 		})
 	}
+}
+
+// Multiple named targetPorts on one Service must not share a target group name,
+// while numeric ports must keep their previous names.
+func Test_buildTargetGroupName_namedPortUniqueness(t *testing.T) {
+	clusterName := "foo"
+	gwKey := types.NamespacedName{Namespace: "my-ns", Name: "my-gw"}
+	routeKey := types.NamespacedName{Namespace: "my-ns", Name: "my-route"}
+	svcKey := types.NamespacedName{Namespace: "my-ns", Name: "my-svc"}
+	builder := targetGroupBuilderImpl{clusterName: clusterName}
+
+	nameFor := func(tgPort int32, identifierPort intstr.IntOrString, targetType elbv2model.TargetType) string {
+		return builder.buildTargetGroupName(nil, gwKey, routeKey, routeutils.HTTPRouteKind, svcKey, tgPort, identifierPort, targetType, elbv2model.ProtocolTCP, nil, nil)
+	}
+
+	// Named ports both collapse to tgPort 1 for IP targets, but must stay unique.
+	first := nameFor(1, intstr.FromString("web"), elbv2model.TargetTypeIP)
+	second := nameFor(1, intstr.FromString("metrics"), elbv2model.TargetTypeIP)
+	assert.NotEqual(t, first, second, "named targetPorts must produce distinct target group names")
+
+	// Numeric IP targets keep their historical name.
+	assert.Equal(t, "k8s-myns-myroute-27d98b9190", nameFor(80, intstr.FromInt32(80), elbv2model.TargetTypeIP))
+
+	// Instance targets hash the NodePort, so the identifier port is irrelevant.
+	assert.Equal(t,
+		nameFor(31000, intstr.FromInt32(80), elbv2model.TargetTypeInstance),
+		nameFor(31000, intstr.FromString("http"), elbv2model.TargetTypeInstance),
+		"instance target names must be independent of the identifier port")
 }
 
 func Test_buildTargetGroupIPAddressType(t *testing.T) {


### PR DESCRIPTION
### Issue

It's related to the issue #4740 and the fix #4741, which fixed a *different* cause of the same error (health-check-driven target group replacement in the synthesizer). This PR fixes a separate, build-time cause: target group **name** collisions when one Service is exposed on multiple named `targetPort`s. No dedicated issue filed yet, I can open one if preferred.

### Description

For IP target groups, `GetTargetGroupPort` returns a constant `1` for any named `targetPort`:
https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/0f415d98b80d0178c5c0630ef0d27cf27cb293a3/pkg/gateway/routeutils/backend_service.go#L86-L87

That port is the only port-derived input to the name hash in `buildTargetGroupName`:
https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/0f415d98b80d0178c5c0630ef0d27cf27cb293a3/pkg/gateway/model/model_build_target_group.go#L331

So when a single Service is exposed on N named `targetPort`s through one route, all N backends hash to the **same** target group name and `CreateTargetGroup` fails with:

```
DuplicateTargetGroupName: A target group with the same name '...' exists, but with different settings
```
which aborts the entire gateway reconcile. The in-model resource ID already stays unique because it uses `GetIdentifierPort()`, so N distinct target groups are built but collapse to one name.

### Fix 
For non-Instance targets, we should hash the per-backend identifier port instead of the resolved TG port. 
For numeric ports `identifierPort.String()` equals `strconv.Itoa(tgPort)`, so existing names are unchanged. Instance targets keep hashing the NodePort.

### Compatibility / churn
- Numeric IP targets and all Instance targets: name unchanged — no target group churn.
- Only IP targets using named `targetPort`s change. Multi named-port Services are currently broken (no stable name to preserve). A single named-port IP Service would see a one-time target group re-creation on upgrade.

### Checklist
- [x] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (no-op)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes