### PR TITLE
Added logic to the target_group_synthesizer to ensure the controller can recover when the maximum unique target groups per ALB is reached

### DIFF
--- a/pkg/deploy/elbv2/target_group_synthesizer.go
+++ b/pkg/deploy/elbv2/target_group_synthesizer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/smithy-go"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -62,13 +63,39 @@ func (s *targetGroupSynthesizer) Synthesize(ctx context.Context) error {
 	// * unmatched targetGroups might still be use by a listener rule.
 	s.unmatchedSDKTGs = unmatchedSDKTGs
 
+	// sdkTGDeleteIndex tracks how many unmatchedSDKTGs were already deleted inline
+	sdkTGDeleteIndex := 0
 	for _, resTG := range unmatchedResTGs {
 		tgStatus, err := s.tgManager.Create(ctx, resTG)
 		if err != nil {
-			return err
+			if !isTooManyUniqueTargetGroupsErr(err) {
+				return err
+			}
+			// Listener rules are always deleted prior to target groups, so
+			// any old TG that is no longer needed should already be dissociable.
+			// Delete one stale TG to free a slot, then retry the create.
+			// Due to eventual consistency the listener-rule dissociation may not be
+			// fully reflected yet. In that case the delete will error and the
+			// controller will requeue and retry.
+			if sdkTGDeleteIndex >= len(s.unmatchedSDKTGs) {
+				return errors.Wrap(err, "unable to synthesize target groups: TooManyUniqueTargetGroupsPerLoadBalancer and no unused target groups available to delete")
+			}
+			s.logger.V(1).Info("TooManyUniqueTargetGroupsPerLoadBalancer detected, deleting unused target group to free quota",
+				"tgArn", awssdk.ToString(s.unmatchedSDKTGs[sdkTGDeleteIndex].TargetGroup.TargetGroupArn))
+			if delErr := s.tgManager.Delete(ctx, s.unmatchedSDKTGs[sdkTGDeleteIndex]); delErr != nil {
+				return delErr
+			}
+			sdkTGDeleteIndex++
+			// Retry the create now that a slot has been freed.
+			tgStatus, err = s.tgManager.Create(ctx, resTG)
+			if err != nil {
+				return err
+			}
 		}
 		resTG.SetStatus(tgStatus)
 	}
+	// Trim the TGs already deleted so PostSynthesize does not attempt them again.
+	s.unmatchedSDKTGs = s.unmatchedSDKTGs[sdkTGDeleteIndex:]
 	for _, resAndSDKTG := range matchedResAndSDKTGs {
 		tgStatus, err := s.tgManager.Update(ctx, resAndSDKTG.resTG, resAndSDKTG.sdkTG)
 		if err != nil {
@@ -214,6 +241,14 @@ func isL4TargetGroup(protocol elbv2model.Protocol) bool {
 	default:
 		return false
 	}
+}
+
+func isTooManyUniqueTargetGroupsErr(err error) bool {
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.ErrorCode() == "TooManyUniqueTargetGroupsPerLoadBalancer"
+	}
+	return false
 }
 
 func isSDKTargetGroupTargetControlPortDrifted(tgSpec elbv2model.TargetGroupSpec, sdkTG TargetGroupWithTags) bool {

--- a/pkg/deploy/elbv2/target_group_synthesizer_test.go
+++ b/pkg/deploy/elbv2/target_group_synthesizer_test.go
@@ -1,10 +1,13 @@
 package elbv2
 
 import (
+	"context"
 	"testing"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	"github.com/aws/smithy-go"
+	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -1193,4 +1196,275 @@ func Test_isL4TargetGroup(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+type mockTGOperation int
+
+const (
+	createTG mockTGOperation = iota
+	deleteTG
+	updateTG
+)
+
+type mockTGCall struct {
+	name string // This will equal Spec.Name for creates and the ARN for deletes/updates
+	op   mockTGOperation
+}
+
+// mockTargetGroupManager simulates a quota-limited TG manager.
+// Create returns TooManyUniqueTargetGroupsPerLoadBalancer when tgCount == maxTGCount.
+// deleteErr optionally causes Delete to fail to simulate the ResourceInUse error.
+type mockTargetGroupManager struct {
+	tgCount    int
+	maxTGCount int
+	deleteErr  error
+	calls      []mockTGCall
+}
+
+func (m *mockTargetGroupManager) Create(_ context.Context, resTG *elbv2model.TargetGroup) (elbv2model.TargetGroupStatus, error) {
+	if m.tgCount == m.maxTGCount {
+		return elbv2model.TargetGroupStatus{}, &smithy.GenericAPIError{
+			Code:    "TooManyUniqueTargetGroupsPerLoadBalancer",
+			Message: "too many unique target groups per load balancer",
+		}
+	}
+	m.calls = append(m.calls, mockTGCall{name: resTG.Spec.Name, op: createTG})
+	m.tgCount++
+	return elbv2model.TargetGroupStatus{TargetGroupARN: resTG.Spec.Name}, nil
+}
+
+func (m *mockTargetGroupManager) Update(_ context.Context, _ *elbv2model.TargetGroup, sdkTG TargetGroupWithTags) (elbv2model.TargetGroupStatus, error) {
+	m.calls = append(m.calls, mockTGCall{name: awssdk.ToString(sdkTG.TargetGroup.TargetGroupArn), op: updateTG})
+	return elbv2model.TargetGroupStatus{TargetGroupARN: awssdk.ToString(sdkTG.TargetGroup.TargetGroupArn)}, nil
+}
+
+func (m *mockTargetGroupManager) Delete(_ context.Context, sdkTG TargetGroupWithTags) error {
+	if m.deleteErr != nil {
+		return m.deleteErr
+	}
+	m.calls = append(m.calls, mockTGCall{name: awssdk.ToString(sdkTG.TargetGroup.TargetGroupArn), op: deleteTG})
+	m.tgCount--
+	return nil
+}
+
+// Unlike the listener_rule_synthesizer the one for target groups
+// does not expose update and delete functions directly but does it inline.
+// Thus we need these helper functions
+
+const testResourceIDTagKey = "ingress.k8s.aws/resource"
+
+type testTrackingProvider struct{}
+
+func (p *testTrackingProvider) ResourceIDTagKey() string { return testResourceIDTagKey }
+func (p *testTrackingProvider) StackTags(_ coremodel.Stack) map[string]string {
+	return map[string]string{}
+}
+func (p *testTrackingProvider) StackTagsLegacy(_ coremodel.Stack) map[string]string {
+	return map[string]string{}
+}
+func (p *testTrackingProvider) StackLabels(_ coremodel.Stack) map[string]string {
+	return map[string]string{}
+}
+func (p *testTrackingProvider) ResourceTags(_ coremodel.Stack, _ coremodel.Resource, _ map[string]string) map[string]string {
+	return map[string]string{}
+}
+func (p *testTrackingProvider) LegacyTagKeys() []string { return nil }
+
+// newTestStack creates a stack and adds desired TGs to it (auto-registered via NewTargetGroup).
+func newTestStack(desiredNames []string) coremodel.Stack {
+	stack := coremodel.NewDefaultStack(coremodel.StackID{Namespace: "ns", Name: "test"})
+	for _, name := range desiredNames {
+		elbv2model.NewTargetGroup(stack, name, elbv2model.TargetGroupSpec{Name: name})
+	}
+	return stack
+}
+
+func staleSdkTG(arn, resourceID string) TargetGroupWithTags {
+	return TargetGroupWithTags{
+		TargetGroup: &elbv2types.TargetGroup{TargetGroupArn: awssdk.String(arn)},
+		Tags:        map[string]string{testResourceIDTagKey: resourceID},
+	}
+}
+
+func newSynthesizerForTest(mock *mockTargetGroupManager, stack coremodel.Stack, sdkTGs []TargetGroupWithTags) *targetGroupSynthesizer {
+	return &targetGroupSynthesizer{
+		tgManager:        mock,
+		trackingProvider: &testTrackingProvider{},
+		featureGates:     config.NewFeatureGates(),
+		logger:           logr.Discard(),
+		stack:            stack,
+		findSDKTargetGroups: func() TargetGroupsResult {
+			return TargetGroupsResult{TargetGroups: sdkTGs}
+		},
+	}
+}
+
+func Test_isTooManyUniqueTargetGroupsErr(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "actual error code returns true",
+			err:  &smithy.GenericAPIError{Code: "TooManyUniqueTargetGroupsPerLoadBalancer"},
+			want: true,
+		},
+		{
+			name: "any API error code returns false",
+			err:  &smithy.GenericAPIError{Code: "TooManyRules"},
+			want: false,
+		},
+		{
+			name: "plain error returns false",
+			err:  errors.New("err"),
+			want: false,
+		},
+		{
+			name: "nil returns false",
+			err:  nil,
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isTooManyUniqueTargetGroupsErr(tt.err))
+		})
+	}
+}
+
+func Test_targetGroupSynthesizer_Synthesize(t *testing.T) {
+	tests := []struct {
+		name          string
+		desiredTGs    []string
+		sdkTGs        []TargetGroupWithTags // existing TGs returned by AWS
+		tgCount       int                   // current number of TGs counted against quota
+		maxTGCount    int
+		deleteErr     error
+		wantErr       bool
+		wantErrSubstr string
+		wantCalls     []mockTGCall
+	}{
+		{
+			name:       "no TGs at all",
+			tgCount:    0,
+			maxTGCount: 100,
+		},
+		{
+			name:       "creates succeed without hitting quota",
+			desiredTGs: []string{"tg-1", "tg-2", "tg-3"},
+			tgCount:    0,
+			maxTGCount: 100,
+			wantCalls: []mockTGCall{
+				{name: "tg-1", op: createTG},
+				{name: "tg-2", op: createTG},
+				{name: "tg-3", op: createTG},
+			},
+		},
+		{
+			name:       "quota hit once",
+			desiredTGs: []string{"tg-new"},
+			sdkTGs:     []TargetGroupWithTags{staleSdkTG("stale-arn-1", "stale-1")},
+			tgCount:    2,
+			maxTGCount: 2,
+			wantCalls: []mockTGCall{
+				{name: "stale-arn-1", op: deleteTG},
+				{name: "tg-new", op: createTG},
+			},
+		},
+		{
+			name:       "quota hit multiple times",
+			desiredTGs: []string{"tg-new-1", "tg-new-2"},
+			sdkTGs: []TargetGroupWithTags{
+				staleSdkTG("stale-arn-1", "stale-1"),
+				staleSdkTG("stale-arn-2", "stale-2"),
+			},
+			tgCount:    2,
+			maxTGCount: 2,
+			wantCalls: []mockTGCall{
+				{name: "stale-arn-1", op: deleteTG},
+				{name: "tg-new-1", op: createTG},
+				{name: "stale-arn-2", op: deleteTG},
+				{name: "tg-new-2", op: createTG},
+			},
+		},
+		{
+			name:          "quota hit but no stale TGs available",
+			desiredTGs:    []string{"tg-new"},
+			sdkTGs:        nil,
+			tgCount:       2,
+			maxTGCount:    2,
+			wantErr:       true,
+			wantErrSubstr: "no unused target groups available to delete",
+		},
+		{
+			name:          "quota hit but stale TG delete fails (eventual consistency)",
+			desiredTGs:    []string{"tg-new"},
+			sdkTGs:        []TargetGroupWithTags{staleSdkTG("stale-arn-1", "stale-1")},
+			tgCount:       2,
+			maxTGCount:    2,
+			deleteErr:     errors.New("ResourceInUse: TG still referenced by a listener rule"),
+			wantErr:       true,
+			wantErrSubstr: "ResourceInUse",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stack := newTestStack(tt.desiredTGs)
+			mock := &mockTargetGroupManager{tgCount: tt.tgCount, maxTGCount: tt.maxTGCount, deleteErr: tt.deleteErr}
+			s := newSynthesizerForTest(mock, stack, tt.sdkTGs)
+
+			err := s.Synthesize(context.Background())
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.wantErrSubstr != "" {
+					assert.Contains(t, err.Error(), tt.wantErrSubstr)
+				}
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantCalls, mock.calls)
+			}
+		})
+	}
+}
+
+func Test_targetGroupSynthesizer_PostSynthesize(t *testing.T) {
+	t.Run("stale TGs already deleted inline by Synthesize are not re-deleted in PostSynthesize", func(t *testing.T) {
+
+		stack := newTestStack([]string{"tg-new-1", "tg-new-2"})
+		staleTGs := []TargetGroupWithTags{
+			staleSdkTG("stale-arn-1", "stale-1"),
+			staleSdkTG("stale-arn-2", "stale-2"),
+		}
+		mock := &mockTargetGroupManager{tgCount: 2, maxTGCount: 2}
+		s := newSynthesizerForTest(mock, stack, staleTGs)
+
+		assert.NoError(t, s.Synthesize(context.Background()))
+		callsAfterSynthesize := append([]mockTGCall(nil), mock.calls...)
+
+		assert.NoError(t, s.PostSynthesize(context.Background()))
+		assert.Equal(t, callsAfterSynthesize, mock.calls)
+	})
+
+	t.Run("stale TGs not consumed inline are deleted in PostSynthesize", func(t *testing.T) {
+
+		stack := newTestStack(nil)
+		staleTGs := []TargetGroupWithTags{
+			staleSdkTG("stale-arn-1", "stale-1"),
+			staleSdkTG("stale-arn-2", "stale-2"),
+		}
+		mock := &mockTargetGroupManager{tgCount: 0, maxTGCount: 100}
+		s := newSynthesizerForTest(mock, stack, staleTGs)
+
+		assert.NoError(t, s.Synthesize(context.Background()))
+		assert.Empty(t, mock.calls)
+
+		assert.NoError(t, s.PostSynthesize(context.Background()))
+		assert.Equal(t, []mockTGCall{
+			{name: "stale-arn-1", op: deleteTG},
+			{name: "stale-arn-2", op: deleteTG},
+		}, mock.calls)
+	})
 }


### PR DESCRIPTION
### Issue

Fixes #4848

### Description

Previously stale target groups were deleted by `PostSynthesize` as target groups can't be deleted while listener rules still reference them, so deletion is deferred until after the listener rule synthesizer has already cleaned up its stale rules. However if `Synthesize` hits the quota error and returns early, `PostSynthesize` never runs, so the stale TGs never get deleted, so the slot never gets freed, so the next reconcile hits the exact same error again.

This PR introduces logic to fix this by adding an inline delete to `Synthesize`. When the quota error is hit, instead of returning immediately, one stale TG is deleted within `Synthesize` to free a slot and retry the create in the same reconcile cycle. Because the inline delete runs before the listener rule synthesizer has cleaned up stale rules in the current cycle, the delete may fail with `ResourceInUse` on the first attempt. In that case the controller requeues. On the next cycle the listener rules from the previous cycle are already gone, so the stale TG delete succeeds and the create goes through / the current deadlock is resolved. The controller recovers in at most two reconcile cycles instead of being stuck forever.

Compared to the `ListenerRuleSynthesizer` this one for target groups handles quota logic inside `Synthesize` on the struct and not via a separate function. Due to this there needs to be the full environment that `Synthesize` expects
and tests for the new functionality became a bit complex.  

**Note:** The logic for deleting and creating TGs could be made easier to understand and tests could be simplified by rewriting the range loop as an index-based loop with the same three-branch structure as the listener rule synthesizer. Would be interested on some thoughts on that?


### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [x] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
