### PR TITLE
docs: warn against manually deleting controller-generated TargetGroupBinding

### DIFF
--- a/docs/guide/targetgroupbinding/targetgroupbinding.md
+++ b/docs/guide/targetgroupbinding/targetgroupbinding.md
@@ -18,6 +18,16 @@ It automatically creates TargetGroupBinding in the same namespace of the Service
 
     You can view all TargetGroupBindings in a namespace by `kubectl get targetgroupbindings -n <your-namespace> -o wide`
 
+!!!warning "Do not manually delete controller-generated TargetGroupBindings"
+Deleting a `TargetGroupBinding` that the controller generated for an Ingress, Service, or Gateway resource:
+
+* deregisters every target from the associated AWS target group, and
+* is **not** immediately reconciled by the controller.
+
+The controller watches the Ingress, Service, and Gateway resources that own the binding, but it does **not** watch the generated `TargetGroupBinding` itself. As a result, a deleted binding is only recreated when the owning resource is updated (for example, editing any annotation) or during the periodic resync (`--sync-period`, which defaults to `10h`). Until then, the load balancer forwards to zero registered targets.
+
+If you delete a controller-generated binding while troubleshooting, force an immediate reconcile by editing any annotation on the owning Ingress, Service, or Gateway resource, and verify that the binding and its targets are restored.
+
 !!!question "EKS Auto Mode users"
 If you are using EKS Auto Mode, please see the
 [EKS Auto Mode documentation](https://docs.aws.amazon.com/eks/latest/userguide/auto-configure-alb.html#_considerations)


### PR DESCRIPTION
### Issue

Fixes #4880

### Description

Adds a warning to the TargetGroupBinding documentation advising operators against manually deleting controller-generated bindings.

Deleting a binding generated for an Ingress, Service, or Gateway resource deregisters every target from the associated AWS target group and is not immediately reconciled, because the controller watches the owning resources rather than the generated binding itself. The warning explains when a deleted binding is recreated (on an update to the owning resource, or during the periodic `--sync-period` resync) and how to force recovery by editing any annotation on the owning resource.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
