### PR TITLE
Paginate ListHostedZones when listing hosted zones

### DIFF
--- a/pkg/aws/services/route53.go
+++ b/pkg/aws/services/route53.go
@@ -102,22 +102,18 @@ type hostedZoneLister interface {
 	ListHostedZones(ctx context.Context, params *route53.ListHostedZonesInput, optFns ...func(*route53.Options)) (*route53.ListHostedZonesOutput, error)
 }
 
-// listAllHostedZones paginates ListHostedZones. The AWS API returns at most 100
-// zones per page, so a single call would silently drop later pages.
+// listAllHostedZones paginates ListHostedZones using the SDK generated paginator.
+// The AWS API returns at most 100 zones per page, so a single call would silently
+// drop later pages.
 func listAllHostedZones(ctx context.Context, lister hostedZoneLister) ([]types.HostedZone, error) {
+	paginator := route53.NewListHostedZonesPaginator(lister, &route53.ListHostedZonesInput{})
 	var zones []types.HostedZone
-	var marker *string
-	for {
-		reqList := &route53.ListHostedZonesInput{Marker: marker}
-		respList, err := lister.ListHostedZones(ctx, reqList)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return nil, err
 		}
-		zones = append(zones, respList.HostedZones...)
-		if !respList.IsTruncated {
-			break
-		}
-		marker = respList.NextMarker
+		zones = append(zones, page.HostedZones...)
 	}
 	return zones, nil
 }

--- a/pkg/aws/services/route53.go
+++ b/pkg/aws/services/route53.go
@@ -89,12 +89,35 @@ func (c *route53Client) listHostedZones(ctx context.Context) ([]types.HostedZone
 		return nil, err
 	}
 
-	reqList := &route53.ListHostedZonesInput{}
-	respList, err := client.ListHostedZones(ctx, reqList)
+	zones, err := listAllHostedZones(ctx, client)
 	if err != nil {
 		return nil, err
 	}
 
-	c.hostedZonesCache.Set(hostedZonesCacheKey, respList.HostedZones, c.hostedZonesCacheTTL)
-	return respList.HostedZones, nil
+	c.hostedZonesCache.Set(hostedZonesCacheKey, zones, c.hostedZonesCacheTTL)
+	return zones, nil
+}
+
+type hostedZoneLister interface {
+	ListHostedZones(ctx context.Context, params *route53.ListHostedZonesInput, optFns ...func(*route53.Options)) (*route53.ListHostedZonesOutput, error)
+}
+
+// listAllHostedZones paginates ListHostedZones. The AWS API returns at most 100
+// zones per page, so a single call would silently drop later pages.
+func listAllHostedZones(ctx context.Context, lister hostedZoneLister) ([]types.HostedZone, error) {
+	var zones []types.HostedZone
+	var marker *string
+	for {
+		reqList := &route53.ListHostedZonesInput{Marker: marker}
+		respList, err := lister.ListHostedZones(ctx, reqList)
+		if err != nil {
+			return nil, err
+		}
+		zones = append(zones, respList.HostedZones...)
+		if !respList.IsTruncated {
+			break
+		}
+		marker = respList.NextMarker
+	}
+	return zones, nil
 }

--- a/pkg/aws/services/route53_test.go
+++ b/pkg/aws/services/route53_test.go
@@ -2,14 +2,38 @@ package services
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/route53"
 	"github.com/aws/aws-sdk-go-v2/service/route53/types"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/cache"
 )
+
+type stubHostedZoneLister struct {
+	pages   map[string]*route53.ListHostedZonesOutput
+	err     error
+	markers []*string
+}
+
+func (s *stubHostedZoneLister) ListHostedZones(_ context.Context, params *route53.ListHostedZonesInput, _ ...func(*route53.Options)) (*route53.ListHostedZonesOutput, error) {
+	s.markers = append(s.markers, params.Marker)
+	if s.err != nil {
+		return nil, s.err
+	}
+	key := ""
+	if params.Marker != nil {
+		key = *params.Marker
+	}
+	out, ok := s.pages[key]
+	if !ok {
+		return nil, errors.New("unexpected marker: " + key)
+	}
+	return out, nil
+}
 
 func newCachedRoute53Client(zones []types.HostedZone) *route53Client {
 	c := &route53Client{
@@ -60,6 +84,82 @@ func TestGetHostedZoneID(t *testing.T) {
 			got, err := c.GetHostedZoneID(context.Background(), tt.domain)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, awssdk.ToString(got))
+		})
+	}
+}
+
+func TestListAllHostedZones(t *testing.T) {
+	page2Marker := "page-2"
+	page1Zones := []types.HostedZone{
+		hostedZone("Z1", "one.example.com."),
+		hostedZone("Z2", "two.example.com."),
+	}
+	page2Zones := []types.HostedZone{
+		hostedZone("Z3", "three.example.com."),
+	}
+	singlePageZones := []types.HostedZone{
+		hostedZone("Z1", "one.example.com."),
+	}
+	apiErr := errors.New("list hosted zones failed")
+
+	tests := []struct {
+		name        string
+		pages       map[string]*route53.ListHostedZonesOutput
+		err         error
+		wantZones   []types.HostedZone
+		wantErr     error
+		wantMarkers []*string
+	}{
+		{
+			name: "two pages",
+			pages: map[string]*route53.ListHostedZonesOutput{
+				"": {
+					HostedZones: page1Zones,
+					IsTruncated: true,
+					NextMarker:  awssdk.String(page2Marker),
+				},
+				page2Marker: {
+					HostedZones: page2Zones,
+					IsTruncated: false,
+				},
+			},
+			wantZones: []types.HostedZone{
+				hostedZone("Z1", "one.example.com."),
+				hostedZone("Z2", "two.example.com."),
+				hostedZone("Z3", "three.example.com."),
+			},
+			wantMarkers: []*string{nil, awssdk.String(page2Marker)},
+		},
+		{
+			name: "single page",
+			pages: map[string]*route53.ListHostedZonesOutput{
+				"": {
+					HostedZones: singlePageZones,
+					IsTruncated: false,
+				},
+			},
+			wantZones: singlePageZones,
+		},
+		{
+			name:    "API error on the first call",
+			err:     apiErr,
+			wantErr: apiErr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lister := &stubHostedZoneLister{pages: tt.pages, err: tt.err}
+			got, err := listAllHostedZones(context.Background(), lister)
+			if tt.wantErr != nil {
+				assert.Equal(t, tt.wantErr, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantZones, got)
+			if tt.wantMarkers != nil {
+				assert.Equal(t, tt.wantMarkers, lister.markers)
+			}
 		})
 	}
 }


### PR DESCRIPTION
### What this PR does

Fixes #4832.

`listHostedZones` called `ListHostedZones` once with no pagination. The AWS API returns at most 100 zones per page, so accounts with more than 100 hosted zones silently dropped zones beyond the first page. `GetHostedZoneID` then reported "no hosted zone found" for valid domains whose parent zone landed on a later page (e.g. a sub-subdomain whose `domain.tld` zone was on page 2).

### Changes

Loop over pages using `IsTruncated` / `NextMarker` until all zones are listed.

### Verification

`go test ./pkg/aws/services/... -count=1` passes, including the new table-driven `TestListAllHostedZones` that drives the pagination loop through a stub `hostedZoneLister` (two pages with marker propagation, single page, and API error cases). `go vet` and `make generate` are clean.
