### PR TITLE
fix(waf): ignore waf acl set to empty string

### DIFF
--- a/pkg/ingress/model_build_load_balancer_addons.go
+++ b/pkg/ingress/model_build_load_balancer_addons.go
@@ -2,6 +2,7 @@ package ingress
 
 import (
 	"context"
+
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/annotations"
@@ -60,7 +61,8 @@ func (t *defaultModelBuildTask) buildWAFv2WebACLAssociation(ctx context.Context,
 			}
 
 			rawWebACLARN := ""
-			if exists := t.annotationParser.ParseStringAnnotation(annotations.IngressSuffixWAFv2ACLARN, &rawWebACLARN, member.Ing.Annotations); !exists {
+			exists := t.annotationParser.ParseStringAnnotation(annotations.IngressSuffixWAFv2ACLARN, &rawWebACLARN, member.Ing.Annotations)
+			if !exists || rawWebACLARN == "" {
 				continue
 			}
 			explicitWebACLARNs.Insert(rawWebACLARN)

--- a/pkg/ingress/model_build_load_balancer_addons_test.go
+++ b/pkg/ingress/model_build_load_balancer_addons_test.go
@@ -70,6 +70,31 @@ func Test_defaultModelBuildTask_buildWAFv2WebACLAssociation(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
+			name: " wafv2-acl-arn set to empty string",
+			fields: fields{
+				ingGroup: Group{
+					Members: []ClassifiedIngress{
+						{
+							Ing: &networking.Ingress{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: "awesome-ns",
+									Name:      "awesome-ing-0",
+									Annotations: map[string]string{
+										"alb.ingress.kubernetes.io/wafv2-acl-arn": "",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				lbARN: core.LiteralStringToken("awesome-lb-arn"),
+			},
+			want:    nil,
+			wantErr: assert.NoError,
+		},
+		{
 			name: "when all ingresses have wafv2-acl-arn annotation set to wafv2-arn-1",
 			fields: fields{
 				ingGroup: Group{


### PR DESCRIPTION
### Description

Our documentation states that WAF ACL should be set to 'none' in order for it to be removed. Right now, an empty string ACL ARN will also remove it.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [ ] Manually tested
- [ ] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
