### PR TITLE
gateway: consolidate HTTPRoute matches differing only by HTTP method

### DIFF
--- a/pkg/gateway/model/model_build_listener_test.go
+++ b/pkg/gateway/model/model_build_listener_test.go
@@ -1422,6 +1422,18 @@ func Test_buildMutualAuthenticationAttributes(t *testing.T) {
 	}
 }
 
+// methodOnlyMatch builds a match on the "/" prefix path that differs from its
+// siblings only by HTTP method.
+func methodOnlyMatch(method string) gwv1.HTTPRouteMatch {
+	return gwv1.HTTPRouteMatch{
+		Path: &gwv1.HTTPPathMatch{
+			Type:  (*gwv1.PathMatchType)(awssdk.String("PathPrefix")),
+			Value: awssdk.String("/"),
+		},
+		Method: (*gwv1.HTTPMethod)(awssdk.String(method)),
+	}
+}
+
 func Test_BuildListenerRules(t *testing.T) {
 	autheticateBehavior := elbv2gw.AuthenticateCognitoActionConditionalBehaviorEnumAuthenticate
 	testCases := []struct {
@@ -1541,6 +1553,104 @@ func Test_BuildListenerRules(t *testing.T) {
 							Field: "path-pattern",
 							PathPatternConfig: &elbv2model.PathPatternConditionConfig{
 								Values: []string{"/*"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:             "matches differing only by method should be consolidated into method-list rules",
+			port:             80,
+			listenerProtocol: elbv2model.ProtocolHTTP,
+			ipAddressType:    elbv2model.IPAddressTypeIPV4,
+			routes: map[int32][]routeutils.RouteDescriptor{
+				80: {
+					&routeutils.MockRoute{
+						Kind:      routeutils.HTTPRouteKind,
+						Name:      "my-route",
+						Namespace: "my-route-ns",
+						Rules: []routeutils.RouteRule{
+							&routeutils.MockRule{
+								RawRule: &gwv1.HTTPRouteRule{
+									Matches: []gwv1.HTTPRouteMatch{
+										methodOnlyMatch("GET"),
+										methodOnlyMatch("HEAD"),
+										methodOnlyMatch("POST"),
+										methodOnlyMatch("PUT"),
+										methodOnlyMatch("PATCH"),
+										methodOnlyMatch("DELETE"),
+									},
+								},
+								BackendRefs: []routeutils.Backend{
+									{
+										ServiceBackend: &routeutils.ServiceBackendConfig{},
+										Weight:         1,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			// Six matches become two rules: the "/" prefix pattern takes one of
+			// the five condition values a rule may carry, leaving four for the
+			// method list.
+			expectedRules: []*elbv2model.ListenerRuleSpec{
+				{
+					Priority: 1,
+					Actions: []elbv2model.Action{
+						{
+							Type: "forward",
+							ForwardConfig: &elbv2model.ForwardActionConfig{
+								TargetGroups: []elbv2model.TargetGroupTuple{
+									{
+										Weight: awssdk.Int32(1),
+									},
+								},
+							},
+						},
+					},
+					Conditions: []elbv2model.RuleCondition{
+						{
+							Field: "path-pattern",
+							PathPatternConfig: &elbv2model.PathPatternConditionConfig{
+								Values: []string{"/*"},
+							},
+						},
+						{
+							Field: "http-request-method",
+							HTTPRequestMethodConfig: &elbv2model.HTTPRequestMethodConditionConfig{
+								Values: []string{"GET", "HEAD", "POST", "PUT"},
+							},
+						},
+					},
+				},
+				{
+					Priority: 2,
+					Actions: []elbv2model.Action{
+						{
+							Type: "forward",
+							ForwardConfig: &elbv2model.ForwardActionConfig{
+								TargetGroups: []elbv2model.TargetGroupTuple{
+									{
+										Weight: awssdk.Int32(1),
+									},
+								},
+							},
+						},
+					},
+					Conditions: []elbv2model.RuleCondition{
+						{
+							Field: "path-pattern",
+							PathPatternConfig: &elbv2model.PathPatternConditionConfig{
+								Values: []string{"/*"},
+							},
+						},
+						{
+							Field: "http-request-method",
+							HTTPRequestMethodConfig: &elbv2model.HTTPRequestMethodConditionConfig{
+								Values: []string{"PATCH", "DELETE"},
 							},
 						},
 					},

--- a/pkg/gateway/routeutils/route_rule_condition.go
+++ b/pkg/gateway/routeutils/route_rule_condition.go
@@ -38,7 +38,9 @@ func BuildHttpRuleConditions(rule RulePrecedence) ([]elbv2model.RuleCondition, e
 		queryParamConditions := buildHttpQueryParamCondition(match.QueryParams)
 		conditions = append(conditions, queryParamConditions...)
 	}
-	if match.Method != nil {
+	if len(rule.HTTPMethods) > 0 {
+		conditions = append(conditions, buildHttpMethodConditionFromValues(rule.HTTPMethods)...)
+	} else if match.Method != nil {
 		methodCondition := buildHttpMethodCondition(match.Method)
 		conditions = append(conditions, methodCondition...)
 	}
@@ -149,11 +151,18 @@ func buildHttpQueryParamCondition(queryParams []gwv1.HTTPQueryParamMatch) []elbv
 }
 
 func buildHttpMethodCondition(method *gwv1.HTTPMethod) []elbv2model.RuleCondition {
+	return buildHttpMethodConditionFromValues([]string{string(*method)})
+}
+
+// buildHttpMethodConditionFromValues builds the single http-request-method
+// condition of a rule. ALB matches the request when any listed method matches, so
+// matches differing only by method share one condition.
+func buildHttpMethodConditionFromValues(methods []string) []elbv2model.RuleCondition {
 	return []elbv2model.RuleCondition{
 		{
 			Field: elbv2model.RuleConditionFieldHTTPRequestMethod,
 			HTTPRequestMethodConfig: &elbv2model.HTTPRequestMethodConditionConfig{
-				Values: []string{string(*method)},
+				Values: methods,
 			},
 		},
 	}

--- a/pkg/gateway/routeutils/route_rule_condition_test.go
+++ b/pkg/gateway/routeutils/route_rule_condition_test.go
@@ -130,6 +130,34 @@ func Test_BuildHttpRuleConditions(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "consolidated methods share one http-request-method condition",
+			rule: RulePrecedence{
+				HTTPMatch: &gwv1.HTTPRouteMatch{
+					Path: &gwv1.HTTPPathMatch{
+						Type:  &exactType,
+						Value: &pathValue,
+					},
+					Method: &methodValue,
+				},
+				HTTPMethods: []string{"GET", "HEAD", "POST", "PUT"},
+			},
+			want: []elbv2model.RuleCondition{
+				{
+					Field: elbv2model.RuleConditionFieldPathPattern,
+					PathPatternConfig: &elbv2model.PathPatternConditionConfig{
+						Values: []string{pathValue},
+					},
+				},
+				{
+					Field: elbv2model.RuleConditionFieldHTTPRequestMethod,
+					HTTPRequestMethodConfig: &elbv2model.HTTPRequestMethodConditionConfig{
+						Values: []string{"GET", "HEAD", "POST", "PUT"},
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/gateway/routeutils/route_rule_method_consolidation.go
+++ b/pkg/gateway/routeutils/route_rule_method_consolidation.go
@@ -1,0 +1,254 @@
+package routeutils
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/v3/apis/gateway/v1"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// maxConditionValuesPerRule is the ALB quota "Condition Values per Rule" (5, not
+// adjustable). An http-request-method condition accepts a value list, so matches
+// that differ only by method can share one rule — but the merged value list still
+// has to fit in the rule's value budget together with the values the other
+// conditions of the same rule consume.
+const maxConditionValuesPerRule = 5
+
+// consolidateHttpMethodMatches merges HTTP matches of the same route rule that
+// are identical in every respect except their method into a single entry whose
+// http-request-method condition carries every method. The Gateway API
+// HTTPRouteMatch.Method field holds a single method, so serving N methods on one
+// path requires N matches, which would otherwise become N ALB rules and eat into
+// the (default 100) rules per load balancer quota.
+//
+// Only matches that set a method participate: a match without a method means
+// "any method", so folding it into a method-bearing group would narrow it.
+//
+// Merged entries keep the lowest MatchIndexInRule of their group. Every member
+// has the same path type/length, header count, query param count and
+// HasMethod=true, so the group's precedence factors equal any member's and the
+// merged entry sorts exactly where its members did.
+//
+// Groups whose methods do not fit the rule's remaining value budget are split
+// into chunks of the largest allowed size; a budget of one value yields the
+// unmerged entries, i.e. today's behavior.
+func consolidateHttpMethodMatches(entries []RulePrecedence) []RulePrecedence {
+	groupMembers := make(map[string][]RulePrecedence, len(entries))
+	groupOrder := make([]string, 0, len(entries))
+
+	for _, entry := range entries {
+		key, mergeable := httpMethodMergeKey(entry)
+		if !mergeable {
+			continue
+		}
+		if _, exists := groupMembers[key]; !exists {
+			groupOrder = append(groupOrder, key)
+		}
+		groupMembers[key] = append(groupMembers[key], entry)
+	}
+
+	// Nothing to do unless at least one group has more than one member.
+	merged := false
+	for _, key := range groupOrder {
+		if len(groupMembers[key]) > 1 {
+			merged = true
+			break
+		}
+	}
+	if !merged {
+		return entries
+	}
+
+	mergedByKey := make(map[string][]RulePrecedence, len(groupOrder))
+	for _, key := range groupOrder {
+		mergedByKey[key] = mergeHttpMethodGroup(groupMembers[key])
+	}
+
+	consolidated := make([]RulePrecedence, 0, len(entries))
+	for _, entry := range entries {
+		key, mergeable := httpMethodMergeKey(entry)
+		if !mergeable {
+			consolidated = append(consolidated, entry)
+			continue
+		}
+		// Emit the whole group in place of its first member and drop the rest.
+		if group, pending := mergedByKey[key]; pending {
+			consolidated = append(consolidated, group...)
+			delete(mergedByKey, key)
+		}
+	}
+	return consolidated
+}
+
+// mergeHttpMethodGroup turns a group of matches that differ only by method into
+// as few entries as the rule's condition value budget allows.
+func mergeHttpMethodGroup(group []RulePrecedence) []RulePrecedence {
+	if len(group) == 1 {
+		return group
+	}
+
+	members := make([]RulePrecedence, len(group))
+	copy(members, group)
+	sort.SliceStable(members, func(i, j int) bool {
+		return members[i].CommonRulePrecedence.MatchIndexInRule < members[j].CommonRulePrecedence.MatchIndexInRule
+	})
+
+	methods := make([]string, 0, len(members))
+	seen := make(map[string]bool, len(members))
+	for _, member := range members {
+		method := string(*member.HTTPMatch.Method)
+		if seen[method] {
+			continue
+		}
+		seen[method] = true
+		methods = append(methods, method)
+	}
+
+	// The methods share one condition, so they get whatever is left of the
+	// rule's value budget after the other conditions of the rule took theirs.
+	chunkSize := maxConditionValuesPerRule - countNonMethodConditionValues(members[0])
+	if chunkSize < 2 {
+		// No room to merge: keep the individual matches untouched.
+		return group
+	}
+
+	entries := make([]RulePrecedence, 0, (len(methods)+chunkSize-1)/chunkSize)
+	for start := 0; start < len(methods); start += chunkSize {
+		end := start + chunkSize
+		if end > len(methods) {
+			end = len(methods)
+		}
+		// The lowest match index of the chunk keeps ordering deterministic and
+		// keeps the chunks in the order their matches were declared.
+		entry := members[start]
+		entry.HTTPMethods = methods[start:end]
+		entries = append(entries, entry)
+	}
+	return entries
+}
+
+// httpMethodMergeKey identifies matches that may be merged with each other: same
+// route rule, same hostname unit and identical path, header and query param
+// matches, with only the method left to differ. Matches without a method are not
+// mergeable ("any method" would be narrowed by the merge).
+func httpMethodMergeKey(entry RulePrecedence) (string, bool) {
+	match := entry.HTTPMatch
+	if match == nil || match.Method == nil {
+		return "", false
+	}
+	common := entry.CommonRulePrecedence
+	var key strings.Builder
+	fmt.Fprintf(&key, "route=%s#rule=%d#host=%q", common.RouteNamespacedName, common.RuleIndexInRoute, common.Hostname)
+	key.WriteString("#path=")
+	if match.Path != nil {
+		if match.Path.Type != nil {
+			key.WriteString(string(*match.Path.Type))
+		}
+		if match.Path.Value != nil {
+			fmt.Fprintf(&key, ":%q", *match.Path.Value)
+		}
+	}
+	// Header and query param matches are keyed in their declared order: it is
+	// the order of the generated conditions, so members of a group produce the
+	// very same condition list.
+	for _, header := range match.Headers {
+		headerType := gwv1.HeaderMatchExact
+		if header.Type != nil {
+			headerType = *header.Type
+		}
+		fmt.Fprintf(&key, "#header=%q:%s:%q", header.Name, headerType, header.Value)
+	}
+	for _, query := range match.QueryParams {
+		queryType := gwv1.QueryParamMatchExact
+		if query.Type != nil {
+			queryType = *query.Type
+		}
+		fmt.Fprintf(&key, "#query=%q:%s:%q", query.Name, queryType, query.Value)
+	}
+	// Conditions coming from the ListenerRuleConfiguration CRD may be scoped to
+	// specific match indexes, so matches that get different ones must not merge.
+	key.WriteString("#sourceIP=")
+	key.WriteString(sourceIpConditionKey(entry))
+	return key.String(), true
+}
+
+// sourceIpConditionKey serializes the source IP conditions the
+// ListenerRuleConfiguration CRD contributes to this particular match.
+func sourceIpConditionKey(entry RulePrecedence) string {
+	rule := entry.CommonRulePrecedence.Rule
+	if rule == nil || rule.GetListenerRuleConfig() == nil {
+		return ""
+	}
+	var key strings.Builder
+	for _, condition := range applicableSourceIpConditions(entry) {
+		fmt.Fprintf(&key, "[%s]", strings.Join(condition.SourceIPConfig.Values, ","))
+	}
+	return key.String()
+}
+
+// applicableSourceIpConditions returns the source IP conditions of the rule's
+// ListenerRuleConfiguration that apply to this match.
+func applicableSourceIpConditions(entry RulePrecedence) []elbv2gw.ListenerRuleCondition {
+	rule := entry.CommonRulePrecedence.Rule
+	if rule == nil || rule.GetListenerRuleConfig() == nil {
+		return nil
+	}
+	matchIndex := entry.CommonRulePrecedence.MatchIndexInRule
+	var conditions []elbv2gw.ListenerRuleCondition
+	for _, condition := range rule.GetListenerRuleConfig().Spec.Conditions {
+		if condition.Field != elbv2gw.ListenerRuleConditionFieldSourceIP || condition.SourceIPConfig == nil {
+			continue
+		}
+		if condition.MatchIndexes == nil {
+			conditions = append(conditions, condition)
+			continue
+		}
+		for _, index := range *condition.MatchIndexes {
+			if index == matchIndex {
+				conditions = append(conditions, condition)
+				break
+			}
+		}
+	}
+	return conditions
+}
+
+// countNonMethodConditionValues counts the condition values the entry consumes
+// besides the http-request-method ones, mirroring what the condition builders
+// emit, so a merged method list can be sized against the ALB per rule value
+// quota.
+func countNonMethodConditionValues(entry RulePrecedence) int {
+	count := 0
+	if entry.CommonRulePrecedence.Hostname != "" {
+		count++
+	}
+	match := entry.HTTPMatch
+	if match.Path != nil && match.Path.Type != nil {
+		switch *match.Path.Type {
+		case gwv1.PathMatchPathPrefix:
+			// "/" becomes the single pattern "/*", any other prefix becomes
+			// both the exact path and its subtree pattern.
+			if match.Path.Value != nil && *match.Path.Value == "/" {
+				count++
+			} else {
+				count += 2
+			}
+		default:
+			count++
+		}
+	}
+	for _, header := range match.Headers {
+		if header.Type != nil && *header.Type == gwv1.HeaderMatchRegularExpression {
+			count++
+			continue
+		}
+		count += len(generateValuesFromMatchHeaderValue(header.Value))
+	}
+	count += len(match.QueryParams)
+	for _, condition := range applicableSourceIpConditions(entry) {
+		count += len(condition.SourceIPConfig.Values)
+	}
+	return count
+}

--- a/pkg/gateway/routeutils/route_rule_method_consolidation_test.go
+++ b/pkg/gateway/routeutils/route_rule_method_consolidation_test.go
@@ -1,0 +1,436 @@
+package routeutils
+
+import (
+	"testing"
+	"time"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/stretchr/testify/assert"
+	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/v3/apis/gateway/v1"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func Test_SortAllRulesByPrecedence_ConsolidatesMethodOnlyMatches(t *testing.T) {
+	exact := (*gwv1.PathMatchType)(awssdk.String("Exact"))
+	prefix := (*gwv1.PathMatchType)(awssdk.String("PathPrefix"))
+	regex := (*gwv1.HeaderMatchType)(awssdk.String("RegularExpression"))
+	created := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	methodMatch := func(pathType *gwv1.PathMatchType, path string, method gwv1.HTTPMethod) gwv1.HTTPRouteMatch {
+		return gwv1.HTTPRouteMatch{
+			Path:   &gwv1.HTTPPathMatch{Type: pathType, Value: awssdk.String(path)},
+			Method: &method,
+		}
+	}
+
+	type wantRule struct {
+		matchIndex int
+		methods    []string
+	}
+
+	tests := []struct {
+		name               string
+		hostnames          []string
+		matches            []gwv1.HTTPRouteMatch
+		listenerRuleConfig *elbv2gw.ListenerRuleConfiguration
+		want               []wantRule
+	}{
+		{
+			name: "six method-only-differing matches collapse into method-list rules",
+			matches: []gwv1.HTTPRouteMatch{
+				methodMatch(exact, "/foo", gwv1.HTTPMethodGet),
+				methodMatch(exact, "/foo", gwv1.HTTPMethodHead),
+				methodMatch(exact, "/foo", gwv1.HTTPMethodPost),
+				methodMatch(exact, "/foo", gwv1.HTTPMethodPut),
+				methodMatch(exact, "/foo", gwv1.HTTPMethodPatch),
+				methodMatch(exact, "/foo", gwv1.HTTPMethodDelete),
+			},
+			// The exact path takes one of the five condition values a rule may
+			// carry, so the six methods are chunked into 4 + 2 instead of six rules.
+			want: []wantRule{
+				{matchIndex: 0, methods: []string{"GET", "HEAD", "POST", "PUT"}},
+				{matchIndex: 4, methods: []string{"PATCH", "DELETE"}},
+			},
+		},
+		{
+			name: "methods fitting the value budget collapse into a single rule",
+			matches: []gwv1.HTTPRouteMatch{
+				methodMatch(exact, "/foo", gwv1.HTTPMethodGet),
+				methodMatch(exact, "/foo", gwv1.HTTPMethodHead),
+				methodMatch(exact, "/foo", gwv1.HTTPMethodPost),
+			},
+			want: []wantRule{
+				{matchIndex: 0, methods: []string{"GET", "HEAD", "POST"}},
+			},
+		},
+		{
+			name:      "hostname takes a value from the budget, shrinking the chunks",
+			hostnames: []string{"example.com"},
+			matches: []gwv1.HTTPRouteMatch{
+				methodMatch(exact, "/foo", gwv1.HTTPMethodGet),
+				methodMatch(exact, "/foo", gwv1.HTTPMethodHead),
+				methodMatch(exact, "/foo", gwv1.HTTPMethodPost),
+				methodMatch(exact, "/foo", gwv1.HTTPMethodPut),
+			},
+			want: []wantRule{
+				{matchIndex: 0, methods: []string{"GET", "HEAD", "POST"}},
+				{matchIndex: 3, methods: []string{"PUT"}},
+			},
+		},
+		{
+			name: "no value budget left for a method list leaves the matches untouched",
+			matches: []gwv1.HTTPRouteMatch{
+				// prefix path (2 values) + 2 header values leaves room for a
+				// single method value, i.e. today's one rule per match.
+				{
+					Path:   &gwv1.HTTPPathMatch{Type: prefix, Value: awssdk.String("/api")},
+					Method: (*gwv1.HTTPMethod)(awssdk.String("GET")),
+					Headers: []gwv1.HTTPHeaderMatch{
+						{Name: "x-one", Value: "a"},
+						{Name: "x-two", Value: "b"},
+					},
+				},
+				{
+					Path:   &gwv1.HTTPPathMatch{Type: prefix, Value: awssdk.String("/api")},
+					Method: (*gwv1.HTTPMethod)(awssdk.String("POST")),
+					Headers: []gwv1.HTTPHeaderMatch{
+						{Name: "x-one", Value: "a"},
+						{Name: "x-two", Value: "b"},
+					},
+				},
+			},
+			want: []wantRule{
+				{matchIndex: 0, methods: nil},
+				{matchIndex: 1, methods: nil},
+			},
+		},
+		{
+			name: "matches differing in path are not merged",
+			matches: []gwv1.HTTPRouteMatch{
+				methodMatch(exact, "/foo", gwv1.HTTPMethodGet),
+				methodMatch(exact, "/bar", gwv1.HTTPMethodPost),
+			},
+			want: []wantRule{
+				// /bar and /foo have the same path type and length, so the match
+				// index breaks the tie, exactly as before consolidation.
+				{matchIndex: 0, methods: nil},
+				{matchIndex: 1, methods: nil},
+			},
+		},
+		{
+			name: "matches differing in path type are not merged",
+			matches: []gwv1.HTTPRouteMatch{
+				methodMatch(exact, "/foo", gwv1.HTTPMethodGet),
+				methodMatch(prefix, "/foo", gwv1.HTTPMethodPost),
+			},
+			want: []wantRule{
+				{matchIndex: 0, methods: nil},
+				{matchIndex: 1, methods: nil},
+			},
+		},
+		{
+			name: "matches differing in headers are not merged",
+			matches: []gwv1.HTTPRouteMatch{
+				{
+					Path:    &gwv1.HTTPPathMatch{Type: exact, Value: awssdk.String("/foo")},
+					Method:  (*gwv1.HTTPMethod)(awssdk.String("GET")),
+					Headers: []gwv1.HTTPHeaderMatch{{Name: "x-one", Value: "a"}},
+				},
+				{
+					Path:    &gwv1.HTTPPathMatch{Type: exact, Value: awssdk.String("/foo")},
+					Method:  (*gwv1.HTTPMethod)(awssdk.String("POST")),
+					Headers: []gwv1.HTTPHeaderMatch{{Name: "x-one", Value: "b"}},
+				},
+			},
+			want: []wantRule{
+				{matchIndex: 0, methods: nil},
+				{matchIndex: 1, methods: nil},
+			},
+		},
+		{
+			name: "matches differing only in header match type are not merged",
+			matches: []gwv1.HTTPRouteMatch{
+				{
+					Path:    &gwv1.HTTPPathMatch{Type: exact, Value: awssdk.String("/foo")},
+					Method:  (*gwv1.HTTPMethod)(awssdk.String("GET")),
+					Headers: []gwv1.HTTPHeaderMatch{{Name: "x-one", Value: "a"}},
+				},
+				{
+					Path:    &gwv1.HTTPPathMatch{Type: exact, Value: awssdk.String("/foo")},
+					Method:  (*gwv1.HTTPMethod)(awssdk.String("POST")),
+					Headers: []gwv1.HTTPHeaderMatch{{Name: "x-one", Type: regex, Value: "a"}},
+				},
+			},
+			want: []wantRule{
+				{matchIndex: 0, methods: nil},
+				{matchIndex: 1, methods: nil},
+			},
+		},
+		{
+			name: "matches differing in query params are not merged",
+			matches: []gwv1.HTTPRouteMatch{
+				{
+					Path:        &gwv1.HTTPPathMatch{Type: exact, Value: awssdk.String("/foo")},
+					Method:      (*gwv1.HTTPMethod)(awssdk.String("GET")),
+					QueryParams: []gwv1.HTTPQueryParamMatch{{Name: "version", Value: "1"}},
+				},
+				{
+					Path:        &gwv1.HTTPPathMatch{Type: exact, Value: awssdk.String("/foo")},
+					Method:      (*gwv1.HTTPMethod)(awssdk.String("POST")),
+					QueryParams: []gwv1.HTTPQueryParamMatch{{Name: "version", Value: "2"}},
+				},
+			},
+			want: []wantRule{
+				{matchIndex: 0, methods: nil},
+				{matchIndex: 1, methods: nil},
+			},
+		},
+		{
+			name: "identical headers and query params still merge",
+			matches: []gwv1.HTTPRouteMatch{
+				{
+					Path:        &gwv1.HTTPPathMatch{Type: exact, Value: awssdk.String("/foo")},
+					Method:      (*gwv1.HTTPMethod)(awssdk.String("GET")),
+					Headers:     []gwv1.HTTPHeaderMatch{{Name: "x-one", Value: "a"}},
+					QueryParams: []gwv1.HTTPQueryParamMatch{{Name: "version", Value: "1"}},
+				},
+				{
+					Path:        &gwv1.HTTPPathMatch{Type: exact, Value: awssdk.String("/foo")},
+					Method:      (*gwv1.HTTPMethod)(awssdk.String("POST")),
+					Headers:     []gwv1.HTTPHeaderMatch{{Name: "x-one", Value: "a"}},
+					QueryParams: []gwv1.HTTPQueryParamMatch{{Name: "version", Value: "1"}},
+				},
+			},
+			want: []wantRule{
+				{matchIndex: 0, methods: []string{"GET", "POST"}},
+			},
+		},
+		{
+			name: "a match without a method is not merged with method-bearing matches",
+			matches: []gwv1.HTTPRouteMatch{
+				{Path: &gwv1.HTTPPathMatch{Type: exact, Value: awssdk.String("/foo")}},
+				methodMatch(exact, "/foo", gwv1.HTTPMethodGet),
+				methodMatch(exact, "/foo", gwv1.HTTPMethodPost),
+			},
+			want: []wantRule{
+				// method-bearing rules are more specific, so they keep sorting first
+				{matchIndex: 1, methods: []string{"GET", "POST"}},
+				{matchIndex: 0, methods: nil},
+			},
+		},
+		{
+			name: "duplicate methods collapse to a single condition value",
+			matches: []gwv1.HTTPRouteMatch{
+				methodMatch(exact, "/foo", gwv1.HTTPMethodGet),
+				methodMatch(exact, "/foo", gwv1.HTTPMethodGet),
+			},
+			want: []wantRule{
+				{matchIndex: 0, methods: []string{"GET"}},
+			},
+		},
+		{
+			name: "matches scoped to different source IP conditions are not merged",
+			matches: []gwv1.HTTPRouteMatch{
+				methodMatch(exact, "/foo", gwv1.HTTPMethodGet),
+				methodMatch(exact, "/foo", gwv1.HTTPMethodPost),
+			},
+			listenerRuleConfig: &elbv2gw.ListenerRuleConfiguration{
+				Spec: elbv2gw.ListenerRuleConfigurationSpec{
+					Conditions: []elbv2gw.ListenerRuleCondition{
+						{
+							Field:          elbv2gw.ListenerRuleConditionFieldSourceIP,
+							SourceIPConfig: &elbv2gw.SourceIPConditionConfig{Values: []string{"10.0.0.0/8"}},
+							MatchIndexes:   &[]int{0},
+						},
+					},
+				},
+			},
+			want: []wantRule{
+				{matchIndex: 0, methods: nil},
+				{matchIndex: 1, methods: nil},
+			},
+		},
+		{
+			name: "matches sharing an unscoped source IP condition are merged",
+			matches: []gwv1.HTTPRouteMatch{
+				methodMatch(exact, "/foo", gwv1.HTTPMethodGet),
+				methodMatch(exact, "/foo", gwv1.HTTPMethodPost),
+			},
+			listenerRuleConfig: &elbv2gw.ListenerRuleConfiguration{
+				Spec: elbv2gw.ListenerRuleConfigurationSpec{
+					Conditions: []elbv2gw.ListenerRuleCondition{
+						{
+							Field:          elbv2gw.ListenerRuleConditionFieldSourceIP,
+							SourceIPConfig: &elbv2gw.SourceIPConditionConfig{Values: []string{"10.0.0.0/8"}},
+						},
+					},
+				},
+			},
+			want: []wantRule{
+				{matchIndex: 0, methods: []string{"GET", "POST"}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			route := &MockRoute{
+				Kind:         HTTPRouteKind,
+				Name:         "route",
+				Namespace:    "ns",
+				Hostnames:    tt.hostnames,
+				CreationTime: created,
+				Rules: []RouteRule{&MockRule{
+					RawRule:            &gwv1.HTTPRouteRule{Matches: tt.matches},
+					ListenerRuleConfig: tt.listenerRuleConfig,
+				}},
+			}
+
+			result := SortAllRulesByPrecedence([]RouteDescriptor{route}, 80)
+
+			assert.Equal(t, len(tt.want), len(result), "unexpected number of ALB rules")
+			assert.LessOrEqual(t, len(result), len(tt.matches), "consolidation must never increase the rule count")
+			for i, want := range tt.want {
+				if i >= len(result) {
+					break
+				}
+				assert.Equalf(t, want.matchIndex, result[i].CommonRulePrecedence.MatchIndexInRule,
+					"rule %d must keep the lowest match index of its group", i+1)
+				assert.Equalf(t, want.methods, result[i].HTTPMethods, "rule %d methods", i+1)
+			}
+		})
+	}
+}
+
+// Test_SortAllRulesByPrecedence_ConsolidationKeepsOrderingAcrossRoutes verifies
+// that a consolidated group sorts exactly where its members sorted: the merged
+// entry keeps the precedence factors of its members, so more specific rules of
+// other routes stay ahead of it and less specific ones stay behind it.
+func Test_SortAllRulesByPrecedence_ConsolidationKeepsOrderingAcrossRoutes(t *testing.T) {
+	exact := (*gwv1.PathMatchType)(awssdk.String("Exact"))
+	prefix := (*gwv1.PathMatchType)(awssdk.String("PathPrefix"))
+	created := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	mkRoute := func(name string, matches []gwv1.HTTPRouteMatch) *MockRoute {
+		return &MockRoute{
+			Kind:         HTTPRouteKind,
+			Name:         name,
+			Namespace:    "ns",
+			Hostnames:    []string{"example.com"},
+			CreationTime: created,
+			Rules:        []RouteRule{&MockRule{RawRule: &gwv1.HTTPRouteRule{Matches: matches}}},
+		}
+	}
+
+	method := func(m string) *gwv1.HTTPMethod {
+		return (*gwv1.HTTPMethod)(awssdk.String(m))
+	}
+
+	// exact /longer-path outranks the consolidated exact /foo rules, which in
+	// turn outrank the prefix /foo rule.
+	moreSpecific := mkRoute("a-more-specific", []gwv1.HTTPRouteMatch{
+		{Path: &gwv1.HTTPPathMatch{Type: exact, Value: awssdk.String("/longer-path")}},
+	})
+	lessSpecific := mkRoute("b-less-specific", []gwv1.HTTPRouteMatch{
+		{Path: &gwv1.HTTPPathMatch{Type: prefix, Value: awssdk.String("/foo")}},
+	})
+	consolidated := mkRoute("c-consolidated", []gwv1.HTTPRouteMatch{
+		{Path: &gwv1.HTTPPathMatch{Type: exact, Value: awssdk.String("/foo")}, Method: method("GET")},
+		{Path: &gwv1.HTTPPathMatch{Type: exact, Value: awssdk.String("/foo")}, Method: method("HEAD")},
+		{Path: &gwv1.HTTPPathMatch{Type: exact, Value: awssdk.String("/foo")}, Method: method("POST")},
+		{Path: &gwv1.HTTPPathMatch{Type: exact, Value: awssdk.String("/foo")}, Method: method("PUT")},
+	})
+
+	routes := []RouteDescriptor{lessSpecific, consolidated, moreSpecific}
+	result := SortAllRulesByPrecedence(routes, 80)
+
+	// 1 + 1 + (4 methods chunked by the hostname-reduced budget into 3 + 1) = 4
+	assert.Equal(t, 4, len(result))
+
+	assert.Equal(t, "ns/a-more-specific", result[0].CommonRulePrecedence.RouteNamespacedName)
+	assert.Equal(t, "ns/c-consolidated", result[1].CommonRulePrecedence.RouteNamespacedName)
+	assert.Equal(t, []string{"GET", "HEAD", "POST"}, result[1].HTTPMethods)
+	assert.Equal(t, "ns/c-consolidated", result[2].CommonRulePrecedence.RouteNamespacedName)
+	assert.Equal(t, []string{"PUT"}, result[2].HTTPMethods)
+	assert.Equal(t, "ns/b-less-specific", result[3].CommonRulePrecedence.RouteNamespacedName)
+}
+
+// Test_SortAllRulesByPrecedence_ConsolidationIsPerRuleAndHostname verifies that
+// matches of different route rules, or of different hostname units of the same
+// rule, never merge: each rule has its own backends and filters, and each
+// hostname unit is its own ALB rule.
+func Test_SortAllRulesByPrecedence_ConsolidationIsPerRuleAndHostname(t *testing.T) {
+	exact := (*gwv1.PathMatchType)(awssdk.String("Exact"))
+	created := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	method := func(m string) *gwv1.HTTPMethod {
+		return (*gwv1.HTTPMethod)(awssdk.String(m))
+	}
+	match := func(m string) gwv1.HTTPRouteMatch {
+		return gwv1.HTTPRouteMatch{
+			Path:   &gwv1.HTTPPathMatch{Type: exact, Value: awssdk.String("/foo")},
+			Method: method(m),
+		}
+	}
+
+	route := &MockRoute{
+		Kind:         HTTPRouteKind,
+		Name:         "route",
+		Namespace:    "ns",
+		Hostnames:    []string{"example.com", "other.example.com"},
+		CreationTime: created,
+		Rules: []RouteRule{
+			&MockRule{RawRule: &gwv1.HTTPRouteRule{Matches: []gwv1.HTTPRouteMatch{match("GET"), match("POST")}}},
+			&MockRule{RawRule: &gwv1.HTTPRouteRule{Matches: []gwv1.HTTPRouteMatch{match("PUT"), match("PATCH")}}},
+		},
+	}
+
+	result := SortAllRulesByPrecedence([]RouteDescriptor{route}, 80)
+
+	// 2 rules × 2 hostnames = 4 consolidated entries (down from 8).
+	assert.Equal(t, 4, len(result))
+	for i := range result {
+		assert.Lenf(t, result[i].HTTPMethods, 2, "entry %d must carry both methods of its own rule and hostname", i+1)
+	}
+
+	byUnit := make(map[string][]string, len(result))
+	for _, entry := range result {
+		key := entry.CommonRulePrecedence.Hostname
+		if entry.CommonRulePrecedence.RuleIndexInRoute == 1 {
+			key += "#rule1"
+		}
+		byUnit[key] = entry.HTTPMethods
+	}
+	assert.Equal(t, []string{"GET", "POST"}, byUnit["other.example.com"])
+	assert.Equal(t, []string{"PUT", "PATCH"}, byUnit["other.example.com#rule1"])
+	assert.Equal(t, []string{"GET", "POST"}, byUnit["example.com"])
+	assert.Equal(t, []string{"PUT", "PATCH"}, byUnit["example.com#rule1"])
+}
+
+// Test_SortAllRulesByPrecedence_GRPCMatchesAreNotConsolidated documents that the
+// consolidation is HTTP only: GRPC method matches become path-pattern conditions
+// whose service and method lengths feed the precedence factors, so merging them
+// would change ordering.
+func Test_SortAllRulesByPrecedence_GRPCMatchesAreNotConsolidated(t *testing.T) {
+	created := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	grpcExact := (*gwv1.GRPCMethodMatchType)(awssdk.String("Exact"))
+
+	route := &MockRoute{
+		Kind:         GRPCRouteKind,
+		Name:         "grpc",
+		Namespace:    "ns",
+		CreationTime: created,
+		Rules: []RouteRule{&MockRule{RawRule: &gwv1.GRPCRouteRule{
+			Matches: []gwv1.GRPCRouteMatch{
+				{Method: &gwv1.GRPCMethodMatch{Type: grpcExact, Service: awssdk.String("svc"), Method: awssdk.String("Get")}},
+				{Method: &gwv1.GRPCMethodMatch{Type: grpcExact, Service: awssdk.String("svc"), Method: awssdk.String("Put")}},
+			},
+		}}},
+	}
+
+	result := SortAllRulesByPrecedence([]RouteDescriptor{route}, 80)
+
+	assert.Equal(t, 2, len(result))
+	for i := range result {
+		assert.Emptyf(t, result[i].HTTPMethods, "GRPC entry %d must not carry consolidated methods", i+1)
+	}
+}

--- a/pkg/gateway/routeutils/route_rule_precedence.go
+++ b/pkg/gateway/routeutils/route_rule_precedence.go
@@ -14,6 +14,12 @@ type RulePrecedence struct {
 	HTTPMatch            *v1.HTTPRouteMatch
 	GRPCMatch            *v1.GRPCRouteMatch
 
+	// HTTPMethods holds every method served by this entry when matches of the
+	// same route rule that differ only by method were consolidated into one ALB
+	// rule. Empty when nothing was consolidated, in which case the method of
+	// HTTPMatch is used.
+	HTTPMethods []string
+
 	// PrecedenceFactor holds the specificity signals used to order this match.
 	// A single struct is used for both HTTPRoute and GRPCRoute rules so that one
 	// comparator can order every rule with a single uniform key — which is a
@@ -140,6 +146,10 @@ func SortAllRulesByPrecedence(routes []RouteDescriptor, port int32) []RulePreced
 			}
 		}
 	}
+
+	// Collapse matches of the same route rule that differ only by method into a
+	// single rule carrying every method, which keeps the ALB rule count down.
+	httpRoutes = consolidateHttpMethodMatches(httpRoutes)
 
 	allRoutes = append(allRoutes, httpRoutes...)
 	allRoutes = append(allRoutes, grpcRoutes...)


### PR DESCRIPTION
The Gateway API HTTPRouteMatch.Method field holds a single method, so serving GET/HEAD/POST/PUT/PATCH/DELETE on one path requires six matches. LBC emitted one ALB listener rule per match, burning six of the default 100 rules per load balancer. ALB's http-request-method condition accepts a value list, so matches of the same HTTPRouteRule that are identical apart from their method can share one rule.

SortAllRulesByPrecedence now folds such matches together before sorting, and BuildHttpRuleConditions emits a single http-request-method condition carrying every method of the merged entry. Matches are only merged when their path, header, query param and applicable source IP conditions are identical; a match without a method means "any method" and is never merged.

The merged entry keeps the lowest MatchIndexInRule of its group. Every member has the same path type/length, header count, query param count and HasMethod=true, so the group's precedence factors equal any member's and it sorts exactly where its members did. Configurations with nothing to merge are unchanged, and the rule count never increases.

The ALB quota "Condition Values per Rule" is 5 and is shared by all condition values of the rule, method values included, so the method list is chunked to whatever the rule's other conditions leave: six methods on the "/" prefix become two rules rather than six.

GRPCRoute is left alone: GRPCRouteMatch.Method is a service/method path match, so there is no method-only axis to consolidate.

### Issue

[<!-- Please link the GitHub issues related to this PR, if available -->](https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4884)

### Description

## What changed

Gateway API `HTTPRouteMatch.Method` holds a single method, so serving
GET/HEAD/POST/PUT/PATCH/DELETE on one path needs six matches, and LBC emitted one
ALB listener rule per match — six rules out of the default quota of 100 per load
balancer. ALB's `http-request-method` condition accepts a value list, so matches
of the same `HTTPRouteRule` that are identical apart from their method are now
folded into a single rule whose method condition carries every method.

Consolidation happens in the precedence/translation layer; the listener model
builder was left untouched.

### Files

| File | Why |
| --- | --- |
| `pkg/gateway/routeutils/route_rule_method_consolidation.go` (new) | `consolidateHttpMethodMatches` groups mergeable matches, merges each group, and sizes the merged method list against the ALB per-rule condition value quota. |
| `pkg/gateway/routeutils/route_rule_precedence.go` | Added `RulePrecedence.HTTPMethods` (the methods of a consolidated entry) and the `consolidateHttpMethodMatches` call in `SortAllRulesByPrecedence`, before the entries are sorted. |
| `pkg/gateway/routeutils/route_rule_condition.go` | `BuildHttpRuleConditions` emits one `http-request-method` condition from `HTTPMethods` when the entry was consolidated; `buildHttpMethodCondition` now delegates to the new `buildHttpMethodConditionFromValues`. Single-method behaviour is byte-identical to before. |
| `pkg/gateway/routeutils/route_rule_method_consolidation_test.go` (new) | Table-driven tests for merging, non-merging, chunking, precedence and GRPC. |
| `pkg/gateway/routeutils/route_rule_condition_test.go` | One case: a consolidated entry produces a single method condition holding the method list. |
| `pkg/gateway/model/model_build_listener_test.go` | One case: six method-only-differing matches produce the consolidated ALB rules with sequential priorities. |

No existing test was weakened, skipped or rewritten, and no existing expectation
changed — the two existing-file edits are purely additive test cases.

## Merge rules

A group is keyed on route namespaced name, rule index, hostname, path match
type+value, header matches (name, type, value, in declared order), query param
matches, and the `ListenerRuleConfiguration` source-IP conditions that apply to
the match's index. Only the method differs within a group.

* A match with **no** method is never merged — no method means "any method", so
  folding it into a method-bearing group would narrow it.
* Duplicate methods within a group collapse to one condition value.
* GRPC is left alone: `GRPCRouteMatch` has no method-only axis (its `Method` is a
  service/method path match, already emitted as a path condition), so there is
  nothing analogous to consolidate. `GRPCRoute` entries are never touched.
* `ListenerRuleConfiguration` CRD and public APIs are unchanged.

## Precedence

Every member of a group has the same path type, path length, header count and
query-param count, and all have `HasMethod = true`, so the group's precedence
factors equal any member's. The merged entry keeps the **lowest**
`MatchIndexInRule` of the group, so it sorts exactly where its members sorted and
ordering relative to other rules is unchanged. Configurations with nothing to
merge take an early return and are bit-for-bit unchanged. The rule count never
increases: a group of N matches yields at most N entries.

## ALB condition value limit (important for reviewers)

The documented ALB quota is **"Condition Values per Rule: 5", not adjustable**
(https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-limits.html).
That budget is per rule and shared by *all* condition values of the rule, method
values included — it is not a per-condition allowance. So the issue's example of
six methods in one rule is not achievable when the rule also carries a path
pattern: the six methods plus the `/*` path value would be seven values.

The merged method list is therefore chunked to
`5 - <values the rule's other conditions consume>`, counting the host header
value, path pattern values (a non-`/` `PathPrefix` match emits two), header
values, query params and applicable source-IP values. Consequences:

* Six methods on the `/` prefix (one path value) → **two** rules,
  `[GET HEAD POST PUT]` and `[PATCH DELETE]` — still a 3× reduction.
* Four or fewer methods on a single-value path → **one** rule.
* If fewer than two values are left in the budget, the group is returned
  unmerged, i.e. exactly today's behaviour.

If a reviewer establishes that ALB accounts for `http-request-method` values
outside the per-rule budget, the only change needed is the `chunkSize`
computation in `mergeHttpMethodGroup` (and the corresponding test expectations).

## Validation

See `test-output.txt`. All of the following passed (exit 0):
`go build ./...`, `go vet ./...`,
`go test ./pkg/gateway/... ./pkg/deploy/elbv2/...`, `gofmt -l .` (clean),
`make lint` (a no-op — the target is `echo "TODO"` upstream) and `make test`
(the full `go test -race ./pkg/... ./webhooks/... ./controllers/...` suite plus
`generate`, `fmt`, `vet`, `manifests`, `helm-lint`). `make test` initially failed
because `yq` was absent from the box; installing `yq` v4.44.3 fixed it. No
generated file changed as a result of `make generate`/`make manifests`.
`golangci-lint` is not wired into this repository.


### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
