### PR TITLE
refactor: Allow automode controllers to customize the gateway controller

### DIFF
--- a/controllers/gateway/gateway_class_controller.go
+++ b/controllers/gateway/gateway_class_controller.go
@@ -15,7 +15,6 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/gateway/constants"
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/gateway/gatewayutils"
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/k8s"
-	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -34,7 +33,7 @@ const (
 )
 
 // NewGatewayClassReconciler constructs a reconciler that responds to gateway class object changes
-func NewGatewayClassReconciler(k8sClient client.Client, eventRecorder record.EventRecorder, controllerConfig config.ControllerConfig, finalizerManager k8s.FinalizerManager, enabledControllers sets.Set[string], logger logr.Logger) Reconciler {
+func NewGatewayClassReconciler(k8sClient client.Client, eventRecorder record.EventRecorder, controllerConfig config.ControllerConfig, finalizerManager k8s.FinalizerManager, enabledControllers sets.Set[string], logger logr.Logger, successCallback func(name string, namespace string), errorCallBack func(name string, namespace string, err error)) Reconciler {
 
 	return &gatewayClassReconciler{
 		k8sClient:                   k8sClient,
@@ -49,6 +48,8 @@ func NewGatewayClassReconciler(k8sClient client.Client, eventRecorder record.Eve
 		configResolverFn:            gatewayutils.ResolveLoadBalancerConfig,
 		defaultTGCResolverFn:        lookUpDefaultTGCByName,
 		gatewayResolverFn:           gatewayutils.GetGatewaysManagedByGatewayClass,
+		successCallback:             successCallback,
+		errorCallBack:               errorCallBack,
 	}
 }
 
@@ -67,6 +68,8 @@ type gatewayClassReconciler struct {
 	configResolverFn            func(ctx context.Context, k8sClient client.Client, reference *gwv1.ParametersReference) (*elbv2gw.LoadBalancerConfiguration, error)
 	defaultTGCResolverFn        func(ctx context.Context, k8sClient client.Client, name, namespace string) (*elbv2gw.TargetGroupConfiguration, error)
 	gatewayResolverFn           func(ctx context.Context, k8sClient client.Client, gwClass *gwv1.GatewayClass) ([]*gwv1.Gateway, error)
+	successCallback             func(name string, namespace string)
+	errorCallBack               func(name string, namespace string, err error)
 }
 
 func (r *gatewayClassReconciler) SetupWatches(_ context.Context, ctrl controller.Controller, mgr ctrl.Manager, _ *kubernetes.Clientset) error {
@@ -106,7 +109,7 @@ func (r *gatewayClassReconciler) SetupWatches(_ context.Context, ctrl controller
 // +kubebuilder:rbac:groups=gateway.k8s.aws,resources=loadbalancerconfigurations,verbs=get;list;watch
 func (r *gatewayClassReconciler) Reconcile(ctx context.Context, req reconcile.Request) (ctrl.Result, error) {
 	err := r.reconcile(ctx, req)
-	return runtime.HandleReconcileError(err, r.logger)
+	return handleReconcileResult(req, err, r.logger, r.successCallback, r.errorCallBack)
 }
 
 func (r *gatewayClassReconciler) reconcile(ctx context.Context, req reconcile.Request) error {

--- a/controllers/gateway/gateway_controller.go
+++ b/controllers/gateway/gateway_controller.go
@@ -39,7 +39,6 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/model/core"
 	elbv2model "sigs.k8s.io/aws-load-balancer-controller/v3/pkg/model/elbv2"
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/networking"
-	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -57,13 +56,13 @@ const (
 var _ Reconciler = &gatewayReconciler{}
 
 // NewNLBGatewayReconciler constructs a gateway reconciler to handle specifically for NLB gateways
-func NewNLBGatewayReconciler(routeLoader routeutils.Loader, referenceCounter referencecounter.ServiceReferenceCounter, cloud services.Cloud, k8sClient client.Client, certDiscovery certs.CertDiscovery, eventRecorder record.EventRecorder, controllerConfig config.ControllerConfig, finalizerManager k8s.FinalizerManager, elbv2TaggingManager elbv2deploy.TaggingManager, trackingProvider tracking.Provider, stackDeployer deploy.StackDeployer, subnetResolver networking.SubnetsResolver, vpcInfoProvider networking.VPCInfoProvider, backendSGProvider networking.BackendSGProvider, sgResolver networking.SecurityGroupResolver, logger logr.Logger, metricsCollector lbcmetrics.MetricCollector, reconcileCounters *metricsutil.ReconcileCounters, targetGroupNameToArnMapper shared_utils.TargetGroupARNMapper, listenerSetStatusSubmitter ListenerSetStatusSubmitter) Reconciler {
-	return newGatewayReconciler(constants.NLBGatewayController, elbv2model.LoadBalancerTypeNetwork, controllerConfig.NLBGatewayMaxConcurrentReconciles, controllerConfig.GatewayFinalizerConfig.NLBGatewayFinalizer, certDiscovery, routeLoader, referenceCounter, routeutils.L4RouteFilter, cloud, k8sClient, eventRecorder, controllerConfig, finalizerManager, elbv2TaggingManager, trackingProvider, stackDeployer, subnetResolver, vpcInfoProvider, backendSGProvider, sgResolver, nlbAddons, targetGroupNameToArnMapper, logger, metricsCollector, reconcileCounters.IncrementNLBGateway, listenerSetStatusSubmitter)
+func NewNLBGatewayReconciler(routeLoader routeutils.Loader, referenceCounter referencecounter.ServiceReferenceCounter, cloud services.Cloud, k8sClient client.Client, certDiscovery certs.CertDiscovery, eventRecorder record.EventRecorder, controllerConfig config.ControllerConfig, finalizerManager k8s.FinalizerManager, elbv2TaggingManager elbv2deploy.TaggingManager, trackingProvider tracking.Provider, stackDeployer deploy.StackDeployer, subnetResolver networking.SubnetsResolver, vpcInfoProvider networking.VPCInfoProvider, backendSGProvider networking.BackendSGProvider, sgResolver networking.SecurityGroupResolver, logger logr.Logger, metricsCollector lbcmetrics.MetricCollector, reconcileCounters *metricsutil.ReconcileCounters, targetGroupNameToArnMapper shared_utils.TargetGroupARNMapper, listenerSetStatusSubmitter ListenerSetStatusSubmitter, successCallback func(name string, namespace string), errorCallBack func(name string, namespace string, err error)) Reconciler {
+	return newGatewayReconciler(constants.NLBGatewayController, elbv2model.LoadBalancerTypeNetwork, controllerConfig.NLBGatewayMaxConcurrentReconciles, controllerConfig.GatewayFinalizerConfig.NLBGatewayFinalizer, certDiscovery, routeLoader, referenceCounter, routeutils.L4RouteFilter, cloud, k8sClient, eventRecorder, controllerConfig, finalizerManager, elbv2TaggingManager, trackingProvider, stackDeployer, subnetResolver, vpcInfoProvider, backendSGProvider, sgResolver, nlbAddons, targetGroupNameToArnMapper, logger, metricsCollector, reconcileCounters.IncrementNLBGateway, listenerSetStatusSubmitter, successCallback, errorCallBack)
 }
 
 // NewALBGatewayReconciler constructs a gateway reconciler to handle specifically for ALB gateways
-func NewALBGatewayReconciler(routeLoader routeutils.Loader, referenceCounter referencecounter.ServiceReferenceCounter, cloud services.Cloud, k8sClient client.Client, certDiscovery certs.CertDiscovery, eventRecorder record.EventRecorder, controllerConfig config.ControllerConfig, finalizerManager k8s.FinalizerManager, elbv2TaggingManager elbv2deploy.TaggingManager, trackingProvider tracking.Provider, stackDeployer deploy.StackDeployer, subnetResolver networking.SubnetsResolver, vpcInfoProvider networking.VPCInfoProvider, backendSGProvider networking.BackendSGProvider, sgResolver networking.SecurityGroupResolver, logger logr.Logger, metricsCollector lbcmetrics.MetricCollector, reconcileCounters *metricsutil.ReconcileCounters, targetGroupNameToArnMapper shared_utils.TargetGroupARNMapper, listenerSetStatusSubmitter ListenerSetStatusSubmitter) Reconciler {
-	return newGatewayReconciler(constants.ALBGatewayController, elbv2model.LoadBalancerTypeApplication, controllerConfig.ALBGatewayMaxConcurrentReconciles, controllerConfig.GatewayFinalizerConfig.ALBGatewayFinalizer, certDiscovery, routeLoader, referenceCounter, routeutils.L7RouteFilter, cloud, k8sClient, eventRecorder, controllerConfig, finalizerManager, elbv2TaggingManager, trackingProvider, stackDeployer, subnetResolver, vpcInfoProvider, backendSGProvider, sgResolver, albAddons, targetGroupNameToArnMapper, logger, metricsCollector, reconcileCounters.IncrementALBGateway, listenerSetStatusSubmitter)
+func NewALBGatewayReconciler(routeLoader routeutils.Loader, referenceCounter referencecounter.ServiceReferenceCounter, cloud services.Cloud, k8sClient client.Client, certDiscovery certs.CertDiscovery, eventRecorder record.EventRecorder, controllerConfig config.ControllerConfig, finalizerManager k8s.FinalizerManager, elbv2TaggingManager elbv2deploy.TaggingManager, trackingProvider tracking.Provider, stackDeployer deploy.StackDeployer, subnetResolver networking.SubnetsResolver, vpcInfoProvider networking.VPCInfoProvider, backendSGProvider networking.BackendSGProvider, sgResolver networking.SecurityGroupResolver, logger logr.Logger, metricsCollector lbcmetrics.MetricCollector, reconcileCounters *metricsutil.ReconcileCounters, targetGroupNameToArnMapper shared_utils.TargetGroupARNMapper, listenerSetStatusSubmitter ListenerSetStatusSubmitter, successCallback func(name string, namespace string), errorCallBack func(name string, namespace string, err error)) Reconciler {
+	return newGatewayReconciler(constants.ALBGatewayController, elbv2model.LoadBalancerTypeApplication, controllerConfig.ALBGatewayMaxConcurrentReconciles, controllerConfig.GatewayFinalizerConfig.ALBGatewayFinalizer, certDiscovery, routeLoader, referenceCounter, routeutils.L7RouteFilter, cloud, k8sClient, eventRecorder, controllerConfig, finalizerManager, elbv2TaggingManager, trackingProvider, stackDeployer, subnetResolver, vpcInfoProvider, backendSGProvider, sgResolver, albAddons, targetGroupNameToArnMapper, logger, metricsCollector, reconcileCounters.IncrementALBGateway, listenerSetStatusSubmitter, successCallback, errorCallBack)
 }
 
 // newGatewayReconciler constructs a reconciler that responds to gateway object changes
@@ -74,7 +73,7 @@ func newGatewayReconciler(controllerName string, lbType elbv2model.LoadBalancerT
 	elbv2TaggingManager elbv2deploy.TaggingManager, trackingProvider tracking.Provider, stackDeployer deploy.StackDeployer,
 	subnetResolver networking.SubnetsResolver, vpcInfoProvider networking.VPCInfoProvider, backendSGProvider networking.BackendSGProvider,
 	sgResolver networking.SecurityGroupResolver, supportedAddons []addon.Addon, targetGroupNameToArnMapper shared_utils.TargetGroupARNMapper, logger logr.Logger, metricsCollector lbcmetrics.MetricCollector,
-	reconcileTracker func(namespaceName types.NamespacedName), listenerSetStatusSubmitter ListenerSetStatusSubmitter) Reconciler {
+	reconcileTracker func(namespaceName types.NamespacedName), listenerSetStatusSubmitter ListenerSetStatusSubmitter, successCallback func(name string, namespace string), errorCallBack func(name string, namespace string, err error)) Reconciler {
 
 	modelBuilder := gatewaymodel.NewModelBuilder(subnetResolver, vpcInfoProvider, cloud.VpcID(), lbType, trackingProvider, elbv2TaggingManager, controllerConfig, cloud.EC2(), cloud.ELBV2(), certDiscovery, k8sClient, controllerConfig.FeatureGates, controllerConfig.ClusterName, controllerConfig.DefaultTags, sets.New(controllerConfig.ExternalManagedTags...), controllerConfig.DefaultSSLPolicy, controllerConfig.DefaultTargetType, controllerConfig.DefaultLoadBalancerScheme, backendSGProvider, sgResolver, controllerConfig.EnableBackendSecurityGroup, controllerConfig.DisableRestrictedSGRules, supportedAddons, logger)
 	stackMarshaller := deploy.NewDefaultStackMarshaller()
@@ -104,6 +103,8 @@ func newGatewayReconciler(controllerName string, lbType elbv2model.LoadBalancerT
 		targetGroupNameToArnMapper: targetGroupNameToArnMapper,
 		listenerSetStatusSubmitter: listenerSetStatusSubmitter,
 		listenerSetEnabled:         controllerConfig.FeatureGates.Enabled(config.GatewayListenerSet),
+		successCallback:            successCallback,
+		errorCallBack:              errorCallBack,
 	}
 }
 
@@ -129,6 +130,8 @@ type gatewayReconciler struct {
 	reconcileTracker           func(namespaceName types.NamespacedName)
 	serviceReferenceCounter    referencecounter.ServiceReferenceCounter
 	gatewayConditionUpdater    func(gw *gwv1.Gateway, targetConditionType string, newStatus metav1.ConditionStatus, reason string, message string) bool
+	successCallback            func(name string, namespace string)
+	errorCallBack              func(name string, namespace string, err error)
 
 	cfgResolver                gatewayConfigResolver
 	lbcEventChan               chan event.TypedGenericEvent[*elbv2gw.LoadBalancerConfiguration]
@@ -185,7 +188,7 @@ type gatewayReconciler struct {
 func (r *gatewayReconciler) Reconcile(ctx context.Context, req reconcile.Request) (ctrl.Result, error) {
 	r.reconcileTracker(req.NamespacedName)
 	err := r.reconcileHelper(ctx, req)
-	return runtime.HandleReconcileError(err, r.logger)
+	return handleReconcileResult(req, err, r.logger, r.successCallback, r.errorCallBack)
 }
 
 func (r *gatewayReconciler) reconcileHelper(ctx context.Context, req reconcile.Request) error {
@@ -206,7 +209,8 @@ func (r *gatewayReconciler) reconcileHelper(ctx context.Context, req reconcile.R
 
 	if err := r.k8sClient.Get(ctx, gwClassNamespacedName, gwClass); err != nil {
 		r.logger.Info("Failed to get GatewayClass", "error", err, "gw-class", gwClassNamespacedName.Name)
-		return client.IgnoreNotFound(err)
+		err = client.IgnoreNotFound(err)
+		return err
 	}
 
 	if string(gwClass.Spec.ControllerName) != r.controllerName {

--- a/controllers/gateway/gateway_controller.go
+++ b/controllers/gateway/gateway_controller.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/certs"
+	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/deploy/tracking"
 
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/shared_utils"
 
@@ -26,7 +27,6 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/config"
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/deploy"
 	elbv2deploy "sigs.k8s.io/aws-load-balancer-controller/v3/pkg/deploy/elbv2"
-	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/deploy/tracking"
 	ctrlerrors "sigs.k8s.io/aws-load-balancer-controller/v3/pkg/error"
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/gateway/constants"
 	gateway_constants "sigs.k8s.io/aws-load-balancer-controller/v3/pkg/gateway/constants"
@@ -34,7 +34,6 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/gateway/referencecounter"
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/gateway/routeutils"
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/k8s"
-	awsmetrics "sigs.k8s.io/aws-load-balancer-controller/v3/pkg/metrics/aws"
 	lbcmetrics "sigs.k8s.io/aws-load-balancer-controller/v3/pkg/metrics/lbc"
 	metricsutil "sigs.k8s.io/aws-load-balancer-controller/v3/pkg/metrics/util"
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/model/core"
@@ -58,30 +57,27 @@ const (
 var _ Reconciler = &gatewayReconciler{}
 
 // NewNLBGatewayReconciler constructs a gateway reconciler to handle specifically for NLB gateways
-func NewNLBGatewayReconciler(routeLoader routeutils.Loader, referenceCounter referencecounter.ServiceReferenceCounter, cloud services.Cloud, k8sClient client.Client, certDiscovery certs.CertDiscovery, eventRecorder record.EventRecorder, controllerConfig config.ControllerConfig, finalizerManager k8s.FinalizerManager, networkingManager networking.NetworkingManager, networkingSGReconciler networking.SecurityGroupReconciler, networkingSGManager networking.SecurityGroupManager, elbv2TaggingManager elbv2deploy.TaggingManager, subnetResolver networking.SubnetsResolver, vpcInfoProvider networking.VPCInfoProvider, backendSGProvider networking.BackendSGProvider, sgResolver networking.SecurityGroupResolver, logger logr.Logger, metricsCollector lbcmetrics.MetricCollector, reconcileCounters *metricsutil.ReconcileCounters, targetGroupCollector awsmetrics.TargetGroupCollector, targetGroupNameToArnMapper shared_utils.TargetGroupARNMapper, listenerSetStatusSubmitter ListenerSetStatusSubmitter) Reconciler {
-	return newGatewayReconciler(constants.NLBGatewayController, elbv2model.LoadBalancerTypeNetwork, controllerConfig.NLBGatewayMaxConcurrentReconciles, constants.NLBGatewayTagPrefix, controllerConfig.GatewayFinalizerConfig.NLBGatewayFinalizer, certDiscovery, routeLoader, referenceCounter, routeutils.L4RouteFilter, cloud, k8sClient, eventRecorder, controllerConfig, finalizerManager, networkingSGReconciler, networkingManager, networkingSGManager, elbv2TaggingManager, subnetResolver, vpcInfoProvider, backendSGProvider, sgResolver, nlbAddons, targetGroupNameToArnMapper, logger, metricsCollector, reconcileCounters.IncrementNLBGateway, targetGroupCollector, listenerSetStatusSubmitter)
+func NewNLBGatewayReconciler(routeLoader routeutils.Loader, referenceCounter referencecounter.ServiceReferenceCounter, cloud services.Cloud, k8sClient client.Client, certDiscovery certs.CertDiscovery, eventRecorder record.EventRecorder, controllerConfig config.ControllerConfig, finalizerManager k8s.FinalizerManager, elbv2TaggingManager elbv2deploy.TaggingManager, trackingProvider tracking.Provider, stackDeployer deploy.StackDeployer, subnetResolver networking.SubnetsResolver, vpcInfoProvider networking.VPCInfoProvider, backendSGProvider networking.BackendSGProvider, sgResolver networking.SecurityGroupResolver, logger logr.Logger, metricsCollector lbcmetrics.MetricCollector, reconcileCounters *metricsutil.ReconcileCounters, targetGroupNameToArnMapper shared_utils.TargetGroupARNMapper, listenerSetStatusSubmitter ListenerSetStatusSubmitter) Reconciler {
+	return newGatewayReconciler(constants.NLBGatewayController, elbv2model.LoadBalancerTypeNetwork, controllerConfig.NLBGatewayMaxConcurrentReconciles, controllerConfig.GatewayFinalizerConfig.NLBGatewayFinalizer, certDiscovery, routeLoader, referenceCounter, routeutils.L4RouteFilter, cloud, k8sClient, eventRecorder, controllerConfig, finalizerManager, elbv2TaggingManager, trackingProvider, stackDeployer, subnetResolver, vpcInfoProvider, backendSGProvider, sgResolver, nlbAddons, targetGroupNameToArnMapper, logger, metricsCollector, reconcileCounters.IncrementNLBGateway, listenerSetStatusSubmitter)
 }
 
 // NewALBGatewayReconciler constructs a gateway reconciler to handle specifically for ALB gateways
-func NewALBGatewayReconciler(routeLoader routeutils.Loader, cloud services.Cloud, k8sClient client.Client, certDiscovery certs.CertDiscovery, referenceCounter referencecounter.ServiceReferenceCounter, eventRecorder record.EventRecorder, controllerConfig config.ControllerConfig, finalizerManager k8s.FinalizerManager, networkingManager networking.NetworkingManager, networkingSGReconciler networking.SecurityGroupReconciler, networkingSGManager networking.SecurityGroupManager, elbv2TaggingManager elbv2deploy.TaggingManager, subnetResolver networking.SubnetsResolver, vpcInfoProvider networking.VPCInfoProvider, backendSGProvider networking.BackendSGProvider, sgResolver networking.SecurityGroupResolver, logger logr.Logger, metricsCollector lbcmetrics.MetricCollector, reconcileCounters *metricsutil.ReconcileCounters, targetGroupCollector awsmetrics.TargetGroupCollector, targetGroupNameToArnMapper shared_utils.TargetGroupARNMapper, listenerSetStatusSubmitter ListenerSetStatusSubmitter) Reconciler {
-	return newGatewayReconciler(constants.ALBGatewayController, elbv2model.LoadBalancerTypeApplication, controllerConfig.ALBGatewayMaxConcurrentReconciles, constants.ALBGatewayTagPrefix, controllerConfig.GatewayFinalizerConfig.ALBGatewayFinalizer, certDiscovery, routeLoader, referenceCounter, routeutils.L7RouteFilter, cloud, k8sClient, eventRecorder, controllerConfig, finalizerManager, networkingSGReconciler, networkingManager, networkingSGManager, elbv2TaggingManager, subnetResolver, vpcInfoProvider, backendSGProvider, sgResolver, albAddons, targetGroupNameToArnMapper, logger, metricsCollector, reconcileCounters.IncrementALBGateway, targetGroupCollector, listenerSetStatusSubmitter)
+func NewALBGatewayReconciler(routeLoader routeutils.Loader, referenceCounter referencecounter.ServiceReferenceCounter, cloud services.Cloud, k8sClient client.Client, certDiscovery certs.CertDiscovery, eventRecorder record.EventRecorder, controllerConfig config.ControllerConfig, finalizerManager k8s.FinalizerManager, elbv2TaggingManager elbv2deploy.TaggingManager, trackingProvider tracking.Provider, stackDeployer deploy.StackDeployer, subnetResolver networking.SubnetsResolver, vpcInfoProvider networking.VPCInfoProvider, backendSGProvider networking.BackendSGProvider, sgResolver networking.SecurityGroupResolver, logger logr.Logger, metricsCollector lbcmetrics.MetricCollector, reconcileCounters *metricsutil.ReconcileCounters, targetGroupNameToArnMapper shared_utils.TargetGroupARNMapper, listenerSetStatusSubmitter ListenerSetStatusSubmitter) Reconciler {
+	return newGatewayReconciler(constants.ALBGatewayController, elbv2model.LoadBalancerTypeApplication, controllerConfig.ALBGatewayMaxConcurrentReconciles, controllerConfig.GatewayFinalizerConfig.ALBGatewayFinalizer, certDiscovery, routeLoader, referenceCounter, routeutils.L7RouteFilter, cloud, k8sClient, eventRecorder, controllerConfig, finalizerManager, elbv2TaggingManager, trackingProvider, stackDeployer, subnetResolver, vpcInfoProvider, backendSGProvider, sgResolver, albAddons, targetGroupNameToArnMapper, logger, metricsCollector, reconcileCounters.IncrementALBGateway, listenerSetStatusSubmitter)
 }
 
 // newGatewayReconciler constructs a reconciler that responds to gateway object changes
 func newGatewayReconciler(controllerName string, lbType elbv2model.LoadBalancerType, maxConcurrentReconciles int,
-	gatewayTagPrefix string, finalizer string, certDiscovery certs.CertDiscovery, routeLoader routeutils.Loader, serviceReferenceCounter referencecounter.ServiceReferenceCounter, routeFilter routeutils.LoadRouteFilter,
+	finalizer string, certDiscovery certs.CertDiscovery, routeLoader routeutils.Loader, serviceReferenceCounter referencecounter.ServiceReferenceCounter, routeFilter routeutils.LoadRouteFilter,
 	cloud services.Cloud, k8sClient client.Client, eventRecorder record.EventRecorder, controllerConfig config.ControllerConfig,
-	finalizerManager k8s.FinalizerManager, networkingSGReconciler networking.SecurityGroupReconciler,
-	networkingManager networking.NetworkingManager, networkingSGManager networking.SecurityGroupManager, elbv2TaggingManager elbv2deploy.TaggingManager,
+	finalizerManager k8s.FinalizerManager,
+	elbv2TaggingManager elbv2deploy.TaggingManager, trackingProvider tracking.Provider, stackDeployer deploy.StackDeployer,
 	subnetResolver networking.SubnetsResolver, vpcInfoProvider networking.VPCInfoProvider, backendSGProvider networking.BackendSGProvider,
 	sgResolver networking.SecurityGroupResolver, supportedAddons []addon.Addon, targetGroupNameToArnMapper shared_utils.TargetGroupARNMapper, logger logr.Logger, metricsCollector lbcmetrics.MetricCollector,
-	reconcileTracker func(namespaceName types.NamespacedName), targetGroupCollector awsmetrics.TargetGroupCollector, listenerSetStatusSubmitter ListenerSetStatusSubmitter) Reconciler {
+	reconcileTracker func(namespaceName types.NamespacedName), listenerSetStatusSubmitter ListenerSetStatusSubmitter) Reconciler {
 
-	trackingProvider := tracking.NewDefaultProvider(gatewayTagPrefix, controllerConfig.ClusterName)
 	modelBuilder := gatewaymodel.NewModelBuilder(subnetResolver, vpcInfoProvider, cloud.VpcID(), lbType, trackingProvider, elbv2TaggingManager, controllerConfig, cloud.EC2(), cloud.ELBV2(), certDiscovery, k8sClient, controllerConfig.FeatureGates, controllerConfig.ClusterName, controllerConfig.DefaultTags, sets.New(controllerConfig.ExternalManagedTags...), controllerConfig.DefaultSSLPolicy, controllerConfig.DefaultTargetType, controllerConfig.DefaultLoadBalancerScheme, backendSGProvider, sgResolver, controllerConfig.EnableBackendSecurityGroup, controllerConfig.DisableRestrictedSGRules, supportedAddons, logger)
-
 	stackMarshaller := deploy.NewDefaultStackMarshaller()
-	stackDeployer := deploy.NewDefaultStackDeployer(cloud, k8sClient, networkingManager, networkingSGManager, networkingSGReconciler, elbv2TaggingManager, controllerConfig, gatewayTagPrefix, logger, metricsCollector, controllerName, true, targetGroupCollector, lbType == elbv2model.LoadBalancerTypeNetwork)
 
 	cfgResolver := newGatewayConfigResolver(controllerConfig.GatewayFinalizerConfig.LoadBalancerConfigurationFinalizer, logger.WithName("config-resolver"))
 

--- a/controllers/gateway/listenerrule_configuration_controller.go
+++ b/controllers/gateway/listenerrule_configuration_controller.go
@@ -18,7 +18,6 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/gateway/constants"
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/gateway/routeutils"
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/k8s"
-	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -33,7 +32,7 @@ const (
 )
 
 // NewListenerRuleConfigurationReconciler constructs a reconciler that responds to listener rule configuration changes
-func NewListenerRuleConfigurationReconciler(k8sClient client.Client, eventRecorder record.EventRecorder, controllerConfig config.ControllerConfig, finalizerManager k8s.FinalizerManager, logger logr.Logger) Reconciler {
+func NewListenerRuleConfigurationReconciler(k8sClient client.Client, eventRecorder record.EventRecorder, controllerConfig config.ControllerConfig, finalizerManager k8s.FinalizerManager, logger logr.Logger, successCallback func(name string, namespace string), errorCallBack func(name string, namespace string, err error)) Reconciler {
 	return &listenerRuleConfigurationReconciler{
 		k8sClient:        k8sClient,
 		eventRecorder:    eventRecorder,
@@ -41,6 +40,8 @@ func NewListenerRuleConfigurationReconciler(k8sClient client.Client, eventRecord
 		finalizerManager: finalizerManager,
 		finalizer:        controllerConfig.GatewayFinalizerConfig.ListenerRuleConfigurationFinalizer,
 		workers:          controllerConfig.GatewayClassMaxConcurrentReconciles,
+		successCallback:  successCallback,
+		errorCallBack:    errorCallBack,
 	}
 }
 
@@ -53,6 +54,8 @@ type listenerRuleConfigurationReconciler struct {
 	finalizerManager k8s.FinalizerManager
 	finalizer        string
 	workers          int
+	successCallback  func(name string, namespace string)
+	errorCallBack    func(name string, namespace string, err error)
 }
 
 func (r *listenerRuleConfigurationReconciler) SetupWatches(_ context.Context, ctrl controller.Controller, mgr ctrl.Manager, clientSet *kubernetes.Clientset) error {
@@ -73,7 +76,8 @@ func (r *listenerRuleConfigurationReconciler) SetupWatches(_ context.Context, ct
 }
 
 func (r *listenerRuleConfigurationReconciler) Reconcile(ctx context.Context, req reconcile.Request) (ctrl.Result, error) {
-	return runtime.HandleReconcileError(r.reconcile(ctx, req), r.logger)
+	err := r.reconcile(ctx, req)
+	return handleReconcileResult(req, err, r.logger, r.successCallback, r.errorCallBack)
 }
 
 func (r *listenerRuleConfigurationReconciler) reconcile(ctx context.Context, req reconcile.Request) error {

--- a/controllers/gateway/loadbalancer_configuration_controller.go
+++ b/controllers/gateway/loadbalancer_configuration_controller.go
@@ -12,7 +12,6 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/gateway/constants"
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/gateway/gatewayutils"
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/k8s"
-	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -22,7 +21,7 @@ import (
 )
 
 // NewLoadbalancerConfigurationReconciler constructs a reconciler that responds to loadbalancer configuration changes
-func NewLoadbalancerConfigurationReconciler(k8sClient client.Client, eventRecorder record.EventRecorder, controllerConfig config.ControllerConfig, finalizerManager k8s.FinalizerManager, logger logr.Logger) Reconciler {
+func NewLoadbalancerConfigurationReconciler(k8sClient client.Client, eventRecorder record.EventRecorder, controllerConfig config.ControllerConfig, finalizerManager k8s.FinalizerManager, logger logr.Logger, successCallback func(name string, namespace string), errorCallBack func(name string, namespace string, err error)) Reconciler {
 
 	return &loadbalancerConfigurationReconciler{
 		k8sClient:        k8sClient,
@@ -31,6 +30,8 @@ func NewLoadbalancerConfigurationReconciler(k8sClient client.Client, eventRecord
 		finalizerManager: finalizerManager,
 		finalizer:        controllerConfig.GatewayFinalizerConfig.LoadBalancerConfigurationFinalizer,
 		workers:          controllerConfig.GatewayClassMaxConcurrentReconciles,
+		successCallback:  successCallback,
+		errorCallBack:    errorCallBack,
 	}
 }
 
@@ -42,6 +43,8 @@ type loadbalancerConfigurationReconciler struct {
 	finalizerManager k8s.FinalizerManager
 	finalizer        string
 	workers          int
+	successCallback  func(name string, namespace string)
+	errorCallBack    func(name string, namespace string, err error)
 }
 
 func (r *loadbalancerConfigurationReconciler) SetupWatches(_ context.Context, ctrl controller.Controller, mgr ctrl.Manager, _ *kubernetes.Clientset) error {
@@ -54,7 +57,8 @@ func (r *loadbalancerConfigurationReconciler) SetupWatches(_ context.Context, ct
 }
 
 func (r *loadbalancerConfigurationReconciler) Reconcile(ctx context.Context, req reconcile.Request) (ctrl.Result, error) {
-	return runtime.HandleReconcileError(r.reconcile(ctx, req), r.logger)
+	err := r.reconcile(ctx, req)
+	return handleReconcileResult(req, err, r.logger, r.successCallback, r.errorCallBack)
 }
 
 func (r *loadbalancerConfigurationReconciler) reconcile(ctx context.Context, req reconcile.Request) error {

--- a/controllers/gateway/targetgroup_configuration_controller.go
+++ b/controllers/gateway/targetgroup_configuration_controller.go
@@ -17,7 +17,6 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/gateway/gatewayutils"
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/gateway/referencecounter"
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/k8s"
-	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -28,7 +27,7 @@ import (
 )
 
 // NewTargetGroupConfigurationReconciler constructs a reconciler that responds to targetgroup configuration changes
-func NewTargetGroupConfigurationReconciler(k8sClient client.Client, eventRecorder record.EventRecorder, controllerConfig config.ControllerConfig, serviceReferenceCounter referencecounter.ServiceReferenceCounter, finalizerManager k8s.FinalizerManager, logger logr.Logger) Reconciler {
+func NewTargetGroupConfigurationReconciler(k8sClient client.Client, eventRecorder record.EventRecorder, controllerConfig config.ControllerConfig, serviceReferenceCounter referencecounter.ServiceReferenceCounter, finalizerManager k8s.FinalizerManager, logger logr.Logger, successCallback func(name string, namespace string), errorCallBack func(name string, namespace string, err error)) Reconciler {
 
 	return &targetgroupConfigurationReconciler{
 		k8sClient:               k8sClient,
@@ -39,6 +38,8 @@ func NewTargetGroupConfigurationReconciler(k8sClient client.Client, eventRecorde
 		serviceReferenceCounter: serviceReferenceCounter,
 		gwRetrieveFn:            gatewayutils.GetGatewaysManagedByLBController,
 		workers:                 controllerConfig.GatewayClassMaxConcurrentReconciles,
+		successCallback:         successCallback,
+		errorCallBack:           errorCallBack,
 	}
 }
 
@@ -53,6 +54,9 @@ type targetgroupConfigurationReconciler struct {
 
 	gwRetrieveFn func(ctx context.Context, k8sClient client.Client, gwController string) ([]*gwv1.Gateway, error)
 	workers      int
+
+	successCallback func(name string, namespace string)
+	errorCallBack   func(name string, namespace string, err error)
 }
 
 func (r *targetgroupConfigurationReconciler) SetupWatches(_ context.Context, ctrl controller.Controller, mgr ctrl.Manager, _ *kubernetes.Clientset) error {
@@ -65,7 +69,8 @@ func (r *targetgroupConfigurationReconciler) SetupWatches(_ context.Context, ctr
 }
 
 func (r *targetgroupConfigurationReconciler) Reconcile(ctx context.Context, req reconcile.Request) (ctrl.Result, error) {
-	return runtime.HandleReconcileError(r.reconcile(ctx, req), r.logger)
+	err := r.reconcile(ctx, req)
+	return handleReconcileResult(req, err, r.logger, r.successCallback, r.errorCallBack)
 }
 
 func (r *targetgroupConfigurationReconciler) reconcile(ctx context.Context, req reconcile.Request) error {

--- a/controllers/gateway/utils.go
+++ b/controllers/gateway/utils.go
@@ -213,7 +213,12 @@ func isGatewayDeleting(gw *gwv1.Gateway) bool {
 func handleReconcileResult(req reconcile.Request, err error, logger logr.Logger, success func(name string, namespace string), fail func(name string, namespace string, err error)) (ctrl.Result, error) {
 	result, translatedError := runtime.HandleReconcileError(err, logger)
 	if translatedError == nil {
-		success(req.Name, req.Namespace)
+		// Only declare success on a truly empty result (genuine completion).
+		// A pending requeue (either immediate via Requeue or delayed via RequeueAfter)
+		// means reconciliation is not done, so we must not declare success.
+		if !result.Requeue && result.RequeueAfter == 0 {
+			success(req.Name, req.Namespace)
+		}
 	} else {
 		fail(req.Name, req.Namespace, translatedError)
 	}

--- a/controllers/gateway/utils.go
+++ b/controllers/gateway/utils.go
@@ -9,13 +9,17 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/v3/apis/gateway/v1"
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/gateway/routeutils"
+	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -204,4 +208,14 @@ func getServicesFromRoutes(listenerRouteMap map[int32][]routeutils.RouteDescript
 // isGatewayDeleting returns true if the gateway has a deletion timestamp set
 func isGatewayDeleting(gw *gwv1.Gateway) bool {
 	return gw.DeletionTimestamp != nil && !gw.DeletionTimestamp.IsZero()
+}
+
+func handleReconcileResult(req reconcile.Request, err error, logger logr.Logger, success func(name string, namespace string), fail func(name string, namespace string, err error)) (ctrl.Result, error) {
+	result, translatedError := runtime.HandleReconcileError(err, logger)
+	if translatedError == nil {
+		success(req.Name, req.Namespace)
+	} else {
+		fail(req.Name, req.Namespace, translatedError)
+	}
+	return result, translatedError
 }

--- a/controllers/gateway/utils_test.go
+++ b/controllers/gateway/utils_test.go
@@ -7,13 +7,19 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	elbv2gw "sigs.k8s.io/aws-load-balancer-controller/v3/apis/gateway/v1"
+	ctrlerrors "sigs.k8s.io/aws-load-balancer-controller/v3/pkg/error"
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/gateway/routeutils"
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/k8s"
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/testutils"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -993,6 +999,127 @@ func Test_generateRouteList(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			res := generateRouteList(tc.routes)
 			assert.Equal(t, tc.expected, res)
+		})
+	}
+}
+
+func Test_handleReconcileResult(t *testing.T) {
+	genericErr := errors.New("something went wrong")
+	wrappedErr := &ctrlerrors.ErrorWithMetrics{Err: genericErr}
+	// A requeue error wrapped in ErrorWithMetrics should still be detected as a requeue.
+	wrappedRequeueErr := &ctrlerrors.ErrorWithMetrics{Err: ctrlerrors.NewRequeueNeeded("dependency not ready")}
+
+	testCases := []struct {
+		name                string
+		err                 error
+		expectedResult      ctrl.Result
+		expectErr           bool
+		expectedErr         error
+		expectSuccessCalled bool
+		expectFailCalled    bool
+	}{
+		{
+			name:                "nil error triggers success callback",
+			err:                 nil,
+			expectedResult:      ctrl.Result{},
+			expectErr:           false,
+			expectSuccessCalled: true,
+			expectFailCalled:    false,
+		},
+		{
+			name:                "requeue needed after error does not trigger any callback",
+			err:                 ctrlerrors.NewRequeueNeededAfter("dependency not ready", 30*time.Second),
+			expectedResult:      ctrl.Result{RequeueAfter: 30 * time.Second},
+			expectErr:           false,
+			expectSuccessCalled: false,
+			expectFailCalled:    false,
+		},
+		{
+			name:                "requeue needed error does not trigger any callback",
+			err:                 ctrlerrors.NewRequeueNeeded("dependency not ready"),
+			expectedResult:      ctrl.Result{Requeue: true},
+			expectErr:           false,
+			expectSuccessCalled: false,
+			expectFailCalled:    false,
+		},
+		{
+			name:                "generic error triggers fail callback and returns error",
+			err:                 genericErr,
+			expectedResult:      ctrl.Result{},
+			expectErr:           true,
+			expectedErr:         genericErr,
+			expectSuccessCalled: false,
+			expectFailCalled:    true,
+		},
+		{
+			// HandleReconcileError unwraps ErrorWithMetrics only to classify it, but returns the
+			// original wrapper as the error, so fail receives the wrapper unchanged.
+			name:                "wrapped error with metrics triggers fail callback with original wrapper",
+			err:                 wrappedErr,
+			expectedResult:      ctrl.Result{},
+			expectErr:           true,
+			expectedErr:         wrappedErr,
+			expectSuccessCalled: false,
+			expectFailCalled:    true,
+		},
+		{
+			name:                "requeue error wrapped in metrics is detected and does not trigger any callback",
+			err:                 wrappedRequeueErr,
+			expectedResult:      ctrl.Result{Requeue: true},
+			expectErr:           false,
+			expectSuccessCalled: false,
+			expectFailCalled:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var successCalled, failCalled bool
+			var gotSuccessName, gotSuccessNamespace string
+			var gotFailName, gotFailNamespace string
+			var gotFailErr error
+
+			success := func(name string, namespace string) {
+				successCalled = true
+				gotSuccessName = name
+				gotSuccessNamespace = namespace
+			}
+			fail := func(name string, namespace string, err error) {
+				failCalled = true
+				gotFailName = name
+				gotFailNamespace = namespace
+				gotFailErr = err
+			}
+
+			req := reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "my-gateway",
+					Namespace: "my-namespace",
+				},
+			}
+
+			result, err := handleReconcileResult(req, tc.err, logr.Discard(), success, fail)
+
+			assert.Equal(t, tc.expectedResult, result)
+			if tc.expectErr {
+				assert.Error(t, err)
+				assert.Equal(t, tc.expectedErr, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, tc.expectSuccessCalled, successCalled)
+			assert.Equal(t, tc.expectFailCalled, failCalled)
+
+			if tc.expectSuccessCalled {
+				assert.Equal(t, req.Name, gotSuccessName)
+				assert.Equal(t, req.Namespace, gotSuccessNamespace)
+			}
+			if tc.expectFailCalled {
+				assert.Equal(t, req.Name, gotFailName)
+				assert.Equal(t, req.Namespace, gotFailNamespace)
+				assert.Equal(t, tc.expectedErr, gotFailErr)
+			}
 		})
 	}
 }

--- a/main.go
+++ b/main.go
@@ -93,7 +93,6 @@ func init() {
 	_ = elbv2api.AddToScheme(scheme)
 	_ = elbv2gw.AddToScheme(scheme)
 	_ = gwv1.AddToScheme(scheme)
-	_ = gwbeta1.AddToScheme(scheme)
 	// +kubebuilder:scaffold:scheme
 }
 

--- a/main.go
+++ b/main.go
@@ -341,6 +341,9 @@ func main() {
 			enabledControllers.Insert(gateway_constants.ALBGatewayController)
 		}
 
+		noOpSuccess := func(_, _ string) {}
+		noOpFailure := func(_, _ string, _ error) {}
+
 		gatewayClassReconciler := gateway.NewGatewayClassReconciler(
 			mgr.GetClient(),
 			mgr.GetEventRecorderFor(gateway_constants.GatewayClassController),
@@ -348,6 +351,8 @@ func main() {
 			finalizerManager,
 			enabledControllers,
 			mgr.GetLogger().WithName("gatewayclass-controller"),
+			noOpSuccess,
+			noOpFailure,
 		)
 
 		controller, err := gatewayClassReconciler.SetupWithManager(ctx, mgr)
@@ -368,6 +373,8 @@ func main() {
 			controllerCFG,
 			finalizerManager,
 			mgr.GetLogger().WithName("loadbalancerconfiguration-controller"),
+			noOpSuccess,
+			noOpFailure,
 		)
 
 		lbCfgController, err := loadbalancerConfigurationReconciler.SetupWithManager(ctx, mgr)
@@ -389,6 +396,8 @@ func main() {
 			serviceReferenceCounter,
 			finalizerManager,
 			mgr.GetLogger().WithName("targetgroupconfiguration-controller"),
+			noOpSuccess,
+			noOpFailure,
 		)
 
 		tgCfgController, err := targetGroupConfigurationReconciler.SetupWithManager(ctx, mgr)
@@ -409,6 +418,8 @@ func main() {
 			controllerCFG,
 			finalizerManager,
 			mgr.GetLogger().WithName("listenerruleconfiguration-controller"),
+			noOpSuccess,
+			noOpFailure,
 		)
 
 		listenerRuleCfgController, err := listenerRuleConfigurationReconciler.SetupWithManager(ctx, mgr)
@@ -526,10 +537,11 @@ func setupGatewayController(ctx context.Context, mgr ctrl.Manager, cfg *gatewayC
 
 	var reconciler gateway.Reconciler
 
-	gatewayTagPrefix := gateway_constants.NLBGatewayTagPrefix
 	if controllerType != gateway_constants.ALBGatewayController && controllerType != gateway_constants.NLBGatewayController {
 		return fmt.Errorf("invalid controller type: %s", controllerType)
 	}
+
+	gatewayTagPrefix := gateway_constants.NLBGatewayTagPrefix
 
 	reconcilerCreator := gateway.NewNLBGatewayReconciler
 	if controllerType == gateway_constants.ALBGatewayController {
@@ -561,6 +573,12 @@ func setupGatewayController(ctx context.Context, mgr ctrl.Manager, cfg *gatewayC
 		cfg.reconcileCounters,
 		cfg.targetGroupARNMapper,
 		cfg.listenerSetStatusUpdater,
+		func(_, _ string) {
+			// We don't track anything in this callback
+		},
+		func(_, _ string, err error) {
+			// We don't track anything in this callback
+		},
 	)
 
 	controller, err := reconciler.SetupWithManager(ctx, mgr)

--- a/main.go
+++ b/main.go
@@ -24,6 +24,8 @@ import (
 
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/aga"
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/certs"
+	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/deploy"
+	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/deploy/tracking"
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/shared_utils"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -38,7 +40,6 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/inject/quic"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gwbeta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"k8s.io/client-go/util/workqueue"
 
@@ -524,60 +525,43 @@ func setupGatewayController(ctx context.Context, mgr ctrl.Manager, cfg *gatewayC
 	logger := ctrl.Log.WithName("controllers").WithName(controllerType)
 
 	var reconciler gateway.Reconciler
-	switch controllerType {
-	case gateway_constants.NLBGatewayController:
-		reconciler = gateway.NewNLBGatewayReconciler(
-			cfg.routeLoader,
-			cfg.serviceReferenceCounter,
-			cfg.cloud,
-			cfg.k8sClient,
-			cfg.certDiscovery,
-			mgr.GetEventRecorderFor(controllerType),
-			cfg.controllerCFG,
-			cfg.finalizerManager,
-			cfg.networkingManager,
-			cfg.sgReconciler,
-			cfg.sgManager,
-			cfg.elbv2TaggingManager,
-			cfg.subnetResolver,
-			cfg.vpcInfoProvider,
-			cfg.backendSGProvider,
-			cfg.sgResolver,
-			logger,
-			cfg.metricsCollector,
-			cfg.reconcileCounters,
-			cfg.targetGroupCollector,
-			cfg.targetGroupARNMapper,
-			cfg.listenerSetStatusUpdater,
-		)
-	case gateway_constants.ALBGatewayController:
-		reconciler = gateway.NewALBGatewayReconciler(
-			cfg.routeLoader,
-			cfg.cloud,
-			cfg.k8sClient,
-			cfg.certDiscovery,
-			cfg.serviceReferenceCounter,
-			mgr.GetEventRecorderFor(controllerType),
-			cfg.controllerCFG,
-			cfg.finalizerManager,
-			cfg.networkingManager,
-			cfg.sgReconciler,
-			cfg.sgManager,
-			cfg.elbv2TaggingManager,
-			cfg.subnetResolver,
-			cfg.vpcInfoProvider,
-			cfg.backendSGProvider,
-			cfg.sgResolver,
-			logger,
-			cfg.metricsCollector,
-			cfg.reconcileCounters,
-			cfg.targetGroupCollector,
-			cfg.targetGroupARNMapper,
-			cfg.listenerSetStatusUpdater,
-		)
-	default:
-		return fmt.Errorf("unknown controller type: %s", controllerType)
+
+	gatewayTagPrefix := gateway_constants.NLBGatewayTagPrefix
+	if controllerType != gateway_constants.ALBGatewayController && controllerType != gateway_constants.NLBGatewayController {
+		return fmt.Errorf("invalid controller type: %s", controllerType)
 	}
+
+	reconcilerCreator := gateway.NewNLBGatewayReconciler
+	if controllerType == gateway_constants.ALBGatewayController {
+		reconcilerCreator = gateway.NewALBGatewayReconciler
+		gatewayTagPrefix = gateway_constants.ALBGatewayTagPrefix
+	}
+
+	trackingProvider := tracking.NewDefaultProvider(gatewayTagPrefix, cfg.controllerCFG.ClusterName)
+	stackDeployer := deploy.NewDefaultStackDeployer(cfg.cloud, cfg.k8sClient, cfg.networkingManager, cfg.sgManager, cfg.sgReconciler, cfg.elbv2TaggingManager, cfg.controllerCFG, gatewayTagPrefix, logger, cfg.metricsCollector, controllerType, true, cfg.targetGroupCollector, controllerType == gateway_constants.NLBGatewayController)
+
+	reconciler = reconcilerCreator(
+		cfg.routeLoader,
+		cfg.serviceReferenceCounter,
+		cfg.cloud,
+		cfg.k8sClient,
+		cfg.certDiscovery,
+		mgr.GetEventRecorderFor(controllerType),
+		cfg.controllerCFG,
+		cfg.finalizerManager,
+		cfg.elbv2TaggingManager,
+		trackingProvider,
+		stackDeployer,
+		cfg.subnetResolver,
+		cfg.vpcInfoProvider,
+		cfg.backendSGProvider,
+		cfg.sgResolver,
+		logger,
+		cfg.metricsCollector,
+		cfg.reconcileCounters,
+		cfg.targetGroupARNMapper,
+		cfg.listenerSetStatusUpdater,
+	)
 
 	controller, err := reconciler.SetupWithManager(ctx, mgr)
 	if err != nil {

--- a/pkg/gateway/crddetect/gateway_feature_flags.go
+++ b/pkg/gateway/crddetect/gateway_feature_flags.go
@@ -18,8 +18,8 @@ var (
 	// lbcGatewayKinds are the AWS vended CRDs required by both ALB and NLB gateway controllers.
 	lbcGatewayKinds = []string{"TargetGroupConfiguration", "LoadBalancerConfiguration", "ListenerRuleConfiguration"}
 
-	albKinds         = map[string][]string{GatewayV1GroupVersion: {"Gateway", "GatewayClass", "HTTPRoute", "GRPCRoute"}, LBCGatewayGroupVersion: lbcGatewayKinds}
-	nlbKinds         = map[string][]string{GatewayV1GroupVersion: {"Gateway", "GatewayClass", "TLSRoute", "TCPRoute", "UDPRoute"}, LBCGatewayGroupVersion: lbcGatewayKinds}
+	albKinds         = map[string][]string{GatewayV1GroupVersion: {"Gateway", "GatewayClass", "HTTPRoute", "GRPCRoute", "ReferenceGrant"}, LBCGatewayGroupVersion: lbcGatewayKinds}
+	nlbKinds         = map[string][]string{GatewayV1GroupVersion: {"Gateway", "GatewayClass", "TLSRoute", "TCPRoute", "UDPRoute", "ReferenceGrant"}, LBCGatewayGroupVersion: lbcGatewayKinds}
 	listenerSetKinds = map[string][]string{GatewayV1GroupVersion: {"ListenerSet"}}
 )
 

--- a/pkg/gateway/crddetect/gateway_feature_flags_test.go
+++ b/pkg/gateway/crddetect/gateway_feature_flags_test.go
@@ -29,7 +29,7 @@ func TestApplyGatewayFeatureFlags(t *testing.T) {
 		{
 			name: "v1 present but LBC CRDs missing",
 			presentKinds: map[string]sets.Set[string]{
-				GatewayV1GroupVersion: sets.New[string]("Gateway", "GatewayClass", "HTTPRoute", "GRPCRoute", "TLSRoute"),
+				GatewayV1GroupVersion: sets.New[string]("Gateway", "GatewayClass", "HTTPRoute", "GRPCRoute", "TLSRoute", "ReferenceGrant"),
 			},
 			albEnabled:         false,
 			nlbEnabled:         false,
@@ -38,7 +38,7 @@ func TestApplyGatewayFeatureFlags(t *testing.T) {
 		{
 			name: "v1 and LBC CRDs present",
 			presentKinds: map[string]sets.Set[string]{
-				GatewayV1GroupVersion:  sets.New[string]("Gateway", "GatewayClass", "HTTPRoute", "GRPCRoute", "TLSRoute"),
+				GatewayV1GroupVersion:  sets.New[string]("Gateway", "GatewayClass", "HTTPRoute", "GRPCRoute", "TLSRoute", "ReferenceGrant"),
 				LBCGatewayGroupVersion: lbcKinds,
 			},
 			albEnabled:         true,
@@ -48,7 +48,7 @@ func TestApplyGatewayFeatureFlags(t *testing.T) {
 		{
 			name: "tcproute and udproute not served at v1 (gateway api < 1.6) - NLB disabled",
 			presentKinds: map[string]sets.Set[string]{
-				GatewayV1GroupVersion:  sets.New[string]("Gateway", "GatewayClass", "HTTPRoute", "GRPCRoute", "TLSRoute"),
+				GatewayV1GroupVersion:  sets.New[string]("Gateway", "GatewayClass", "HTTPRoute", "GRPCRoute", "TLSRoute", "ReferenceGrant"),
 				LBCGatewayGroupVersion: lbcKinds,
 			},
 			albEnabled:         true,
@@ -58,7 +58,7 @@ func TestApplyGatewayFeatureFlags(t *testing.T) {
 		{
 			name: "all standard CRDs present but LBC CRDs missing",
 			presentKinds: map[string]sets.Set[string]{
-				GatewayV1GroupVersion: sets.New[string]("Gateway", "GatewayClass", "HTTPRoute", "GRPCRoute", "TLSRoute", "TCPRoute", "UDPRoute"),
+				GatewayV1GroupVersion: sets.New[string]("Gateway", "GatewayClass", "HTTPRoute", "GRPCRoute", "TLSRoute", "TCPRoute", "UDPRoute", "ReferenceGrant"),
 			},
 			albEnabled:         false,
 			nlbEnabled:         false,
@@ -67,7 +67,7 @@ func TestApplyGatewayFeatureFlags(t *testing.T) {
 		{
 			name: "all present including LBC CRDs but ListenerSet missing",
 			presentKinds: map[string]sets.Set[string]{
-				GatewayV1GroupVersion:  sets.New[string]("Gateway", "GatewayClass", "HTTPRoute", "GRPCRoute", "TLSRoute", "TCPRoute", "UDPRoute"),
+				GatewayV1GroupVersion:  sets.New[string]("Gateway", "GatewayClass", "HTTPRoute", "GRPCRoute", "TLSRoute", "TCPRoute", "UDPRoute", "ReferenceGrant"),
 				LBCGatewayGroupVersion: lbcKinds,
 			},
 			albEnabled:         true,
@@ -77,7 +77,7 @@ func TestApplyGatewayFeatureFlags(t *testing.T) {
 		{
 			name: "all present including ListenerSet and LBC CRDs",
 			presentKinds: map[string]sets.Set[string]{
-				GatewayV1GroupVersion:  sets.New[string]("Gateway", "GatewayClass", "HTTPRoute", "GRPCRoute", "TLSRoute", "TCPRoute", "UDPRoute", "ListenerSet"),
+				GatewayV1GroupVersion:  sets.New[string]("Gateway", "GatewayClass", "HTTPRoute", "GRPCRoute", "TLSRoute", "TCPRoute", "UDPRoute", "ListenerSet", "ReferenceGrant"),
 				LBCGatewayGroupVersion: lbcKinds,
 			},
 			albEnabled:         true,
@@ -87,7 +87,7 @@ func TestApplyGatewayFeatureFlags(t *testing.T) {
 		{
 			name: "gateway missing",
 			presentKinds: map[string]sets.Set[string]{
-				GatewayV1GroupVersion:  sets.New[string]("GatewayClass", "HTTPRoute", "GRPCRoute", "TLSRoute", "TCPRoute", "UDPRoute"),
+				GatewayV1GroupVersion:  sets.New[string]("GatewayClass", "HTTPRoute", "GRPCRoute", "TLSRoute", "TCPRoute", "UDPRoute", "ReferenceGrant"),
 				LBCGatewayGroupVersion: lbcKinds,
 			},
 			albEnabled:         false,
@@ -97,7 +97,7 @@ func TestApplyGatewayFeatureFlags(t *testing.T) {
 		{
 			name: "gateway class missing",
 			presentKinds: map[string]sets.Set[string]{
-				GatewayV1GroupVersion:  sets.New[string]("Gateway", "HTTPRoute", "GRPCRoute", "TLSRoute", "TCPRoute", "UDPRoute"),
+				GatewayV1GroupVersion:  sets.New[string]("Gateway", "HTTPRoute", "GRPCRoute", "TLSRoute", "TCPRoute", "UDPRoute", "ReferenceGrant"),
 				LBCGatewayGroupVersion: lbcKinds,
 			},
 			albEnabled:         false,
@@ -107,7 +107,7 @@ func TestApplyGatewayFeatureFlags(t *testing.T) {
 		{
 			name: "httproute missing",
 			presentKinds: map[string]sets.Set[string]{
-				GatewayV1GroupVersion:  sets.New[string]("Gateway", "GatewayClass", "GRPCRoute", "TLSRoute", "TCPRoute", "UDPRoute"),
+				GatewayV1GroupVersion:  sets.New[string]("Gateway", "GatewayClass", "GRPCRoute", "TLSRoute", "TCPRoute", "UDPRoute", "ReferenceGrant"),
 				LBCGatewayGroupVersion: lbcKinds,
 			},
 			albEnabled:         false,
@@ -117,7 +117,7 @@ func TestApplyGatewayFeatureFlags(t *testing.T) {
 		{
 			name: "grpcroute missing",
 			presentKinds: map[string]sets.Set[string]{
-				GatewayV1GroupVersion:  sets.New[string]("Gateway", "GatewayClass", "HTTPRoute", "TLSRoute", "TCPRoute", "UDPRoute"),
+				GatewayV1GroupVersion:  sets.New[string]("Gateway", "GatewayClass", "HTTPRoute", "TLSRoute", "TCPRoute", "UDPRoute", "ReferenceGrant"),
 				LBCGatewayGroupVersion: lbcKinds,
 			},
 			albEnabled:         false,
@@ -127,7 +127,7 @@ func TestApplyGatewayFeatureFlags(t *testing.T) {
 		{
 			name: "tlsroute missing",
 			presentKinds: map[string]sets.Set[string]{
-				GatewayV1GroupVersion:  sets.New[string]("Gateway", "GatewayClass", "HTTPRoute", "GRPCRoute", "TCPRoute", "UDPRoute"),
+				GatewayV1GroupVersion:  sets.New[string]("Gateway", "GatewayClass", "HTTPRoute", "GRPCRoute", "TCPRoute", "UDPRoute", "ReferenceGrant"),
 				LBCGatewayGroupVersion: lbcKinds,
 			},
 			albEnabled:         true,
@@ -137,7 +137,7 @@ func TestApplyGatewayFeatureFlags(t *testing.T) {
 		{
 			name: "tcproute missing",
 			presentKinds: map[string]sets.Set[string]{
-				GatewayV1GroupVersion:  sets.New[string]("Gateway", "GatewayClass", "HTTPRoute", "GRPCRoute", "TLSRoute", "UDPRoute"),
+				GatewayV1GroupVersion:  sets.New[string]("Gateway", "GatewayClass", "HTTPRoute", "GRPCRoute", "TLSRoute", "UDPRoute", "ReferenceGrant"),
 				LBCGatewayGroupVersion: lbcKinds,
 			},
 			albEnabled:         true,
@@ -147,7 +147,7 @@ func TestApplyGatewayFeatureFlags(t *testing.T) {
 		{
 			name: "udproute missing",
 			presentKinds: map[string]sets.Set[string]{
-				GatewayV1GroupVersion:  sets.New[string]("Gateway", "GatewayClass", "HTTPRoute", "GRPCRoute", "TLSRoute", "TCPRoute"),
+				GatewayV1GroupVersion:  sets.New[string]("Gateway", "GatewayClass", "HTTPRoute", "GRPCRoute", "TLSRoute", "TCPRoute", "ReferenceGrant"),
 				LBCGatewayGroupVersion: lbcKinds,
 			},
 			albEnabled:         true,
@@ -175,7 +175,7 @@ func TestApplyGatewayFeatureFlags(t *testing.T) {
 		{
 			name: "partial LBC CRDs - TargetGroupConfiguration missing",
 			presentKinds: map[string]sets.Set[string]{
-				GatewayV1GroupVersion:  sets.New[string]("Gateway", "GatewayClass", "HTTPRoute", "GRPCRoute"),
+				GatewayV1GroupVersion:  sets.New[string]("Gateway", "GatewayClass", "HTTPRoute", "GRPCRoute", "ReferenceGrant"),
 				LBCGatewayGroupVersion: sets.New[string]("LoadBalancerConfiguration", "ListenerRuleConfiguration"),
 			},
 			albEnabled:         false,


### PR DESCRIPTION
### Issue

<!-- Please link the GitHub issues related to this PR, if available -->

### Description

Key changes:

Makes the Gateway stack deployer and tracking provider injectable instead of constructing them internally.
Adds reconcile success/error callbacks for Gateway API controllers.
Makes Gateway controller setup more reusable between ALB and NLB implementations.
Fixes Gateway API CRD detection to require ReferenceGrant.
Removes the no-longer-needed v1beta1 Gateway API scheme registration.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
