### PR TITLE
fix(targetgroupbinding): respect backend security group opt-out

### DIFF
--- a/pkg/networking/networking_manager.go
+++ b/pkg/networking/networking_manager.go
@@ -98,30 +98,31 @@ type defaultNetworkingManager struct {
 }
 
 func (m *defaultNetworkingManager) ReconcileForPodEndpoints(ctx context.Context, tgb *elbv2api.TargetGroupBinding, endpoints []backend.PodEndpoint) error {
-	var ingressPermissionsPerSG map[string][]IPPermissionInfo
-	if tgb.Spec.Networking != nil {
-		var err error
-		ingressPermissionsPerSG, err = m.computeIngressPermissionsPerSGWithPodEndpoints(ctx, *tgb.Spec.Networking, endpoints)
-		if err != nil {
-			return err
-		}
+	if tgb.Spec.Networking == nil {
+		return nil
+	}
+	ingressPermissionsPerSG, err := m.computeIngressPermissionsPerSGWithPodEndpoints(ctx, *tgb.Spec.Networking, endpoints)
+	if err != nil {
+		return err
 	}
 	return m.reconcileWithIngressPermissionsPerSG(ctx, tgb, ingressPermissionsPerSG)
 }
 
 func (m *defaultNetworkingManager) ReconcileForNodePortEndpoints(ctx context.Context, tgb *elbv2api.TargetGroupBinding, endpoints []backend.NodePortEndpoint) error {
-	var ingressPermissionsPerSG map[string][]IPPermissionInfo
-	if tgb.Spec.Networking != nil {
-		var err error
-		ingressPermissionsPerSG, err = m.computeIngressPermissionsPerSGWithNodePortEndpoints(ctx, *tgb.Spec.Networking, endpoints)
-		if err != nil {
-			return err
-		}
+	if tgb.Spec.Networking == nil {
+		return nil
+	}
+	ingressPermissionsPerSG, err := m.computeIngressPermissionsPerSGWithNodePortEndpoints(ctx, *tgb.Spec.Networking, endpoints)
+	if err != nil {
+		return err
 	}
 	return m.reconcileWithIngressPermissionsPerSG(ctx, tgb, ingressPermissionsPerSG)
 }
 
 func (m *defaultNetworkingManager) Cleanup(ctx context.Context, tgb *elbv2api.TargetGroupBinding) error {
+	if tgb.Spec.Networking == nil {
+		return nil
+	}
 	return m.reconcileWithIngressPermissionsPerSG(ctx, tgb, nil)
 }
 

--- a/pkg/networking/networking_manager_test.go
+++ b/pkg/networking/networking_manager_test.go
@@ -2095,3 +2095,39 @@ func (m *mockSGReconciler) ReconcileIngress(ctx context.Context, sgID string, de
 	})
 	return nil
 }
+
+func Test_defaultNetworkingManager_NetworkingOptOut(t *testing.T) {
+	mockReconciler := &mockSGReconciler{}
+	m := &defaultNetworkingManager{
+		ingressPermissionsPerSGByTGB: make(map[types.NamespacedName]map[string][]IPPermissionInfo),
+		trackedEndpointSGs:           sets.NewString(),
+		sgReconciler:                 mockReconciler,
+	}
+
+	tgb := &elbv2api.TargetGroupBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "test-tgb",
+		},
+		Spec: elbv2api.TargetGroupBindingSpec{
+			Networking: nil,
+		},
+	}
+
+	ctx := context.Background()
+
+	// ReconcileForPodEndpoints with Spec.Networking nil should be a no-op
+	err := m.ReconcileForPodEndpoints(ctx, tgb, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(mockReconciler.calls), "ReconcileForPodEndpoints should not invoke sgReconciler when Spec.Networking is nil")
+
+	// ReconcileForNodePortEndpoints with Spec.Networking nil should be a no-op
+	err = m.ReconcileForNodePortEndpoints(ctx, tgb, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(mockReconciler.calls), "ReconcileForNodePortEndpoints should not invoke sgReconciler when Spec.Networking is nil")
+
+	// Cleanup with Spec.Networking nil should be a no-op
+	err = m.Cleanup(ctx, tgb)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(mockReconciler.calls), "Cleanup should not invoke sgReconciler when Spec.Networking is nil")
+}

--- a/pkg/targetgroupbinding/resource_manager.go
+++ b/pkg/targetgroupbinding/resource_manager.go
@@ -152,8 +152,10 @@ func (m *defaultResourceManager) Cleanup(ctx context.Context, tgb *elbv2api.Targ
 		return err
 	}
 
-	if err := m.networkingManager.Cleanup(ctx, tgb); err != nil {
-		return err
+	if tgb.Spec.Networking != nil {
+		if err := m.networkingManager.Cleanup(ctx, tgb); err != nil {
+			return err
+		}
 	}
 	if err := m.updatePodAsHealthyForDeletedTGB(ctx, tgb); err != nil {
 		return err
@@ -208,10 +210,12 @@ func (m *defaultResourceManager) reconcileWithIPTargetType(ctx context.Context, 
 	matchedEndpointAndTargets, unmatchedEndpoints, unmatchedTargets := matchPodEndpointWithTargets(tgb, endpoints, notDrainingTargets)
 
 	needNetworkingRequeue := false
-	if err := m.networkingManager.ReconcileForPodEndpoints(ctx, tgb, endpoints); err != nil {
-		tgbScopedLogger.Error(err, "Requesting network requeue due to error from ReconcileForPodEndpoints")
-		m.eventRecorder.Event(tgb, corev1.EventTypeWarning, k8s.TargetGroupBindingEventReasonFailedNetworkReconcile, err.Error())
-		needNetworkingRequeue = true
+	if tgb.Spec.Networking != nil {
+		if err := m.networkingManager.ReconcileForPodEndpoints(ctx, tgb, endpoints); err != nil {
+			tgbScopedLogger.Error(err, "Requesting network requeue due to error from ReconcileForPodEndpoints")
+			m.eventRecorder.Event(tgb, corev1.EventTypeWarning, k8s.TargetGroupBindingEventReasonFailedNetworkReconcile, err.Error())
+			needNetworkingRequeue = true
+		}
 	}
 
 	preflightNeedFurtherProbe := false
@@ -335,9 +339,11 @@ func (m *defaultResourceManager) reconcileWithInstanceTargetType(ctx context.Con
 
 	_, unmatchedEndpoints, unmatchedTargets := matchNodePortEndpointWithTargets(endpoints, notDrainingTargets)
 
-	if err := m.networkingManager.ReconcileForNodePortEndpoints(ctx, tgb, endpoints); err != nil {
-		tgbScopedLogger.Error(err, "Requesting network requeue due to error from ReconcileForNodePortEndpoints")
-		return "", "", false, ctrlerrors.NewErrorWithMetrics(controllerName, "reconcile_nodeport_endpoints_error", err, m.metricsCollector)
+	if tgb.Spec.Networking != nil {
+		if err := m.networkingManager.ReconcileForNodePortEndpoints(ctx, tgb, endpoints); err != nil {
+			tgbScopedLogger.Error(err, "Requesting network requeue due to error from ReconcileForNodePortEndpoints")
+			return "", "", false, ctrlerrors.NewErrorWithMetrics(controllerName, "reconcile_nodeport_endpoints_error", err, m.metricsCollector)
+		}
 	}
 
 	if len(unmatchedEndpoints) > 0 || len(unmatchedTargets) > 0 {

--- a/pkg/targetgroupbinding/resource_manager_test.go
+++ b/pkg/targetgroupbinding/resource_manager_test.go
@@ -23,10 +23,13 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/equality"
 	"sigs.k8s.io/aws-load-balancer-controller/v3/pkg/k8s"
 	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -1438,6 +1441,263 @@ func Test_needReadinessGateFlip(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := needReadinessGateFlip(tt.endpoints, condType)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+type trackingNetworkingManager struct {
+	reconcileForPodEndpointsCalls      int
+	reconcileForNodePortEndpointsCalls int
+	cleanupCalls                       int
+	attemptGarbageCollectionCalls      int
+}
+
+func (m *trackingNetworkingManager) ReconcileForPodEndpoints(ctx context.Context, tgb *elbv2api.TargetGroupBinding, endpoints []backend.PodEndpoint) error {
+	m.reconcileForPodEndpointsCalls++
+	return nil
+}
+
+func (m *trackingNetworkingManager) ReconcileForNodePortEndpoints(ctx context.Context, tgb *elbv2api.TargetGroupBinding, endpoints []backend.NodePortEndpoint) error {
+	m.reconcileForNodePortEndpointsCalls++
+	return nil
+}
+
+func (m *trackingNetworkingManager) Cleanup(ctx context.Context, tgb *elbv2api.TargetGroupBinding) error {
+	m.cleanupCalls++
+	return nil
+}
+
+func (m *trackingNetworkingManager) AttemptGarbageCollection(ctx context.Context) error {
+	m.attemptGarbageCollectionCalls++
+	return nil
+}
+
+type fakeEndpointResolver struct {
+	podEndpoints      []backend.PodEndpoint
+	nodePortEndpoints []backend.NodePortEndpoint
+	err               error
+}
+
+func (f *fakeEndpointResolver) ResolvePodEndpoints(ctx context.Context, svcKey types.NamespacedName, port intstr.IntOrString, endpointSliceAddressType discovery.AddressType) ([]backend.PodEndpoint, error) {
+	return f.podEndpoints, f.err
+}
+
+func (f *fakeEndpointResolver) ResolveNodePortEndpoints(ctx context.Context, svcKey types.NamespacedName, port intstr.IntOrString, opts ...backend.EndpointResolveOption) ([]backend.NodePortEndpoint, error) {
+	return f.nodePortEndpoints, f.err
+}
+
+type fakeTargetsManager struct {
+	targets []TargetInfo
+	err     error
+}
+
+func (f *fakeTargetsManager) ListTargets(ctx context.Context, tgb *elbv2api.TargetGroupBinding) ([]TargetInfo, error) {
+	return f.targets, f.err
+}
+
+func (f *fakeTargetsManager) RegisterTargets(ctx context.Context, tgb *elbv2api.TargetGroupBinding, targets []elbv2types.TargetDescription) error {
+	return f.err
+}
+
+func (f *fakeTargetsManager) DeregisterTargets(ctx context.Context, tgb *elbv2api.TargetGroupBinding, targets []elbv2types.TargetDescription) error {
+	return f.err
+}
+
+type fakeMultiClusterManager struct {
+	cleanupCalls int
+}
+
+func (f *fakeMultiClusterManager) FilterTargetsForDeregistration(ctx context.Context, tgb *elbv2api.TargetGroupBinding, targetInfo []TargetInfo) ([]TargetInfo, bool, error) {
+	return targetInfo, false, nil
+}
+
+func (f *fakeMultiClusterManager) UpdateTrackedIPTargets(ctx context.Context, updateTrackedTargets bool, endpoints []backend.PodEndpoint, tgb *elbv2api.TargetGroupBinding) error {
+	return nil
+}
+
+func (f *fakeMultiClusterManager) UpdateTrackedInstanceTargets(ctx context.Context, updateRequested bool, endpoints []backend.NodePortEndpoint, tgb *elbv2api.TargetGroupBinding) error {
+	return nil
+}
+
+func (f *fakeMultiClusterManager) CleanUp(ctx context.Context, tgb *elbv2api.TargetGroupBinding) error {
+	f.cleanupCalls++
+	return nil
+}
+
+type fakePodInfoRepo struct{}
+
+func (f *fakePodInfoRepo) ListKeys(_ context.Context) []types.NamespacedName {
+	return nil
+}
+
+func (f *fakePodInfoRepo) Get(_ context.Context, key types.NamespacedName) (k8s.PodInfo, bool, error) {
+	return k8s.PodInfo{}, false, nil
+}
+
+func Test_defaultResourceManager_NetworkingOptOut(t *testing.T) {
+	targetTypeIP := elbv2api.TargetTypeIP
+	targetTypeInstance := elbv2api.TargetTypeInstance
+
+	tests := []struct {
+		name                         string
+		targetType                   *elbv2api.TargetType
+		networking                   *elbv2api.TargetGroupBindingNetworking
+		expectPodReconcileCalls      int
+		expectNodePortReconcileCalls int
+	}{
+		{
+			name:                         "IP target with Spec.Networking nil - networkingManager should NOT be called",
+			targetType:                   &targetTypeIP,
+			networking:                   nil,
+			expectPodReconcileCalls:      0,
+			expectNodePortReconcileCalls: 0,
+		},
+		{
+			name:       "IP target with Spec.Networking configured - networkingManager SHOULD be called",
+			targetType: &targetTypeIP,
+			networking: &elbv2api.TargetGroupBindingNetworking{
+				Ingress: []elbv2api.NetworkingIngressRule{},
+			},
+			expectPodReconcileCalls:      1,
+			expectNodePortReconcileCalls: 0,
+		},
+		{
+			name:                         "Instance target with Spec.Networking nil - networkingManager should NOT be called",
+			targetType:                   &targetTypeInstance,
+			networking:                   nil,
+			expectPodReconcileCalls:      0,
+			expectNodePortReconcileCalls: 0,
+		},
+		{
+			name:       "Instance target with Spec.Networking configured - networkingManager SHOULD be called",
+			targetType: &targetTypeInstance,
+			networking: &elbv2api.TargetGroupBindingNetworking{
+				Ingress: []elbv2api.NetworkingIngressRule{},
+			},
+			expectPodReconcileCalls:      0,
+			expectNodePortReconcileCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k8sSchema := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sSchema)
+			elbv2api.AddToScheme(k8sSchema)
+			k8sClient := testclient.NewClientBuilder().WithScheme(k8sSchema).Build()
+
+			netMgr := &trackingNetworkingManager{}
+			epResolver := &fakeEndpointResolver{}
+			tgMgr := &fakeTargetsManager{}
+			mcMgr := &fakeMultiClusterManager{}
+
+			m := &defaultResourceManager{
+				k8sClient:                k8sClient,
+				targetsManager:           tgMgr,
+				endpointResolver:         epResolver,
+				networkingManager:        netMgr,
+				multiClusterManager:      mcMgr,
+				eventRecorder:            record.NewFakeRecorder(10),
+				logger:                   logr.New(&log.NullLogSink{}),
+				metricsCollector:         lbcmetrics.NewMockCollector(),
+				requeueDuration:          time.Second,
+				maxTargetsPerTargetGroup: 0,
+			}
+
+			tgb := &elbv2api.TargetGroupBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "test-tgb",
+				},
+				Spec: elbv2api.TargetGroupBindingSpec{
+					TargetGroupARN: "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/tg/123456",
+					TargetType:     tt.targetType,
+					ServiceRef: elbv2api.ServiceReference{
+						Name: "test-svc",
+						Port: intstr.FromInt(80),
+					},
+					Networking: tt.networking,
+				},
+			}
+
+			ctx := context.Background()
+			err := k8sClient.Create(ctx, tgb)
+			assert.NoError(t, err)
+
+			_, err = m.Reconcile(ctx, tgb)
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.expectPodReconcileCalls, netMgr.reconcileForPodEndpointsCalls, "reconcileForPodEndpointsCalls mismatch")
+			assert.Equal(t, tt.expectNodePortReconcileCalls, netMgr.reconcileForNodePortEndpointsCalls, "reconcileForNodePortEndpointsCalls mismatch")
+		})
+	}
+}
+
+func Test_defaultResourceManager_Cleanup_NetworkingOptOut(t *testing.T) {
+	tests := []struct {
+		name               string
+		networking         *elbv2api.TargetGroupBindingNetworking
+		expectCleanupCalls int
+	}{
+		{
+			name:               "Cleanup with Spec.Networking nil - networkingManager.Cleanup should NOT be called",
+			networking:         nil,
+			expectCleanupCalls: 0,
+		},
+		{
+			name: "Cleanup with Spec.Networking configured - networkingManager.Cleanup SHOULD be called",
+			networking: &elbv2api.TargetGroupBindingNetworking{
+				Ingress: []elbv2api.NetworkingIngressRule{},
+			},
+			expectCleanupCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k8sSchema := runtime.NewScheme()
+			clientgoscheme.AddToScheme(k8sSchema)
+			elbv2api.AddToScheme(k8sSchema)
+			k8sClient := testclient.NewClientBuilder().WithScheme(k8sSchema).Build()
+
+			netMgr := &trackingNetworkingManager{}
+			tgMgr := &fakeTargetsManager{}
+			mcMgr := &fakeMultiClusterManager{}
+
+			m := &defaultResourceManager{
+				k8sClient:           k8sClient,
+				targetsManager:      tgMgr,
+				networkingManager:   netMgr,
+				multiClusterManager: mcMgr,
+				eventRecorder:       record.NewFakeRecorder(10),
+				logger:              logr.New(&log.NullLogSink{}),
+				metricsCollector:    lbcmetrics.NewMockCollector(),
+				podInfoRepo:         &fakePodInfoRepo{},
+			}
+
+			targetTypeIP := elbv2api.TargetTypeIP
+			tgb := &elbv2api.TargetGroupBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "test-tgb",
+				},
+				Spec: elbv2api.TargetGroupBindingSpec{
+					TargetGroupARN: "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/tg/123456",
+					TargetType:     &targetTypeIP,
+					ServiceRef: elbv2api.ServiceReference{
+						Name: "test-svc",
+						Port: intstr.FromInt(80),
+					},
+					Networking: tt.networking,
+				},
+			}
+
+			ctx := context.Background()
+			err := m.Cleanup(ctx, tgb)
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.expectCleanupCalls, netMgr.cleanupCalls, "cleanupCalls mismatch")
+			assert.Equal(t, 1, mcMgr.cleanupCalls, "multiClusterManager.CleanUp should always be called")
 		})
 	}
 }


### PR DESCRIPTION
## What does this PR do?

This PR ensures that `TargetGroupBinding` reconciliation skips backend security group management when `tgb.Spec.Networking` is not configured (`nil`).

Specifically:
- In `pkg/targetgroupbinding/resource_manager.go`, invocations of `networkingManager.ReconcileForPodEndpoints`, `networkingManager.ReconcileForNodePortEndpoints`, and `networkingManager.Cleanup` are guarded with `if tgb.Spec.Networking != nil`.
- In `pkg/networking/networking_manager.go`, early returns (`return nil`) are added to `ReconcileForPodEndpoints`, `ReconcileForNodePortEndpoints`, and `Cleanup` when `tgb.Spec.Networking == nil`.

## Why is this needed?

When an Ingress or Service is configured with:
- `alb.ingress.kubernetes.io/manage-backend-security-group-rules: "false"` or
- `service.beta.kubernetes.io/aws-load-balancer-manage-backend-security-group-rules: "false"`,

the controller creates a `TargetGroupBinding` where `Spec.Networking` is `nil`.

However, the `TargetGroupBinding` reconciler previously called `NetworkingManager` unconditionally for both IP and Instance targets, as well as during cleanup. Inside `NetworkingManager`, execution fell through to `reconcileWithIngressPermissionsPerSG(ctx, tgb, nil)` rather than treating nil networking as an opt-out. This triggered cluster-wide security group discovery and rule reconciliation.

In environments where the controller's IAM role operates under restrictive IAM Permissions Boundaries (which explicitly deny `ec2:AuthorizeSecurityGroupIngress` because security groups are pre-provisioned by infrastructure pipelines), this resulted in:
